### PR TITLE
Add Send bound to graph operator node trait object

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -27,7 +27,7 @@ pub struct OperatorNode {
     name: Option<String>,
     inputs: Vec<Option<NodeId>>,
     outputs: Vec<Option<NodeId>>,
-    operator: Box<dyn Operator + Sync>,
+    operator: Box<dyn Operator + Send + Sync>,
 }
 
 pub struct ValueNode {
@@ -250,7 +250,7 @@ impl Graph {
     pub fn add_op(
         &mut self,
         name: Option<&str>,
-        op: Box<dyn Operator + Sync>,
+        op: Box<dyn Operator + Send + Sync>,
         inputs: &[Option<NodeId>],
         outputs: &[Option<NodeId>],
     ) -> NodeId {

--- a/src/model.rs
+++ b/src/model.rs
@@ -245,7 +245,7 @@ fn array_from_iter<const N: usize, T: Default + Copy, I: Iterator<Item = T>>(
 }
 
 /// Result of deserializing an operator node from a model file.
-pub type ReadOpResult = Result<Box<dyn Operator + Sync>, ReadOpError>;
+pub type ReadOpResult = Result<Box<dyn Operator + Send + Sync>, ReadOpError>;
 
 /// A function that deserializes an operator node.
 pub type ReadOpFunction = dyn Fn(&OperatorNode) -> ReadOpResult;


### PR DESCRIPTION
This makes `Model` instances `Send`, which amongst other uses enables storing them in PyO3 classes (that is, structs with the `#[pyclass]` annotation).

Relates to https://github.com/robertknight/ocrs/issues/17.