### PR TITLE
Add initial support for model metadata in RTen models

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ mod gemm;
 mod graph;
 mod iter_util;
 mod model;
+mod model_metadata;
 mod number;
 mod slice_reductions;
 mod timer;
@@ -44,6 +45,7 @@ pub mod ops;
 
 pub use graph::{Dimension, NodeId, RunOptions};
 pub use model::{DefaultOperatorFactory, Model, ModelLoadError, NodeInfo, OpRegistry};
+pub use model_metadata::ModelMetadata;
 pub use ops::{FloatOperators, Input, Operators, Output};
 pub use timer::Timer;
 pub use timing::TimingSort;

--- a/src/model_metadata.rs
+++ b/src/model_metadata.rs
@@ -1,0 +1,148 @@
+use crate::schema_generated as sg;
+
+/// Metadata for an RTen model.
+///
+/// This provides access to information such as:
+///
+///  - The ONNX model that was used to generate it
+///  - The license
+///  - Details of the training run that produced the model
+///  - Related URLs
+#[derive(Default)]
+pub struct ModelMetadata {
+    onnx_hash: Option<String>,
+    description: Option<String>,
+    license: Option<String>,
+    commit: Option<String>,
+    code_repository: Option<String>,
+    model_repository: Option<String>,
+    run_id: Option<String>,
+    run_url: Option<String>,
+}
+
+impl ModelMetadata {
+    /// Deserialize a ModelMetadata from data in a flatbuffers file.
+    pub(crate) fn deserialize(metadata: sg::Metadata<'_>) -> ModelMetadata {
+        ModelMetadata {
+            onnx_hash: metadata.onnx_hash().map(|s| s.to_string()),
+            description: metadata.description().map(|s| s.to_string()),
+            license: metadata.license().map(|s| s.to_string()),
+            commit: metadata.commit().map(|s| s.to_string()),
+            code_repository: metadata.code_repository().map(|s| s.to_string()),
+            model_repository: metadata.model_repository().map(|s| s.to_string()),
+            run_id: metadata.run_id().map(|s| s.to_string()),
+            run_url: metadata.run_url().map(|s| s.to_string()),
+        }
+    }
+
+    /// Return the SHA-256 hash of the ONNX model used to generate this RTen
+    /// model.
+    pub fn onnx_hash(&self) -> Option<&str> {
+        self.onnx_hash.as_deref()
+    }
+
+    /// Return a short description of what this model does.
+    pub fn description(&self) -> Option<&str> {
+        self.description.as_deref()
+    }
+
+    /// Return the license identifier for this model. It is recommended that
+    /// this be an SPDX identifier.
+    pub fn license(&self) -> Option<&str> {
+        self.license.as_deref()
+    }
+
+    /// Return the commit from the repository referenced by
+    /// [code_repository](ModelMetadata::code_repository) which was used to
+    /// create this model.
+    pub fn commit(&self) -> Option<&str> {
+        self.commit.as_deref()
+    }
+
+    /// Return the URL of the repository (eg. on GitHub) containing the model's
+    /// code.
+    pub fn code_repository(&self) -> Option<&str> {
+        self.code_repository.as_deref()
+    }
+
+    /// Return the URL of the repository (eg. on Hugging Face) where the model
+    /// is hosted.
+    pub fn model_repository(&self) -> Option<&str> {
+        self.model_repository.as_deref()
+    }
+
+    /// Return the ID of the training run that produced this model.
+    ///
+    /// When models are developed using experiment tracking services such as
+    /// Weights and Biases, this enables looking up the training run that
+    /// produced the model.
+    pub fn run_id(&self) -> Option<&str> {
+        self.run_id.as_deref()
+    }
+
+    /// Return a URL for the training run that produced this model.
+    ///
+    /// When models are developed using experiment tracking services such as
+    /// Weights and Biases, this enables looking up the training run that
+    /// produced the model.
+    pub fn run_url(&self) -> Option<&str> {
+        self.run_url.as_deref()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ModelMetadata;
+    use crate::schema_generated as sg;
+    use flatbuffers::FlatBufferBuilder;
+
+    #[test]
+    fn test_model_metadata() {
+        let mut builder = FlatBufferBuilder::with_capacity(1024);
+
+        let onnx_hash = builder.create_string("abc");
+        let description = builder.create_string("A simple model");
+        let license = builder.create_string("BSD-2-Clause");
+        let commit = builder.create_string("def");
+        let code_repository = builder.create_string("https://github.com/robertknight/rten");
+        let model_repository = builder.create_string("https://huggingface.co/robertknight/rten");
+        let run_id = builder.create_string("1234");
+        let run_url =
+            builder.create_string("https://wandb.ai/robertknight/text-detection/runs/1234");
+
+        let mut meta_builder = sg::MetadataBuilder::new(&mut builder);
+        meta_builder.add_onnx_hash(onnx_hash);
+        meta_builder.add_description(description);
+        meta_builder.add_license(license);
+        meta_builder.add_commit(commit);
+        meta_builder.add_code_repository(code_repository);
+        meta_builder.add_model_repository(model_repository);
+        meta_builder.add_run_id(run_id);
+        meta_builder.add_run_url(run_url);
+        let metadata = meta_builder.finish();
+
+        builder.finish_minimal(metadata);
+        let data = builder.finished_data();
+
+        let deserialized_meta = flatbuffers::root::<sg::Metadata>(&data).unwrap();
+        let model_metadata = ModelMetadata::deserialize(deserialized_meta);
+
+        assert_eq!(model_metadata.onnx_hash(), Some("abc"));
+        assert_eq!(model_metadata.description(), Some("A simple model"));
+        assert_eq!(model_metadata.license(), Some("BSD-2-Clause"));
+        assert_eq!(model_metadata.commit(), Some("def"));
+        assert_eq!(
+            model_metadata.code_repository(),
+            Some("https://github.com/robertknight/rten")
+        );
+        assert_eq!(
+            model_metadata.model_repository(),
+            Some("https://huggingface.co/robertknight/rten")
+        );
+        assert_eq!(model_metadata.run_id(), Some("1234"));
+        assert_eq!(
+            model_metadata.run_url(),
+            Some("https://wandb.ai/robertknight/text-detection/runs/1234")
+        );
+    }
+}

--- a/src/schema.fbs
+++ b/src/schema.fbs
@@ -437,9 +437,40 @@ table Graph {
   outputs:[uint];
 }
 
+table Metadata {
+  // SHA-256 hash of the ONNX model that was used as the source for this RTen
+  // model.
+  onnx_hash:string;
+
+  // A short description of what this model does.
+  description:string;
+
+  // Identifier for the license used in this model.
+  //
+  // This should be an SPDX (https://spdx.org/licenses/) identifier for openly
+  // licensed models.
+  license:string;
+
+  // Commit ID for the code that produced this model.
+  commit:string;
+
+  // URL of repository where the model's code is hosted (eg. GitHub).
+  code_repository:string;
+
+  // URL of repository where the model is hosted (eg. Hugging Face).
+  model_repository:string;
+
+  // Identifier for the training run that produced this model.
+  run_id:string;
+
+  // URL of logs etc. for the training run that produced this model.
+  run_url:string;
+}
+
 table Model {
   schema_version:int;
   graph:Graph (required);
+  metadata:Metadata;
 }
 
 root_type Model;

--- a/src/schema_generated.rs
+++ b/src/schema_generated.rs
@@ -7943,6 +7943,292 @@ impl core::fmt::Debug for Graph<'_> {
         ds.finish()
     }
 }
