### PR TITLE
Add optimized GEMM implementation for vector-matrix multiplications

### DIFF
--- a/rten-vecmath/src/lib.rs
+++ b/rten-vecmath/src/lib.rs
@@ -19,7 +19,7 @@
 
 mod erf;
 mod exp;
-mod simd_vec;
+pub mod simd_vec;
 mod softmax;
 mod tanh;
 mod ulp;

--- a/rten-vecmath/src/simd_vec.rs
+++ b/rten-vecmath/src/simd_vec.rs
@@ -20,12 +20,18 @@ use crate::MAX_LEN;
 
 /// Trait for SIMD vectors containing 32-bit integers.
 ///
+/// # Safety
+///
+/// The caller must ensure that the SIMD instructions used by a type
+/// implementing this trait are available on the current system.
+///
 /// All functions in this trait are unsafe due to limitations of Rust's
-/// #[target_feature] macro. See
-/// https://rust-lang.github.io/rfcs/2396-target-feature-1.1.html. Also as
+/// `#[target_feature]` macro. See
+/// <https://rust-lang.github.io/rfcs/2396-target-feature-1.1.html>. Also as
 /// a consequence of this, standard operations like add, multiply etc. are
 /// implemented as functions in this trait rather than using the standard
 /// trait from `std::ops`.
