### PR TITLE
Add LayerNormalization operator, Depth Anything example

### DIFF
--- a/rten-examples/Cargo.toml
+++ b/rten-examples/Cargo.toml
@@ -43,6 +43,10 @@ path = "src/imagenet.rs"
 name = "yolo"
 path = "src/yolo.rs"
 
+[[bin]]
+name = "depth_anything"
+path = "src/depth_anything.rs"
+
 # Text
 [[bin]]
 name = "bert_qa"

--- a/rten-examples/README.md
+++ b/rten-examples/README.md
@@ -53,6 +53,7 @@ The examples have been chosen to cover common tasks and popular models.
   This example works with a wide variety of models, such as ResNet, MobileNet,
   ConvNeXt, ViT.
 - **deeplab** - Semantic segmentation of images using [DeepLabv3](https://arxiv.org/abs/1706.05587)
+- **depth_anything** - Monocular depth estimation using [Depth Anything](https://github.com/LiheYoung/Depth-Anything)
 - **detr** - Object detection using [DETR](https://research.facebook.com/publications/end-to-end-object-detection-with-transformers/)
 - **yolo** - Object detection using [YOLO v8](https://github.com/ultralytics/ultralytics)
 

--- a/rten-examples/src/depth_anything.rs
+++ b/rten-examples/src/depth_anything.rs
@@ -1,0 +1,113 @@
+use std::collections::VecDeque;
+use std::error::Error;
+use std::fs;
+
+use rten::{FloatOperators, Model};
+use rten_imageio::{normalize_image, read_image, write_image};
+use rten_tensor::prelude::*;
+use rten_tensor::{NdTensor, Tensor};
+
+struct Args {
+    model: String,
+    image: String,
+    output: String,
+}
+
+fn parse_args() -> Result<Args, lexopt::Error> {
+    use lexopt::prelude::*;
+
+    let mut values = VecDeque::new();
+    let mut parser = lexopt::Parser::from_env();
+
+    while let Some(arg) = parser.next()? {
+        match arg {
+            Value(val) => values.push_back(val.string()?),
+            Long("help") => {
+                println!(
+                    "Perform monocular depth estimation on an image.
+
+Usage: {bin_name} <model> <image> [<output>]
+
+Args:
+
+  <model> - Input Depth Anything model
+  <image> - Image to process
+  <output> - Path to save depth image to. Defaults to \"depth-map.png\".
+",
+                    bin_name = parser.bin_name().unwrap_or("deeplab")
+                );
+                std::process::exit(0);
+            }
+            _ => return Err(arg.unexpected()),
+        }
+    }
+
+    let model = values.pop_front().ok_or("missing `model` arg")?;
+    let image = values.pop_front().ok_or("missing `image` arg")?;
+    let output = values.pop_front().unwrap_or("depth-map.png".into());
+
+    let args = Args {
+        image,
+        model,
+        output,
+    };
+
+    Ok(args)
+}
+
+/// Perform monocular depth estimation using [Depth Anything][depth_anything].
+///
+/// The ONNX models can be obtained from
+/// https://github.com/fabio-sim/Depth-Anything-ONNX. See the
+/// [releases](https://github.com/fabio-sim/Depth-Anything-ONNX/releases) page
+/// for pre-trained model links. The small ("vits") model is recommended for
+/// CPU inference.
+///
+/// After downloading the model, it can be run on an image using:
+///
+/// ```
+/// tools/convert-onnx.py depth_anything.onnx
+/// cargo run --release --bin depth_anything depth_anything.rten image.jpg
+/// ```
+///
+/// This will generate a depth map as `depth-map.png`.
+///
+/// [depth_anything]: <https://github.com/LiheYoung/Depth-Anything>
+fn main() -> Result<(), Box<dyn Error>> {
+    let args = parse_args()?;
+    let model_bytes = fs::read(args.model)?;
+    let model = Model::load(&model_bytes)?;
+
+    let mut image: Tensor = read_image(&args.image)?.into();
+    let [_, orig_height, orig_width] = image.shape().try_into()?;
+    normalize_image(image.nd_view_mut());
+    image.insert_axis(0); // Add batch dim
+
+    // Input size taken from README in https://github.com/fabio-sim/Depth-Anything-ONNX.
+    let [input_h, input_w] = [518, 518];
+    let image = image.resize_image([input_h, input_w])?;
+
+    // Run model to estimate depth for each pixel.
+    // Generates a (batch, depth, height, width) tensor, where `depth` == 1.
+    let mut output: NdTensor<f32, 4> = model.run_one(image.view().into(), None)?.try_into()?;
+
+    // Normalize depth values to be in the range [0, 1].
+    let min = output
+        .reduce_min(None, false /* keep_dims */)?
+        .item()
+        .copied()
+        .unwrap();
+    let max = output
+        .reduce_max(None, false /* keep_dims */)?
+        .item()
+        .copied()
+        .unwrap();
+    output.apply(|x| (x - min) / (max - min));
+
+    // Resize output map back to original input size and write to file.
+    let resized = output.resize_image([orig_height, orig_width])?;
+    let resized = resized.slice::<3, _>(0);
+    write_image(&args.output, resized)?;
+
+    Ok(())
+}

--- a/src/model.rs
+++ b/src/model.rs
@@ -854,6 +854,7 @@ fn read_resize_op(node: &OperatorNode) -> ReadOpResult {
     let coord_mode = match attrs.coord_mode() {
         sg::CoordTransformMode::Asymmetric => CoordTransformMode::Asymmetric,
         sg::CoordTransformMode::HalfPixel => CoordTransformMode::HalfPixel,
+        sg::CoordTransformMode::AlignCorners => CoordTransformMode::AlignCorners,
         _ => CoordTransformMode::default(),
     };
 

--- a/src/model_builder.rs
+++ b/src/model_builder.rs
@@ -8,10 +8,10 @@ use crate::graph::Dimension;
 use crate::ops::{
     ArgMax, ArgMin, AveragePool, BatchNormalization, BoxOrder, Cast, Concat, ConstantOfShape, Conv,
     ConvTranspose, CoordTransformMode, DataType, Flatten, Gather, GatherElements, Gemm,
-    HardSigmoid, InstanceNormalization, LeakyRelu, LogSoftmax, MaxPool, Mod, NearestMode,
-    NonMaxSuppression, OneHot, Padding, ReduceMax, ReduceMean, ReduceMin, ReduceProd, ReduceSum,
-    Reshape, Resize, ResizeMode, Scalar, ScatterElements, ScatterReduction, Softmax, Split, TopK,
-    Transpose, Trilu,
+    HardSigmoid, InstanceNormalization, LayerNormalization, LeakyRelu, LogSoftmax, MaxPool, Mod,
+    NearestMode, NonMaxSuppression, OneHot, Padding, ReduceMax, ReduceMean, ReduceMin, ReduceProd,
+    ReduceSum, Reshape, Resize, ResizeMode, Scalar, ScatterElements, ScatterReduction, Softmax,
+    Split, TopK, Transpose, Trilu,
 };
 use crate::schema_generated as sg;
 
@@ -52,6 +52,7 @@ pub enum OpType {
     HardSwish,
     Identity,
     InstanceNormalization(InstanceNormalization),
+    LayerNormalization(LayerNormalization),
     LeakyRelu(LeakyRelu),
     Less,
     LessOrEqual,
@@ -469,6 +470,14 @@ impl<'a> ModelBuilder<'a> {
                 InstanceNormalization,
                 BatchNormalizationAttrs,
                 sg::BatchNormalizationAttrsArgs {
+                    epsilon: args.epsilon.unwrap_or(1e-5)
+                }
+            ),
+            OpType::LayerNormalization(args) => op_with_attrs!(
+                LayerNormalization,
+                LayerNormalizationAttrs,
+                sg::LayerNormalizationAttrsArgs {
+                    axis: args.axis as i32,
                     epsilon: args.epsilon.unwrap_or(1e-5)
                 }
             ),

--- a/src/model_builder.rs
+++ b/src/model_builder.rs
@@ -574,6 +574,7 @@ impl<'a> ModelBuilder<'a> {
                 let coord_mode = match args.coord_mode {
                     CoordTransformMode::Asymmetric => sg::CoordTransformMode::Asymmetric,
                     CoordTransformMode::HalfPixel => sg::CoordTransformMode::HalfPixel,
+                    CoordTransformMode::AlignCorners => sg::CoordTransformMode::AlignCorners,
                 };
                 let nearest_mode = match args.nearest_mode {
                     NearestMode::Ceil => sg::NearestMode::Ceil,

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -65,8 +65,8 @@ pub use layout::{
 pub use matmul::{gemm_op, matmul, Gemm, MatMul};
 pub use non_max_suppression::{non_max_suppression, BoxOrder, NonMaxSuppression};
 pub use norm::{
-    batch_norm, batch_norm_in_place, instance_normalization, log_softmax, softmax,
-    BatchNormalization, InstanceNormalization, LogSoftmax, Softmax,
+    batch_norm, batch_norm_in_place, instance_normalization, layer_normalization, log_softmax,
+    softmax, BatchNormalization, InstanceNormalization, LayerNormalization, LogSoftmax, Softmax,
 };
 pub use pad::{pad, Pad};
 pub use pooling::{

--- a/src/ops/operators.rs
+++ b/src/ops/operators.rs
@@ -6,7 +6,8 @@ use rten_tensor::{DynLayout, NdLayout, NdTensorView, Tensor, TensorBase, TensorV
 use crate::number::{Identities, IsInt};
 use crate::ops::OpError;
 use crate::ops::{
-    arg_max, div, matmul, mul, pad, reduce_l2, reduce_mean, resize_image, softmax, topk,
+    arg_max, div, matmul, mul, pad, reduce_l2, reduce_max, reduce_mean, reduce_min, resize_image,
+    softmax, topk,
 };
 
 /// Trait which exposes ONNX operators as methods of tensors.
@@ -61,7 +62,9 @@ pub trait FloatOperators {
     fn matmul(&self, other: TensorView) -> Result<Tensor, OpError>;
 
     fn reduce_l2(&self, axes: Option<&[i32]>, keep_dims: bool) -> Result<Tensor, OpError>;
+    fn reduce_max(&self, axes: Option<&[i32]>, keep_dims: bool) -> Result<Tensor, OpError>;
     fn reduce_mean(&self, axes: Option<&[i32]>, keep_dims: bool) -> Result<Tensor, OpError>;
+    fn reduce_min(&self, axes: Option<&[i32]>, keep_dims: bool) -> Result<Tensor, OpError>;
 
     /// Resize an NCHW image tensor to a given `[height, width]` using bilinear
     /// interpolation.
@@ -180,6 +183,14 @@ impl<S: AsRef<[f32]>> FloatOperators for TensorBase<f32, S, DynLayout> {
         reduce_l2(self.view(), axes, keep_dims)
     }
 
+    fn reduce_max(&self, axes: Option<&[i32]>, keep_dims: bool) -> Result<Tensor, OpError> {
+        reduce_max(self.view(), axes, keep_dims)
+    }
+
+    fn reduce_min(&self, axes: Option<&[i32]>, keep_dims: bool) -> Result<Tensor, OpError> {
+        reduce_min(self.view(), axes, keep_dims)
+    }
+
     fn reduce_mean(&self, axes: Option<&[i32]>, keep_dims: bool) -> Result<Tensor, OpError> {
         reduce_mean(self.view(), axes, keep_dims)
     }
@@ -200,6 +211,14 @@ impl<S: AsRef<[f32]>, const N: usize> FloatOperators for TensorBase<f32, S, NdLa
 
     fn reduce_l2(&self, axes: Option<&[i32]>, keep_dims: bool) -> Result<Tensor, OpError> {
         reduce_l2(self.as_dyn(), axes, keep_dims)
+    }
+
+    fn reduce_max(&self, axes: Option<&[i32]>, keep_dims: bool) -> Result<Tensor, OpError> {
+        reduce_max(self.as_dyn(), axes, keep_dims)
+    }
+
+    fn reduce_min(&self, axes: Option<&[i32]>, keep_dims: bool) -> Result<Tensor, OpError> {
+        reduce_min(self.as_dyn(), axes, keep_dims)
     }
 
     fn reduce_mean(&self, axes: Option<&[i32]>, keep_dims: bool) -> Result<Tensor, OpError> {

--- a/src/schema.fbs
+++ b/src/schema.fbs
@@ -125,7 +125,8 @@ enum DataType: byte {
 // Coordinate transform modes for Resize operator.
 enum CoordTransformMode: byte {
   HalfPixel,
-  Asymmetric
+  Asymmetric,
+  AlignCorners
 }
 
 // Rounding modes supported by Resize operator when `ResizeMode` is `Nearest`.

--- a/src/schema.fbs
+++ b/src/schema.fbs
@@ -103,6 +103,7 @@ enum OperatorType: byte {
   NonMaxSuppression,
   Sign,
   GatherElements,
+  LayerNormalization
 }
 
 enum RNNDirection: byte {
@@ -174,6 +175,7 @@ union OperatorAttrs {
   TriluAttrs,
   ScatterNDAttrs,
   NonMaxSuppressionAttrs,
+  LayerNormalizationAttrs,
 }
 
 table ArgMaxAttrs {
@@ -237,6 +239,11 @@ table ConvTransposeAttrs {
 
 table FlattenAttrs {
   axis:int;
+}
+
+table LayerNormalizationAttrs {
+  axis:int;
+  epsilon:float;
 }
 
 table GatherAttrs {

--- a/src/schema_generated.rs
+++ b/src/schema_generated.rs
@@ -754,15 +754,16 @@ pub const ENUM_MIN_COORD_TRANSFORM_MODE: i8 = 0;
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
-pub const ENUM_MAX_COORD_TRANSFORM_MODE: i8 = 1;
+pub const ENUM_MAX_COORD_TRANSFORM_MODE: i8 = 2;
 #[deprecated(
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_COORD_TRANSFORM_MODE: [CoordTransformMode; 2] = [
+pub const ENUM_VALUES_COORD_TRANSFORM_MODE: [CoordTransformMode; 3] = [
     CoordTransformMode::HalfPixel,
     CoordTransformMode::Asymmetric,
+    CoordTransformMode::AlignCorners,
 ];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -772,15 +773,18 @@ pub struct CoordTransformMode(pub i8);
 impl CoordTransformMode {
     pub const HalfPixel: Self = Self(0);
     pub const Asymmetric: Self = Self(1);
+    pub const AlignCorners: Self = Self(2);
 
     pub const ENUM_MIN: i8 = 0;
-    pub const ENUM_MAX: i8 = 1;
-    pub const ENUM_VALUES: &'static [Self] = &[Self::HalfPixel, Self::Asymmetric];
+    pub const ENUM_MAX: i8 = 2;
+    pub const ENUM_VALUES: &'static [Self] =
+        &[Self::HalfPixel, Self::Asymmetric, Self::AlignCorners];
     /// Returns the variant's name or "" if unknown.
     pub fn variant_name(self) -> Option<&'static str> {
         match self {
             Self::HalfPixel => Some("HalfPixel"),
             Self::Asymmetric => Some("Asymmetric"),
+            Self::AlignCorners => Some("AlignCorners"),
             _ => None,
         }
     }

--- a/src/schema_generated.rs
+++ b/src/schema_generated.rs
@@ -18,13 +18,13 @@ pub const ENUM_MIN_OPERATOR_TYPE: i8 = 0;
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
-pub const ENUM_MAX_OPERATOR_TYPE: i8 = 92;
+pub const ENUM_MAX_OPERATOR_TYPE: i8 = 93;
 #[deprecated(
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 93] = [
+pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 94] = [
     OperatorType::Add,
     OperatorType::ArgMin,
     OperatorType::ArgMax,
@@ -118,6 +118,7 @@ pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 93] = [
     OperatorType::NonMaxSuppression,
     OperatorType::Sign,
     OperatorType::GatherElements,
+    OperatorType::LayerNormalization,
 ];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -218,9 +219,10 @@ impl OperatorType {
     pub const NonMaxSuppression: Self = Self(90);
     pub const Sign: Self = Self(91);
     pub const GatherElements: Self = Self(92);
+    pub const LayerNormalization: Self = Self(93);
 
     pub const ENUM_MIN: i8 = 0;
-    pub const ENUM_MAX: i8 = 92;
+    pub const ENUM_MAX: i8 = 93;
     pub const ENUM_VALUES: &'static [Self] = &[
         Self::Add,
         Self::ArgMin,
@@ -315,6 +317,7 @@ impl OperatorType {
         Self::NonMaxSuppression,
         Self::Sign,
         Self::GatherElements,
+        Self::LayerNormalization,
     ];
     /// Returns the variant's name or "" if unknown.
     pub fn variant_name(self) -> Option<&'static str> {
@@ -412,6 +415,7 @@ impl OperatorType {
             Self::NonMaxSuppression => Some("NonMaxSuppression"),
             Self::Sign => Some("Sign"),
             Self::GatherElements => Some("GatherElements"),
+            Self::LayerNormalization => Some("LayerNormalization"),
             _ => None,
         }
     }
@@ -1034,13 +1038,13 @@ pub const ENUM_MIN_OPERATOR_ATTRS: u8 = 0;
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
-pub const ENUM_MAX_OPERATOR_ATTRS: u8 = 29;
+pub const ENUM_MAX_OPERATOR_ATTRS: u8 = 30;
 #[deprecated(
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_OPERATOR_ATTRS: [OperatorAttrs; 30] = [
+pub const ENUM_VALUES_OPERATOR_ATTRS: [OperatorAttrs; 31] = [
     OperatorAttrs::NONE,
     OperatorAttrs::ArgMaxAttrs,
     OperatorAttrs::AveragePoolAttrs,
@@ -1071,6 +1075,7 @@ pub const ENUM_VALUES_OPERATOR_ATTRS: [OperatorAttrs; 30] = [
     OperatorAttrs::TriluAttrs,
     OperatorAttrs::ScatterNDAttrs,
     OperatorAttrs::NonMaxSuppressionAttrs,
+    OperatorAttrs::LayerNormalizationAttrs,
 ];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -1108,9 +1113,10 @@ impl OperatorAttrs {
     pub const TriluAttrs: Self = Self(27);
     pub const ScatterNDAttrs: Self = Self(28);
     pub const NonMaxSuppressionAttrs: Self = Self(29);
+    pub const LayerNormalizationAttrs: Self = Self(30);
 
     pub const ENUM_MIN: u8 = 0;
-    pub const ENUM_MAX: u8 = 29;
+    pub const ENUM_MAX: u8 = 30;
     pub const ENUM_VALUES: &'static [Self] = &[
         Self::NONE,
         Self::ArgMaxAttrs,
@@ -1142,6 +1148,7 @@ impl OperatorAttrs {
         Self::TriluAttrs,
         Self::ScatterNDAttrs,
         Self::NonMaxSuppressionAttrs,
+        Self::LayerNormalizationAttrs,
     ];
     /// Returns the variant's name or "" if unknown.
     pub fn variant_name(self) -> Option<&'static str> {
@@ -1176,6 +1183,7 @@ impl OperatorAttrs {
             Self::TriluAttrs => Some("TriluAttrs"),
             Self::ScatterNDAttrs => Some("ScatterNDAttrs"),
             Self::NonMaxSuppressionAttrs => Some("NonMaxSuppressionAttrs"),
+            Self::LayerNormalizationAttrs => Some("LayerNormalizationAttrs"),
             _ => None,
         }
     }
@@ -3184,6 +3192,134 @@ impl core::fmt::Debug for FlattenAttrs<'_> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let mut ds = f.debug_struct("FlattenAttrs");
         ds.field("axis", &self.axis());
+        ds.finish()
+    }
+}
+pub enum LayerNormalizationAttrsOffset {}
+#[derive(Copy, Clone, PartialEq)]
+
+pub struct LayerNormalizationAttrs<'a> {
+    pub _tab: flatbuffers::Table<'a>,
+}
+
+impl<'a> flatbuffers::Follow<'a> for LayerNormalizationAttrs<'a> {
+    type Inner = LayerNormalizationAttrs<'a>;
+    #[inline]
+    unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self {
+            _tab: flatbuffers::Table::new(buf, loc),
+        }
+    }
+}
+
+impl<'a> LayerNormalizationAttrs<'a> {
+    pub const VT_AXIS: flatbuffers::VOffsetT = 4;
+    pub const VT_EPSILON: flatbuffers::VOffsetT = 6;
+
+    #[inline]
+    pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+        LayerNormalizationAttrs { _tab: table }
+    }
+    #[allow(unused_mut)]
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+        args: &'args LayerNormalizationAttrsArgs,
+    ) -> flatbuffers::WIPOffset<LayerNormalizationAttrs<'bldr>> {
+        let mut builder = LayerNormalizationAttrsBuilder::new(_fbb);
+        builder.add_epsilon(args.epsilon);
+        builder.add_axis(args.axis);
+        builder.finish()
+    }
+
+    #[inline]
+    pub fn axis(&self) -> i32 {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab
+                .get::<i32>(LayerNormalizationAttrs::VT_AXIS, Some(0))
+                .unwrap()
+        }
+    }
+    #[inline]
+    pub fn epsilon(&self) -> f32 {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab
+                .get::<f32>(LayerNormalizationAttrs::VT_EPSILON, Some(0.0))
+                .unwrap()
+        }
+    }
+}
+
+impl flatbuffers::Verifiable for LayerNormalizationAttrs<'_> {
+    #[inline]
+    fn run_verifier(
+        v: &mut flatbuffers::Verifier,
+        pos: usize,
+    ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+        use self::flatbuffers::Verifiable;
+        v.visit_table(pos)?
+            .visit_field::<i32>("axis", Self::VT_AXIS, false)?
+            .visit_field::<f32>("epsilon", Self::VT_EPSILON, false)?
+            .finish();
+        Ok(())
+    }
+}
+pub struct LayerNormalizationAttrsArgs {
+    pub axis: i32,
+    pub epsilon: f32,
+}
+impl<'a> Default for LayerNormalizationAttrsArgs {
+    #[inline]
+    fn default() -> Self {
+        LayerNormalizationAttrsArgs {
+            axis: 0,
+            epsilon: 0.0,
+        }
+    }
+}
+
+pub struct LayerNormalizationAttrsBuilder<'a: 'b, 'b> {
+    fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+    start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b> LayerNormalizationAttrsBuilder<'a, 'b> {
+    #[inline]
+    pub fn add_axis(&mut self, axis: i32) {
+        self.fbb_
+            .push_slot::<i32>(LayerNormalizationAttrs::VT_AXIS, axis, 0);
+    }
+    #[inline]
+    pub fn add_epsilon(&mut self, epsilon: f32) {
+        self.fbb_
+            .push_slot::<f32>(LayerNormalizationAttrs::VT_EPSILON, epsilon, 0.0);
+    }
+    #[inline]
+    pub fn new(
+        _fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+    ) -> LayerNormalizationAttrsBuilder<'a, 'b> {
+        let start = _fbb.start_table();
+        LayerNormalizationAttrsBuilder {
+            fbb_: _fbb,
+            start_: start,
+        }
+    }
+    #[inline]
+    pub fn finish(self) -> flatbuffers::WIPOffset<LayerNormalizationAttrs<'a>> {
+        let o = self.fbb_.end_table(self.start_);
+        flatbuffers::WIPOffset::new(o.value())
+    }
+}
+
+impl core::fmt::Debug for LayerNormalizationAttrs<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut ds = f.debug_struct("LayerNormalizationAttrs");
+        ds.field("axis", &self.axis());
+        ds.field("epsilon", &self.epsilon());
         ds.finish()
     }
 }
@@ -6200,6 +6336,21 @@ impl<'a> OperatorNode<'a> {
             None
         }
     }
+
+    #[inline]
+    #[allow(non_snake_case)]
+    pub fn attrs_as_layer_normalization_attrs(&self) -> Option<LayerNormalizationAttrs<'a>> {
+        if self.attrs_type() == OperatorAttrs::LayerNormalizationAttrs {
+            self.attrs().map(|t| {
+                // Safety:
+                // Created from a valid Table for this object
+                // Which contains a valid union in this slot
+                unsafe { LayerNormalizationAttrs::init_from_table(t) }
+            })
+        } else {
+            None
+        }
+    }
 }
 
 impl flatbuffers::Verifiable for OperatorNode<'_> {
@@ -6242,6 +6393,7 @@ impl flatbuffers::Verifiable for OperatorNode<'_> {
           OperatorAttrs::TriluAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<TriluAttrs>>("OperatorAttrs::TriluAttrs", pos),
           OperatorAttrs::ScatterNDAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<ScatterNDAttrs>>("OperatorAttrs::ScatterNDAttrs", pos),
           OperatorAttrs::NonMaxSuppressionAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<NonMaxSuppressionAttrs>>("OperatorAttrs::NonMaxSuppressionAttrs", pos),
+          OperatorAttrs::LayerNormalizationAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<LayerNormalizationAttrs>>("OperatorAttrs::LayerNormalizationAttrs", pos),
           _ => Ok(()),
         }
      })?