+pub enum MetadataOffset {}
+#[derive(Copy, Clone, PartialEq)]
+
+pub struct Metadata<'a> {
+    pub _tab: flatbuffers::Table<'a>,
+}
+
+impl<'a> flatbuffers::Follow<'a> for Metadata<'a> {
+    type Inner = Metadata<'a>;
+    #[inline]
+    unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self {
+            _tab: flatbuffers::Table::new(buf, loc),
+        }
+    }
+}
+
+impl<'a> Metadata<'a> {
+    pub const VT_ONNX_HASH: flatbuffers::VOffsetT = 4;
+    pub const VT_DESCRIPTION: flatbuffers::VOffsetT = 6;
+    pub const VT_LICENSE: flatbuffers::VOffsetT = 8;
+    pub const VT_COMMIT: flatbuffers::VOffsetT = 10;
+    pub const VT_CODE_REPOSITORY: flatbuffers::VOffsetT = 12;
+    pub const VT_MODEL_REPOSITORY: flatbuffers::VOffsetT = 14;
+    pub const VT_RUN_ID: flatbuffers::VOffsetT = 16;
+    pub const VT_RUN_URL: flatbuffers::VOffsetT = 18;
+
+    #[inline]
+    pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+        Metadata { _tab: table }
+    }
+    #[allow(unused_mut)]
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+        args: &'args MetadataArgs<'args>,
+    ) -> flatbuffers::WIPOffset<Metadata<'bldr>> {
+        let mut builder = MetadataBuilder::new(_fbb);
+        if let Some(x) = args.run_url {
+            builder.add_run_url(x);
+        }
+        if let Some(x) = args.run_id {
+            builder.add_run_id(x);
+        }
+        if let Some(x) = args.model_repository {
+            builder.add_model_repository(x);
+        }
+        if let Some(x) = args.code_repository {
+            builder.add_code_repository(x);
+        }
+        if let Some(x) = args.commit {
+            builder.add_commit(x);
+        }
+        if let Some(x) = args.license {
+            builder.add_license(x);
+        }
+        if let Some(x) = args.description {
+            builder.add_description(x);
+        }
+        if let Some(x) = args.onnx_hash {
+            builder.add_onnx_hash(x);
+        }
+        builder.finish()
+    }
+
+    #[inline]
+    pub fn onnx_hash(&self) -> Option<&'a str> {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab
+                .get::<flatbuffers::ForwardsUOffset<&str>>(Metadata::VT_ONNX_HASH, None)
+        }
+    }
+    #[inline]
+    pub fn description(&self) -> Option<&'a str> {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab
+                .get::<flatbuffers::ForwardsUOffset<&str>>(Metadata::VT_DESCRIPTION, None)
+        }
+    }
+    #[inline]
+    pub fn license(&self) -> Option<&'a str> {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab
+                .get::<flatbuffers::ForwardsUOffset<&str>>(Metadata::VT_LICENSE, None)
+        }
+    }
+    #[inline]
+    pub fn commit(&self) -> Option<&'a str> {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab
+                .get::<flatbuffers::ForwardsUOffset<&str>>(Metadata::VT_COMMIT, None)
+        }
+    }
+    #[inline]
+    pub fn code_repository(&self) -> Option<&'a str> {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab
+                .get::<flatbuffers::ForwardsUOffset<&str>>(Metadata::VT_CODE_REPOSITORY, None)
+        }
+    }
+    #[inline]
+    pub fn model_repository(&self) -> Option<&'a str> {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab
+                .get::<flatbuffers::ForwardsUOffset<&str>>(Metadata::VT_MODEL_REPOSITORY, None)
+        }
+    }
+    #[inline]
+    pub fn run_id(&self) -> Option<&'a str> {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab
+                .get::<flatbuffers::ForwardsUOffset<&str>>(Metadata::VT_RUN_ID, None)
+        }
+    }
+    #[inline]
+    pub fn run_url(&self) -> Option<&'a str> {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab
+                .get::<flatbuffers::ForwardsUOffset<&str>>(Metadata::VT_RUN_URL, None)
+        }
+    }
+}
+
+impl flatbuffers::Verifiable for Metadata<'_> {
+    #[inline]
+    fn run_verifier(
+        v: &mut flatbuffers::Verifier,
+        pos: usize,
+    ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+        use self::flatbuffers::Verifiable;
+        v.visit_table(pos)?
+            .visit_field::<flatbuffers::ForwardsUOffset<&str>>(
+                "onnx_hash",
+                Self::VT_ONNX_HASH,
+                false,
+            )?
+            .visit_field::<flatbuffers::ForwardsUOffset<&str>>(
+                "description",
+                Self::VT_DESCRIPTION,
+                false,
+            )?
+            .visit_field::<flatbuffers::ForwardsUOffset<&str>>("license", Self::VT_LICENSE, false)?
+            .visit_field::<flatbuffers::ForwardsUOffset<&str>>("commit", Self::VT_COMMIT, false)?
+            .visit_field::<flatbuffers::ForwardsUOffset<&str>>(
+                "code_repository",
+                Self::VT_CODE_REPOSITORY,
+                false,
+            )?
+            .visit_field::<flatbuffers::ForwardsUOffset<&str>>(
+                "model_repository",
+                Self::VT_MODEL_REPOSITORY,
+                false,
+            )?
+            .visit_field::<flatbuffers::ForwardsUOffset<&str>>("run_id", Self::VT_RUN_ID, false)?
+            .visit_field::<flatbuffers::ForwardsUOffset<&str>>("run_url", Self::VT_RUN_URL, false)?
+            .finish();
+        Ok(())
+    }
+}
+pub struct MetadataArgs<'a> {
+    pub onnx_hash: Option<flatbuffers::WIPOffset<&'a str>>,
+    pub description: Option<flatbuffers::WIPOffset<&'a str>>,
+    pub license: Option<flatbuffers::WIPOffset<&'a str>>,
+    pub commit: Option<flatbuffers::WIPOffset<&'a str>>,
+    pub code_repository: Option<flatbuffers::WIPOffset<&'a str>>,
+    pub model_repository: Option<flatbuffers::WIPOffset<&'a str>>,
+    pub run_id: Option<flatbuffers::WIPOffset<&'a str>>,
+    pub run_url: Option<flatbuffers::WIPOffset<&'a str>>,
+}
+impl<'a> Default for MetadataArgs<'a> {
+    #[inline]
+    fn default() -> Self {
+        MetadataArgs {
+            onnx_hash: None,
+            description: None,
+            license: None,
+            commit: None,
+            code_repository: None,
+            model_repository: None,
+            run_id: None,
+            run_url: None,
+        }
+    }
+}
+
+pub struct MetadataBuilder<'a: 'b, 'b> {
+    fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+    start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b> MetadataBuilder<'a, 'b> {
+    #[inline]
+    pub fn add_onnx_hash(&mut self, onnx_hash: flatbuffers::WIPOffset<&'b str>) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(Metadata::VT_ONNX_HASH, onnx_hash);
+    }
+    #[inline]
+    pub fn add_description(&mut self, description: flatbuffers::WIPOffset<&'b str>) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(Metadata::VT_DESCRIPTION, description);
+    }
+    #[inline]
+    pub fn add_license(&mut self, license: flatbuffers::WIPOffset<&'b str>) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(Metadata::VT_LICENSE, license);
+    }
+    #[inline]
+    pub fn add_commit(&mut self, commit: flatbuffers::WIPOffset<&'b str>) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(Metadata::VT_COMMIT, commit);
+    }
+    #[inline]
+    pub fn add_code_repository(&mut self, code_repository: flatbuffers::WIPOffset<&'b str>) {
+        self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(
+            Metadata::VT_CODE_REPOSITORY,
+            code_repository,
+        );
+    }
+    #[inline]
+    pub fn add_model_repository(&mut self, model_repository: flatbuffers::WIPOffset<&'b str>) {
+        self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(
+            Metadata::VT_MODEL_REPOSITORY,
+            model_repository,
+        );
+    }
+    #[inline]
+    pub fn add_run_id(&mut self, run_id: flatbuffers::WIPOffset<&'b str>) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(Metadata::VT_RUN_ID, run_id);
+    }
+    #[inline]
+    pub fn add_run_url(&mut self, run_url: flatbuffers::WIPOffset<&'b str>) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(Metadata::VT_RUN_URL, run_url);
+    }
+    #[inline]
+    pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> MetadataBuilder<'a, 'b> {
+        let start = _fbb.start_table();
+        MetadataBuilder {
+            fbb_: _fbb,
+            start_: start,
+        }
+    }
+    #[inline]
+    pub fn finish(self) -> flatbuffers::WIPOffset<Metadata<'a>> {
+        let o = self.fbb_.end_table(self.start_);
+        flatbuffers::WIPOffset::new(o.value())
+    }
+}
+
+impl core::fmt::Debug for Metadata<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut ds = f.debug_struct("Metadata");
+        ds.field("onnx_hash", &self.onnx_hash());
+        ds.field("description", &self.description());
+        ds.field("license", &self.license());
+        ds.field("commit", &self.commit());
+        ds.field("code_repository", &self.code_repository());
+        ds.field("model_repository", &self.model_repository());
+        ds.field("run_id", &self.run_id());
+        ds.field("run_url", &self.run_url());
+        ds.finish()
+    }
+}
 pub enum ModelOffset {}
 #[derive(Copy, Clone, PartialEq)]
 
