### PR TITLE
Implement a GEMM kernel that uses AVX + FMA instructions for x64

### DIFF
--- a/src/linalg.rs
+++ b/src/linalg.rs
@@ -101,71 +101,170 @@ fn blocks(start: usize, end: usize, step: usize) -> BlockIter {
     BlockIter { start, end, step }
 }
 
-/// Kernel that computes a small tile of the output matrix of size HxW.
+/// Kernel that computes a small tile of a matrix multiplication output.
 ///
-/// This corresponds to Loop 6 of the algorithm in Page 4 of
+/// The tile size depends upon the kernel and is specified by the `MR` and `NR`
+/// associated constants. The MR and NR values are chosen such that an `MR * NR`
+/// tile can fit in registers. NR is generally determined by the width of the
+/// registers used (eg. for SSE, 128 bits = 4x32 floats, so NR is 4) and MR by
+/// the number available.
+///
+/// The kernel corresponds to Loop 6 of the algorithm in Page 4 of
 /// https://dl.acm.org/doi/pdf/10.1145/2925987.
-fn kernel<const H: usize, const W: usize>(
-    out: &mut [f32],
-    out_row_stride: usize,
-    a: &[f32],
-    b: &[f32],
-    depth: usize,
-) {
-    assert!(a.len() >= depth * H);
-    assert!(b.len() >= depth * W);
-    assert!(out.len() >= (H - 1) * out_row_stride + W);
+trait Kernel {
+    /// Height of output tiles computed by the kernel.
+    const MR: usize;
 
-    // Accumulate into a fixed-sized array to allow the compiler to generate
-    // more efficient code for the loop over `depth`.
-    let mut tmp = [[0.0; W]; H];
-    for k in 0..depth {
-        let a_off = k * H;
-        let b_off = k * W;
+    /// Width of output tiles computed by the kernel.
+    const NR: usize;
 
-        for i in 0..H {
-            for j in 0..W {
-                // Safety: Indexes are less than lengths asserted above.
-                unsafe {
-                    tmp[i][j] += a.get_unchecked(a_off + i) * b.get_unchecked(b_off + j);
+    /// Return true if this kernel is usable on the current system.
+    ///
+    /// It is unsafe to call `kernel` if this is false.
+    fn supported() -> bool;
+
+    /// Compute an `MR * NR`-sized tile of the output matrix.
+    fn kernel(out: &mut [f32], out_row_stride: usize, a: &[f32], b: &[f32], depth: usize);
+}
+
+/// Optimized kernel for x64 CPUs that support AVX + FMA instructions.
+#[cfg(target_arch = "x86_64")]
+struct FMAKernel {}
+
+#[cfg(target_arch = "x86_64")]
+impl Kernel for FMAKernel {
+    const MR: usize = 8;
+    const NR: usize = 8; // AVX registers are 256 bits wide = 8 x f32
+
+    fn supported() -> bool {
+        is_x86_feature_detected!("fma")
+    }
+
+    fn kernel(out: &mut [f32], out_row_stride: usize, a: &[f32], b: &[f32], depth: usize) {
+        unsafe { Self::kernel_fma(out, out_row_stride, a, b, depth) }
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+impl FMAKernel {
+    #[target_feature(enable = "fma")]
+    unsafe fn kernel_fma(
+        out: &mut [f32],
+        out_row_stride: usize,
+        a: &[f32],
+        b: &[f32],
+        depth: usize,
+    ) {
+        const MR: usize = FMAKernel::MR;
+        const NR: usize = FMAKernel::NR;
+
+        use core::arch::x86_64::{
+            _mm256_add_ps, _mm256_fmadd_ps, _mm256_loadu_ps, _mm256_set1_ps, _mm256_setzero_ps,
+            _mm256_storeu_ps,
+        };
+
+        // Check that buffer accesses below are going to be valid.
+        assert!(a.len() >= depth * MR);
+        assert!(b.len() >= depth * NR);
+        assert!(out.len() >= (MR - 1) * out_row_stride + NR);
+
+        let a_ptr = a.as_ptr();
+        let b_ptr = b.as_ptr();
+
+        // Accumulate into a fixed-sized array to allow the compiler to generate
+        // more efficient code for the loop over `depth`.
+        let mut tmp = [_mm256_setzero_ps(); MR];
+        for k in 0..depth {
+            let a_off = k * MR;
+            let b_off = k * NR;
+
+            let b_row = _mm256_loadu_ps(b_ptr.add(b_off));
+            for i in 0..MR {
+                let a_val = *a_ptr.add(a_off + i);
+                let a_broadcast = _mm256_set1_ps(a_val);
+                tmp[i] = _mm256_fmadd_ps(a_broadcast, b_row, tmp[i]);
+            }
+        }
+
+        for i in 0..MR {
+            let out_ptr = out.as_mut_ptr().add(out_row_stride * i);
+            let out_val = _mm256_loadu_ps(out_ptr);
+            let out_val = _mm256_add_ps(out_val, tmp[i]);
+            _mm256_storeu_ps(out_ptr, out_val);
+        }
+    }
+}
+
+/// This is the base kernel that does not use architecture-specific intrinsics
+/// but is autovectorization-friendly. It is expected to perform the same as
+/// a kernel using SSE intrinsics (or equivalent).
+struct BaseKernel {}
+
+impl Kernel for BaseKernel {
+    const MR: usize = 8;
+
+    // The base kernel will most likely be compiled to SSE or equivalent. SSE
+    // registers are 128 bits wide = 4 x f32.
+    const NR: usize = 4;
+
+    fn supported() -> bool {
+        true
+    }
+
+    fn kernel(out: &mut [f32], out_row_stride: usize, a: &[f32], b: &[f32], depth: usize) {
+        const MR: usize = BaseKernel::MR;
+        const NR: usize = BaseKernel::NR;
+
+        assert!(a.len() >= depth * MR);
+        assert!(b.len() >= depth * NR);
+        assert!(out.len() >= (MR - 1) * out_row_stride + NR);
+
+        // Accumulate into a fixed-sized array to allow the compiler to generate
+        // more efficient code for the loop over `depth`.
+        let mut tmp = [[0.0; NR]; MR];
+        for k in 0..depth {
+            let a_off = k * MR;
+            let b_off = k * NR;
+
+            for i in 0..MR {
+                for j in 0..NR {
+                    // Safety: Indexes are less than lengths asserted above.
+                    unsafe {
+                        tmp[i][j] += a.get_unchecked(a_off + i) * b.get_unchecked(b_off + j);
+                    }
                 }
             }
         }
-    }
 
-    for i in 0..H {
-        for j in 0..W {
-            // Safety: Index is less than length asserted above.
-            unsafe {
-                *out.get_unchecked_mut(out_row_stride * i + j) += tmp[i][j];
+        for i in 0..MR {
+            for j in 0..NR {
+                // Safety: Index is less than length asserted above.
+                unsafe {
+                    *out.get_unchecked_mut(out_row_stride * i + j) += tmp[i][j];
+                }
             }
         }
     }
 }
 
-/// Pack a block of the "A" matrix.
+/// Pack a block of the "A" matrix for use by kernel K.
 ///
-/// The packed buffer is laid out as a sequence of `ceil(rows.len() / PANEL_HEIGHT)`
-/// row panels. Each row panel has size `PANEL_HEIGHT * cols.len()` and uses
-/// column-major order. If `rows.len()` is not a multiple of `PANEL_HEIGHT`, the
+/// The packed buffer is laid out as a sequence of `ceil(rows.len() / K::MR)`
+/// row panels. Each row panel has size `K::MR * cols.len()` and uses
+/// column-major order. If `rows.len()` is not a multiple of `K::MR`, the
 /// final panel is zero-padded.
-fn pack_a_block<const PANEL_HEIGHT: usize>(
-    out: &mut [f32],
-    a: Matrix,
-    rows: Range<usize>,
-    cols: Range<usize>,
-) {
+fn pack_a_block<K: Kernel>(out: &mut [f32], a: Matrix, rows: Range<usize>, cols: Range<usize>) {
     let a_rows = rows.len();
     let a_cols = cols.len();
 
-    let n_panels = round_up(a_rows, PANEL_HEIGHT) / PANEL_HEIGHT;
+    let n_panels = round_up(a_rows, K::MR) / K::MR;
     for panel in 0..n_panels {
-        let panel_offset = panel * a_cols * PANEL_HEIGHT;
-        let panel_start_row = panel * PANEL_HEIGHT;
+        let panel_offset = panel * a_cols * K::MR;
+        let panel_start_row = panel * K::MR;
 
         for col in 0..a_cols {
-            let out_col_offset = panel_offset + col * PANEL_HEIGHT;
-            for row in 0..PANEL_HEIGHT {
+            let out_col_offset = panel_offset + col * K::MR;
+            for row in 0..K::MR {
                 let a_row = rows.start + panel_start_row + row;
                 out[out_col_offset + row] = if a_row < rows.end {
                     a.data[a_row * a.row_stride + (cols.start + col) * a.col_stride]
@@ -177,43 +276,37 @@ fn pack_a_block<const PANEL_HEIGHT: usize>(
     }
 }
 
-/// Pack a block of the "B" matrix.
+/// Pack a block of the "B" matrix for use by kernel K.
 ///
 /// The packed buffer is laid out as a sequence of `ceil(cols.len() /
-/// PANEL_WIDTH)` column panels. Each column panel has size `rows.len() *
-/// PANEL_WIDTH` and uses row-major order. If `cols.len()` is not a multiple of
-/// `PANEL_WIDTH`, the final panel is zero-padded.
-fn pack_b_block<const PANEL_WIDTH: usize>(
-    out: &mut [f32],
-    b: Matrix,
-    rows: Range<usize>,
-    cols: Range<usize>,
-) {
+/// K::NR)` column panels. Each column panel has size `rows.len() *
+/// K::NR` and uses row-major order. If `cols.len()` is not a multiple of
+/// `K::NR`, the final panel is zero-padded.
+fn pack_b_block<K: Kernel>(out: &mut [f32], b: Matrix, rows: Range<usize>, cols: Range<usize>) {
     let b_cols = cols.len();
     let b_rows = rows.len();
 
-    let n_panels = round_up(b_cols, PANEL_WIDTH) / PANEL_WIDTH;
+    let n_panels = round_up(b_cols, K::NR) / K::NR;
     for panel in 0..n_panels {
-        let panel_offset = panel * b_rows * PANEL_WIDTH;
-        let panel_start_col = panel * PANEL_WIDTH;
+        let panel_offset = panel * b_rows * K::NR;
+        let panel_start_col = panel * K::NR;
 
-        if b_cols - panel_start_col >= PANEL_WIDTH {
+        if b_cols - panel_start_col >= K::NR {
             // Optimized loop for panels that don't need any padding
             let out_offset = panel_offset;
             let b_offset =
                 rows.start * b.row_stride + (cols.start + panel_start_col) * b.col_stride;
 
-            assert!(out.len() >= out_offset + (b_rows - 1) * PANEL_WIDTH + PANEL_WIDTH);
+            assert!(out.len() >= out_offset + (b_rows - 1) * K::NR + K::NR);
             assert!(
-                b.data.len()
-                    > b_offset + (b_rows - 1) * b.row_stride + (PANEL_WIDTH - 1) * b.col_stride
+                b.data.len() > b_offset + (b_rows - 1) * b.row_stride + (K::NR - 1) * b.col_stride
             );
 
             for row in 0..b_rows {
-                for col in 0..PANEL_WIDTH {
+                for col in 0..K::NR {
                     // Safety: Indexes are less than lengths asserted above.
                     unsafe {
-                        *out.get_unchecked_mut(out_offset + row * PANEL_WIDTH + col) = *b
+                        *out.get_unchecked_mut(out_offset + row * K::NR + col) = *b
                             .data
                             .get_unchecked(b_offset + row * b.row_stride + col * b.col_stride);
                     }
@@ -222,10 +315,10 @@ fn pack_b_block<const PANEL_WIDTH: usize>(
         } else {
             // Fallback for final panel if padding is required
             for row in 0..b_rows {
-                let out_row_offset = panel_offset + row * PANEL_WIDTH;
+                let out_row_offset = panel_offset + row * K::NR;
                 let b_row_offset = (rows.start + row) * b.row_stride;
 
-                for col in 0..PANEL_WIDTH {
+                for col in 0..K::NR {
                     let out_col = panel_start_col + col;
                     let b_offset =
                         b_row_offset + (cols.start + panel_start_col + col) * b.col_stride;
@@ -294,14 +387,43 @@ pub fn gemm_tensors(output: &mut Tensor, a: &Tensor, b: &Tensor) {
 
 /// Multiply two matrices and add the results to `out_data`.
 ///
-/// This is a low-level API that operates directly on slices. Use `gemm` for
-/// a more convenient way to multiply two 2D tensors.
-///
 /// The implementation uses the general approach of BLIS
 /// (https://github.com/flame/blis), and was informed by the matrixmultiply
 /// crate (https://github.com/bluss/matrixmultiply). See Pages 3-5 of
 /// https://dl.acm.org/doi/pdf/10.1145/2925987 for an outline of the algorithm.
 pub fn gemm(out_data: &mut [f32], out_row_stride: usize, a: Matrix, b: Matrix) {
+    #[cfg(target_arch = "x86_64")]
+    {
+        if FMAKernel::supported() {
+            return gemm_impl::<FMAKernel, { FMAKernel::MR * FMAKernel::NR }>(
+                out_data,
+                out_row_stride,
+                a,
+                b,
+            );
+        }
+    }
+    gemm_impl::<BaseKernel, { BaseKernel::MR * BaseKernel::NR }>(out_data, out_row_stride, a, b)
+}
+
+#[cfg(test)]
+pub fn gemm_base_kernel(out_data: &mut [f32], out_row_stride: usize, a: Matrix, b: Matrix) {
+    gemm_impl::<BaseKernel, { BaseKernel::MR * BaseKernel::NR }>(out_data, out_row_stride, a, b)
+}
+
+/// Perform matrix multiplication with a given kernel.
+///
+/// `MR_NR` should be computed as `K::MR * K::NR`. This function can't compute
+/// that itself due to Rust limitations on using generic parameters in const
+/// expressions.
+fn gemm_impl<K: Kernel, const MR_NR: usize>(
+    out_data: &mut [f32],
+    out_row_stride: usize,
+    a: Matrix,
+    b: Matrix,
+) {
+    assert!(K::supported());
+
     if a.cols != b.rows {
         panic!("Columns of matrix `a` must match rows of matrix `b`");
     }
@@ -316,14 +438,9 @@ pub fn gemm(out_data: &mut [f32], out_row_stride: usize, a: Matrix, b: Matrix) {
     // Sizes of blocks that the width (nc), depth (kc) and height (mc)
     // dimensions are partitioned into in the outer loops. These are chosen
     // so that blocks can fit in specific cache levels.
-    let nc = round_up(1024.min(b.cols), NR);
-    let mc = round_up(64.min(a.rows), MR);
+    let nc = round_up(1024.min(b.cols), K::NR);
+    let mc = round_up(64.min(a.rows), K::MR);
     let kc = 256.min(a.cols);
-
-    // Size of output tiles in rows (MR) and columns (NR) computed by innermost
-    // loops. These are chosen so that an MRxNR tile can fit in registers.
-    const MR: usize = 8;
-    const NR: usize = 4;
 
     // Buffer for packed blocks of the matrix. Conceptually there are two
     // buffers, but we coalesce them into one allocation.
@@ -333,12 +450,12 @@ pub fn gemm(out_data: &mut [f32], out_row_stride: usize, a: Matrix, b: Matrix) {
     // performance.
     let packed_b_size = kc * nc;
     let packed_a_size = mc * kc;
-    let mut packed = vec![0.0; packed_b_size + packed_a_size];
+    let mut packed = vec![0.; packed_b_size + packed_a_size];
 
     for (col_start, col_end) in blocks(0, b.cols, nc) {
         for (depth_start, depth_end) in blocks(0, a.cols, kc) {
             let panel_length = depth_end - depth_start;
-            pack_b_block::<NR>(
+            pack_b_block::<K>(
                 &mut packed[..packed_b_size],
                 b,
                 depth_start..depth_end,
@@ -346,7 +463,7 @@ pub fn gemm(out_data: &mut [f32], out_row_stride: usize, a: Matrix, b: Matrix) {
             );
 
             for (row_start, row_end) in blocks(0, a.rows, mc) {
-                pack_a_block::<MR>(
+                pack_a_block::<K>(
                     &mut packed[packed_b_size..],
                     a,
                     row_start..row_end,
@@ -356,16 +473,16 @@ pub fn gemm(out_data: &mut [f32], out_row_stride: usize, a: Matrix, b: Matrix) {
                 let packed_b = &packed[..packed_b_size];
                 let packed_a = &packed[packed_b_size..];
 
-                let b_panel_size = panel_length * NR;
-                let a_panel_size = MR * panel_length;
+                let b_panel_size = panel_length * K::NR;
+                let a_panel_size = K::MR * panel_length;
 
-                for (tile_col_start, tile_col_end) in blocks(col_start, col_end, NR) {
-                    let b_panel_idx = (tile_col_start - col_start) / NR;
+                for (tile_col_start, tile_col_end) in blocks(col_start, col_end, K::NR) {
+                    let b_panel_idx = (tile_col_start - col_start) / K::NR;
                     let b_panel_offset = b_panel_idx * b_panel_size;
                     let b_panel = &packed_b[b_panel_offset..b_panel_offset + b_panel_size];
 
-                    for (tile_row_start, tile_row_end) in blocks(row_start, row_end, MR) {
-                        let a_panel_idx = (tile_row_start - row_start) / MR;
+                    for (tile_row_start, tile_row_end) in blocks(row_start, row_end, K::MR) {
+                        let a_panel_idx = (tile_row_start - row_start) / K::MR;
                         let a_panel_offset = a_panel_idx * a_panel_size;
                         let a_panel = &packed_a[a_panel_offset..a_panel_offset + a_panel_size];
 
@@ -375,31 +492,25 @@ pub fn gemm(out_data: &mut [f32], out_row_stride: usize, a: Matrix, b: Matrix) {
                         let used_rows = tile_row_end - tile_row_start;
                         let used_cols = tile_col_end - tile_col_start;
 
-                        if used_rows == MR && used_cols == NR {
-                            kernel::<MR, NR>(
-                                out_tile,
-                                out_row_stride,
-                                a_panel,
-                                b_panel,
-                                panel_length,
-                            );
+                        if used_rows == K::MR && used_cols == K::NR {
+                            K::kernel(out_tile, out_row_stride, a_panel, b_panel, panel_length);
                         } else {
                             // If this is not a full size tile, run the kernel on a temporary
                             // buffer that is the size of a full tile, then copy the results back
                             // to the output. This allows the same kernel implementation to be used
                             // whether the tile is full-sized or not.
-                            let mut tmp = [0.; MR * NR];
+                            let mut tmp_out_tile = [0.; MR_NR];
 
-                            kernel::<MR, NR>(&mut tmp, NR, a_panel, b_panel, panel_length);
+                            K::kernel(&mut tmp_out_tile, K::NR, a_panel, b_panel, panel_length);
 
                             assert!(out_tile.len() >= (used_rows - 1) * out_row_stride + used_cols);
-                            assert!(tmp.len() >= (used_rows - 1) * NR + used_cols);
+                            assert!(tmp_out_tile.len() >= (used_rows - 1) * K::NR + used_cols);
                             for i in 0..used_rows {
                                 for j in 0..used_cols {
                                     // Safety: Index is less than length asserted above.
                                     unsafe {
                                         *out_tile.get_unchecked_mut(out_row_stride * i + j) +=
-                                            tmp[i * NR + j];
+                                            tmp_out_tile[i * K::NR + j];
                                     }
                                 }
                             }
@@ -413,7 +524,7 @@ pub fn gemm(out_data: &mut [f32], out_row_stride: usize, a: Matrix, b: Matrix) {
 
 #[cfg(test)]
 mod tests {
-    use crate::linalg::{add_scaled_vector, gemm_tensors};
+    use crate::linalg::{add_scaled_vector, gemm, gemm_base_kernel, Matrix};
     use crate::rng::XorShiftRNG;
     use crate::tensor::{rand, zeros, Tensor};
     use crate::test_util::expect_equal;
@@ -432,6 +543,44 @@ mod tests {
         }
 
         output
+    }
+
+    #[derive(Clone, Copy, Debug)]
+    enum Kernel {
+        /// Use the preferred kernel for the current platform
+        Auto,
+        /// Use the fallback/base kernel
+        Base,
+    }
+
+    fn run_gemm(output: &mut Tensor, a: &Tensor, b: &Tensor, kernel: Kernel) {
+        let [a_rows, a_cols] = a.dims();
+        let [b_rows, b_cols] = b.dims();
+        let out_row_stride = output.stride(0);
+
+        let gemm_fn = match kernel {
+            Kernel::Auto => gemm,
+            Kernel::Base => gemm_base_kernel,
+        };
+
+        gemm_fn(
+            output.data_mut(),
+            out_row_stride,
+            Matrix {
+                data: a.data(),
+                rows: a_rows,
+                cols: a_cols,
+                row_stride: a.stride(0),
+                col_stride: a.stride(1),
+            },
+            Matrix {
+                data: b.data(),
+                rows: b_rows,
+                cols: b_cols,
+                row_stride: b.stride(0),
+                col_stride: b.stride(1),
+            },
+        );
     }
 
     #[test]
@@ -480,8 +629,25 @@ mod tests {
         add_scaled_vector(&mut dest, &src, 2, 1, 1.0);
     }
 
+    // Simplest possible test case for easy debugging.
     #[test]
-    fn test_gemm() -> Result<(), String> {
+    fn test_simple_gemm() -> Result<(), String> {
+        let a = Tensor::from_data(vec![2, 2], vec![1., 2., 3., 4.]);
+        let b = Tensor::from_data(vec![2, 2], vec![5., 6., 7., 8.]);
+        let expected = reference_gemm(&a, &b);
+
+        let mut result = zeros::<f32>(&[a.shape()[0], b.shape()[1]]);
+        run_gemm(&mut result, &a, &b, Kernel::Auto);
+        expect_equal(&result, &expected)?;
+
+        let mut result = zeros::<f32>(&[a.shape()[0], b.shape()[1]]);
+        run_gemm(&mut result, &a, &b, Kernel::Base);
+        expect_equal(&result, &expected)?;
+
+        Ok(())
+    }
+
+    fn test_gemm_with_kernel(kernel: Kernel) -> Result<(), String> {
         // "Interesting" sizes for the row, column and depth dimensions of the
         // computation. These are chosen to cover cases that are less than,
         // equal to and above the tile/block sizes which the algorithm divides
@@ -520,7 +686,7 @@ mod tests {
             let b = rand(&rhs_size, &mut rng);
             let mut result = zeros::<f32>(&[lhs_size[0], rhs_size[1]]);
 
-            gemm_tensors(&mut result, &a, &b);
+            run_gemm(&mut result, &a, &b, kernel);
 
             let expected = reference_gemm(&a, &b);
 
@@ -534,6 +700,16 @@ mod tests {
         }
 
         Ok(())
+    }
+
+    #[test]
+    fn test_gemm_with_fastest_kernel() -> Result<(), String> {
+        test_gemm_with_kernel(Kernel::Auto)
+    }
+
+    #[test]
+    fn test_gemm_with_base_kernel() -> Result<(), String> {
+        test_gemm_with_kernel(Kernel::Base)
     }
 
     #[test]
@@ -551,7 +727,7 @@ mod tests {
         let [_, b_cols] = b.dims();
 
         let mut result = zeros(&[a_rows, b_cols]);
-        gemm_tensors(&mut result, &a, &b);
+        run_gemm(&mut result, &a, &b, Kernel::Auto);
 
         let expected = reference_gemm(&a, &b);
         expect_equal(&result, &expected)


### PR DESCRIPTION
The auto-vectorized code for the base kernel uses SSE instructions, except when building for WASM without SIMD, and performs about the same as the SSE `sgemm` from the matrixmultiply crate. Using AVX + FMA provides a significant performance boost. Time in matmul ops in MobileViT goes from ~78ms to ~35ms. The AVX + FMA kernel implementation is very simple, but nevertheless performs about the same as matrixmultiply's FMA kernel and should be easy to adapt for other architectures or data types as needed.

**Before:** (on my final-Intel gen MacBook Pro)

```
[I]  ~/p/wasnn > cargo run --release --example imagenet mobilevit.model car-256.png mobilevit
   Compiling wasnn v0.1.0 (/Users/robert/projects/wasnn)
    Finished release [optimized] target(s) in 17.62s
     Running `target/release/examples/imagenet mobilevit.model car-256.png mobilevit`
Graph run of 878 ops finished in 311.173ms
Add        5.60ms   (1.83%)
Concat     0.34ms   (0.11%)
Conv       120.99ms (39.48%)
Div        4.06ms   (1.33%)
Gather     0.02ms   (0.01%)
Gemm       1.03ms   (0.34%)
MatMul     78.82ms  (25.72%)
Mul        5.59ms   (1.83%)
Pow        1.32ms   (0.43%)
ReduceMean 2.01ms   (0.66%)
Reshape    3.99ms   (1.30%)
Shape      0.01ms   (0.00%)
Sigmoid    61.60ms  (20.10%)
Softmax    15.84ms  (5.17%)
Sqrt       0.00ms   (0.00%)
Sub        4.48ms   (1.46%)
Transpose  0.73ms   (0.24%)
Unsqueeze  0.01ms   (0.00%)
[Other]    4.72ms   (1.54%)
```

**After:**

```
Graph run of 878 ops finished in 211.199ms
Add        5.49ms  (2.68%)
Concat     0.33ms  (0.16%)
Conv       64.19ms (31.29%)
Div        4.09ms  (1.99%)
Gather     0.02ms  (0.01%)
Gemm       0.89ms  (0.43%)
MatMul     34.52ms (16.83%)
Mul        5.25ms  (2.56%)
Pow        1.22ms  (0.60%)
ReduceMean 2.01ms  (0.98%)
Reshape    4.23ms  (2.06%)
Shape      0.01ms  (0.00%)
Sigmoid    62.30ms (30.37%)
Softmax    15.28ms (7.45%)
Sqrt       0.00ms  (0.00%)
Sub        4.59ms  (2.24%)
Transpose  0.73ms  (0.36%)
Unsqueeze  0.01ms  (0.00%)
[Other]    6.04ms  (2.94%)
```