### PR TITLE
Update rten-convert project metadata and README for PyPI release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,5 @@ __pycache__
 /target
 /rten-convert/rten_convert.egg-info
 
-# Optimized neural network models
-*.model
+# Converted rten ML models
+*.rten

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ classification example:
 git clone https://github.com/robertknight/rten.git
 cd rten
 
-# Install dependencies for model conversion
+# Install model conversion tool
 pip install -e rten-convert
 
 # Install dependencies for Python scripts
@@ -78,13 +78,12 @@ The conversion tool requires Python >= 3.10. To convert an existing ONNX model,
 run:
 
 ```sh
-git clone https://github.com/robertknight/rten.git
-pip install -e rten/rten-convert
-rten-convert your-model.onnx output.rten
+pip install rten-convert
+rten-convert your-model.onnx
 ```
 
-The RTen model format does not yet guarantee long-term backwards compatibility,
-so be aware that you may need to recompile models from ONNX for new releases.
+See the [rten-convert README](rten-convert/) for more information about usage
+and version compatibility.
 
 ## Usage in JavaScript
 

--- a/rten-convert/LICENSE
+++ b/rten-convert/LICENSE
@@ -1,0 +1,25 @@
+Copyright (c) 2023 RTen project contributors.
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/rten-convert/README.md
+++ b/rten-convert/README.md
@@ -1,7 +1,35 @@
-The conversion tool requires Python >= 3.10. To convert an existing ONNX model,
-run:
+# rten-convert
+
+rten-convert converts ONNX models to `.rten` format, for use with the
+[RTen](https://github.com/robertknight/rten) machine learning runtime.
+
+## Installation
+
+The conversion tool requires Python >= 3.10. To install the tool, run:
+
+```sh
+pip install rten-convert
+```
+
+## Usage
+
+```sh
+rten-convert your-model.onnx your-model.rten
+```
+
+The second argument is optional. If omitted the output filename will be the
+input filename with the `.onnx` extension replaced with `.rten`.
+
+## Versioning
+
+The `rten-convert` tool and `rten` library use common version numbering. A
+model produced by `rten-convert` version X can be executed by `rten` version X
+or newer.
+
+## Development
+
+To install this tool from a checkout of the Git repository, run:
 
 ```sh
 pip install -e .
-rten-convert your-model.onnx output.rten
 ```

--- a/rten-convert/pyproject.toml
+++ b/rten-convert/pyproject.toml
@@ -1,8 +1,21 @@
 [project]
 name = "rten-convert"
+description = "Convert ONNX models to .rten format"
 requires-python = ">=3.10"
 version = "0.4.0"
-dependencies = ["flatbuffers", "onnx", "numpy", "setuptools"]
+dependencies = ["flatbuffers", "onnx", "numpy"]
+readme = "README.md"
+classifiers = [
+  "License :: OSI Approved :: MIT License",
+]
 
 [project.scripts]
 rten-convert = "rten_convert.converter:main"
+
+[project.urls]
+Homepage = "https://github.com/robertknight/rten"
+Issues = "https://github.com/robertknight/rten/issues"
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Update READMEs and rten-convert project metadata following the [Python packaging guide](https://packaging.python.org/en/latest/tutorials/packaging-projects/). The current version has now been [released](https://pypi.org/project/rten-convert/) and can be installed with:

```sh
pip install rten-convert
```