### PR TITLE
Make various iterators generic over the tensor layout

### DIFF
--- a/rten-tensor/src/iterators.rs
+++ b/rten-tensor/src/iterators.rs
@@ -7,6 +7,51 @@ use crate::{
     to_slice_items, DynIndices, Layout, NdTensorView, NdTensorViewMut, TensorView, TensorViewMut,
 };
 
+/// Borrowed reference to a tensor's data and layout. This differs from
+/// [TensorView] in that it borrows the layout rather than having its own.
+///
+/// `'d` is the lifetime of the data and `'l` the lifetime of the layout.
+pub(crate) struct ViewRef<'d, 'l, T, L: Layout> {
+    data: &'d [T],
+    layout: &'l L,
+}
+
+impl<'d, 'l, T, L: Layout> ViewRef<'d, 'l, T, L> {
+    pub(crate) fn new(data: &'d [T], layout: &'l L) -> ViewRef<'d, 'l, T, L> {
+        ViewRef { data, layout }
+    }
+
+    fn contiguous_data(&self) -> Option<&'d [T]> {
+        self.layout.is_contiguous().then_some(self.data)
+    }
+
+    fn shape(&self) -> L::Index<'_> {
+        self.layout.shape()
+    }
+}
+
+impl<'d, 'l, T, L: Layout> Clone for ViewRef<'d, 'l, T, L> {
+    fn clone(&self) -> ViewRef<'d, 'l, T, L> {
+        ViewRef {
+            data: self.data,
+            layout: self.layout,
+        }
+    }
+}
+
+/// Mutably borrowed reference to a tensor's data and layout. This differs from
+/// [TensorViewMut] in that it borrows the layout rather than having its own.
+pub(crate) struct MutViewRef<'d, 'l, T, L: Layout> {
+    data: &'d mut [T],
+    layout: &'l L,
+}
+
+impl<'d, 'l, T, L: Layout> MutViewRef<'d, 'l, T, L> {
+    pub(crate) fn new(data: &'d mut [T], layout: &'l L) -> MutViewRef<'d, 'l, T, L> {
+        MutViewRef { data, layout }
+    }
+}
+
 /// IterPos tracks the position within a single dimension of an IndexingIter.
 #[derive(Copy, Clone, Debug)]
 struct IterPos {
@@ -233,8 +278,8 @@ enum IterKind<'a, T> {
 }
 
 impl<'a, T> Iter<'a, T> {
-    pub(super) fn new(view: &TensorView<'a, T>) -> Iter<'a, T> {
-        if let Some(data) = view.data() {
+    pub(super) fn new<L: Layout>(view: ViewRef<'a, '_, T, L>) -> Iter<'a, T> {
+        if let Some(data) = view.contiguous_data() {
             Iter {
                 iter: IterKind::Direct(data.iter()),
             }
@@ -245,14 +290,13 @@ impl<'a, T> Iter<'a, T> {
         }
     }
 
-    pub(super) fn slice(view: &TensorView<'a, T>, range: &[SliceItem]) -> Iter<'a, T> {
+    pub(super) fn slice<L: Layout>(
+        view: ViewRef<'a, '_, T, L>,
+        range: &[SliceItem],
+    ) -> Iter<'a, T> {
         let iter = IndexingIter {
-            base: IndexingIterBase::slice(view.layout(), range),
-
-            // Safety: The `Iterator::next` impl must only yield offsets from
-            // this slice that belong to the tensor slice. This is true of
-            // the offsets yielded by `IndexingIterBase`.
-            data: unsafe { view.data_unchecked() },
+            base: IndexingIterBase::slice(view.layout, range),
+            data: view.data,
         };
         Iter {
             iter: IterKind::Indexing(iter),
@@ -302,25 +346,17 @@ struct IndexingIter<'a, T> {
 }
 
 impl<'a, T> IndexingIter<'a, T> {
-    fn new(view: &TensorView<'a, T>) -> IndexingIter<'a, T> {
+    fn new<L: Layout>(view: ViewRef<'a, '_, T, L>) -> IndexingIter<'a, T> {
         IndexingIter {
-            base: IndexingIterBase::new(view.layout()),
-
-            // Safety: The `Iterator::next` impl must only yield offsets from
-            // this slice that belong to the tensor view. This is true of
-            // the offsets yielded by `IndexingIterBase`.
-            data: unsafe { view.data_unchecked() },
+            base: IndexingIterBase::new(view.layout),
+            data: view.data,
         }
     }
 
-    fn broadcast(view: &TensorView<'a, T>, shape: &[usize]) -> IndexingIter<'a, T> {
+    fn broadcast<L: Layout>(view: ViewRef<'a, '_, T, L>, shape: &[usize]) -> IndexingIter<'a, T> {
         IndexingIter {
-            base: IndexingIterBase::broadcast(view.layout(), shape),
-
-            // Safety: The `Iterator::next` impl must only yield offsets from
-            // this slice that belong to the broadcasted tensor view. This is
-            // true of the offsets yielded by `IndexingIterBase`.
-            data: unsafe { view.data_unchecked() },
+            base: IndexingIterBase::broadcast(view.layout, shape),
+            data: view.data,
         }
     }
 }
@@ -362,14 +398,14 @@ enum IterMutKind<'a, T> {
 }
 
 impl<'a, T> IterMut<'a, T> {
-    pub(super) fn new<L: Layout>(data: &'a mut [T], layout: &L) -> IterMut<'a, T> {
-        if layout.is_contiguous() {
+    pub(super) fn new<L: Layout>(view: MutViewRef<'a, '_, T, L>) -> IterMut<'a, T> {
+        if view.layout.is_contiguous() {
             IterMut {
-                iter: IterMutKind::Direct(data.iter_mut()),
+                iter: IterMutKind::Direct(view.data.iter_mut()),
             }
         } else {
             IterMut {
-                iter: IterMutKind::Indexing(IndexingIterMut::new(data, layout)),
+                iter: IterMutKind::Indexing(IndexingIterMut::new(view)),
             }
         }
     }
@@ -417,15 +453,15 @@ struct IndexingIterMut<'a, T> {
 }
 
 impl<'a, T> IndexingIterMut<'a, T> {
-    fn new<L: Layout>(data: &'a mut [T], layout: &L) -> IndexingIterMut<'a, T> {
+    fn new<L: Layout>(view: MutViewRef<'a, '_, T, L>) -> IndexingIterMut<'a, T> {
         // See notes in `Layout` about internal overlap.
         assert!(
-            !layout.is_broadcast(),
+            !view.layout.is_broadcast(),
             "Cannot mutably iterate over broadcasting view"
         );
         IndexingIterMut {
-            base: IndexingIterBase::new(layout),
-            data,
+            base: IndexingIterBase::new(view.layout),
+            data: view.data,
         }
     }
 }
@@ -565,16 +601,20 @@ fn can_broadcast_by_cycling(from_shape: &[usize], to_shape: &[usize]) -> bool {
 }
 
 impl<'a, T> BroadcastIter<'a, T> {
-    pub fn new(view: &TensorView<'a, T>, to_shape: &[usize]) -> BroadcastIter<'a, T> {
+    pub(crate) fn new<L: Layout>(
+        view: ViewRef<'a, '_, T, L>,
+        to_shape: &[usize],
+    ) -> BroadcastIter<'a, T> {
+        let tmp_view = view.clone();
         let iter = match (
-            view.data(),
-            can_broadcast_by_cycling(view.shape(), to_shape),
+            view.contiguous_data(),
+            can_broadcast_by_cycling(view.shape().as_ref(), to_shape),
         ) {
             (Some(data), true) => {
                 let iter_len = to_shape.iter().product();
                 BroadcastIterKind::Direct(data.iter().cycle().take(iter_len))
             }
-            _ => BroadcastIterKind::Indexing(IndexingIter::broadcast(view, to_shape)),
+            _ => BroadcastIterKind::Indexing(IndexingIter::broadcast(tmp_view, to_shape)),
         };
         BroadcastIter { iter }
     }
@@ -773,21 +813,21 @@ struct LaneRanges {
 }
 
 impl LaneRanges {
-    fn new<T>(tensor: &TensorView<T>, dim: usize) -> LaneRanges {
-        let slice_starts: Vec<SliceItem> = (0..tensor.ndim())
+    fn new<L: Layout>(layout: &L, dim: usize) -> LaneRanges {
+        let slice_starts: Vec<SliceItem> = (0..layout.ndim())
             .map(|i| {
                 if i == dim {
                     (0..1).into()
                 } else {
-                    (0..(tensor.shape()[i] as isize)).into()
+                    (0..(layout.size(i) as isize)).into()
                 }
             })
             .collect();
-        let offsets = tensor.slice_offsets(&slice_starts);
+        let offsets = Offsets::slice(layout, &slice_starts);
         LaneRanges {
             offsets,
-            dim_size: tensor.size(dim),
-            dim_stride: tensor.stride(dim),
+            dim_size: layout.size(dim),
+            dim_stride: layout.stride(dim),
         }
     }
 }
@@ -837,12 +877,10 @@ impl<'a, T> ExactSizeIterator for Lane<'a, T> {}
 impl<'a, T> Lanes<'a, T> {
     /// Create an iterator which yields all possible slices over the `dim`
     /// dimension of `tensor`.
-    pub(crate) fn new(tensor: TensorView<'a, T>, dim: usize) -> Lanes<'a, T> {
+    pub(crate) fn new<L: Layout>(view: ViewRef<'a, '_, T, L>, dim: usize) -> Lanes<'a, T> {
         Lanes {
-            // Safety: `Lane`s yielded by this iterator will only yield elements
-            // that belong to this lane.
-            data: unsafe { tensor.data_unchecked() },
-            ranges: LaneRanges::new(&tensor, dim),
+            data: view.data,
+            ranges: LaneRanges::new(view.layout, dim),
         }
     }
 }
@@ -867,22 +905,22 @@ impl<'a, T> Iterator for Lanes<'a, T> {
 /// in implementing this for an iterator that returns mutable references, but
 /// it has a similar interface.
 pub struct LanesMut<'a, T> {
-    tensor: TensorViewMut<'a, T>,
+    data: &'a mut [T],
     ranges: LaneRanges,
 }
 
 impl<'a, T> LanesMut<'a, T> {
     /// Create an iterator which yields all possible slices over the `dim`
-    /// dimension of `tensor`.
-    pub(crate) fn new(tensor: TensorViewMut<'a, T>, dim: usize) -> LanesMut<'a, T> {
+    /// dimension of `view`.
+    pub(crate) fn new<L: Layout>(view: MutViewRef<'a, '_, T, L>, dim: usize) -> LanesMut<'a, T> {
         // See notes in `Layout` about internal overlap.
         assert!(
-            !tensor.layout().is_broadcast(),
+            !view.layout.is_broadcast(),
             "Cannot mutably iterate over broadcasting view"
         );
         LanesMut {
-            ranges: LaneRanges::new(&tensor.view(), dim),
-            tensor,
+            ranges: LaneRanges::new(view.layout, dim),
+            data: view.data,
         }
     }
 }
@@ -915,7 +953,7 @@ impl<'a, T> Iterator for LanesMut<'a, T> {
             // Safety: This is a non-broadcasting view, so each `LaneMut`
             // yielded by this iterator will yield a distinct set of elements.
             let slice = unsafe {
-                let slice = &mut self.tensor.data_mut_unchecked()[range];
+                let slice = &mut self.data[range];
                 std::mem::transmute::<&mut [T], &'a mut [T]>(slice)
             };
 
@@ -1013,14 +1051,14 @@ mod tests {
     #[test]
     fn test_lanes_empty() {
         let x = Tensor::<i32>::zeros(&[5, 0]);
-        assert!(Lanes::new(x.view(), 0).next().is_none());
-        assert!(Lanes::new(x.view(), 1).next().is_none());
+        assert!(Lanes::new(x.view().view_ref(), 0).next().is_none());
+        assert!(Lanes::new(x.view().view_ref(), 1).next().is_none());
     }
 
     #[test]
     fn test_lanes_mut_empty() {
         let mut x = Tensor::<i32>::zeros(&[5, 0]);
-        assert!(LanesMut::new(x.view_mut(), 0).next().is_none());
-        assert!(LanesMut::new(x.view_mut(), 1).next().is_none());
+        assert!(LanesMut::new(x.mut_view_ref(), 0).next().is_none());
+        assert!(LanesMut::new(x.mut_view_ref(), 1).next().is_none());
     }
 }

--- a/rten-tensor/src/layout.rs
+++ b/rten-tensor/src/layout.rs
@@ -49,6 +49,12 @@ pub trait Layout {
         is_contiguous(self.shape(), self.strides())
     }
 
+    /// Return true if iterating over elements in this layout will visit
+    /// elements multiple times.
+    fn is_broadcast(&self) -> bool {
+        !self.is_empty() && self.strides().as_ref().iter().any(|&stride| stride == 0)
+    }
+
     /// Returns true if the array has no elements.
     fn is_empty(&self) -> bool {
         self.len() == 0
@@ -680,12 +686,6 @@ impl DynLayout {
 
     pub fn resize_dim(&mut self, dim: usize, new_size: usize) {
         self.shape_and_strides[dim] = new_size;
-    }
-
-    /// Return true if iterating over elements in this layout will visit
-    /// elements multiple times.
-    pub fn is_broadcast(&self) -> bool {
-        !self.is_empty() && self.strides().iter().any(|&stride| stride == 0)
     }
 
     pub fn make_contiguous(&mut self) {

--- a/rten-tensor/src/layout.rs
+++ b/rten-tensor/src/layout.rs
@@ -570,7 +570,7 @@ impl Layout for DynLayout {
 impl DynLayout {
     /// Construct a layout with dimension sizes given by `shape` and default
     /// (contiguous) strides.
-    pub fn new(shape: &[usize]) -> DynLayout {
+    pub fn from_shape(shape: &[usize]) -> DynLayout {
         DynLayout {
             shape_and_strides: Self::contiguous_shape_and_strides(shape),
         }
@@ -764,7 +764,7 @@ impl DynLayout {
             self.is_contiguous(),
             "can only reshape a contiguous tensor/view"
         );
-        *self = DynLayout::new(shape);
+        *self = DynLayout::from_shape(shape);
     }
 
     pub fn reshaped(&self, shape: &[usize]) -> DynLayout {
@@ -855,11 +855,11 @@ mod tests {
     #[test]
     fn test_is_broadcast() {
         // Non-empty, contiguous layout
-        let layout = DynLayout::new(&[5, 5]);
+        let layout = DynLayout::from_shape(&[5, 5]);
         assert!(!layout.is_broadcast());
 
         // Empty layout
-        let layout = DynLayout::new(&[5, 0]);
+        let layout = DynLayout::from_shape(&[5, 0]);
         assert!(!layout.is_broadcast());
 
         // Broadcasting layout
@@ -902,7 +902,7 @@ mod tests {
 
     #[test]
     fn test_move_axis() {
-        let mut layout = DynLayout::new(&[2, 4, 8]);
+        let mut layout = DynLayout::from_shape(&[2, 4, 8]);
         assert_eq!(layout.strides(), [32, 8, 1]);
 
         layout.move_axis(1, 0);
@@ -921,41 +921,41 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_move_axis_invalid_from() {
-        let mut layout = DynLayout::new(&[2, 4, 8]);
+        let mut layout = DynLayout::from_shape(&[2, 4, 8]);
         layout.move_axis(3, 0);
     }
 
     #[test]
     #[should_panic]
     fn test_move_axis_invalid_to() {
-        let mut layout = DynLayout::new(&[2, 4, 8]);
+        let mut layout = DynLayout::from_shape(&[2, 4, 8]);
         layout.move_axis(0, 3);
     }
 
     #[test]
     #[should_panic(expected = "permutation is invalid")]
     fn test_permute_invalid_len() {
-        let mut layout = DynLayout::new(&[5, 5]);
+        let mut layout = DynLayout::from_shape(&[5, 5]);
         layout.permute(&[1, 0, 3]);
     }
 
     #[test]
     #[should_panic(expected = "permutation is invalid")]
     fn test_permute_too_few_dims() {
-        let mut layout = DynLayout::new(&[5, 5]);
+        let mut layout = DynLayout::from_shape(&[5, 5]);
         layout.permute(&[1]);
     }
 
     #[test]
     #[should_panic(expected = "permutation is invalid")]
     fn test_permute_repeated_dims() {
-        let mut layout = DynLayout::new(&[5, 5]);
+        let mut layout = DynLayout::from_shape(&[5, 5]);
         layout.permute(&[1, 1]);
     }
 
     #[test]
     fn test_squeezed() {
-        let layout = DynLayout::new(&[1, 1, 10, 20]);
+        let layout = DynLayout::from_shape(&[1, 1, 10, 20]);
         let squeezed = layout.squeezed();
         assert_eq!(squeezed.shape(), &[10, 20]);
         assert_eq!(squeezed.strides(), &[20, 1]);
@@ -964,41 +964,41 @@ mod tests {
     #[test]
     #[should_panic(expected = "Slice index is invalid for tensor shape")]
     fn test_slice_invalid_index() {
-        let layout = DynLayout::new(&[3, 5]);
+        let layout = DynLayout::from_shape(&[3, 5]);
         layout.slice(&[SliceItem::Index(4), SliceItem::Index(0)]);
     }
 
     #[test]
     #[should_panic(expected = "Slice index is invalid for tensor shape")]
     fn test_slice_invalid_negative_index() {
-        let layout = DynLayout::new(&[3, 5]);
+        let layout = DynLayout::from_shape(&[3, 5]);
         layout.slice(&[SliceItem::Index(-4)]);
     }
 
     #[test]
     #[should_panic(expected = "Slice range is invalid for tensor shape")]
     fn test_slice_invalid_range() {
-        let layout = DynLayout::new(&[3, 5]);
+        let layout = DynLayout::from_shape(&[3, 5]);
         layout.slice(&[SliceItem::Range((1..4).into()), SliceItem::Index(0)]);
     }
 
     #[test]
     #[should_panic(expected = "Slice range is invalid for tensor shape")]
     fn test_slice_invalid_from_range() {
-        let layout = DynLayout::new(&[3, 5]);
+        let layout = DynLayout::from_shape(&[3, 5]);
         layout.slice(&[SliceItem::Range((4..).into()), SliceItem::Index(0)]);
     }
 
     #[test]
     #[should_panic(expected = "Cannot slice with negative step")]
     fn test_slice_negative_step() {
-        let layout = DynLayout::new(&[3, 5]);
+        let layout = DynLayout::from_shape(&[3, 5]);
         layout.slice(&[SliceItem::full_range(), SliceItem::range(0, None, -1)]);
     }
 
     #[test]
     fn test_size_stride() {
-        let layout = DynLayout::new(&[10, 20, 30]);
+        let layout = DynLayout::from_shape(&[10, 20, 30]);
         for (dim, (&size, &stride)) in
             zip(layout.shape().iter(), layout.strides().iter()).enumerate()
         {

--- a/rten-tensor/src/layout.rs
+++ b/rten-tensor/src/layout.rs
@@ -839,6 +839,12 @@ impl<const N: usize> From<&NdLayout<N>> for DynLayout {
     }
 }
 
+impl<const N: usize> From<NdLayout<N>> for DynLayout {
+    fn from(value: NdLayout<N>) -> DynLayout {
+        DynLayout::from(&value)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::iter::zip;

--- a/rten-tensor/src/lib.rs
+++ b/rten-tensor/src/lib.rs
@@ -49,7 +49,7 @@ pub use iterators::{
     AxisChunks, AxisChunksMut, AxisIter, AxisIterMut, BroadcastIter, InnerIter, InnerIterMut, Iter,
     IterMut, Lanes, LanesMut, Offsets,
 };
-pub use layout::{is_valid_permutation, DynLayout, Layout, MatrixLayout};
+pub use layout::{is_valid_permutation, DynLayout, Layout, MatrixLayout, NdLayout};
 pub use ndtensor::{
     Matrix, MatrixMut, NdTensor, NdTensorBase, NdTensorView, NdTensorViewMut, NdView,
 };

--- a/rten-tensor/src/ndtensor.rs
+++ b/rten-tensor/src/ndtensor.rs
@@ -681,8 +681,8 @@ impl<T, S: AsRef<[T]>, const N: usize> Layout for NdTensorBase<T, S, N> {
         self.layout.len()
     }
 
-    fn offset(&self, index: [usize; N]) -> usize {
-        self.layout.offset(index)
+    fn try_offset(&self, index: [usize; N]) -> Option<usize> {
+        self.layout.try_offset(index)
     }
 
     fn is_empty(&self) -> bool {
@@ -772,8 +772,8 @@ impl<T, S: AsRef<[T]>, const N: usize> Layout for UncheckedNdTensor<T, S, N> {
         N
     }
 
-    fn offset(&self, index: [usize; N]) -> usize {
-        self.base.layout.offset_unchecked(index)
+    fn try_offset(&self, index: [usize; N]) -> Option<usize> {
+        self.base.try_offset(index)
     }
 
     fn len(&self) -> usize {

--- a/rten-tensor/src/ndtensor.rs
+++ b/rten-tensor/src/ndtensor.rs
@@ -662,7 +662,7 @@ impl<T, S: AsRef<[T]> + AsMut<[T]>, const N: usize> IndexMut<[usize; N]> for NdT
 }
 
 impl<T, S: AsRef<[T]>, const N: usize> Layout for NdTensorBase<T, S, N> {
-    type Index<'a> = [usize; N] where S: 'a, T: 'a;
+    type Index<'a> = [usize; N];
     type Indices = NdIndices<N>;
 
     fn ndim(&self) -> usize {
@@ -671,6 +671,10 @@ impl<T, S: AsRef<[T]>, const N: usize> Layout for NdTensorBase<T, S, N> {
 
     fn len(&self) -> usize {
         self.layout.len()
+    }
+
+    fn offset(&self, index: [usize; N]) -> usize {
+        self.layout.offset(index)
     }
 
     fn is_empty(&self) -> bool {
@@ -753,11 +757,15 @@ pub struct UncheckedNdTensor<T, S: AsRef<[T]>, const N: usize> {
 }
 
 impl<T, S: AsRef<[T]>, const N: usize> Layout for UncheckedNdTensor<T, S, N> {
-    type Index<'a> = [usize; N] where S: 'a, T: 'a;
+    type Index<'a> = [usize; N];
     type Indices = NdIndices<N>;
 
     fn ndim(&self) -> usize {
         N
+    }
+
+    fn offset(&self, index: [usize; N]) -> usize {
+        self.base.layout.offset_unchecked(index)
     }
 
     fn len(&self) -> usize {

--- a/rten-tensor/src/tensor.rs
+++ b/rten-tensor/src/tensor.rs
@@ -372,7 +372,7 @@ impl<'a, T> TensorView<'a, T> {
 
     #[inline]
     fn get<I: AsRef<[usize]>>(&self, index: I) -> Option<&'a T> {
-        let offset = self.layout.try_offset(index)?;
+        let offset = self.layout.try_offset(index.as_ref())?;
         Some(&self.data[offset])
     }
 
@@ -494,8 +494,8 @@ impl<T, S: AsRef<[T]>> Layout for TensorBase<T, S> {
         self.layout.ndim()
     }
 
-    fn offset(&self, index: &[usize]) -> usize {
-        self.layout.offset(index)
+    fn try_offset(&self, index: &[usize]) -> Option<usize> {
+        self.layout.try_offset(index)
     }
 
     /// Returns the number of elements in the array.
@@ -634,7 +634,7 @@ impl<T, S: AsRef<[T]> + AsMut<[T]>> TensorBase<T, S> {
     /// bounds in any dimension.
     #[inline]
     pub fn get_mut<I: AsRef<[usize]>>(&mut self, index: I) -> Option<&mut T> {
-        let offset = self.layout.try_offset(index)?;
+        let offset = self.layout.try_offset(index.as_ref())?;
         Some(&mut self.data.as_mut()[offset])
     }
 

--- a/rten-tensor/src/tensor.rs
+++ b/rten-tensor/src/tensor.rs
@@ -112,7 +112,7 @@ pub trait View: Layout {
         };
         Tensor {
             data,
-            layout: DynLayout::new(self.shape().as_ref()),
+            layout: DynLayout::from_shape(self.shape().as_ref()),
             element_type: PhantomData,
         }
     }
@@ -271,7 +271,7 @@ impl<T, S: AsRef<[T]>> TensorBase<T, S> {
         );
         TensorBase {
             data,
-            layout: DynLayout::new(shape),
+            layout: DynLayout::from_shape(shape),
             element_type: PhantomData,
         }
     }
@@ -483,7 +483,7 @@ impl<'a, T> TensorView<'a, T> {
             let data = self.to_vec();
             TensorBase {
                 data: Cow::Owned(data),
-                layout: DynLayout::new(self.layout().shape()),
+                layout: DynLayout::from_shape(self.layout().shape()),
                 element_type: PhantomData,
             }
         }
@@ -792,7 +792,7 @@ impl<T> Tensor<T> {
         let data = vec![T::default(); n_elts];
         Tensor {
             data,
-            layout: DynLayout::new(shape),
+            layout: DynLayout::from_shape(shape),
             element_type: PhantomData,
         }
     }
@@ -806,7 +806,7 @@ impl<T> Tensor<T> {
         let data = vec![value; n_elts];
         Tensor {
             data,
-            layout: DynLayout::new(shape),
+            layout: DynLayout::from_shape(shape),
             element_type: PhantomData,
         }
     }
@@ -916,7 +916,7 @@ impl<T> Tensor<T> {
         // However there are cases of custom strides where copies could be
         // avoided. See https://pytorch.org/docs/stable/generated/torch.Tensor.view.html.
         self.make_contiguous();
-        self.layout = DynLayout::new(shape);
+        self.layout = DynLayout::from_shape(shape);
     }
 
     /// Like [Tensor::reshape] but consumes self.

--- a/rten-tensor/src/tensor.rs
+++ b/rten-tensor/src/tensor.rs
@@ -888,7 +888,7 @@ impl<T> Tensor<T> {
 
     /// Clone this tensor with a new shape. The new shape must have the same
     /// total number of elements as the existing shape. See `reshape`.
-    pub fn clone_with_shape(&self, shape: &[usize]) -> Tensor<T>
+    pub fn to_shape(&self, shape: &[usize]) -> Tensor<T>
     where
         T: Clone,
     {
@@ -1531,7 +1531,7 @@ mod tests {
     fn test_partial_eq() {
         let x = tensor!([1, 2, 3, 4, 5]);
         let y = x.clone();
-        let z = x.clone_with_shape(&[1, 5]);
+        let z = x.to_shape(&[1, 5]);
 
         // Int tensors are equal if they have the same shape and elements.
         assert_eq!(&x, &y);
@@ -1723,10 +1723,10 @@ mod tests {
     }
 
     #[test]
-    fn test_clone_with_shape() {
+    fn test_to_shape() {
         let mut rng = XorShiftRng::new(1234);
         let x = Tensor::rand(&[10, 5, 3, 7], &mut rng);
-        let y = x.clone_with_shape(&[10, 5, 3 * 7]);
+        let y = x.to_shape(&[10, 5, 3 * 7]);
 
         assert_eq!(y.shape(), &[10, 5, 3 * 7]);
         assert_eq!(y.data(), x.data());

--- a/rten-tensor/src/tensor.rs
+++ b/rten-tensor/src/tensor.rs
@@ -558,12 +558,16 @@ impl<'a, T> TensorView<'a, T> {
 }
 
 impl<T, S: AsRef<[T]>> Layout for TensorBase<T, S> {
-    type Index<'a> = <DynLayout as Layout>::Index<'a> where S: 'a, T: 'a;
+    type Index<'a> = <DynLayout as Layout>::Index<'a>;
     type Indices = <DynLayout as Layout>::Indices;
 
     /// Return the number of dimensions.
     fn ndim(&self) -> usize {
         self.layout.ndim()
+    }
+
+    fn offset(&self, index: &[usize]) -> usize {
+        self.layout.offset(index)
     }
 
     /// Returns the number of elements in the array.

--- a/src/ops/conv.rs
+++ b/src/ops/conv.rs
@@ -646,7 +646,7 @@ pub fn conv_transpose(
         );
 
         col2im(
-            &mut output.nd_slice_mut([n]),
+            &mut output.nd_view_mut::<4>().slice_mut([n]),
             &col2im_mat
                 .nd_view::<2>()
                 .reshaped([in_h, in_w, out_c, k_h, k_w]),

--- a/src/ops/layout.rs
+++ b/src/ops/layout.rs
@@ -607,7 +607,7 @@ mod tests {
         // Reshape with an unspecified (-1) dim and nonzero-length input
         let input = Tensor::from_data(&[2, 2], vec![-0.5, 0.5, 3.0, -5.5]);
         let shape = ndtensor!([1, -1, 2]);
-        let expected = input.clone_with_shape(&[1, 2, 2]);
+        let expected = input.to_shape(&[1, 2, 2]);
         let result = reshape(input.view(), &shape.view(), false /* allow_zero */).unwrap();
         expect_equal(&result, &expected)?;
 
@@ -620,7 +620,7 @@ mod tests {
             false, /* allow_zero */
         )
         .unwrap();
-        let expected = zero_sized_input.clone_with_shape(&[100, 0]);
+        let expected = zero_sized_input.to_shape(&[100, 0]);
         expect_equal(&result, &expected)?;
 
         Ok(())
@@ -632,14 +632,14 @@ mod tests {
         // size should be copied.
         let input = Tensor::from_data(&[1, 1, 4], vec![-0.5, 0.5, 3.0, -5.5]);
         let shape = ndtensor!([-1, 0]);
-        let expected = input.clone_with_shape(&[4, 1]);
+        let expected = input.to_shape(&[4, 1]);
         let result = reshape(input.view(), &shape.view(), false /* allow_zero */).unwrap();
         expect_equal(&result, &expected)?;
 
         // Case where copied input dim is also zero.
         let input = Tensor::<f32>::from_data(&[0], vec![]);
         let shape = ndtensor!([0]);
-        let expected = input.clone_with_shape(&[0]);
+        let expected = input.to_shape(&[0]);
         let result = reshape(input.view(), &shape.view(), false /* allow_zero */).unwrap();
         expect_equal(&result, &expected)?;
 
@@ -658,7 +658,7 @@ mod tests {
         let input = Tensor::<f32>::from_data(&[0, 0, 10], vec![]);
         let shape = ndtensor!([10, 0, 0]);
         let result = reshape(input.view(), &shape.view(), true /* allow_zero */).unwrap();
-        let expected = input.clone_with_shape(&[10, 0, 0]);
+        let expected = input.to_shape(&[10, 0, 0]);
         expect_equal(&result, &expected)?;
 
         Ok(())
@@ -698,7 +698,7 @@ mod tests {
     fn test_reshape_in_place() {
         let mut input = Tensor::from_data(&[2, 2], vec![-0.5, 0.5, 3.0, -5.5]);
         let shape = ndtensor!([4]);
-        let expected = input.clone_with_shape(&[4]);
+        let expected = input.to_shape(&[4]);
         reshape_in_place(&mut input, &shape.view(), false /* allow_zero */).unwrap();
         assert_eq!(&input, &expected);
     }
@@ -707,7 +707,7 @@ mod tests {
     fn test_reshape_op() -> Result<(), Box<dyn Error>> {
         let input = Tensor::from_data(&[2, 2], vec![-0.5, 0.5, 3.0, -5.5]);
         let shape = Tensor::from_data(&[1], vec![4]);
-        let expected = input.clone_with_shape(&[4]);
+        let expected = input.to_shape(&[4]);
 
         let op = Reshape { allow_zero: false };
         let result = op

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -146,11 +146,15 @@ impl<'a> Input<'a> {
 }
 
 impl<'a> Layout for Input<'a> {
-    type Index<'b> = <DynLayout as Layout>::Index<'b> where Self: 'b;
+    type Index<'b> = <DynLayout as Layout>::Index<'b>;
     type Indices = <DynLayout as Layout>::Indices;
 
     fn ndim(&self) -> usize {
         self.layout().ndim()
+    }
+
+    fn offset(&self, index: Self::Index<'_>) -> usize {
+        self.layout().offset(index)
     }
 
     fn len(&self) -> usize {
@@ -310,6 +314,10 @@ impl Layout for Output {
 
     fn ndim(&self) -> usize {
         self.layout().ndim()
+    }
+
+    fn offset(&self, index: Self::Index<'_>) -> usize {
+        self.layout().offset(index)
     }
 
     fn len(&self) -> usize {

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -153,8 +153,8 @@ impl<'a> Layout for Input<'a> {
         self.layout().ndim()
     }
 
-    fn offset(&self, index: Self::Index<'_>) -> usize {
-        self.layout().offset(index)
+    fn try_offset(&self, index: Self::Index<'_>) -> Option<usize> {
+        self.layout().try_offset(index)
     }
 
     fn len(&self) -> usize {
@@ -316,8 +316,8 @@ impl Layout for Output {
         self.layout().ndim()
     }
 
-    fn offset(&self, index: Self::Index<'_>) -> usize {
-        self.layout().offset(index)
+    fn try_offset(&self, index: Self::Index<'_>) -> Option<usize> {
+        self.layout().try_offset(index)
     }
 
     fn len(&self) -> usize {

--- a/src/ops/norm.rs
+++ b/src/ops/norm.rs
@@ -20,6 +20,8 @@ pub fn batch_norm_in_place(
     epsilon: f32,
 ) -> Result<(), OpError> {
     let [batch, chans, in_h, in_w] = check_dims!(input, 4, "NCHW");
+    let mut input = input.nd_view_mut::<4>();
+
     for n in 0..batch {
         for c in 0..chans {
             let chan_mean = mean[[c]];
@@ -27,7 +29,7 @@ pub fn batch_norm_in_place(
             let chan_scale = scale[[c]];
             let chan_bias = bias[[c]];
 
-            let mut out_view = input.nd_slice_mut([n, c]);
+            let mut out_view = input.slice_mut([n, c]);
             let mut out_view = out_view.unchecked_mut();
 
             // The batch norm formula, from the ONNX spec, is:

--- a/src/ops/pooling.rs
+++ b/src/ops/pooling.rs
@@ -2,7 +2,7 @@ use std::iter::zip;
 
 use rayon::prelude::*;
 use rten_tensor::prelude::*;
-use rten_tensor::{NdTensorView, NdTensorViewMut, Tensor, TensorView};
+use rten_tensor::{NdTensor, NdTensorView, NdTensorViewMut, Tensor, TensorView};
 
 use crate::check_dims;
 use crate::gemm::div_ceil;
@@ -104,14 +104,14 @@ pub fn average_pool(
     let [kernel_h, kernel_w] = kernel_size;
     let [stride_h, stride_w] = strides;
 
-    let mut output = Tensor::zeros(&[batch, in_c, out_h, out_w]);
-    let input = input.view();
+    let mut output = NdTensor::zeros([batch, in_c, out_h, out_w]);
+    let input = input.nd_view::<4>();
 
     for n in 0..batch {
         for chan in 0..in_c {
-            let mut out_view = output.nd_slice_mut([n, chan]);
+            let mut out_view = output.slice_mut([n, chan]);
             let mut out_view = out_view.unchecked_mut();
-            let in_view = input.nd_slice([n, chan]).unchecked();
+            let in_view = input.slice([n, chan]).unchecked();
 
             for out_y in 0..out_h {
                 for out_x in 0..out_w {
@@ -140,7 +140,7 @@ pub fn average_pool(
         }
     }
 
-    Ok(output)
+    Ok(output.into_dyn())
 }
 
 #[derive(Debug)]

--- a/src/ops/reduce.rs
+++ b/src/ops/reduce.rs
@@ -849,7 +849,7 @@ mod tests {
         expect_equal(&result, &expected)?;
 
         let result = reduce_l2(input.view(), Some(&[2]), true /* keep_dims */).unwrap();
-        let expected = expected.clone_with_shape(&[3, 2, 1]);
+        let expected = expected.to_shape(&[3, 2, 1]);
         expect_equal(&result, &expected)?;
 
         Ok(())


### PR DESCRIPTION
This PR contains some preparation for unifying the `TensorBase` and `NdTensorBase` structs, in order to enforce a more consistent API between them.

There are also some small API changes to the existing APIs of `NdLayout`/`DynLayout` and `TensorBase`/`NdTensorBase` to prepare for a unified API, including some removal of APIs that are no longer used internally.