@@ -7963,6 +8249,7 @@ impl<'a> flatbuffers::Follow<'a> for Model<'a> {
 impl<'a> Model<'a> {
     pub const VT_SCHEMA_VERSION: flatbuffers::VOffsetT = 4;
     pub const VT_GRAPH: flatbuffers::VOffsetT = 6;
+    pub const VT_METADATA: flatbuffers::VOffsetT = 8;
 
     #[inline]
     pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
@@ -7974,6 +8261,9 @@ impl<'a> Model<'a> {
         args: &'args ModelArgs<'args>,
     ) -> flatbuffers::WIPOffset<Model<'bldr>> {
         let mut builder = ModelBuilder::new(_fbb);
+        if let Some(x) = args.metadata {
+            builder.add_metadata(x);
+        }
         if let Some(x) = args.graph {
             builder.add_graph(x);
         }
@@ -8003,6 +8293,16 @@ impl<'a> Model<'a> {
                 .unwrap()
         }
     }
+    #[inline]
+    pub fn metadata(&self) -> Option<Metadata<'a>> {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab
+                .get::<flatbuffers::ForwardsUOffset<Metadata>>(Model::VT_METADATA, None)
+        }
+    }
 }
 
 impl flatbuffers::Verifiable for Model<'_> {
@@ -8015,6 +8315,11 @@ impl flatbuffers::Verifiable for Model<'_> {
         v.visit_table(pos)?
             .visit_field::<i32>("schema_version", Self::VT_SCHEMA_VERSION, false)?
             .visit_field::<flatbuffers::ForwardsUOffset<Graph>>("graph", Self::VT_GRAPH, true)?
