### PR TITLE
Add benchmark for vector-matrix product

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,17 +14,14 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-    - name: Setup rust
+    - name: Install Rust wasm toolchain
       run: rustup target add wasm32-unknown-unknown
       if: ${{ matrix.os == 'ubuntu-latest' }}
     - name: Cache
       uses: actions/cache@v3
       with:
         path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
+          ~/.cargo/
           target/
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Install wasm-bindgen

--- a/src/gemm.rs
+++ b/src/gemm.rs
@@ -1460,6 +1460,12 @@ mod tests {
                 n: 128,
                 k: 512,
             },
+            // Vector-matrix. This is common in transformer decoders for example.
+            Case {
+                m: 1,
+                n: 4096,
+                k: 512,
+            },
         ];
 
         println!("Testing kernel {}", GemmExecutor::new().kernel_name());
@@ -1472,6 +1478,10 @@ mod tests {
             // equal efficiency.
             let target_ops: u64 = 512 * 512 * 512 * 1000;
             let iters = target_ops / (m * n * k) as u64;
+
+            // Cap the number of iterations, for cases where the equal-efficiency
+            // assumption is untrue.
+            let iters = iters.min(1000);
 
             let mut rng = XorShiftRng::new(1234);
             let mut result = Tensor::zeros(&[m, n]);


### PR DESCRIPTION
MatMul operations with with shapes like this come up frequently in transformer decoders. This runs at about 1/4 the speed of Accelerate on my Intel i5-1038NG7.

[1] https://gist.github.com/robertknight/3e7bf748b5435657ca671930c30e4ec7