### PR TITLE
Partially support optional inputs in non-trailing positions

### DIFF
--- a/src/model_builder.rs
+++ b/src/model_builder.rs
@@ -201,7 +201,7 @@ impl<'a> ModelBuilder<'a> {
         &mut self,
         id: &str,
         op_info: OpType,
-        inputs: &[u32],
+        inputs: &[Option<u32>],
         outputs: &[u32],
     ) -> u32 {
         // Generate an (op_type, attr_type, attrs) tuple for an operator with
@@ -415,8 +415,17 @@ impl<'a> ModelBuilder<'a> {
             OpType::Where => op!(Where),
         };
 
-        let input_vec = self.builder.create_vector(inputs);
-        let output_vec = self.builder.create_vector(outputs);
+        let input_ids: Vec<i32> = inputs
+            .iter()
+            .map(|&id| match id {
+                Some(id) => id as i32,
+                None => -1,
+            })
+            .collect();
+        let output_ids: Vec<i32> = outputs.iter().map(|&id| id as i32).collect();
+
+        let input_vec = self.builder.create_vector(&input_ids);
+        let output_vec = self.builder.create_vector(&output_ids);
         let op_node = sg::OperatorNode::create(
             &mut self.builder,
             &sg::OperatorNodeArgs {

--- a/src/schema.fbs
+++ b/src/schema.fbs
@@ -219,11 +219,11 @@ table OperatorNode {
   type:OperatorType;
   attrs:OperatorAttrs;
 
-  // Indexes of input nodes
-  inputs:[uint];
+  // Indexes of input nodes. Negative values indicate missing optional inputs.
+  inputs:[int];
 
-  // Indexes of output nodes
-  outputs:[uint];
+  // Indexes of output nodes. Negative values indicate unused outputs.
+  outputs:[int];
 }
 
 union ConstantData {

--- a/src/schema_generated.rs
+++ b/src/schema_generated.rs
@@ -3853,26 +3853,26 @@ impl<'a> OperatorNode<'a> {
         }
     }
     #[inline]
-    pub fn inputs(&self) -> Option<flatbuffers::Vector<'a, u32>> {
+    pub fn inputs(&self) -> Option<flatbuffers::Vector<'a, i32>> {
         // Safety:
         // Created from valid Table for this object
         // which contains a valid value in this slot
         unsafe {
             self._tab
-                .get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u32>>>(
+                .get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, i32>>>(
                     OperatorNode::VT_INPUTS,
                     None,
                 )
         }
     }
     #[inline]
-    pub fn outputs(&self) -> Option<flatbuffers::Vector<'a, u32>> {
+    pub fn outputs(&self) -> Option<flatbuffers::Vector<'a, i32>> {
         // Safety:
         // Created from valid Table for this object
         // which contains a valid value in this slot
         unsafe {
             self._tab
-                .get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u32>>>(
+                .get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, i32>>>(
                     OperatorNode::VT_OUTPUTS,
                     None,
                 )
@@ -4213,8 +4213,8 @@ impl flatbuffers::Verifiable for OperatorNode<'_> {
           _ => Ok(()),
         }
      })?
-     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, u32>>>("inputs", Self::VT_INPUTS, false)?
-     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, u32>>>("outputs", Self::VT_OUTPUTS, false)?
+     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, i32>>>("inputs", Self::VT_INPUTS, false)?
+     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, i32>>>("outputs", Self::VT_OUTPUTS, false)?
      .finish();
         Ok(())
     }
@@ -4223,8 +4223,8 @@ pub struct OperatorNodeArgs<'a> {
     pub type_: OperatorType,
     pub attrs_type: OperatorAttrs,
     pub attrs: Option<flatbuffers::WIPOffset<flatbuffers::UnionWIPOffset>>,
-    pub inputs: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u32>>>,
-    pub outputs: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u32>>>,
+    pub inputs: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, i32>>>,
+    pub outputs: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, i32>>>,
 }
 impl<'a> Default for OperatorNodeArgs<'a> {
     #[inline]
@@ -4263,12 +4263,12 @@ impl<'a: 'b, 'b> OperatorNodeBuilder<'a, 'b> {
             .push_slot_always::<flatbuffers::WIPOffset<_>>(OperatorNode::VT_ATTRS, attrs);
     }
     #[inline]
