### PR TITLE
Add GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+on:
+  pull_request:
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Setup rust
+      run: rustup target add wasm32-unknown-unknown
+    - name: Cache
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+    - name: Install wasm-bindgen
+      run: which wasm-bindgen || cargo install wasm-bindgen-cli
+    - name: Build
+      run: cargo build
+    - name: WASM build
+      run: make wasm
+    - name: Test
+      run: cargo test
+    - name: Lint
+      run: make lint


### PR DESCRIPTION
This was straightforward, except for:

- The Rust cache config is taken from https://github.com/actions/cache/blob/main/examples.md#rust---cargo
- The wasm-bindgen CLI takes a significant amount of time to build (sigh) so only do so if not already cached
