### PR TITLE
Extract image processing and page layout modules into separate crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -453,7 +453,6 @@ checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 name = "wasnn"
 version = "0.1.0"
 dependencies = [
- "fastrand",
  "flatbuffers",
  "image",
  "libm",
@@ -462,6 +461,24 @@ dependencies = [
  "serde_json",
  "smallvec",
  "wasm-bindgen",
+ "wasnn-imageproc",
+ "wasnn-ocr",
+ "wasnn-tensor",
+]
+
+[[package]]
+name = "wasnn-imageproc"
+version = "0.1.0"
+dependencies = [
+ "wasnn-tensor",
+]
+
+[[package]]
+name = "wasnn-ocr"
+version = "0.1.0"
+dependencies = [
+ "fastrand",
+ "wasnn-imageproc",
  "wasnn-tensor",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,7 @@
 [workspace]
 members = [
+  "wasnn-imageproc",
+  "wasnn-ocr",
   "wasnn-tensor"
 ]
 
@@ -19,10 +21,11 @@ wasm-bindgen = "0.2.83"
 wasnn-tensor = { path = "./wasnn-tensor" }
 
 [dev-dependencies]
-fastrand = "1.9.0"
 image = { version = "0.24.6", default-features = false, features = ["png", "jpeg", "webp"] }
 png = "0.17.6"
 serde_json = "1.0.91"
+wasnn-imageproc = { path = "./wasnn-imageproc" }
+wasnn-ocr = { path = "./wasnn-ocr" }
 
 [lib]
 crate-type = ["lib", "cdylib"]

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ checkformatting:
 
 .PHONY: lint
 lint:
-	cargo clippy -- -Aclippy::needless_range_loop -Aclippy::too_many_arguments -Aclippy::derivable_impls -Aclippy::manual_memcpy -Aclippy::assertions_on_constants -Aclippy::uninlined_format_args
+	cargo clippy --workspace -- -Aclippy::needless_range_loop -Aclippy::too_many_arguments -Aclippy::derivable_impls -Aclippy::manual_memcpy -Aclippy::assertions_on_constants -Aclippy::uninlined_format_args
 
 .PHONY: test
 test:

--- a/examples/ocr.rs
+++ b/examples/ocr.rs
@@ -7,11 +7,11 @@ use std::fs;
 use std::io::BufWriter;
 
 use wasnn::ctc::{CtcDecoder, CtcHypothesis};
-use wasnn::geometry::{draw_polygon, Point, Polygon, Rect, RotatedRect};
 use wasnn::ops::{pad, resize, CoordTransformMode, NearestMode, ResizeMode, ResizeTarget};
-use wasnn::page_layout::{find_connected_component_rects, find_text_lines, line_polygon};
 use wasnn::Timer;
 use wasnn::{Dimension, Model, RunOptions};
+use wasnn_imageproc::{draw_polygon, Point, Polygon, Rect, RotatedRect};
+use wasnn_ocr::page_layout::{find_connected_component_rects, find_text_lines, line_polygon};
 use wasnn_tensor::{tensor, Tensor, TensorLayout, TensorView};
 
 /// Read an image from `path` into a CHW tensor.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,8 +8,6 @@ mod wasm_api;
 // Temporarily included in this crate. These functions should be moved into
 // a separate crate in future.
 pub mod ctc;
-pub mod geometry;
-pub mod page_layout;
 
 pub mod ops;
 

--- a/wasnn-imageproc/Cargo.toml
+++ b/wasnn-imageproc/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "wasnn-imageproc"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+wasnn-tensor = { path = "../wasnn-tensor" }
+
+[lib]
+crate-type = ["lib"]

--- a/wasnn-imageproc/src/lib.rs
+++ b/wasnn-imageproc/src/lib.rs
@@ -1,6 +1,5 @@
-//! Geometry functions for pre and post-processing images.
-//!
-//! TODO: Move these out of Wasnn and into a separate crate.
+//! Functions for pre and post-processing images.
+
 use std::fmt;
 use std::fmt::Display;
 use std::iter::zip;

--- a/wasnn-ocr/Cargo.toml
+++ b/wasnn-ocr/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "wasnn-ocr"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+wasnn-imageproc = { path = "../wasnn-imageproc" }
+wasnn-tensor = { path = "../wasnn-tensor" }
+
+[dev-dependencies]
+fastrand = "1.9.0"
+
+[lib]
+crate-type = ["lib"]

--- a/wasnn-ocr/src/lib.rs
+++ b/wasnn-ocr/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod page_layout;

--- a/wasnn-ocr/src/page_layout.rs
+++ b/wasnn-ocr/src/page_layout.rs
@@ -2,12 +2,11 @@ use std::cmp::Ordering;
 use std::collections::BinaryHeap;
 use std::iter::zip;
 
-use wasnn_tensor::NdTensorView;
-
-use crate::geometry::{
+use wasnn_imageproc::{
     find_contours, min_area_rect, simplify_polygon, Line, Point, Rect, RetrievalMode, RotatedRect,
     Vec2,
 };
+use wasnn_tensor::NdTensorView;
 
 struct Partition {
     score: f32,
@@ -528,10 +527,11 @@ pub fn line_polygon(words: &[RotatedRect]) -> Vec<Point> {
 
 #[cfg(test)]
 mod tests {
-    use super::max_empty_rects;
-    use crate::geometry::{fill_rect, Point, Polygon, Rect, RotatedRect, Vec2};
-    use crate::page_layout::{find_connected_component_rects, find_text_lines, line_polygon};
+    use wasnn_imageproc::{fill_rect, Point, Polygon, Rect, RotatedRect, Vec2};
     use wasnn_tensor::NdTensor;
+
+    use super::max_empty_rects;
+    use crate::page_layout::{find_connected_component_rects, find_text_lines, line_polygon};
 
     /// Generate a grid of uniformly sized and spaced rects.
     ///


### PR DESCRIPTION
These are outside the scope of the core ONNX model inference engine. The image processing library is likely to be useful for many applications, and page layout is much more OCR-specific, although you might still want to use it without the OCR part itself (eg. if working with a digital PDF or something).