### PR TITLE
Use generic implementation for GEMM microkernel

### DIFF
--- a/rten-vecmath/src/simd_vec.rs
+++ b/rten-vecmath/src/simd_vec.rs
@@ -225,6 +225,18 @@ pub trait SimdFloat: Copy + Sized {
         let reduced = elements.into_iter().fold(accum, f);
         Self::splat(reduced)
     }
+
+    /// Prefetch the cache line containing `data`, for reading.
+    #[inline]
+    unsafe fn prefetch(_data: *const f32) {
+        // Noop
+    }
+
+    /// Prefetch the cache line containing `data`, for writing.
+    #[inline]
+    unsafe fn prefetch_write(_data: *mut f32) {
+        // Noop
+    }
 }
 
 /// Treat an `i32` as a single-lane SIMD "vector".

--- a/rten-vecmath/src/simd_vec/x86_64.rs
+++ b/rten-vecmath/src/simd_vec/x86_64.rs
@@ -3,8 +3,8 @@ use std::arch::x86_64::{
     _mm256_blendv_ps, _mm256_castsi256_ps, _mm256_cmp_ps, _mm256_cmpgt_epi32, _mm256_cvttps_epi32,
     _mm256_div_ps, _mm256_fmadd_ps, _mm256_loadu_ps, _mm256_loadu_si256, _mm256_max_ps,
     _mm256_mul_ps, _mm256_set1_epi32, _mm256_set1_ps, _mm256_setzero_si256, _mm256_slli_epi32,
-    _mm256_storeu_ps, _mm256_storeu_si256, _mm256_sub_epi32, _mm256_sub_ps, _CMP_GE_OQ, _CMP_LE_OQ,
-    _CMP_LT_OQ,
+    _mm256_storeu_ps, _mm256_storeu_si256, _mm256_sub_epi32, _mm256_sub_ps, _mm_prefetch,
+    _CMP_GE_OQ, _CMP_LE_OQ, _CMP_LT_OQ, _MM_HINT_ET0, _MM_HINT_T0,
 };
 
 use crate::simd_vec::{SimdFloat, SimdInt};
@@ -199,5 +199,17 @@ impl SimdFloat for __m256 {
     #[target_feature(enable = "fma")]
     unsafe fn store(self, ptr: *mut f32) {
         _mm256_storeu_ps(ptr, self)
+    }
+
+    /// Prefetch the cache line containing `data`, for reading.
+    #[inline]
+    unsafe fn prefetch(data: *const f32) {
+        _mm_prefetch(data as *const i8, _MM_HINT_T0);
+    }
+
+    /// Prefetch the cache line containing `data`, for writing.
+    #[inline]
+    unsafe fn prefetch_write(data: *mut f32) {
+        _mm_prefetch(data as *const i8, _MM_HINT_ET0);
     }
 }

--- a/src/gemm/kernels/aarch64.rs
+++ b/src/gemm/kernels/aarch64.rs
@@ -1,9 +1,9 @@
 use std::arch::aarch64::float32x4_t;
 
 use rten_tensor::Matrix;
+use rten_vecmath::simd_vec::SimdFloat;
 
-use super::{simd_gemv, Kernel};
-use crate::iter_util::unroll_loop;
+use super::{simd_gemm, simd_gemv, Kernel};
 
 #[derive(Default)]
 pub struct ArmNeonKernel {}
