### PR TITLE
Implement Resize operator

### DIFF
--- a/src/model_builder.rs
+++ b/src/model_builder.rs
@@ -4,8 +4,8 @@ use flatbuffers::{FlatBufferBuilder, UnionWIPOffset, Vector, WIPOffset};
 
 use crate::ops::{
     AveragePool, BatchNormalization, Cast, Clip, Concat, ConstantOfShape, Conv, ConvTranspose,
-    DataType, Gather, Gemm, LeakyRelu, MaxPool, Padding, ReduceMean, Scalar, Softmax, Split,
-    Squeeze, Transpose, Unsqueeze,
+    DataType, Gather, Gemm, LeakyRelu, MaxPool, Padding, ReduceMean, Resize, ResizeMode, Scalar,
+    Softmax, Split, Squeeze, Transpose, Unsqueeze,
 };
 use crate::schema_generated as sg;
 use crate::tensor::Tensor;
@@ -40,6 +40,7 @@ pub enum OpType {
     ReduceMean(ReduceMean),
     Relu,
     Reshape,
+    Resize(Resize),
     Shape,
     Sigmoid,
     Slice,
@@ -364,6 +365,13 @@ impl<'a> ModelBuilder<'a> {
             }),
             OpType::Relu => op!(Relu),
             OpType::Reshape => op!(Reshape),
+            OpType::Resize(args) => op_with_attrs!(Resize, ResizeAttrs, {
+                let mode = match args.mode {
+                    ResizeMode::Nearest => sg::ResizeMode::Nearest,
+                    ResizeMode::Linear => sg::ResizeMode::Linear,
+                };
+                sg::ResizeAttrsArgs { mode }
+            }),
             OpType::Shape => op!(Shape),
             OpType::Sigmoid => op!(Sigmoid),
             OpType::Slice => op!(Slice),

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -12,6 +12,7 @@ mod matmul;
 mod norm;
 mod pooling;
 mod reduce;