+#[allow(clippy::missing_safety_doc)]
 pub trait SimdInt: Copy + Sized {
     /// The number of elements in the SIMD vector.
     const LEN: usize;
@@ -44,6 +50,9 @@ pub trait SimdInt: Copy + Sized {
     }
 
     /// Broadcast `val` to all elements in a new vector.
+    ///
+    /// # Safety
+    /// The caller must ensure SIMD operations on this type are supported.
     unsafe fn splat(val: i32) -> Self;
 
     /// Return a mask indicating whether `self > other`.
@@ -86,12 +95,18 @@ pub trait SimdInt: Copy + Sized {
 
 /// Trait for SIMD vectors containing single-precision floats.
 ///
+/// # Safety
+///
+/// The caller must ensure that the SIMD instructions used by a type
+/// implementing this trait are available on the current system.
+///
 /// All functions in this trait are unsafe due to limitations of Rust's
-/// #[target_feature] macro. See
-/// https://rust-lang.github.io/rfcs/2396-target-feature-1.1.html. Also as
+/// `#[target_feature]` macro. See
+/// <https://rust-lang.github.io/rfcs/2396-target-feature-1.1.html>. Also as
 /// a consequence of this, standard operations like add, multiply etc. are
 /// implemented as functions in this trait rather than using the standard
 /// trait from `std::ops`.
+#[allow(clippy::missing_safety_doc)]
 pub trait SimdFloat: Copy + Sized {
     /// The number of elements in the SIMD vector.
     const LEN: usize;

--- a/rten-vecmath/src/simd_vec.rs
+++ b/rten-vecmath/src/simd_vec.rs
@@ -38,6 +38,7 @@ pub trait SimdInt: Copy + Sized {
     type Mask: Copy;
 
     /// Return a new vector with all elements set to zero.
+    #[inline]
     unsafe fn zero() -> Self {
         Self::splat(0)
     }
@@ -103,21 +104,25 @@ pub trait SimdFloat: Copy + Sized {
     type Mask: Copy;
 
     /// Shorthand for `Self::splat(1.0)`.
+    #[inline]
     unsafe fn one() -> Self {
         Self::splat(1.0)
     }
 
     /// Shorthand for `Self::splat(0.0)`.
+    #[inline]
     unsafe fn zero() -> Self {
         Self::splat(0.0)
     }
 
     /// Compute `-self`.
+    #[inline]
     unsafe fn neg(self) -> Self {
         Self::zero().sub(self)
     }
 
     /// Compute `1. / self`.
+    #[inline]
     unsafe fn reciprocal(self) -> Self {
         Self::one().div(self)
     }
@@ -167,6 +172,7 @@ pub trait SimdFloat: Copy + Sized {
     /// Evaluate a polynomial using Horner's method.
     ///
     /// Computes `self * coeffs[0] + self^2 * coeffs[1] ... self^n * coeffs[N]`
+    #[inline]
     unsafe fn poly_eval(self, coeffs: &[Self]) -> Self {
         let mut y = coeffs[coeffs.len() - 1];
         for i in (0..coeffs.len() - 1).rev() {
@@ -193,6 +199,7 @@ pub trait SimdFloat: Copy + Sized {
 
     /// Reduce the elements in this vector to a single value using `f`, then
     /// return a new vector with the accumulated value broadcast to each lane.
+    #[inline]
     unsafe fn fold_splat<F: Fn(f32, f32) -> f32>(self, accum: f32, f: F) -> Self {
         let mut elements = [accum; MAX_LEN];
         self.store(elements.as_mut_ptr());
@@ -208,18 +215,22 @@ impl SimdInt for i32 {
     type Float = f32;
     type Mask = bool;
 
+    #[inline]
     unsafe fn zero() -> Self {
         0
     }
 
+    #[inline]
     unsafe fn splat(val: i32) -> Self {
         val
     }
 
+    #[inline]
     unsafe fn gt(self, other: Self) -> Self::Mask {
         self > other
     }
 
+    #[inline]
     unsafe fn blend(self, other: Self, mask: Self::Mask) -> Self {
         if !mask {
             self
@@ -228,26 +239,32 @@ impl SimdInt for i32 {
         }
     }
 
+    #[inline]
     unsafe fn add(self, rhs: Self) -> Self {
         self + rhs
     }
 
+    #[inline]
     unsafe fn sub(self, rhs: Self) -> Self {
         self - rhs
     }
 
+    #[inline]
     unsafe fn shl<const COUNT: i32>(self) -> Self {
         self << COUNT
     }
 
+    #[inline]
     unsafe fn reinterpret_as_float(self) -> Self::Float {
         f32::from_bits(self as u32)
     }
 
+    #[inline]
     unsafe fn load(ptr: *const i32) -> Self {
         *ptr
     }
 
+    #[inline]
     unsafe fn store(self, ptr: *mut i32) {
         *ptr = self;
     }
@@ -260,62 +277,77 @@ impl SimdFloat for f32 {
     type Int = i32;
     type Mask = bool;
 
+    #[inline]
     unsafe fn one() -> Self {
         1.
     }
 
+    #[inline]
     unsafe fn zero() -> Self {
         0.
     }
 
+    #[inline]
     unsafe fn splat(val: f32) -> Self {
         val
     }
 
+    #[inline]
     unsafe fn abs(self) -> Self {
         self.abs()
     }
 
+    #[inline]
     unsafe fn mul_add(self, a: Self, b: Self) -> Self {
         (self * a) + b
     }
 
+    #[inline]
     unsafe fn add(self, rhs: Self) -> Self {
         self + rhs
     }
 
+    #[inline]
     unsafe fn sub(self, rhs: Self) -> Self {
         self - rhs
     }
 
+    #[inline]
     unsafe fn to_int_trunc(self) -> Self::Int {
         self as i32
     }
 
+    #[inline]
     unsafe fn mul(self, rhs: Self) -> Self {
         self * rhs
     }
 
+    #[inline]
     unsafe fn div(self, rhs: Self) -> Self {
         self / rhs
     }
 
+    #[inline]
     unsafe fn ge(self, rhs: Self) -> Self::Mask {
         self >= rhs
     }
 
+    #[inline]
     unsafe fn le(self, rhs: Self) -> Self::Mask {
         self <= rhs
     }
 
+    #[inline]
     unsafe fn lt(self, rhs: Self) -> Self::Mask {
         self < rhs
     }
 
+    #[inline]
     unsafe fn max(self, rhs: Self) -> Self {
         f32::max(self, rhs)
     }
 
+    #[inline]
     unsafe fn blend(self, rhs: Self, mask: Self::Mask) -> Self {
         if !mask {
             self
@@ -324,10 +356,12 @@ impl SimdFloat for f32 {
         }
     }
 
+    #[inline]
     unsafe fn load(ptr: *const f32) -> Self {
         *ptr
     }
 
+    #[inline]
     unsafe fn store(self, ptr: *mut f32) {
         *ptr = self;
     }

--- a/rten-vecmath/src/simd_vec/aarch64.rs
+++ b/rten-vecmath/src/simd_vec/aarch64.rs
@@ -13,42 +13,52 @@ impl SimdInt for int32x4_t {
 
     const LEN: usize = 4;
 
+    #[inline]
     unsafe fn zero() -> Self {
         vdupq_n_s32(0)
     }
 
+    #[inline]
     unsafe fn splat(val: i32) -> Self {
         vdupq_n_s32(val)
     }
 
+    #[inline]
     unsafe fn gt(self, other: Self) -> Self::Mask {
         vcgtq_s32(self, other)
     }
 
+    #[inline]
     unsafe fn blend(self, other: Self, mask: Self::Mask) -> Self {
         vbslq_s32(mask, other, self)
     }
 
+    #[inline]
     unsafe fn add(self, rhs: Self) -> Self {
         vaddq_s32(self, rhs)
     }
 
+    #[inline]
     unsafe fn sub(self, rhs: Self) -> Self {
         vsubq_s32(self, rhs)
     }
 
+    #[inline]
     unsafe fn shl<const COUNT: i32>(self) -> Self {
         vshlq_n_s32(self, COUNT)
     }
 
+    #[inline]
     unsafe fn reinterpret_as_float(self) -> Self::Float {
         vreinterpretq_f32_s32(self)
     }
 
+    #[inline]
     unsafe fn load(ptr: *const i32) -> Self {
         vld1q_s32(ptr)
     }
 
+    #[inline]
     unsafe fn store(self, ptr: *mut i32) {
         vst1q_s32(ptr, self)
     }
@@ -60,62 +70,77 @@ impl SimdFloat for float32x4_t {
 
     const LEN: usize = 4;
 
+    #[inline]
     unsafe fn splat(val: f32) -> Self {
         vdupq_n_f32(val)
     }
 
+    #[inline]
     unsafe fn abs(self) -> Self {
         vabsq_f32(self)
     }
 
+    #[inline]
     unsafe fn mul_add(self, a: Self, b: Self) -> Self {
         vfmaq_f32(b, self, a)
     }
 
+    #[inline]
     unsafe fn sub(self, rhs: Self) -> Self {
         vsubq_f32(self, rhs)
     }
 
+    #[inline]
     unsafe fn add(self, rhs: Self) -> Self {
         vaddq_f32(self, rhs)
     }
 
+    #[inline]
     unsafe fn to_int_trunc(self) -> Self::Int {
         vcvtq_s32_f32(self)
     }
 
+    #[inline]
     unsafe fn mul(self, rhs: Self) -> Self {
         vmulq_f32(self, rhs)
     }
 
+    #[inline]
     unsafe fn div(self, rhs: Self) -> Self {
         vdivq_f32(self, rhs)
     }
 
+    #[inline]
     unsafe fn ge(self, rhs: Self) -> Self::Mask {
         vcgeq_f32(self, rhs)
     }
 
+    #[inline]
     unsafe fn le(self, rhs: Self) -> Self::Mask {
         vcleq_f32(self, rhs)
     }
 
+    #[inline]
     unsafe fn lt(self, rhs: Self) -> Self::Mask {
         vcltq_f32(self, rhs)
     }
 
+    #[inline]
     unsafe fn max(self, rhs: Self) -> Self {
         vmaxq_f32(self, rhs)
     }
 
+    #[inline]
     unsafe fn blend(self, other: Self, mask: Self::Mask) -> Self {
         vbslq_f32(mask, other, self)
     }
 
+    #[inline]
     unsafe fn load(ptr: *const f32) -> Self {
         vld1q_f32(ptr)
     }
 
+    #[inline]
     unsafe fn store(self, ptr: *mut f32) {
         vst1q_f32(ptr, self)
     }

--- a/rten-vecmath/src/simd_vec/x86_64.rs
+++ b/rten-vecmath/src/simd_vec/x86_64.rs
@@ -15,54 +15,63 @@ impl SimdInt for __m256i {
 
     const LEN: usize = 8;
 
+    #[inline]
     #[target_feature(enable = "avx2")]
     #[target_feature(enable = "fma")]
     unsafe fn zero() -> Self {
         _mm256_setzero_si256()
     }
 
+    #[inline]
     #[target_feature(enable = "avx2")]
     #[target_feature(enable = "fma")]
     unsafe fn splat(val: i32) -> Self {
         _mm256_set1_epi32(val)
     }
 
+    #[inline]
     #[target_feature(enable = "avx2")]
     #[target_feature(enable = "fma")]
     unsafe fn gt(self, other: Self) -> Self::Mask {
         _mm256_cmpgt_epi32(self, other)
     }
 
+    #[inline]
     #[target_feature(enable = "avx2")]
     #[target_feature(enable = "fma")]
     unsafe fn blend(self, other: Self, mask: Self::Mask) -> Self {
         _mm256_blendv_epi8(self, other, mask)
     }
 
+    #[inline]
     #[target_feature(enable = "avx2")]
     #[target_feature(enable = "fma")]
     unsafe fn add(self, rhs: Self) -> Self {
         _mm256_add_epi32(self, rhs)
     }
 
+    #[inline]
     #[target_feature(enable = "avx2")]
     #[target_feature(enable = "fma")]
     unsafe fn sub(self, rhs: Self) -> Self {
         _mm256_sub_epi32(self, rhs)
     }
 
+    #[inline]
     #[target_feature(enable = "avx2")]
     #[target_feature(enable = "fma")]
     unsafe fn shl<const COUNT: i32>(self) -> Self {
         _mm256_slli_epi32(self, COUNT)
     }
 
+    #[inline]
     #[target_feature(enable = "avx2")]
     #[target_feature(enable = "fma")]
     unsafe fn reinterpret_as_float(self) -> Self::Float {
         _mm256_castsi256_ps(self)
     }
 
+    #[inline]
     #[target_feature(enable = "avx2")]
     #[target_feature(enable = "fma")]
     unsafe fn load(ptr: *const i32) -> Self {
@@ -70,6 +79,7 @@ impl SimdInt for __m256i {
         _mm256_loadu_si256(ptr as *const __m256i)
     }
 
+    #[inline]
     #[target_feature(enable = "avx2")]
     #[target_feature(enable = "fma")]
     unsafe fn store(self, ptr: *mut i32) {
@@ -84,12 +94,14 @@ impl SimdFloat for __m256 {
 
     const LEN: usize = 8;
 
+    #[inline]
     #[target_feature(enable = "avx2")]
     #[target_feature(enable = "fma")]
     unsafe fn splat(val: f32) -> Self {
         _mm256_set1_ps(val)
     }
 
+    #[inline]
     #[target_feature(enable = "avx2")]
     #[target_feature(enable = "fma")]
     unsafe fn abs(self) -> Self {
@@ -98,78 +110,91 @@ impl SimdFloat for __m256 {
         _mm256_andnot_ps(sign_bit, self)
     }
 
+    #[inline]
     #[target_feature(enable = "avx2")]
     #[target_feature(enable = "fma")]
     unsafe fn mul_add(self, a: Self, b: Self) -> Self {
         _mm256_fmadd_ps(self, a, b)
     }
 
+    #[inline]
     #[target_feature(enable = "avx2")]
     #[target_feature(enable = "fma")]
     unsafe fn sub(self, rhs: Self) -> Self {
         _mm256_sub_ps(self, rhs)
     }
 
+    #[inline]
     #[target_feature(enable = "avx2")]
     #[target_feature(enable = "fma")]
     unsafe fn add(self, rhs: Self) -> Self {
         _mm256_add_ps(self, rhs)
     }
 
+    #[inline]
     #[target_feature(enable = "avx2")]
     #[target_feature(enable = "fma")]
     unsafe fn to_int_trunc(self) -> Self::Int {
         _mm256_cvttps_epi32(self)
     }
 
+    #[inline]
     #[target_feature(enable = "avx2")]
     #[target_feature(enable = "fma")]
     unsafe fn mul(self, rhs: Self) -> Self {
         _mm256_mul_ps(self, rhs)
     }
 
+    #[inline]
     #[target_feature(enable = "avx2")]
     #[target_feature(enable = "fma")]
     unsafe fn div(self, rhs: Self) -> Self {
         _mm256_div_ps(self, rhs)
     }
 
+    #[inline]
     #[target_feature(enable = "avx2")]
     #[target_feature(enable = "fma")]
     unsafe fn ge(self, rhs: Self::Mask) -> Self {
         _mm256_cmp_ps(self, rhs, _CMP_GE_OQ)
     }
 
+    #[inline]
     #[target_feature(enable = "avx2")]
     #[target_feature(enable = "fma")]
     unsafe fn le(self, rhs: Self::Mask) -> Self {
         _mm256_cmp_ps(self, rhs, _CMP_LE_OQ)
     }
 
+    #[inline]
     #[target_feature(enable = "avx2")]
     #[target_feature(enable = "fma")]
     unsafe fn lt(self, rhs: Self::Mask) -> Self {
         _mm256_cmp_ps(self, rhs, _CMP_LT_OQ)
     }
 
+    #[inline]
     #[target_feature(enable = "avx2")]
     #[target_feature(enable = "fma")]
     unsafe fn max(self, rhs: Self) -> Self {
         _mm256_max_ps(self, rhs)
     }
 
+    #[inline]
     #[target_feature(enable = "avx2")]
     #[target_feature(enable = "fma")]
     unsafe fn blend(self, rhs: Self, mask: Self::Mask) -> Self {
         _mm256_blendv_ps(self, rhs, mask)
     }
 
+    #[inline]
     #[target_feature(enable = "avx2")]
     #[target_feature(enable = "fma")]
     unsafe fn load(ptr: *const f32) -> Self {
         _mm256_loadu_ps(ptr)
     }
 
+    #[inline]
     #[target_feature(enable = "avx2")]
     #[target_feature(enable = "fma")]
     unsafe fn store(self, ptr: *mut f32) {

--- a/src/gemm.rs
+++ b/src/gemm.rs
@@ -64,7 +64,7 @@ pub fn add_scaled_vector(
         "src and dest vector sizes do not match"
     );
 
-    unroll_loop!(src_els, i, 4, {
+    unroll_loop!(0..src_els, i, 4, {
         unsafe {
             *dest.get_unchecked_mut(i * dest_stride) += *src.get_unchecked(i * src_stride) * scale;
         }

--- a/src/gemm/kernels/aarch64.rs
+++ b/src/gemm/kernels/aarch64.rs
@@ -1,5 +1,8 @@
-use super::Kernel;
+use std::arch::aarch64::float32x4_t;
 
+use rten_tensor::Matrix;
+
+use super::{simd_gemv, Kernel};
 use crate::iter_util::unroll_loop;
 
 #[derive(Default)]
@@ -90,6 +93,10 @@ impl Kernel for ArmNeonKernel {
                 }
             }
         }
+    }
+
+    unsafe fn gemv_kernel(out: &mut [f32], a: &[f32], b: Matrix, alpha: f32, beta: f32) {
+        simd_gemv::<float32x4_t, 2>(out, a, b, alpha, beta);
     }
 }
 

--- a/src/gemm/kernels/aarch64.rs
+++ b/src/gemm/kernels/aarch64.rs
@@ -45,7 +45,7 @@ impl Kernel for ArmNeonKernel {
         let mut tmp = [[vdupq_n_f32(0.); NR_REGS]; MR];
         let mut b_rows = [vdupq_n_f32(0.); NR_REGS];
 
-        unroll_loop!(depth, k, 8, {
+        unroll_loop!(0..depth, k, 8, {
             let a_off = k * MR;
             let b_off = k * NR;
 

--- a/src/iter_util.rs
+++ b/src/iter_util.rs
@@ -136,9 +136,9 @@ impl MaybeParIter for Range<usize> {
 
 #[macro_export]
 macro_rules! unroll_loop {
-    ($count:expr, $loop_var:ident, $factor: literal, $block:tt) => {
-        let mut n = $count;
-        let mut $loop_var = 0;
+    ($range:expr, $loop_var:ident, $factor: literal, $block:tt) => {
+        let mut n = $range.len();
+        let mut $loop_var = $range.start;
         while n >= $factor {
             for _i in 0..$factor {
                 $block;
@@ -225,7 +225,7 @@ mod tests {
     #[test]
     fn test_unroll_loop() {
         let mut items: Vec<i32> = Vec::new();
-        unroll_loop!(10, i, 4, {
+        unroll_loop!(0..10, i, 4, {
             items.push(i);
         });
         assert_eq!(items, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);


### PR DESCRIPTION
When the LHS / "A" matrix argument to a matrix multiplication is a row vector,
use an optimized vector-matrix ("gemv" in BLAS terminology) function which avoids the overhead of
packing, as otherwise packing costs consume most of the execution time.

Vector-matrix multiplications are common in autoregressive transformers,
including LLMs.

Rather than implement the same algorithm separately for each architecture, the
generic SIMD wrappers in rten-vecmath are reused.

Tested on an Intel i5-1038NG7, this improves the performance of the
vector-matrix product in the `bench_gemm` benchmark by ~4x (5 -> 20 GFLOPS).

**TODO:**

- [x] Compare performance on Arm
- [x] Handle `alpha` and `beta` values in the gemv fast-path. These are currently ignored and treated as if they are (1, 1).
- [x] Add tests for various `alpha` / `beta` value combinations