+            .visit_field::<flatbuffers::ForwardsUOffset<Metadata>>(
+                "metadata",
+                Self::VT_METADATA,
+                false,
+            )?
             .finish();
         Ok(())
     }
@@ -8022,6 +8327,7 @@ impl flatbuffers::Verifiable for Model<'_> {
 pub struct ModelArgs<'a> {
     pub schema_version: i32,
     pub graph: Option<flatbuffers::WIPOffset<Graph<'a>>>,
+    pub metadata: Option<flatbuffers::WIPOffset<Metadata<'a>>>,
 }
 impl<'a> Default for ModelArgs<'a> {
     #[inline]
@@ -8029,6 +8335,7 @@ impl<'a> Default for ModelArgs<'a> {
         ModelArgs {
             schema_version: 0,
             graph: None, // required field
+            metadata: None,
         }
     }
 }
@@ -8047,6 +8354,11 @@ impl<'a: 'b, 'b> ModelBuilder<'a, 'b> {
     pub fn add_graph(&mut self, graph: flatbuffers::WIPOffset<Graph<'b>>) {
         self.fbb_
             .push_slot_always::<flatbuffers::WIPOffset<Graph>>(Model::VT_GRAPH, graph);
+    }
+    #[inline]
+    pub fn add_metadata(&mut self, metadata: flatbuffers::WIPOffset<Metadata<'b>>) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<Metadata>>(Model::VT_METADATA, metadata);
     }
     #[inline]
     pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> ModelBuilder<'a, 'b> {
@@ -8069,6 +8381,7 @@ impl core::fmt::Debug for Model<'_> {
         let mut ds = f.debug_struct("Model");
         ds.field("schema_version", &self.schema_version());
         ds.field("graph", &self.graph());
+        ds.field("metadata", &self.metadata());
         ds.finish()
     }
 }

