### PR TITLE
Implement more general broadcasting

### DIFF
--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -21,8 +21,8 @@ mod slice;
 mod unary_elementwise;
 
 pub use binary_elementwise::{
-    add, add_in_place, choose_broadcast_shape, div, div_in_place, equal, less, mul, mul_in_place,
-    pow, pow_in_place, sub, sub_in_place, where_op,
+    add, add_in_place, div, div_in_place, equal, less, mul, mul_in_place, pow, pow_in_place, sub,
+    sub_in_place, where_op,
 };
 pub use binary_elementwise::{Add, Div, Equal, Less, Mul, Pow, Sub, Where};
 pub use conv::{conv, conv_transpose};


### PR DESCRIPTION
Previously broadcasting of binary elementwise ops only allowed one of the inputs to be broadcast to the shape of the other. Numpy/ONNX requires more general broadcasting where the result can combine dimensions from each. eg. `[1, 5] x [2, 1, 1] => [2, 1, 5]`. This commit supports this more general behavior.

Also change the Expand op, per the ONNX spec, to broadcast _with_ the target shape rather than _to_ it.