-    pub fn add_inputs(&mut self, inputs: flatbuffers::WIPOffset<flatbuffers::Vector<'b, u32>>) {
+    pub fn add_inputs(&mut self, inputs: flatbuffers::WIPOffset<flatbuffers::Vector<'b, i32>>) {
         self.fbb_
             .push_slot_always::<flatbuffers::WIPOffset<_>>(OperatorNode::VT_INPUTS, inputs);
     }
     #[inline]
-    pub fn add_outputs(&mut self, outputs: flatbuffers::WIPOffset<flatbuffers::Vector<'b, u32>>) {
+    pub fn add_outputs(&mut self, outputs: flatbuffers::WIPOffset<flatbuffers::Vector<'b, i32>>) {
         self.fbb_
             .push_slot_always::<flatbuffers::WIPOffset<_>>(OperatorNode::VT_OUTPUTS, outputs);
     }

--- a/tools/schema_generated.py
+++ b/tools/schema_generated.py
@@ -2517,14 +2517,14 @@ class OperatorNode(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(10))
         if o != 0:
             a = self._tab.Vector(o)
-            return self._tab.Get(flatbuffers.number_types.Uint32Flags, a + flatbuffers.number_types.UOffsetTFlags.py_type(j * 4))
+            return self._tab.Get(flatbuffers.number_types.Int32Flags, a + flatbuffers.number_types.UOffsetTFlags.py_type(j * 4))
         return 0
 
     # OperatorNode
     def InputsAsNumpy(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(10))
         if o != 0:
-            return self._tab.GetVectorAsNumpy(flatbuffers.number_types.Uint32Flags, o)
+            return self._tab.GetVectorAsNumpy(flatbuffers.number_types.Int32Flags, o)
         return 0
 
     # OperatorNode
@@ -2544,14 +2544,14 @@ class OperatorNode(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(12))
         if o != 0:
             a = self._tab.Vector(o)
-            return self._tab.Get(flatbuffers.number_types.Uint32Flags, a + flatbuffers.number_types.UOffsetTFlags.py_type(j * 4))
+            return self._tab.Get(flatbuffers.number_types.Int32Flags, a + flatbuffers.number_types.UOffsetTFlags.py_type(j * 4))
         return 0
 
     # OperatorNode
     def OutputsAsNumpy(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(12))
         if o != 0:
-            return self._tab.GetVectorAsNumpy(flatbuffers.number_types.Uint32Flags, o)
+            return self._tab.GetVectorAsNumpy(flatbuffers.number_types.Int32Flags, o)
         return 0
 
     # OperatorNode
@@ -2640,7 +2640,7 @@ class OperatorNodeT(object):
             else:
                 OperatorNodeStartInputsVector(builder, len(self.inputs))
                 for i in reversed(range(len(self.inputs))):
-                    builder.PrependUint32(self.inputs[i])
+                    builder.PrependInt32(self.inputs[i])
                 inputs = builder.EndVector()
         if self.outputs is not None:
             if np is not None and type(self.outputs) is np.ndarray:
@@ -2648,7 +2648,7 @@ class OperatorNodeT(object):
             else:
                 OperatorNodeStartOutputsVector(builder, len(self.outputs))
                 for i in reversed(range(len(self.outputs))):
-                    builder.PrependUint32(self.outputs[i])
+                    builder.PrependInt32(self.outputs[i])
                 outputs = builder.EndVector()
         OperatorNodeStart(builder)
         OperatorNodeAddType(builder, self.type)


### PR DESCRIPTION
ONNX models can have omitted optional inputs and outputs in a non-trailing position. eg. Given an operator with inputs A, B? C? and outputs X, Y?, Z?, where "?" denotes optional, it should be possible to omit B and Y, but still provide C and Z.

This commit adds support for this in the FlatBuffers model format and dataflow graph. The `Operator::run` API does not yet support this, as it requires some significant refactoring. As a temporary step, the graph executor will pass an empty float tensor if an input is omitted.

Omitted input/outputs in non-trailing positions are represented differently depending on the context:

 1. In the ONNX model, the input or output name is set to an empty string [1]

 2. In convert-onnx.py, entries in an operator node's input/output list are `int|None`s

 3. In the FlatBuffers model, a negative node index is used in `OperatorNode.{inputs, outputs}`

 4. In the Rust model graph, entries in an operator node's input/output list change from `NodeId` to `Option<NodeId>`.

 5. Finally, in the Operator API, we'll need to change the `&[Input]` list to `&[Option<Input>]` or some other struct.

[1] https://github.com/onnx/onnx/blob/main/docs/IR.md#optional-inputs-and-outputs