@@ -6607,6 +6759,16 @@ impl core::fmt::Debug for OperatorNode<'_> {
             }
             OperatorAttrs::NonMaxSuppressionAttrs => {
                 if let Some(x) = self.attrs_as_non_max_suppression_attrs() {
+                    ds.field("attrs", &x)
+                } else {
+                    ds.field(
+                        "attrs",
+                        &"InvalidFlatbuffer: Union discriminant does not match value.",
+                    )
+                }
+            }
+            OperatorAttrs::LayerNormalizationAttrs => {
+                if let Some(x) = self.attrs_as_layer_normalization_attrs() {
                     ds.field("attrs", &x)
                 } else {
                     ds.field(

--- a/tools/convert-onnx.py
+++ b/tools/convert-onnx.py
@@ -698,6 +698,11 @@ def op_node_from_onnx_operator(
             attrs = sg.BatchNormalizationAttrsT()
             attrs.epsilon = op_reader.get_attr("epsilon", "float", 1e-5)
 
+        case "LayerNormalization":
+            attrs = sg.LayerNormalizationAttrsT()
+            attrs.axis = op_reader.get_attr("axis", "int", -1)
+            attrs.epsilon = op_reader.get_attr("epsilon", "float", 1e-5)
+
         case "LeakyRelu":
             attrs = sg.LeakyReluAttrsT()
             attrs.alpha = op_reader.get_attr("alpha", "float", 0.01)

--- a/tools/schema_generated.py
+++ b/tools/schema_generated.py
@@ -122,6 +122,7 @@ class DataType(object):
 class CoordTransformMode(object):
     HalfPixel = 0
     Asymmetric = 1
+    AlignCorners = 2
 
 
 class NearestMode(object):

--- a/tools/schema_generated.py
+++ b/tools/schema_generated.py
@@ -100,6 +100,7 @@ class OperatorType(object):
     NonMaxSuppression = 90
     Sign = 91
     GatherElements = 92
+    LayerNormalization = 93
 
 
 class RNNDirection(object):
@@ -166,6 +167,7 @@ class OperatorAttrs(object):
     TriluAttrs = 27
     ScatterNDAttrs = 28
     NonMaxSuppressionAttrs = 29
+    LayerNormalizationAttrs = 30
 
 def OperatorAttrsCreator(unionType, table):
     from flatbuffers.table import Table
@@ -229,6 +231,8 @@ def OperatorAttrsCreator(unionType, table):
         return ScatterNDAttrsT.InitFromBuf(table.Bytes, table.Pos)
     if unionType == OperatorAttrs().NonMaxSuppressionAttrs:
         return NonMaxSuppressionAttrsT.InitFromBuf(table.Bytes, table.Pos)
+    if unionType == OperatorAttrs().LayerNormalizationAttrs:
+        return LayerNormalizationAttrsT.InitFromBuf(table.Bytes, table.Pos)
     return None
 
 
@@ -1546,6 +1550,96 @@ class FlattenAttrsT(object):
         FlattenAttrsAddAxis(builder, self.axis)
         flattenAttrs = FlattenAttrsEnd(builder)
         return flattenAttrs
+
+
+class LayerNormalizationAttrs(object):
+    __slots__ = ['_tab']
+
+    @classmethod
+    def GetRootAs(cls, buf, offset=0):
+        n = flatbuffers.encode.Get(flatbuffers.packer.uoffset, buf, offset)
+        x = LayerNormalizationAttrs()
+        x.Init(buf, n + offset)
+        return x
+
+    @classmethod
+    def GetRootAsLayerNormalizationAttrs(cls, buf, offset=0):
+        """This method is deprecated. Please switch to GetRootAs."""
+        return cls.GetRootAs(buf, offset)
+    @classmethod
+    def LayerNormalizationAttrsBufferHasIdentifier(cls, buf, offset, size_prefixed=False):
+        return flatbuffers.util.BufferHasIdentifier(buf, offset, b"\x52\x54\x45\x4E", size_prefixed=size_prefixed)
+
+    # LayerNormalizationAttrs
+    def Init(self, buf, pos):
+        self._tab = flatbuffers.table.Table(buf, pos)
+
+    # LayerNormalizationAttrs
+    def Axis(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
+        if o != 0:
+            return self._tab.Get(flatbuffers.number_types.Int32Flags, o + self._tab.Pos)
+        return 0
+
+    # LayerNormalizationAttrs
+    def Epsilon(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(6))
+        if o != 0:
+            return self._tab.Get(flatbuffers.number_types.Float32Flags, o + self._tab.Pos)
+        return 0.0
+
+def LayerNormalizationAttrsStart(builder):
+    builder.StartObject(2)
+
+def LayerNormalizationAttrsAddAxis(builder, axis):
+    builder.PrependInt32Slot(0, axis, 0)
+
+def LayerNormalizationAttrsAddEpsilon(builder, epsilon):
+    builder.PrependFloat32Slot(1, epsilon, 0.0)
+
+def LayerNormalizationAttrsEnd(builder):
+    return builder.EndObject()
+
+
+
+class LayerNormalizationAttrsT(object):
+
+    # LayerNormalizationAttrsT
+    def __init__(self):
+        self.axis = 0  # type: int
+        self.epsilon = 0.0  # type: float
+
+    @classmethod
+    def InitFromBuf(cls, buf, pos):
+        layerNormalizationAttrs = LayerNormalizationAttrs()
+        layerNormalizationAttrs.Init(buf, pos)
+        return cls.InitFromObj(layerNormalizationAttrs)
+
+    @classmethod
+    def InitFromPackedBuf(cls, buf, pos=0):
+        n = flatbuffers.encode.Get(flatbuffers.packer.uoffset, buf, pos)
+        return cls.InitFromBuf(buf, pos+n)
+
+    @classmethod
+    def InitFromObj(cls, layerNormalizationAttrs):
+        x = LayerNormalizationAttrsT()
+        x._UnPack(layerNormalizationAttrs)
+        return x
+
+    # LayerNormalizationAttrsT
+    def _UnPack(self, layerNormalizationAttrs):
+        if layerNormalizationAttrs is None:
+            return
+        self.axis = layerNormalizationAttrs.Axis()
+        self.epsilon = layerNormalizationAttrs.Epsilon()
+
+    # LayerNormalizationAttrsT
+    def Pack(self, builder):
+        LayerNormalizationAttrsStart(builder)
+        LayerNormalizationAttrsAddAxis(builder, self.axis)
+        LayerNormalizationAttrsAddEpsilon(builder, self.epsilon)
+        layerNormalizationAttrs = LayerNormalizationAttrsEnd(builder)
+        return layerNormalizationAttrs
 
 
 class GatherAttrs(object):
@@ -3637,7 +3731,7 @@ class OperatorNodeT(object):
     def __init__(self):
         self.type = 0  # type: int
         self.attrsType = 0  # type: int
-        self.attrs = None  # type: Union[None, ArgMaxAttrsT, AveragePoolAttrsT, BatchNormalizationAttrsT, CastAttrsT, ConcatAttrsT, ConstantOfShapeAttrsT, ConvAttrsT, ConvTransposeAttrsT, FlattenAttrsT, GatherAttrsT, GemmAttrsT, GRUAttrsT, LeakyReluAttrsT, LSTMAttrsT, MaxPoolAttrsT, ReduceMeanAttrsT, ReshapeAttrsT, ResizeAttrsT, SplitAttrsT, SoftmaxAttrsT, TransposeAttrsT, ModAttrsT, ScatterElementsAttrsT, OneHotAttrsT, TopKAttrsT, HardSigmoidAttrsT, TriluAttrsT, ScatterNDAttrsT, NonMaxSuppressionAttrsT]
+        self.attrs = None  # type: Union[None, ArgMaxAttrsT, AveragePoolAttrsT, BatchNormalizationAttrsT, CastAttrsT, ConcatAttrsT, ConstantOfShapeAttrsT, ConvAttrsT, ConvTransposeAttrsT, FlattenAttrsT, GatherAttrsT, GemmAttrsT, GRUAttrsT, LeakyReluAttrsT, LSTMAttrsT, MaxPoolAttrsT, ReduceMeanAttrsT, ReshapeAttrsT, ResizeAttrsT, SplitAttrsT, SoftmaxAttrsT, TransposeAttrsT, ModAttrsT, ScatterElementsAttrsT, OneHotAttrsT, TopKAttrsT, HardSigmoidAttrsT, TriluAttrsT, ScatterNDAttrsT, NonMaxSuppressionAttrsT, LayerNormalizationAttrsT]
         self.inputs = None  # type: List[int]
         self.outputs = None  # type: List[int]
 


### PR DESCRIPTION
Implement the `LayerNormalization` operator, which is ubiquitous in all transformer models, but was decomposed into other operators by PyTorch until recently (I think).

This was added to get the [Depth Anything](https://github.com/LiheYoung/Depth-Anything) model working. Credit to https://github.com/fabio-sim/Depth-Anything-ONNX for the ONNX conversion.

![depth-anything-rten](https://github.com/robertknight/rten/assets/2458/1892803d-f7c3-46a9-95bc-2a8385e990f0)

TODO:

- [x] Deserialization tests for LayerNormalization
- [x] Tests for `align_corners` impl