### PR TITLE
Add alternative strategy for batched matrix multiplication

### DIFF
--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -7,7 +7,7 @@ pub fn run_bench<F: FnMut()>(trials: usize, description: &str, mut f: F) {
         return;
     }
 
-    let mut times = Vec::new();
+    let mut times = Vec::with_capacity(trials);
     for _ in 0..trials {
         let mut t = Timer::new();
         t.start();


### PR DESCRIPTION
Previously batched matrix multiplication was handled by prepacking one or neither of the inputs, depending on how often each is re-used, and then performing one `gemm` call per matrix in the output shape. This is inefficient if the `A` input has only a small number of rows (as in #50). This PR implements a new strategy for the `MatMul` operator when `A` is a batch and `B` is a single matrix, by reshaping the inputs so that instead of many low-arithmetic intensity `gemm` calls, a single higher-arithmetic intensity call is performed. The output is then reshaped to restore the batch dimensions.

Testing with the benchmark added here and slight variations, the new method is a big improvement when M <= 8, a modest win for M ~ 8-24 and is roughly even, or a very slight win after that. The AVX kernel has MR=6, so this seems as-expected.

See https://github.com/robertknight/rten/issues/50