### PR TITLE
Add WASM GEMM microkernel

### DIFF
--- a/src/gemm/kernels.rs
+++ b/src/gemm/kernels.rs
@@ -12,6 +12,9 @@ pub mod aarch64;
 #[cfg(target_arch = "x86_64")]
 pub mod x86_64;
 
+#[cfg(target_arch = "wasm32")]
+pub mod wasm;
+
 /// Compute an output block of a vector-matrix product ("gemv" in BLAS APIs).
 ///
 /// Multiple output columns are computed at a time, using `NR_REGS` SIMD

--- a/src/gemm/kernels/wasm.rs
+++ b/src/gemm/kernels/wasm.rs
@@ -1,0 +1,43 @@
+use rten_tensor::Matrix;
+use rten_vecmath::simd_vec::wasm::v128f;
+use rten_vecmath::simd_vec::SimdFloat;
+
+use super::{simd_gemm, simd_gemv, Kernel};
+
+#[derive(Default)]
+pub struct WasmKernel {}
+
+impl Kernel for WasmKernel {
+    const MR: usize = 8;
+    const NR: usize = 8;
+
+    fn name() -> &'static str {
+        "wasm32"
+    }
+
+    fn supported() -> bool {
+        true
+    }
+
+    unsafe fn kernel(
+        tile_ptr: *mut f32,
+        tile_row_stride: usize,
+        a: &[f32],
+        b: &[f32],
+        depth: usize,
+        alpha: f32,
+        beta: f32,
+    ) {
+        const MR: usize = WasmKernel::MR;
+        const NR: usize = WasmKernel::NR;
+        const NR_REGS: usize = NR / <v128f as SimdFloat>::LEN;
+
+        simd_gemm::<v128f, MR, NR_REGS>(tile_ptr, tile_row_stride, a, b, depth, alpha, beta);
+    }
+
+    unsafe fn gemv_kernel(out: &mut [f32], a: &[f32], b: Matrix, alpha: f32, beta: f32) {
+        simd_gemv::<v128f, 4>(out, a, b, alpha, beta);
+    }
+}
+
+super::impl_gemmops!(WasmKernel);


### PR DESCRIPTION
Performance on Intel is slightly better than before due to a larger tile size (MR=8, NR=8 rather than MR=8, NR=4). Performance on Arm, tested on Graviton 2 (AWS c6g), is about 40% better.

Performance of TensorFlow.js is still noticeably better on Arm though:

Results on c6g before for M=N=K=512:

- Before (rten): ~7.75 GFLOPS
- After (rten): ~11 GFLOPS
- TF.js: ~14.5 GFLOPS

I suspect TF.js might be using fused multiply-add from the WASM relaxed SIMD instruction set, but I need to verify this.

WASM binaries containing WASM relaxed SIMD instructions are not yet supported by wasm-bindgen, but this change will make it easier to adopt once it is.