+mod resize;
 
 pub use activations::{
     clip, clip_in_place, erf, erf_in_place, leaky_relu, leaky_relu_in_place, relu, relu_in_place,
@@ -34,6 +35,7 @@ pub use norm::{batch_norm, batch_norm_in_place, BatchNormalization};
 pub use pooling::{average_pool, global_average_pool, max_pool};
 pub use pooling::{AveragePool, GlobalAveragePool, MaxPool};
 pub use reduce::{reduce_mean, ReduceMean};
+pub use resize::{resize, Resize, ResizeMode, ResizeTarget};
 
 #[derive(Copy, Clone, Debug)]
 pub enum Padding {

--- a/src/ops/resize.rs
+++ b/src/ops/resize.rs
@@ -1,0 +1,448 @@
+use std::iter::zip;
+
+use crate::ops::{get_input, get_optional_input, Input, IntoOpResult, OpError, Operator, Output};
+use crate::tensor::Tensor;
+
+/// Specifies an output size for a resize operation.
+pub enum ResizeTarget<'a> {
+    /// Vector of scale factors for each dimension. The length should match the
+    /// input rank.
+    Scales(&'a Tensor),
+
+    /// Vector of output sizes for each dimension. The length should match the
+    /// input rank.
+    Sizes(&'a Tensor<i32>),
+}
+
+struct Image<'a> {
+    data: &'a [f32],
+    height: usize,
+    width: usize,
+    h_stride: usize,
+    w_stride: usize,
+}
+
+struct ImageMut<'a> {
+    data: &'a mut [f32],
+    height: usize,
+    width: usize,
+    h_stride: usize,
+    w_stride: usize,
+}
+
+/// Compute the input image coordinate that corresponds to an output coordinate,
+/// where `scale` is the scale factor from output to input.
+///
+/// ONNX supports several modes for transforming coords, specified by the
+/// `coordinate_transformation_mode` attribute. The default, implemented here,
+/// is the "half pixel" mode. The half pixel mode is consistent with how OpenCV
+/// (`cv2.resize`) and PyTorch (`torch.nn.functional.interpolate`) work. See
+/// https://jricheimer.github.io/tensorflow/2019/02/11/resize-confusion/
+/// for rationale.
+fn input_coord(dest_coord: usize, scale: f32) -> f32 {
+    scale * (dest_coord as f32 + 0.5) - 0.5
+}
+
+fn nearest_resize(input: &Image, output: &mut ImageMut) {
+    // Scale factors to map output coords to input coords.
+    let inv_scale_y = input.height as f32 / output.height as f32;
+    let inv_scale_x = input.width as f32 / output.width as f32;
+
+    for y in 0..output.height {
+        let in_y = (y as f32 * inv_scale_y) as usize;
+        for x in 0..output.width {
+            let in_x = (x as f32 * inv_scale_x) as usize;
+            let out = input.data[in_y * input.h_stride + in_x * input.w_stride];
+            output.data[y * output.h_stride + x * output.w_stride] = out;
+        }
+    }
+}
+
+fn bilinear_resize(input: &Image, output: &mut ImageMut) {
+    // Scale factors to map output coords to input coords.
+    let inv_scale_y = input.height as f32 / output.height as f32;
+    let inv_scale_x = input.width as f32 / output.width as f32;
+
+    for y in 0..output.height {
+        let in_y = input_coord(y, inv_scale_y).clamp(0., input.height as f32 - 1.);
+        let in_y1 = in_y as usize;
+        let in_y2 = (in_y1 + 1).min(input.height - 1);
+        let weight_y = in_y - (in_y1 as f32);
+
+        for x in 0..output.width {
+            let in_x = input_coord(x, inv_scale_x).clamp(0., input.width as f32 - 1.);
+            let in_x1 = in_x as usize;
+            let in_x2 = (in_x1 + 1).min(input.width - 1);
+            let weight_x = in_x - (in_x1 as f32);
+
+            let in_tl = input.data[in_y1 * input.h_stride + in_x1 * input.w_stride];
+            let in_tr = input.data[in_y1 * input.h_stride + in_x2 * input.w_stride];
+            let in_bl = input.data[in_y2 * input.h_stride + in_x1 * input.w_stride];
+            let in_br = input.data[in_y2 * input.h_stride + in_x2 * input.w_stride];
+
+            // Interpolate in X direction
+            let out_top = (1. - weight_x) * in_tl + weight_x * in_tr;
+            let out_bottom = (1. - weight_x) * in_bl + weight_x * in_br;
+
+            // Interpolate in Y direction
+            let out = (1. - weight_y) * out_top + weight_y * out_bottom;
+
+            output.data[y * output.h_stride + x * output.w_stride] = out;
+        }
+    }
+}
+
+pub fn resize(input: &Tensor, target: ResizeTarget, mode: ResizeMode) -> Result<Tensor, OpError> {
+    let scales = match target {
+        ResizeTarget::Scales(s) => s.clone(),
+        ResizeTarget::Sizes(sizes) => {
+            // TODO - Check sizes shape is correct
+            let scales = zip(input.shape().iter(), sizes.elements())
+                .map(|(&in_size, out_size)| (out_size as f32) / (in_size) as f32)
+                .collect();
+            Tensor::from_vec(scales)
+        }
+    };
+
+    if scales.ndim() != 1 || scales.len() != input.ndim() {
+        return Err(OpError::IncompatibleInputShapes(
+            "scales should be a vector with length equal to input rank",
+        ));
+    }
+
+    // The current implementation only supports NCHW tensors with scale factors
+    // other than 1.0 for the H and W dims.
+    if input.ndim() != 4 {
+        return Err(OpError::UnsupportedValue("input must be an NCHW tensor"));
+    }
+    let [batch, chans, height, width] = input.dims();
+
+    let scales_valid = (0..input.ndim())
+        .all(|dim| dim == input.ndim() - 1 || dim == input.ndim() - 2 || scales[[dim]] == 1.);
+    if !scales_valid {
+        return Err(OpError::UnsupportedValue(
+            "only height and width dimensions can be resized",
+        ));
+    }
+
+    let out_shape: Vec<_> = zip(input.shape().iter(), scales.elements())
+        .map(|(&size, scale)| ((size as f32) * scale) as usize)
+        .collect();
+    let mut output = Tensor::zeros(out_shape.as_slice());
+
+    if output.is_empty() {
+        return Ok(output);
+    }
+
+    for n in 0..batch {
+        for c in 0..chans {
+            let in_offset = input.offset([n, c, 0, 0]);
+            let in_image = Image {
+                data: &input.data()[in_offset..],
+                h_stride: input.stride(2),
+                height,
+                w_stride: input.stride(3),
+                width,
+            };
+            let out_offset = output.offset([n, c, 0, 0]);
+            let mut out_image = ImageMut {
+                h_stride: output.stride(2),
+                height: output.shape()[2],
+                w_stride: output.stride(3),
+                width: output.shape()[3],
+                data: &mut output.data_mut()[out_offset..],
+            };
+
+            match mode {
+                ResizeMode::Nearest => {
+                    nearest_resize(&in_image, &mut out_image);
+                }
+                ResizeMode::Linear => {
+                    bilinear_resize(&in_image, &mut out_image);
+                }
+            };
+        }
+    }
+
+    Ok(output)
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum ResizeMode {
+    Nearest,
+    Linear,
+}
+
+#[derive(Debug)]
+pub struct Resize {
+    pub mode: ResizeMode,
+}
+
+impl Operator for Resize {
+    fn name(&self) -> &str {
+        "Resize"
+    }
+
+    fn run(&self, inputs: &[Input]) -> Result<Vec<Output>, OpError> {
+        let input = get_input(inputs, 0)?;
+
+        // The `roi` input is marked as optional in ONNX, but the spec also says
+        // that one of the subsequent `scales` or `sizes` inputs must be provided.
+        //
+        // Wasnn doesn't yet support omitting an optional input and then specifying
+        // a subsequent optional input, so for now we require that `roi` and
+        // `scales` must be provided, but `sizes` can be omitted.
+        //
+        // The `roi` input is only used if the `coordinate_transformation_mode`
+        // attr is `tf_crop_and_resize`, which is not currently supported.
+
+        let _roi = get_input::<f32>(inputs, 1)?;
+        let scales = get_input(inputs, 2)?;
+        let sizes = get_optional_input(inputs, 3)?;
+
+        let target = if let Some(sizes) = sizes {
+            ResizeTarget::Sizes(sizes)
+        } else {
+            ResizeTarget::Scales(scales)
+        };
+
+        resize(input, target, self.mode).into_op_result()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::ops::{resize, OpError, ResizeMode, ResizeTarget};
+    use crate::tensor::Tensor;
+    use crate::test_util::expect_equal;
+
+    // Reference values for these tests can be computed with either OpenCV
+    // (`cv2.resize`) or PyTorch (`torch.nn.functional.interpolate`).
+
+    #[test]
+    fn test_resize_nearest() -> Result<(), String> {
+        struct Case {
+            image: Tensor,
+            scales: Vec<f32>,
+            expected: Tensor,
+        }
+
+        let cases = [
+            // Scale width and height by 0x
+            Case {
+                image: Tensor::from_data(vec![1, 1, 2, 2], vec![0.2, 0.7, 0.3, 0.8]),
+                scales: vec![1., 1., 0., 0.],
+                expected: Tensor::from_data(vec![1, 1, 0, 0], vec![]),
+            },
+            // Scale width and height by 0.5x
+            Case {
+                image: Tensor::from_data(vec![1, 1, 2, 2], vec![0.2, 0.7, 0.3, 0.8]),
+                scales: vec![1., 1., 0.5, 0.5],
+                expected: Tensor::from_data(vec![1, 1, 1, 1], vec![0.2]),
+            },
+            // Scale width and height by 1x
+            Case {
+                image: Tensor::from_data(vec![1, 1, 2, 2], vec![0.2, 0.7, 0.3, 0.8]),
+                scales: vec![1., 1., 1., 1.],
+                expected: Tensor::from_data(vec![1, 1, 2, 2], vec![0.2, 0.7, 0.3, 0.8]),
+            },
+            // Scale width and height by 1.5x
+            Case {
+                image: Tensor::from_data(vec![1, 1, 2, 2], vec![0.2, 0.7, 0.3, 0.8]),
+                scales: vec![1., 1., 1.5, 1.5],
+                expected: Tensor::from_data(
+                    vec![1, 1, 3, 3],
+                    vec![
+                        0.2000, 0.2000, 0.7000, // Y=0
+                        0.2000, 0.2000, 0.7000, // Y=1
+                        0.3000, 0.3000, 0.8000, // Y=2
+                    ],
+                ),
+            },
+            // Scale width and height by 2x
+            Case {
+                image: Tensor::from_data(vec![1, 1, 2, 2], vec![0.2, 0.7, 0.3, 0.8]),
+                scales: vec![1., 1., 2., 2.],
+                expected: Tensor::from_data(
+                    vec![1, 1, 4, 4],
+                    vec![
+                        0.2, 0.2, 0.7, 0.7, // Y=0
+                        0.2, 0.2, 0.7, 0.7, // Y=1
+                        0.3, 0.3, 0.8, 0.8, // Y=2
+                        0.3, 0.3, 0.8, 0.8, // Y=3
+                    ],
+                ),
+            },
+            // Scale width and height by 3x
+            Case {
+                image: Tensor::from_data(vec![1, 1, 2, 2], vec![0.2, 0.7, 0.3, 0.8]),
+                scales: vec![1., 1., 3., 3.],
+                expected: Tensor::from_data(
+                    vec![1, 1, 6, 6],
+                    vec![
+                        0.2000, 0.2000, 0.2000, 0.7000, 0.7000, 0.7000, // Y=0
+                        0.2000, 0.2000, 0.2000, 0.7000, 0.7000, 0.7000, // Y=1
+                        0.2000, 0.2000, 0.2000, 0.7000, 0.7000, 0.7000, // Y=2
+                        0.3000, 0.3000, 0.3000, 0.8000, 0.8000, 0.8000, // Y=3
+                        0.3000, 0.3000, 0.3000, 0.8000, 0.8000, 0.8000, // Y=4
+                        0.3000, 0.3000, 0.3000, 0.8000, 0.8000, 0.8000, // Y=5
+                    ],
+                ),
+            },
+        ];
+
+        for case in cases {
+            let scales = Tensor::from_vec(case.scales);
+            let result = resize(
+                &case.image,
+                ResizeTarget::Scales(&scales),
+                ResizeMode::Nearest,
+            )
+            .unwrap();
+
+            expect_equal(&result, &case.expected)?;
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_resize_bilinear() -> Result<(), String> {
+        struct Case {
+            image: Tensor,
+            scales: Vec<f32>,
+            expected: Tensor,
+        }
+
+        let cases = [
+            // Scale width and height by 0x
+            Case {
+                image: Tensor::from_data(vec![1, 1, 2, 2], vec![0.2, 0.7, 0.3, 0.8]),
+                scales: vec![1., 1., 0., 0.],
+                expected: Tensor::from_data(vec![1, 1, 0, 0], vec![]),
+            },
+            // Scale width and height by 0.5x
+            Case {
+                image: Tensor::from_data(vec![1, 1, 2, 2], vec![0.2, 0.7, 0.3, 0.8]),
+                scales: vec![1., 1., 0.5, 0.5],
+
+                // OpenCV and PyTorch produce different results for this case.
+                // This result matches OpenCV. This relates to the `half_pixel`
+                // vs `pytorch_half_pixel` values for the `coordinate_transformation_mode`
+                // attribute in the ONNX op.
+                expected: Tensor::from_data(vec![1, 1, 1, 1], vec![0.5]),
+            },
+            // Scale width and height by 1x
+            Case {
+                image: Tensor::from_data(vec![1, 1, 2, 2], vec![0.2, 0.7, 0.3, 0.8]),
+                scales: vec![1., 1., 1., 1.],
+                expected: Tensor::from_data(vec![1, 1, 2, 2], vec![0.2, 0.7, 0.3, 0.8]),
+            },
+            // Scale width and height by 1.5x
+            Case {
+                image: Tensor::from_data(vec![1, 1, 2, 2], vec![0.2, 0.7, 0.3, 0.8]),
+                scales: vec![1., 1., 1.5, 1.5],
+                expected: Tensor::from_data(
+                    vec![1, 1, 3, 3],
+                    vec![
+                        0.2, 0.45, 0.7, // Y=0
+                        0.25, 0.5, 0.75, // Y=1
+                        0.3, 0.55, 0.8, // Y=2
+                    ],
+                ),
+            },
+            // Scale width and height by 2x
+            Case {
+                image: Tensor::from_data(vec![1, 1, 2, 2], vec![0.2, 0.7, 0.3, 0.8]),
+                scales: vec![1., 1., 2., 2.],
+                expected: Tensor::from_data(
+                    vec![1, 1, 4, 4],
+                    vec![
+                        0.2, 0.325, 0.575, 0.7, // Y=0
+                        0.225, 0.35, 0.6, 0.725, // Y=1
+                        0.275, 0.4, 0.65, 0.775, // Y=2
+                        0.3, 0.425, 0.675, 0.8, // Y=3
+                    ],
+                ),
+            },
+            // Scale width and height by 3x
+            Case {
+                image: Tensor::from_data(vec![1, 1, 2, 2], vec![0.2, 0.7, 0.3, 0.8]),
+                scales: vec![1., 1., 3., 3.],
+                expected: Tensor::from_data(
+                    vec![1, 1, 6, 6],
+                    vec![
+                        0.2000, 0.2000, 0.3667, 0.5333, 0.7000, 0.7000, // Y=0
+                        0.2000, 0.2000, 0.3667, 0.5333, 0.7000, 0.7000, // Y=1
+                        0.2333, 0.2333, 0.4000, 0.5667, 0.7333, 0.7333, // Y=2
+                        0.2667, 0.2667, 0.4333, 0.6000, 0.7667, 0.7667, // Y=3
+                        0.3000, 0.3000, 0.4667, 0.6333, 0.8000, 0.8000, // Y=4
+                        0.3000, 0.3000, 0.4667, 0.6333, 0.8000, 0.8000, // Y=5
+                    ],
+                ),
+            },
+        ];
+
+        for case in cases {
+            let scales = Tensor::from_vec(case.scales);
+
+            let result = resize(
+                &case.image,
+                ResizeTarget::Scales(&scales),
+                ResizeMode::Linear,
+            )
+            .unwrap();
+
+            expect_equal(&result, &case.expected)?;
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_resize_invalid_inputs() {
+        struct Case {
+            image: Tensor,
+            scales: Tensor,
+            expected: OpError,
+        }
+
+        let cases = [
+            Case {
+                image: Tensor::from_vec(vec![1., 1.]),
+                scales: Tensor::from_vec(vec![1.]),
+                expected: OpError::UnsupportedValue("input must be an NCHW tensor"),
+            },
+            Case {
+                image: Tensor::from_data(vec![1, 1, 2, 2], vec![0.2, 0.7, 0.3, 0.8]),
+                scales: Tensor::from_data(vec![1, 1, 2, 2], vec![1., 1., 3., 3.]),
+                expected: OpError::IncompatibleInputShapes(
+                    "scales should be a vector with length equal to input rank",
+                ),
+            },
+            Case {
+                image: Tensor::from_data(vec![1, 1, 2, 2], vec![0.2, 0.7, 0.3, 0.8]),
+                scales: Tensor::from_vec(vec![3., 3.]),
+                expected: OpError::IncompatibleInputShapes(
+                    "scales should be a vector with length equal to input rank",
+                ),
+            },
+            Case {
+                image: Tensor::from_data(vec![1, 1, 2, 2], vec![0.2, 0.7, 0.3, 0.8]),
+                scales: Tensor::from_vec(vec![2., 1., 3., 3.]),
+                expected: OpError::UnsupportedValue(
+                    "only height and width dimensions can be resized",
+                ),
+            },
+        ];
+
+        for case in cases {
+            let result = resize(
+                &case.image,
+                ResizeTarget::Scales(&case.scales),
+                ResizeMode::Linear,
+            );
+            assert_eq!(result.err(), Some(case.expected));
+        }
+    }
+}

--- a/src/schema.fbs
+++ b/src/schema.fbs
@@ -35,6 +35,7 @@ enum OperatorType: byte {
   ReduceMean,
   Relu,
   Reshape,
+  Resize,
   Shape,
   Sigmoid,
   Slice,
@@ -58,6 +59,11 @@ enum DataType: byte {
   Float
 }
 
+enum ResizeMode: byte {
+  Nearest,
+  Linear
+}
+
 // Operator-specific configuration
 union OperatorAttrs {
   AveragePoolAttrs,
@@ -74,11 +80,12 @@ union OperatorAttrs {
   MaxPoolAttrs,
   PadAttrs,
   ReduceMeanAttrs,
+  ResizeAttrs,
   SplitAttrs,
   SqueezeAttrs,
   SoftmaxAttrs,
   TransposeAttrs,
-  UnsqueezeAttrs
+  UnsqueezeAttrs,
 }
 
 table AveragePoolAttrs {
@@ -190,6 +197,10 @@ table TransposeAttrs {
 
 table UnsqueezeAttrs {
   axes:[uint] (required);
+}
+
+table ResizeAttrs {
+  mode:ResizeMode;
 }
 
 // Node in the dataflow graph

--- a/src/schema_generated.rs
+++ b/src/schema_generated.rs
@@ -18,13 +18,13 @@ pub const ENUM_MIN_OPERATOR_TYPE: i8 = 0;
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
-pub const ENUM_MAX_OPERATOR_TYPE: i8 = 38;
+pub const ENUM_MAX_OPERATOR_TYPE: i8 = 39;
 #[deprecated(
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 39] = [
+pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 40] = [
     OperatorType::Add,
     OperatorType::AveragePool,
     OperatorType::BatchNormalization,
@@ -53,6 +53,7 @@ pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 39] = [
     OperatorType::ReduceMean,
     OperatorType::Relu,
     OperatorType::Reshape,
+    OperatorType::Resize,
     OperatorType::Shape,
     OperatorType::Sigmoid,
     OperatorType::Slice,
@@ -99,20 +100,21 @@ impl OperatorType {
     pub const ReduceMean: Self = Self(25);
     pub const Relu: Self = Self(26);
     pub const Reshape: Self = Self(27);
-    pub const Shape: Self = Self(28);
-    pub const Sigmoid: Self = Self(29);
-    pub const Slice: Self = Self(30);
-    pub const Split: Self = Self(31);
-    pub const Sqrt: Self = Self(32);
-    pub const Squeeze: Self = Self(33);
-    pub const Softmax: Self = Self(34);
-    pub const Sub: Self = Self(35);
-    pub const Transpose: Self = Self(36);
-    pub const Unsqueeze: Self = Self(37);
-    pub const Where: Self = Self(38);
+    pub const Resize: Self = Self(28);
+    pub const Shape: Self = Self(29);
+    pub const Sigmoid: Self = Self(30);
+    pub const Slice: Self = Self(31);
+    pub const Split: Self = Self(32);
+    pub const Sqrt: Self = Self(33);
+    pub const Squeeze: Self = Self(34);
+    pub const Softmax: Self = Self(35);
+    pub const Sub: Self = Self(36);
+    pub const Transpose: Self = Self(37);
+    pub const Unsqueeze: Self = Self(38);
+    pub const Where: Self = Self(39);
 
     pub const ENUM_MIN: i8 = 0;
-    pub const ENUM_MAX: i8 = 38;
+    pub const ENUM_MAX: i8 = 39;
     pub const ENUM_VALUES: &'static [Self] = &[
         Self::Add,
         Self::AveragePool,
@@ -142,6 +144,7 @@ impl OperatorType {
         Self::ReduceMean,
         Self::Relu,
         Self::Reshape,
+        Self::Resize,
         Self::Shape,
         Self::Sigmoid,
         Self::Slice,
@@ -185,6 +188,7 @@ impl OperatorType {
             Self::ReduceMean => Some("ReduceMean"),
             Self::Relu => Some("Relu"),
             Self::Reshape => Some("Reshape"),
+            Self::Resize => Some("Resize"),
             Self::Shape => Some("Shape"),
             Self::Sigmoid => Some("Sigmoid"),
             Self::Slice => Some("Slice"),
@@ -434,18 +438,107 @@ impl flatbuffers::SimpleToVerifyInSlice for DataType {}
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
-pub const ENUM_MIN_OPERATOR_ATTRS: u8 = 0;
+pub const ENUM_MIN_RESIZE_MODE: i8 = 0;
 #[deprecated(
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
-pub const ENUM_MAX_OPERATOR_ATTRS: u8 = 19;
+pub const ENUM_MAX_RESIZE_MODE: i8 = 1;
 #[deprecated(
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_OPERATOR_ATTRS: [OperatorAttrs; 20] = [
+pub const ENUM_VALUES_RESIZE_MODE: [ResizeMode; 2] = [ResizeMode::Nearest, ResizeMode::Linear];
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[repr(transparent)]
+pub struct ResizeMode(pub i8);
+#[allow(non_upper_case_globals)]
+impl ResizeMode {
+    pub const Nearest: Self = Self(0);
+    pub const Linear: Self = Self(1);
+
+    pub const ENUM_MIN: i8 = 0;
+    pub const ENUM_MAX: i8 = 1;
+    pub const ENUM_VALUES: &'static [Self] = &[Self::Nearest, Self::Linear];
+    /// Returns the variant's name or "" if unknown.
+    pub fn variant_name(self) -> Option<&'static str> {
+        match self {
+            Self::Nearest => Some("Nearest"),
+            Self::Linear => Some("Linear"),
+            _ => None,
+        }
+    }
+}
+impl core::fmt::Debug for ResizeMode {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        if let Some(name) = self.variant_name() {
+            f.write_str(name)
+        } else {
+            f.write_fmt(format_args!("<UNKNOWN {:?}>", self.0))
+        }
+    }
+}
+impl<'a> flatbuffers::Follow<'a> for ResizeMode {
+    type Inner = Self;
+    #[inline]
+    unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        let b = flatbuffers::read_scalar_at::<i8>(buf, loc);
+        Self(b)
+    }
+}
+
+impl flatbuffers::Push for ResizeMode {
+    type Output = ResizeMode;
+    #[inline]
+    unsafe fn push(&self, dst: &mut [u8], _written_len: usize) {
+        flatbuffers::emplace_scalar::<i8>(dst, self.0);
+    }
+}
+
+impl flatbuffers::EndianScalar for ResizeMode {
+    type Scalar = i8;
+    #[inline]
+    fn to_little_endian(self) -> i8 {
+        self.0.to_le()
+    }
+    #[inline]
+    #[allow(clippy::wrong_self_convention)]
+    fn from_little_endian(v: i8) -> Self {
+        let b = i8::from_le(v);
+        Self(b)
+    }
+}
+
+impl<'a> flatbuffers::Verifiable for ResizeMode {
+    #[inline]
+    fn run_verifier(
+        v: &mut flatbuffers::Verifier,
+        pos: usize,
+    ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+        use self::flatbuffers::Verifiable;
+        i8::run_verifier(v, pos)
+    }
+}
+
+impl flatbuffers::SimpleToVerifyInSlice for ResizeMode {}
+#[deprecated(
+    since = "2.0.0",
+    note = "Use associated constants instead. This will no longer be generated in 2021."
+)]
+pub const ENUM_MIN_OPERATOR_ATTRS: u8 = 0;
+#[deprecated(
+    since = "2.0.0",
+    note = "Use associated constants instead. This will no longer be generated in 2021."
+)]
+pub const ENUM_MAX_OPERATOR_ATTRS: u8 = 20;
+#[deprecated(
+    since = "2.0.0",
+    note = "Use associated constants instead. This will no longer be generated in 2021."
+)]
+#[allow(non_camel_case_types)]
+pub const ENUM_VALUES_OPERATOR_ATTRS: [OperatorAttrs; 21] = [
     OperatorAttrs::NONE,
     OperatorAttrs::AveragePoolAttrs,
     OperatorAttrs::BatchNormalizationAttrs,
@@ -461,6 +554,7 @@ pub const ENUM_VALUES_OPERATOR_ATTRS: [OperatorAttrs; 20] = [
     OperatorAttrs::MaxPoolAttrs,
     OperatorAttrs::PadAttrs,
     OperatorAttrs::ReduceMeanAttrs,
+    OperatorAttrs::ResizeAttrs,
     OperatorAttrs::SplitAttrs,
     OperatorAttrs::SqueezeAttrs,
     OperatorAttrs::SoftmaxAttrs,
@@ -488,14 +582,15 @@ impl OperatorAttrs {
     pub const MaxPoolAttrs: Self = Self(12);
     pub const PadAttrs: Self = Self(13);
     pub const ReduceMeanAttrs: Self = Self(14);
-    pub const SplitAttrs: Self = Self(15);
-    pub const SqueezeAttrs: Self = Self(16);
-    pub const SoftmaxAttrs: Self = Self(17);
-    pub const TransposeAttrs: Self = Self(18);
-    pub const UnsqueezeAttrs: Self = Self(19);
+    pub const ResizeAttrs: Self = Self(15);
+    pub const SplitAttrs: Self = Self(16);
+    pub const SqueezeAttrs: Self = Self(17);
+    pub const SoftmaxAttrs: Self = Self(18);
+    pub const TransposeAttrs: Self = Self(19);
+    pub const UnsqueezeAttrs: Self = Self(20);
 
     pub const ENUM_MIN: u8 = 0;
-    pub const ENUM_MAX: u8 = 19;
+    pub const ENUM_MAX: u8 = 20;
     pub const ENUM_VALUES: &'static [Self] = &[
         Self::NONE,
         Self::AveragePoolAttrs,
@@ -512,6 +607,7 @@ impl OperatorAttrs {
         Self::MaxPoolAttrs,
         Self::PadAttrs,
         Self::ReduceMeanAttrs,
+        Self::ResizeAttrs,
         Self::SplitAttrs,
         Self::SqueezeAttrs,
         Self::SoftmaxAttrs,
@@ -536,6 +632,7 @@ impl OperatorAttrs {
             Self::MaxPoolAttrs => Some("MaxPoolAttrs"),
             Self::PadAttrs => Some("PadAttrs"),
             Self::ReduceMeanAttrs => Some("ReduceMeanAttrs"),
+            Self::ResizeAttrs => Some("ResizeAttrs"),
             Self::SplitAttrs => Some("SplitAttrs"),
             Self::SqueezeAttrs => Some("SqueezeAttrs"),
             Self::SoftmaxAttrs => Some("SoftmaxAttrs"),
@@ -3487,6 +3584,110 @@ impl core::fmt::Debug for UnsqueezeAttrs<'_> {
         ds.finish()
     }
 }
+pub enum ResizeAttrsOffset {}
+#[derive(Copy, Clone, PartialEq)]
+
+pub struct ResizeAttrs<'a> {
+    pub _tab: flatbuffers::Table<'a>,
+}
+
+impl<'a> flatbuffers::Follow<'a> for ResizeAttrs<'a> {
+    type Inner = ResizeAttrs<'a>;
+    #[inline]
+    unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self {
+            _tab: flatbuffers::Table::new(buf, loc),
+        }
+    }
+}
+
+impl<'a> ResizeAttrs<'a> {
+    pub const VT_MODE: flatbuffers::VOffsetT = 4;
+
+    #[inline]
+    pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+        ResizeAttrs { _tab: table }
+    }
+    #[allow(unused_mut)]
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+        args: &'args ResizeAttrsArgs,
+    ) -> flatbuffers::WIPOffset<ResizeAttrs<'bldr>> {
+        let mut builder = ResizeAttrsBuilder::new(_fbb);
+        builder.add_mode(args.mode);
+        builder.finish()
+    }
+
+    #[inline]
+    pub fn mode(&self) -> ResizeMode {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab
+                .get::<ResizeMode>(ResizeAttrs::VT_MODE, Some(ResizeMode::Nearest))
+                .unwrap()
+        }
+    }
+}
+
+impl flatbuffers::Verifiable for ResizeAttrs<'_> {
+    #[inline]
+    fn run_verifier(
+        v: &mut flatbuffers::Verifier,
+        pos: usize,
+    ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+        use self::flatbuffers::Verifiable;
+        v.visit_table(pos)?
+            .visit_field::<ResizeMode>("mode", Self::VT_MODE, false)?
+            .finish();
+        Ok(())
+    }
+}
+pub struct ResizeAttrsArgs {
+    pub mode: ResizeMode,
+}
+impl<'a> Default for ResizeAttrsArgs {
+    #[inline]
+    fn default() -> Self {
+        ResizeAttrsArgs {
+            mode: ResizeMode::Nearest,
+        }
+    }
+}
+
+pub struct ResizeAttrsBuilder<'a: 'b, 'b> {
+    fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+    start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b> ResizeAttrsBuilder<'a, 'b> {
+    #[inline]
+    pub fn add_mode(&mut self, mode: ResizeMode) {
+        self.fbb_
+            .push_slot::<ResizeMode>(ResizeAttrs::VT_MODE, mode, ResizeMode::Nearest);
+    }
+    #[inline]
+    pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> ResizeAttrsBuilder<'a, 'b> {
+        let start = _fbb.start_table();
+        ResizeAttrsBuilder {
+            fbb_: _fbb,
+            start_: start,
+        }
+    }
+    #[inline]
+    pub fn finish(self) -> flatbuffers::WIPOffset<ResizeAttrs<'a>> {
+        let o = self.fbb_.end_table(self.start_);
+        flatbuffers::WIPOffset::new(o.value())
+    }
+}
+
+impl core::fmt::Debug for ResizeAttrs<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut ds = f.debug_struct("ResizeAttrs");
+        ds.field("mode", &self.mode());
+        ds.finish()
+    }
+}
 pub enum OperatorNodeOffset {}
 #[derive(Copy, Clone, PartialEq)]
 
