### PR TITLE
Fix slow model downloads by changing download source

### DIFF
--- a/ocrs-cli/src/main.rs
+++ b/ocrs-cli/src/main.rs
@@ -206,12 +206,11 @@ impl<T, E: std::fmt::Display> FileErrorContext<T> for Result<T, E> {
 }
 
 /// Default text detection model.
-const DETECTION_MODEL: &str =
-    "https://s3.amazonaws.com/io.github.robertknight/ocrs-models/text-detection.rten";
+const DETECTION_MODEL: &str = "https://ocrs-models.s3-accelerate.amazonaws.com/text-detection.rten";
 
 /// Default text recognition model.
 const RECOGNITION_MODEL: &str =
-    "https://s3.amazonaws.com/io.github.robertknight/ocrs-models/text-recognition.rten";
+    "https://ocrs-models.s3-accelerate.amazonaws.com/text-recognition.rten";
 
 fn main() -> Result<(), Box<dyn Error>> {
     let args = parse_args()?;


### PR DESCRIPTION
Fix slow model downloads by moving models to a different bucket which has S3 Transfer Acceleration enabled. I couldn't enable this for the original bucket because AWS doesn't support S3TA for buckets with a period in their name.

With the original URL I was able to reproduce sporadic slow downloads when downloading with ureq, reqwest and curl.

Fixes https://github.com/robertknight/rten/issues/22