### PR TITLE
Add M1 runner to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,12 +7,16 @@ on:
     - 'ci/**'
 jobs:
   ci:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-14]
+    runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout
       uses: actions/checkout@v3
     - name: Setup rust
       run: rustup target add wasm32-unknown-unknown
+      if: ${{ matrix.os == 'ubuntu-latest' }}
     - name: Cache
       uses: actions/cache@v3
       with:
@@ -25,10 +29,12 @@ jobs:
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Install wasm-bindgen
       run: which wasm-bindgen || cargo install wasm-bindgen-cli
+      if: ${{ matrix.os == 'ubuntu-latest' }}
     - name: Build
       run: cargo build
     - name: WASM build
       run: make wasm
+      if: ${{ matrix.os == 'ubuntu-latest' }}
     - name: Test
       run: make test
     - name: Lint


### PR DESCRIPTION
Add an M1 runner to CI to provide coverage of ARM-specific code.

See https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/

Fixes https://github.com/robertknight/rten/issues/33