@@ -29,70 +29,11 @@ impl Kernel for ArmNeonKernel {
         alpha: f32,
         beta: f32,
     ) {
-        use std::arch::aarch64::{
-            vaddq_f32, vdupq_n_f32, vfmaq_f32, vld1q_f32, vmulq_f32, vst1q_f32,
-        };
-
         const MR: usize = ArmNeonKernel::MR;
         const NR: usize = ArmNeonKernel::NR;
-        const REG_SIZE: usize = 4;
-        const NR_REGS: usize = NR / REG_SIZE;
+        const NR_REGS: usize = NR / <float32x4_t as SimdFloat>::LEN;
 
-        assert!(a.len() >= depth * MR);
-        assert!(b.len() >= depth * NR);
-
-        let a_ptr = a.as_ptr();
-        let b_ptr = b.as_ptr();
-
-        // Outer product accumulation tile that fits in registers.
-        let mut tmp = [[vdupq_n_f32(0.); NR_REGS]; MR];
-        let mut b_rows = [vdupq_n_f32(0.); NR_REGS];
-
-        unroll_loop!(0..depth, k, 8, {
-            let a_off = k * MR;
-            let b_off = k * NR;
-
-            for i in 0..NR_REGS {
-                b_rows[i] = vld1q_f32(b_ptr.add(b_off + i * REG_SIZE));
-            }
-
-            for i in 0..MR {
-                let a_val = *a_ptr.add(a_off + i);
-                let a_broadcast = vdupq_n_f32(a_val);
-
-                for j in 0..NR_REGS {
-                    tmp[i][j] = vfmaq_f32(tmp[i][j], a_broadcast, b_rows[j]);
-                }
-            }
-        });
-
-        if beta == 0. && alpha == 1. {
-            for i in 0..MR {
-                for j in 0..NR_REGS {
-                    let out_ptr = tile_ptr.add(tile_row_stride * i + j * REG_SIZE);
-                    vst1q_f32(out_ptr, tmp[i][j]);
-                }
-            }
-        } else if beta == 1. && alpha == 1. {
-            for i in 0..MR {
-                for j in 0..NR_REGS {
-                    let out_ptr = tile_ptr.add(tile_row_stride * i + j * REG_SIZE);
-                    let out_val = vaddq_f32(vld1q_f32(out_ptr), tmp[i][j]);
-                    vst1q_f32(out_ptr, out_val);
-                }
-            }
-        } else {
-            let alpha_broadcast = vdupq_n_f32(alpha);
-            let beta_broadcast = vdupq_n_f32(beta);
-            for i in 0..MR {
-                for j in 0..NR_REGS {
-                    let out_ptr = tile_ptr.add(tile_row_stride * i + j * REG_SIZE);
-                    let out_val = vmulq_f32(vld1q_f32(out_ptr), beta_broadcast);
-                    let out_val = vfmaq_f32(out_val, tmp[i][j], alpha_broadcast);
-                    vst1q_f32(out_ptr, out_val);
-                }
-            }
-        }
+        simd_gemm::<float32x4_t, MR, NR_REGS>(tile_ptr, tile_row_stride, a, b, depth, alpha, beta);
     }
 
     unsafe fn gemv_kernel(out: &mut [f32], a: &[f32], b: Matrix, alpha: f32, beta: f32) {

--- a/src/gemm/kernels/x86_64.rs
+++ b/src/gemm/kernels/x86_64.rs
@@ -1,6 +1,9 @@
-use rten_tensor::Matrix;
+use std::arch::x86_64::__m256;
 
-use super::{simd_gemv, Kernel};
+use rten_tensor::Matrix;
+use rten_vecmath::simd_vec::SimdFloat;
+
+use super::{simd_gemm, simd_gemv, Kernel};
 
 /// Optimized kernel for x64 CPUs that support AVX + FMA instructions.
 #[derive(Default)]
@@ -18,9 +21,11 @@ impl Kernel for FmaKernel {
     }
 
     fn supported() -> bool {
-        is_x86_feature_detected!("fma")
+        is_x86_feature_detected!("avx2") && is_x86_feature_detected!("fma")
     }
 
+    #[target_feature(enable = "avx2")]
+    #[target_feature(enable = "fma")]
     unsafe fn kernel(
         tile_ptr: *mut f32,
         tile_row_stride: usize,
@@ -30,125 +35,17 @@ impl Kernel for FmaKernel {
         alpha: f32,
         beta: f32,
     ) {
-        Self::kernel_fma(tile_ptr, tile_row_stride, a, b, depth, alpha, beta)
+        const MR: usize = FmaKernel::MR;
+        const NR: usize = FmaKernel::NR;
+        const NR_REGS: usize = NR / <__m256 as SimdFloat>::LEN;
+
+        simd_gemm::<__m256, MR, NR_REGS>(tile_ptr, tile_row_stride, a, b, depth, alpha, beta);
     }
 
     #[target_feature(enable = "avx2")]
     #[target_feature(enable = "fma")]
     unsafe fn gemv_kernel(out: &mut [f32], a: &[f32], b: Matrix, alpha: f32, beta: f32) {
-        use core::arch::x86_64::__m256;
         simd_gemv::<__m256, 2>(out, a, b, alpha, beta);
-    }
-}
-
-impl FmaKernel {
-    #[target_feature(enable = "fma")]
-    unsafe fn kernel_fma(
-        tile_ptr: *mut f32,
-        tile_row_stride: usize,
-        a: &[f32],
-        b: &[f32],
-        depth: usize,
-        alpha: f32,
-        beta: f32,
-    ) {
-        use core::arch::x86_64::{
-            __m256, _mm256_add_ps, _mm256_fmadd_ps, _mm256_loadu_ps, _mm256_mul_ps, _mm256_set1_ps,
-            _mm256_setzero_ps, _mm256_storeu_ps, _mm_prefetch, _MM_HINT_ET0, _MM_HINT_T0,
-        };
-        use std::mem::size_of;
-
-        const MR: usize = FmaKernel::MR;
-        const NR: usize = FmaKernel::NR;
-
-        const REG_SIZE: usize = size_of::<__m256>() / size_of::<f32>();
-        const NR_REGS: usize = NR / REG_SIZE;
-        assert!(NR % REG_SIZE == 0);
-
-        // Check that buffer accesses below are going to be valid.
-        assert!(a.len() >= depth * MR);
-        assert!(b.len() >= depth * NR);
-        assert!(depth > 0);
-
-        let a_ptr = a.as_ptr();
-        let b_ptr = b.as_ptr();
-
-        let mut tmp = [[_mm256_setzero_ps(); NR_REGS]; MR];
-        let mut b_rows = [_mm256_setzero_ps(); NR_REGS];
-
-        // Perform first `depth - 1` outer product updates.
-        for k in 0..depth - 1 {
-            let a_off = k * MR;
-            let b_off = k * NR;
-
-            // Prefetch B for the next iteration.
-            _mm_prefetch(b_ptr.add((k + 1) * NR) as *const i8, _MM_HINT_T0);
-
-            for i in 0..NR_REGS {
-                b_rows[i] = _mm256_loadu_ps(b_ptr.add(b_off + i * REG_SIZE));
-            }
-
-            for i in 0..MR {
-                let a_val = *a_ptr.add(a_off + i);
-                let a_broadcast = _mm256_set1_ps(a_val);
-
-                for j in 0..NR_REGS {
-                    tmp[i][j] = _mm256_fmadd_ps(a_broadcast, b_rows[j], tmp[i][j]);
-                }
-            }
-        }
-
-        // Prefetch output before the final computation loop.
-        for i in 0..MR {
-            _mm_prefetch(tile_ptr.add(tile_row_stride * i) as *const i8, _MM_HINT_ET0);
-        }
-
-        // Perform final outer product update.
-        let k = depth - 1;
-        let a_off = k * MR;
-        let b_off = k * NR;
-
-        for i in 0..NR_REGS {
-            b_rows[i] = _mm256_loadu_ps(b_ptr.add(b_off + i * REG_SIZE));
-        }
-
-        for i in 0..MR {
-            let a_val = *a_ptr.add(a_off + i);
-            let a_broadcast = _mm256_set1_ps(a_val);
-
-            for j in 0..NR_REGS {
-                tmp[i][j] = _mm256_fmadd_ps(a_broadcast, b_rows[j], tmp[i][j]);
-            }
-        }
-
-        // Write to output tile
-        if beta == 0. && alpha == 1. {
-            for i in 0..MR {
-                for j in 0..NR_REGS {
-                    let out_ptr = tile_ptr.add(tile_row_stride * i + j * REG_SIZE);
-                    _mm256_storeu_ps(out_ptr, tmp[i][j]);
-                }
-            }
-        } else if beta == 1. && alpha == 1. {
-            for i in 0..MR {
-                for j in 0..NR_REGS {
-                    let out_ptr = tile_ptr.add(tile_row_stride * i + j * REG_SIZE);
-                    let out_val = _mm256_add_ps(_mm256_loadu_ps(out_ptr), tmp[i][j]);
-                    _mm256_storeu_ps(out_ptr, out_val);
-                }
-            }
-        } else {
-            let alpha_broadcast = _mm256_set1_ps(alpha);
-            let beta_broadcast = _mm256_set1_ps(beta);
-            for i in 0..MR {
-                for j in 0..NR_REGS {
-                    let out_ptr = tile_ptr.add(tile_row_stride * i + j * REG_SIZE);
-                    let out_val = _mm256_mul_ps(_mm256_loadu_ps(out_ptr), beta_broadcast);
-                    let out_val = _mm256_fmadd_ps(tmp[i][j], alpha_broadcast, out_val);
-                    _mm256_storeu_ps(out_ptr, out_val);
-                }
-            }
-        }
     }
 }
 

--- a/src/iter_util.rs
+++ b/src/iter_util.rs
@@ -134,9 +134,15 @@ impl MaybeParIter for Range<usize> {
     }
 }
 
+/// Generate an unrolled loop.
+///
+/// `$range` is a `Range` specifying the loop start and end. `$loop_var` is the
+/// name of the variable containing the current iteration inside `$block`.
+/// `$factor` should be a constant expression specifying the unroll factor,
+/// typically a small value such as 4 or 8.
 #[macro_export]
 macro_rules! unroll_loop {
-    ($range:expr, $loop_var:ident, $factor: literal, $block:tt) => {
+    ($range:expr, $loop_var:ident, $factor: expr, $block:tt) => {
         let mut n = $range.len();
         let mut $loop_var = $range.start;
         while n >= $factor {


### PR DESCRIPTION
The current GEMM microkernels for all architectures had the same structure except for the intrinsics used and the tile size. As a result it is possible to unify them into a single generic implementation, parametrized by the vector register type and tile dimensions. An exception is AVX-512 since rten-vecmath is missing a `SimdFloat` implementation for that instruction set.

I verified that the performance for Intel / Arm is the same or slightly better than before when tested on my Intel laptop and AWS c6i / c6g instances.

It will probably be the case in future that one or more architectures does need some architecture-specific tweaks to get the best performance, but the generic implementation will at least provide a decent baseline.