@@ -3808,6 +4009,21 @@ impl<'a> OperatorNode<'a> {
 
     #[inline]
     #[allow(non_snake_case)]
+    pub fn attrs_as_resize_attrs(&self) -> Option<ResizeAttrs<'a>> {
+        if self.attrs_type() == OperatorAttrs::ResizeAttrs {
+            self.attrs().map(|t| {
+                // Safety:
+                // Created from a valid Table for this object
+                // Which contains a valid union in this slot
+                unsafe { ResizeAttrs::init_from_table(t) }
+            })
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    #[allow(non_snake_case)]
     pub fn attrs_as_split_attrs(&self) -> Option<SplitAttrs<'a>> {
         if self.attrs_type() == OperatorAttrs::SplitAttrs {
             self.attrs().map(|t| {
@@ -3907,6 +4123,7 @@ impl flatbuffers::Verifiable for OperatorNode<'_> {
           OperatorAttrs::MaxPoolAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<MaxPoolAttrs>>("OperatorAttrs::MaxPoolAttrs", pos),
           OperatorAttrs::PadAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<PadAttrs>>("OperatorAttrs::PadAttrs", pos),
           OperatorAttrs::ReduceMeanAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<ReduceMeanAttrs>>("OperatorAttrs::ReduceMeanAttrs", pos),
+          OperatorAttrs::ResizeAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<ResizeAttrs>>("OperatorAttrs::ResizeAttrs", pos),
           OperatorAttrs::SplitAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<SplitAttrs>>("OperatorAttrs::SplitAttrs", pos),
           OperatorAttrs::SqueezeAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<SqueezeAttrs>>("OperatorAttrs::SqueezeAttrs", pos),
           OperatorAttrs::SoftmaxAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<SoftmaxAttrs>>("OperatorAttrs::SoftmaxAttrs", pos),
@@ -4127,6 +4344,16 @@ impl core::fmt::Debug for OperatorNode<'_> {
             }
             OperatorAttrs::ReduceMeanAttrs => {
                 if let Some(x) = self.attrs_as_reduce_mean_attrs() {
+                    ds.field("attrs", &x)
+                } else {
+                    ds.field(
+                        "attrs",
+                        &"InvalidFlatbuffer: Union discriminant does not match value.",
+                    )
+                }
+            }
+            OperatorAttrs::ResizeAttrs => {
+                if let Some(x) = self.attrs_as_resize_attrs() {
                     ds.field("attrs", &x)
                 } else {
                     ds.field(

--- a/tools/schema_generated.py
+++ b/tools/schema_generated.py
@@ -35,17 +35,18 @@ class OperatorType(object):
     ReduceMean = 25
     Relu = 26
     Reshape = 27
-    Shape = 28
-    Sigmoid = 29
-    Slice = 30
-    Split = 31
-    Sqrt = 32
-    Squeeze = 33
-    Softmax = 34
-    Sub = 35
-    Transpose = 36
-    Unsqueeze = 37
-    Where = 38
+    Resize = 28
+    Shape = 29
+    Sigmoid = 30
+    Slice = 31
+    Split = 32
+    Sqrt = 33
+    Squeeze = 34
+    Softmax = 35
+    Sub = 36
+    Transpose = 37
+    Unsqueeze = 38
+    Where = 39
 
 
 class PadMode(object):
@@ -56,6 +57,11 @@ class PadMode(object):
 class DataType(object):
     Int32 = 0
     Float = 1
+
+
+class ResizeMode(object):
+    Nearest = 0
+    Linear = 1
 
 
 class OperatorAttrs(object):
@@ -74,11 +80,12 @@ class OperatorAttrs(object):
     MaxPoolAttrs = 12
     PadAttrs = 13
     ReduceMeanAttrs = 14
-    SplitAttrs = 15
-    SqueezeAttrs = 16
-    SoftmaxAttrs = 17
-    TransposeAttrs = 18
-    UnsqueezeAttrs = 19
+    ResizeAttrs = 15
+    SplitAttrs = 16
+    SqueezeAttrs = 17
+    SoftmaxAttrs = 18
+    TransposeAttrs = 19
+    UnsqueezeAttrs = 20
 
 
 class Scalar(object):
@@ -1103,6 +1110,40 @@ def UnsqueezeAttrsStart(builder): builder.StartObject(1)
 def UnsqueezeAttrsAddAxes(builder, axes): builder.PrependUOffsetTRelativeSlot(0, flatbuffers.number_types.UOffsetTFlags.py_type(axes), 0)
 def UnsqueezeAttrsStartAxesVector(builder, numElems): return builder.StartVector(4, numElems, 4)
 def UnsqueezeAttrsEnd(builder): return builder.EndObject()
+
+
+class ResizeAttrs(object):
+    __slots__ = ['_tab']
+
+    @classmethod
+    def GetRootAs(cls, buf, offset=0):
+        n = flatbuffers.encode.Get(flatbuffers.packer.uoffset, buf, offset)
+        x = ResizeAttrs()
+        x.Init(buf, n + offset)
+        return x
+
+    @classmethod
+    def GetRootAsResizeAttrs(cls, buf, offset=0):
+        """This method is deprecated. Please switch to GetRootAs."""
+        return cls.GetRootAs(buf, offset)
+    @classmethod
+    def ResizeAttrsBufferHasIdentifier(cls, buf, offset, size_prefixed=False):
+        return flatbuffers.util.BufferHasIdentifier(buf, offset, b"\x4D\x4F\x44\x4C", size_prefixed=size_prefixed)
+
+    # ResizeAttrs
+    def Init(self, buf, pos):
+        self._tab = flatbuffers.table.Table(buf, pos)
+
+    # ResizeAttrs
+    def Mode(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
+        if o != 0:
+            return self._tab.Get(flatbuffers.number_types.Int8Flags, o + self._tab.Pos)
+        return 0
+
+def ResizeAttrsStart(builder): builder.StartObject(1)
+def ResizeAttrsAddMode(builder, mode): builder.PrependInt8Slot(0, mode, 0)
+def ResizeAttrsEnd(builder): return builder.EndObject()
 
 
 class OperatorNode(object):


### PR DESCRIPTION
Implement initial support for Resize operator. This operator has a lot of flexibility. The initial implementation only supports nearest neighbour and bilinear resizing of image tensors in NCHW format.