--- a/tools/convert-onnx.py
+++ b/tools/convert-onnx.py
@@ -601,7 +601,11 @@ def op_node_from_onnx_operator(
             match to:
                 case TensorProto.DataType.FLOAT:
                     attrs.to = sg.DataType.Float
-                case TensorProto.DataType.BOOL | TensorProto.DataType.INT32 | TensorProto.DataType.INT64:
+                case (
+                    TensorProto.DataType.BOOL
+                    | TensorProto.DataType.INT32
+                    | TensorProto.DataType.INT64
+                ):
                     attrs.to = sg.DataType.Int32
                 case _:
                     raise Exception(f"Unsupported target type for cast {to}")
@@ -769,7 +773,14 @@ def op_node_from_onnx_operator(
             attrs = sg.OneHotAttrsT()
             attrs.axis = op_reader.get_attr("axis", "int", -1)
 
-        case "ReduceL2" | "ReduceMax" | "ReduceMean" | "ReduceMin" | "ReduceProd" | "ReduceSum":
+        case (
+            "ReduceL2"
+            | "ReduceMax"
+            | "ReduceMean"
+            | "ReduceMin"
+            | "ReduceProd"
+            | "ReduceSum"
+        ):
             attrs = sg.ReduceMeanAttrsT()
             attrs.axes = op_reader.get_attr("axes", "ints", None)
             attrs.keepDims = bool(op_reader.get_attr("keepdims", "int", 1))

--- a/tools/schema_generated.py
+++ b/tools/schema_generated.py
@@ -4755,6 +4755,198 @@ class GraphT(object):
         return graph
 
 
+class Metadata(object):
+    __slots__ = ['_tab']
+
+    @classmethod
+    def GetRootAs(cls, buf, offset=0):
+        n = flatbuffers.encode.Get(flatbuffers.packer.uoffset, buf, offset)
+        x = Metadata()
+        x.Init(buf, n + offset)
+        return x
+
+    @classmethod
+    def GetRootAsMetadata(cls, buf, offset=0):
+        """This method is deprecated. Please switch to GetRootAs."""
+        return cls.GetRootAs(buf, offset)
+    @classmethod
+    def MetadataBufferHasIdentifier(cls, buf, offset, size_prefixed=False):
+        return flatbuffers.util.BufferHasIdentifier(buf, offset, b"\x52\x54\x45\x4E", size_prefixed=size_prefixed)
+
+    # Metadata
+    def Init(self, buf, pos):
+        self._tab = flatbuffers.table.Table(buf, pos)
+
+    # Metadata
+    def OnnxHash(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
+        if o != 0:
+            return self._tab.String(o + self._tab.Pos)
+        return None
+
+    # Metadata
+    def Description(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(6))
+        if o != 0:
+            return self._tab.String(o + self._tab.Pos)
+        return None
+
+    # Metadata
+    def License(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(8))
+        if o != 0:
+            return self._tab.String(o + self._tab.Pos)
+        return None
+
+    # Metadata
+    def Commit(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(10))
+        if o != 0:
+            return self._tab.String(o + self._tab.Pos)
+        return None
+
+    # Metadata
+    def CodeRepository(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(12))
+        if o != 0:
+            return self._tab.String(o + self._tab.Pos)
+        return None
+
+    # Metadata
+    def ModelRepository(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(14))
+        if o != 0:
+            return self._tab.String(o + self._tab.Pos)
+        return None
+
+    # Metadata
+    def RunId(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(16))
+        if o != 0:
+            return self._tab.String(o + self._tab.Pos)
+        return None
+
+    # Metadata
+    def RunUrl(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(18))
+        if o != 0:
+            return self._tab.String(o + self._tab.Pos)
+        return None
+
+def MetadataStart(builder):
+    builder.StartObject(8)
+
+def MetadataAddOnnxHash(builder, onnxHash):
+    builder.PrependUOffsetTRelativeSlot(0, flatbuffers.number_types.UOffsetTFlags.py_type(onnxHash), 0)
+
+def MetadataAddDescription(builder, description):
+    builder.PrependUOffsetTRelativeSlot(1, flatbuffers.number_types.UOffsetTFlags.py_type(description), 0)
+
+def MetadataAddLicense(builder, license):
+    builder.PrependUOffsetTRelativeSlot(2, flatbuffers.number_types.UOffsetTFlags.py_type(license), 0)
+
+def MetadataAddCommit(builder, commit):
+    builder.PrependUOffsetTRelativeSlot(3, flatbuffers.number_types.UOffsetTFlags.py_type(commit), 0)
+
+def MetadataAddCodeRepository(builder, codeRepository):
+    builder.PrependUOffsetTRelativeSlot(4, flatbuffers.number_types.UOffsetTFlags.py_type(codeRepository), 0)
+
+def MetadataAddModelRepository(builder, modelRepository):
+    builder.PrependUOffsetTRelativeSlot(5, flatbuffers.number_types.UOffsetTFlags.py_type(modelRepository), 0)
+
+def MetadataAddRunId(builder, runId):
+    builder.PrependUOffsetTRelativeSlot(6, flatbuffers.number_types.UOffsetTFlags.py_type(runId), 0)
+
+def MetadataAddRunUrl(builder, runUrl):
+    builder.PrependUOffsetTRelativeSlot(7, flatbuffers.number_types.UOffsetTFlags.py_type(runUrl), 0)
+
+def MetadataEnd(builder):
+    return builder.EndObject()
+
+
+
+class MetadataT(object):
+
+    # MetadataT
+    def __init__(self):
+        self.onnxHash = None  # type: str
+        self.description = None  # type: str
+        self.license = None  # type: str
+        self.commit = None  # type: str
+        self.codeRepository = None  # type: str
+        self.modelRepository = None  # type: str
+        self.runId = None  # type: str
+        self.runUrl = None  # type: str
+
+    @classmethod
+    def InitFromBuf(cls, buf, pos):
+        metadata = Metadata()
+        metadata.Init(buf, pos)
+        return cls.InitFromObj(metadata)
+
+    @classmethod
+    def InitFromPackedBuf(cls, buf, pos=0):
+        n = flatbuffers.encode.Get(flatbuffers.packer.uoffset, buf, pos)
+        return cls.InitFromBuf(buf, pos+n)
+
+    @classmethod
+    def InitFromObj(cls, metadata):
+        x = MetadataT()
+        x._UnPack(metadata)
+        return x
+
+    # MetadataT
+    def _UnPack(self, metadata):
+        if metadata is None:
+            return
+        self.onnxHash = metadata.OnnxHash()
+        self.description = metadata.Description()
+        self.license = metadata.License()
+        self.commit = metadata.Commit()
+        self.codeRepository = metadata.CodeRepository()
+        self.modelRepository = metadata.ModelRepository()
+        self.runId = metadata.RunId()
+        self.runUrl = metadata.RunUrl()
+
+    # MetadataT
+    def Pack(self, builder):
+        if self.onnxHash is not None:
+            onnxHash = builder.CreateString(self.onnxHash)
+        if self.description is not None:
+            description = builder.CreateString(self.description)
+        if self.license is not None:
+            license = builder.CreateString(self.license)
+        if self.commit is not None:
+            commit = builder.CreateString(self.commit)
+        if self.codeRepository is not None:
+            codeRepository = builder.CreateString(self.codeRepository)
+        if self.modelRepository is not None:
+            modelRepository = builder.CreateString(self.modelRepository)
+        if self.runId is not None:
+            runId = builder.CreateString(self.runId)
+        if self.runUrl is not None:
+            runUrl = builder.CreateString(self.runUrl)
+        MetadataStart(builder)
+        if self.onnxHash is not None:
+            MetadataAddOnnxHash(builder, onnxHash)
+        if self.description is not None:
+            MetadataAddDescription(builder, description)
+        if self.license is not None:
+            MetadataAddLicense(builder, license)
+        if self.commit is not None:
+            MetadataAddCommit(builder, commit)
+        if self.codeRepository is not None:
+            MetadataAddCodeRepository(builder, codeRepository)
+        if self.modelRepository is not None:
+            MetadataAddModelRepository(builder, modelRepository)
+        if self.runId is not None:
+            MetadataAddRunId(builder, runId)
+        if self.runUrl is not None:
+            MetadataAddRunUrl(builder, runUrl)
+        metadata = MetadataEnd(builder)
+        return metadata
+
+
 class Model(object):
     __slots__ = ['_tab']
 
@@ -4794,14 +4986,27 @@ class Model(object):
             return obj
         return None
 
+    # Model
+    def Metadata(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(8))
+        if o != 0:
+            x = self._tab.Indirect(o + self._tab.Pos)
+            obj = Metadata()
+            obj.Init(self._tab.Bytes, x)
+            return obj
+        return None
+
 def ModelStart(builder):
-    builder.StartObject(2)
+    builder.StartObject(3)
 
 def ModelAddSchemaVersion(builder, schemaVersion):
     builder.PrependInt32Slot(0, schemaVersion, 0)
 
 def ModelAddGraph(builder, graph):
     builder.PrependUOffsetTRelativeSlot(1, flatbuffers.number_types.UOffsetTFlags.py_type(graph), 0)
+
+def ModelAddMetadata(builder, metadata):
+    builder.PrependUOffsetTRelativeSlot(2, flatbuffers.number_types.UOffsetTFlags.py_type(metadata), 0)
 
 def ModelEnd(builder):
     return builder.EndObject()
@@ -4818,6 +5023,7 @@ class ModelT(object):
     def __init__(self):
         self.schemaVersion = 0  # type: int
         self.graph = None  # type: Optional[GraphT]
+        self.metadata = None  # type: Optional[MetadataT]
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -4843,15 +5049,21 @@ class ModelT(object):
         self.schemaVersion = model.SchemaVersion()
         if model.Graph() is not None:
             self.graph = GraphT.InitFromObj(model.Graph())
+        if model.Metadata() is not None:
+            self.metadata = MetadataT.InitFromObj(model.Metadata())
 
     # ModelT
     def Pack(self, builder):
         if self.graph is not None:
             graph = self.graph.Pack(builder)
+        if self.metadata is not None:
+            metadata = self.metadata.Pack(builder)
         ModelStart(builder)
         ModelAddSchemaVersion(builder, self.schemaVersion)
         if self.graph is not None:
             ModelAddGraph(builder, graph)
+        if self.metadata is not None:
+            ModelAddMetadata(builder, metadata)
         model = ModelEnd(builder)
         return model
 


### PR DESCRIPTION
Add initial support for storing model metadata in RTen models. Metadata is accessed via `Model::metadata` in Rust and added to converted models by specifying a JSON file containing the metadata when running `convert-onnx.py`, using a new `--metadata` flag.

The ONNX spec is quite bare-bones with respect to standard metadata fields. RTen is a bit more prescriptive about what _should_ be included and the formats of those fields.

Summary of changes:

- Add `Metadata` table to FlatBuffers schema for `.rten` models
- Add support for writing `Metadata` table when converting ONNX models
- Add `Model::metadata` to access model metadata
- Print model metadata when running `rten-cli <model_path>`

Part of https://github.com/robertknight/rten/issues/20