### PR TITLE
 Convert operator input list from `&[Input]` to InputList

### DIFF
--- a/src/ops/matmul.rs
+++ b/src/ops/matmul.rs
@@ -1,10 +1,7 @@
 use std::iter::zip;
 
 use crate::linalg::{gemm, Matrix};
-use crate::ops::{
-    choose_broadcast_shape, get_input, get_optional_input, Input, IntoOpResult, OpError, Operator,
-    Output,
-};
+use crate::ops::{choose_broadcast_shape, InputList, IntoOpResult, OpError, Operator, Output};
 use crate::tensor::{from_data, zeros, Tensor};
 
 #[derive(Debug)]
@@ -81,10 +78,10 @@ impl Operator for Gemm {
         "Gemm"
     }
 
-    fn run(&self, inputs: &[Input]) -> Result<Vec<Output>, OpError> {
-        let a = get_input(inputs, 0)?;
-        let b = get_input(inputs, 1)?;
-        let c = get_optional_input(inputs, 2)?;
+    fn run(&self, inputs: InputList) -> Result<Vec<Output>, OpError> {
+        let a = inputs.require_as(0)?;
+        let b = inputs.require_as(1)?;
+        let c = inputs.get_as(2)?;
         gemm_op(
             a,
             b,
@@ -170,9 +167,9 @@ impl Operator for MatMul {
         "MatMul"
     }
 
-    fn run(&self, inputs: &[Input]) -> Result<Vec<Output>, OpError> {
-        let a = get_input(inputs, 0)?;
-        let b = get_input(inputs, 1)?;
+    fn run(&self, inputs: InputList) -> Result<Vec<Output>, OpError> {
+        let a = inputs.require_as(0)?;
+        let b = inputs.require_as(1)?;
         matmul(a, b).into_op_result()
     }
 }

--- a/src/ops/norm.rs
+++ b/src/ops/norm.rs
@@ -1,4 +1,4 @@
-use crate::ops::{get_input, Input, IntoOpResult, OpError, Operator, Output};
+use crate::ops::{InputList, IntoOpResult, OpError, Operator, Output};
 use crate::tensor::Tensor;
 
 /// Perform in-place batch normalization on the NCHW tensor `out`.
@@ -65,12 +65,12 @@ impl Operator for BatchNormalization {
         "BatchNormalization"
     }
 
-    fn run(&self, inputs: &[Input]) -> Result<Vec<Output>, OpError> {
-        let input = get_input(inputs, 0)?;
-        let scale = get_input(inputs, 1)?;
-        let bias = get_input(inputs, 2)?;
-        let mean = get_input(inputs, 3)?;
-        let var = get_input(inputs, 4)?;
+    fn run(&self, inputs: InputList) -> Result<Vec<Output>, OpError> {
+        let input = inputs.require_as(0)?;
+        let scale = inputs.require_as(1)?;
+        let bias = inputs.require_as(2)?;
+        let mean = inputs.require_as(3)?;
+        let var = inputs.require_as(4)?;
 
         batch_norm(input, scale, bias, mean, var, self.epsilon).into_op_result()
     }
@@ -79,12 +79,12 @@ impl Operator for BatchNormalization {
         true
     }
 
-    fn run_in_place(&self, input: Output, other: &[Input]) -> Result<Output, OpError> {
-        let mut output = input.into_float().ok_or(OpError::UnsupportedInputType)?;
-        let scale = get_input(other, 0)?;
-        let bias = get_input(other, 1)?;
-        let mean = get_input(other, 2)?;
-        let var = get_input(other, 3)?;
+    fn run_in_place(&self, input: Output, other: InputList) -> Result<Output, OpError> {
+        let mut output = input.into_float().ok_or(OpError::IncorrectInputType)?;
+        let scale = other.require_as(0)?;
+        let bias = other.require_as(1)?;
+        let mean = other.require_as(2)?;
+        let var = other.require_as(3)?;
 
         batch_norm_in_place(&mut output, scale, bias, mean, var, self.epsilon);
 
@@ -141,8 +141,8 @@ impl Operator for Softmax {
         "Softmax"
     }
 
-    fn run(&self, inputs: &[Input]) -> Result<Vec<Output>, OpError> {
-        let input = get_input(inputs, 0)?;
+    fn run(&self, inputs: InputList) -> Result<Vec<Output>, OpError> {
+        let input = inputs.require_as(0)?;
         softmax(input, self.axis).into_op_result()
     }
 
@@ -150,8 +150,8 @@ impl Operator for Softmax {
         true
     }
 
-    fn run_in_place(&self, input: Output, _other: &[Input]) -> Result<Output, OpError> {
-        let mut output = input.into_float().ok_or(OpError::UnsupportedInputType)?;
+    fn run_in_place(&self, input: Output, _other: InputList) -> Result<Output, OpError> {
+        let mut output = input.into_float().ok_or(OpError::IncorrectInputType)?;
         softmax_in_place(&mut output, self.axis);
         Ok(output.into())
     }

--- a/src/ops/pooling.rs
+++ b/src/ops/pooling.rs
@@ -1,5 +1,5 @@
 use crate::linalg::div_ceil;
-use crate::ops::{get_input, Input, IntoOpResult, OpError, Operator, Output, Padding};
+use crate::ops::{InputList, IntoOpResult, OpError, Operator, Output, Padding};
 use crate::tensor::{zeros, Tensor};
 
 /// Calculate the output size and padding for a convolution or pooling operation.
@@ -120,8 +120,8 @@ impl Operator for AveragePool {
         "AveragePool"
     }
 
-    fn run(&self, inputs: &[Input]) -> Result<Vec<Output>, OpError> {
-        let input = get_input(inputs, 0)?;
+    fn run(&self, inputs: InputList) -> Result<Vec<Output>, OpError> {
+        let input = inputs.require_as(0)?;
         average_pool(input, self.kernel_size, self.strides, self.padding).into_op_result()
     }
 }
@@ -156,8 +156,8 @@ impl Operator for GlobalAveragePool {
         "GlobalAveragePool"
     }
 
-    fn run(&self, inputs: &[Input]) -> Result<Vec<Output>, OpError> {
-        let input = get_input(inputs, 0)?;
+    fn run(&self, inputs: InputList) -> Result<Vec<Output>, OpError> {
+        let input = inputs.require_as(0)?;
         global_average_pool(input).into_op_result()
     }
 }
@@ -224,8 +224,8 @@ impl Operator for MaxPool {
         "MaxPool"
     }
 
-    fn run(&self, inputs: &[Input]) -> Result<Vec<Output>, OpError> {
-        let input = get_input(inputs, 0)?;
+    fn run(&self, inputs: InputList) -> Result<Vec<Output>, OpError> {
+        let input = inputs.require_as(0)?;
         max_pool(input, self.kernel_size, self.strides, self.padding).into_op_result()
     }
 }

--- a/src/ops/reduce.rs
+++ b/src/ops/reduce.rs
@@ -1,5 +1,5 @@
 use crate::ops::layout::squeeze_in_place;
-use crate::ops::{get_input, resolve_axes, Input, IntoOpResult, OpError, Operator, Output};
+use crate::ops::{resolve_axes, InputList, IntoOpResult, OpError, Operator, Output};
 use crate::tensor::{IndexIterator, SliceRange, Tensor};
 
 /// Trait for reducing a subset of elements from a tensor to a single value.
@@ -122,8 +122,8 @@ impl Operator for ReduceMean {
         "ReduceMean"
     }
 
-    fn run(&self, inputs: &[Input]) -> Result<Vec<Output>, OpError> {
-        let input = get_input(inputs, 0)?;
+    fn run(&self, inputs: InputList) -> Result<Vec<Output>, OpError> {
+        let input = inputs.require_as(0)?;
         reduce_mean(
             input,
             self.axes.as_ref().map(|axis| &axis[..]),

--- a/src/ops/unary_elementwise.rs
+++ b/src/ops/unary_elementwise.rs
@@ -2,7 +2,7 @@ extern crate libm;
 
 use std::fmt::Debug;
 
-use crate::ops::{get_input, Input, IntoOpResult, OpError, Operator, Output};
+use crate::ops::{InputList, IntoOpResult, OpError, Operator, Output};
 use crate::tensor::Tensor;
 
 /// Trait for operators which take a single float tensor and apply a function
@@ -29,8 +29,8 @@ impl<Op: UnaryFloatOp + Debug> Operator for Op {
         self.name()
     }
 
-    fn run(&self, inputs: &[Input]) -> Result<Vec<Output>, OpError> {
-        let input = get_input(inputs, 0)?;
+    fn run(&self, inputs: InputList) -> Result<Vec<Output>, OpError> {
+        let input = inputs.require_as(0)?;
         self.map(input).into_op_result()
     }
 
@@ -38,8 +38,8 @@ impl<Op: UnaryFloatOp + Debug> Operator for Op {
         true
     }
 
-    fn run_in_place(&self, input: Output, _: &[Input]) -> Result<Output, OpError> {
-        let mut output = input.into_float().ok_or(OpError::UnsupportedInputType)?;
+    fn run_in_place(&self, input: Output, _: InputList) -> Result<Output, OpError> {
+        let mut output = input.into_float().ok_or(OpError::IncorrectInputType)?;
         self.apply(&mut output);
         Ok(output.into())
     }


### PR DESCRIPTION
Change the container for operator inputs from a slice of `Input`s to an `InputList` struct. This solves two problems:

- It provies a concise syntax in operator implementations for
 extracting arguments and producing appropriate errors if they are
 missing or of the wrong type.

- It allows making inputs in non-trailing positions optional. This
 could have been done by changing the `inputs` argument to
 `&[Option<Input>]`, but that would have required operators to deal
 with unpacking nested `Options`s. InputList handles this internally.

In the process the two OpError variants for incorrect or unexpected inputs were
combined into one. The current input validation doesn't always make it easy to
know which is the case at the point where the error is generated.