### PR TITLE
Align name of `Forward` enum variant for RNN ops with ONNX attribute value

### DIFF
--- a/rten-convert/rten_convert/converter.py
+++ b/rten-convert/rten_convert/converter.py
@@ -295,7 +295,7 @@ class ONNXOperatorReader:
                     f'Replacing unsupported value "{val}" for "{name}" attr in {op} op with "{fallback}"'
                 )
                 return convert_attr(fallback)
-            raise ValueError(f"Unsupported value {val} for {name} attr")
+            raise ValueError(f'Unsupported value "{val}" for "{name}" attr')
 
     def ignore_attr(self, name: str):
         """

--- a/rten-convert/rten_convert/schema_generated.py
+++ b/rten-convert/rten_convert/schema_generated.py
@@ -105,7 +105,7 @@ class OperatorType(object):
 
 
 class RNNDirection(object):
-    Forwards = 0
+    Forward = 0
     Reverse = 1
     Bidirectional = 2
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -704,10 +704,10 @@ fn read_gru_op(node: &OperatorNode) -> ReadOpResult {
 
     let hidden_size = attrs.hidden_size() as usize;
     let direction = match attrs.direction() {
-        sg::RNNDirection::Forwards => Direction::Forwards,
+        sg::RNNDirection::Forward => Direction::Forward,
         sg::RNNDirection::Reverse => Direction::Reverse,
         sg::RNNDirection::Bidirectional => Direction::Bidirectional,
-        _ => Direction::Forwards,
+        _ => Direction::Forward,
     };
 
     Ok(Box::new(ops::GRU {
@@ -762,10 +762,10 @@ fn read_lstm_op(node: &OperatorNode) -> ReadOpResult {
 
     let hidden_size = attrs.hidden_size() as usize;
     let direction = match attrs.direction() {
-        sg::RNNDirection::Forwards => Direction::Forwards,
+        sg::RNNDirection::Forward => Direction::Forward,
         sg::RNNDirection::Reverse => Direction::Reverse,
         sg::RNNDirection::Bidirectional => Direction::Bidirectional,
-        _ => Direction::Forwards,
+        _ => Direction::Forward,
     };
 
     Ok(Box::new(ops::LSTM {

--- a/src/ops/rnn.rs
+++ b/src/ops/rnn.rs
@@ -15,7 +15,7 @@ use crate::ops::{
 /// Direction that an RNN operator will traverse the input sequence in.
 #[derive(Copy, Clone, Debug)]
 pub enum Direction {
-    Forwards,
+    Forward,
     Reverse,
     Bidirectional,
 }
@@ -24,16 +24,16 @@ impl Direction {
     /// Number of directions that an RNN operator will traverse the sequence in.
     pub fn num_directions(self) -> usize {
         match self {
-            Self::Forwards | Self::Reverse => 1,
+            Self::Forward | Self::Reverse => 1,
             Self::Bidirectional => 2,
         }
     }
 }
 
-/// Forwards or backwards iterator over values in a range.
+/// Forward or backward iterator over values in a range.
 enum Sequence {
-    Forwards(Range<usize>),
-    Backwards(Rev<Range<usize>>),
+    Forward(Range<usize>),
+    Backward(Rev<Range<usize>>),
 }
 
 impl Iterator for Sequence {
@@ -41,8 +41,8 @@ impl Iterator for Sequence {
 
     fn next(&mut self) -> Option<usize> {
         match self {
-            Sequence::Forwards(range) => range.next(),
-            Sequence::Backwards(rev_range) => rev_range.next(),
+            Sequence::Forward(range) => range.next(),
+            Sequence::Backward(rev_range) => rev_range.next(),
         }
     }
 }
@@ -57,9 +57,9 @@ fn sequence_for_dir(op_dirs: Direction, dir: usize, seq_len: usize) -> Sequence 
         (0, Direction::Reverse) | (1, Direction::Bidirectional)
     );
     if reversed {
-        Sequence::Backwards((0..seq_len).rev())
+        Sequence::Backward((0..seq_len).rev())
     } else {
-        Sequence::Forwards(0..seq_len)
+        Sequence::Forward(0..seq_len)
     }
 }
 
@@ -1045,11 +1045,11 @@ mod tests {
         let cases = &[
             Case {
                 name: "lstm_forwards",
-                dir: Direction::Forwards,
+                dir: Direction::Forward,
             },
             Case {
                 name: "lstm_initial",
-                dir: Direction::Forwards,
+                dir: Direction::Forward,
             },
             Case {
                 name: "lstm_bidirectional",
@@ -1057,11 +1057,11 @@ mod tests {
             },
             Case {
                 name: "gru_forwards",
-                dir: Direction::Forwards,
+                dir: Direction::Forward,
             },
             Case {
                 name: "gru_initial",
-                dir: Direction::Forwards,
+                dir: Direction::Forward,
             },
             Case {
                 name: "gru_bidirectional",

--- a/src/schema.fbs
+++ b/src/schema.fbs
@@ -108,7 +108,7 @@ enum OperatorType: ubyte {
 }
 
 enum RNNDirection: ubyte {
-  Forwards,
+  Forward,
   Reverse,
   Bidirectional
 }

--- a/src/schema_generated.rs
+++ b/src/schema_generated.rs
@@ -492,7 +492,7 @@ pub const ENUM_MAX_RNNDIRECTION: u8 = 2;
 )]
 #[allow(non_camel_case_types)]
 pub const ENUM_VALUES_RNNDIRECTION: [RNNDirection; 3] = [
-    RNNDirection::Forwards,
+    RNNDirection::Forward,
     RNNDirection::Reverse,
     RNNDirection::Bidirectional,
 ];
@@ -502,17 +502,17 @@ pub const ENUM_VALUES_RNNDIRECTION: [RNNDirection; 3] = [
 pub struct RNNDirection(pub u8);
 #[allow(non_upper_case_globals)]
 impl RNNDirection {
-    pub const Forwards: Self = Self(0);
+    pub const Forward: Self = Self(0);
     pub const Reverse: Self = Self(1);
     pub const Bidirectional: Self = Self(2);
 
     pub const ENUM_MIN: u8 = 0;
     pub const ENUM_MAX: u8 = 2;
-    pub const ENUM_VALUES: &'static [Self] = &[Self::Forwards, Self::Reverse, Self::Bidirectional];
+    pub const ENUM_VALUES: &'static [Self] = &[Self::Forward, Self::Reverse, Self::Bidirectional];
     /// Returns the variant's name or "" if unknown.
     pub fn variant_name(self) -> Option<&'static str> {
         match self {
-            Self::Forwards => Some("Forwards"),
+            Self::Forward => Some("Forward"),
             Self::Reverse => Some("Reverse"),
             Self::Bidirectional => Some("Bidirectional"),
             _ => None,
@@ -3662,7 +3662,7 @@ impl<'a> GRUAttrs<'a> {
         // which contains a valid value in this slot
         unsafe {
             self._tab
-                .get::<RNNDirection>(GRUAttrs::VT_DIRECTION, Some(RNNDirection::Forwards))
+                .get::<RNNDirection>(GRUAttrs::VT_DIRECTION, Some(RNNDirection::Forward))
                 .unwrap()
         }
     }
@@ -3714,7 +3714,7 @@ impl<'a> Default for GRUAttrsArgs {
     #[inline]
     fn default() -> Self {
         GRUAttrsArgs {
-            direction: RNNDirection::Forwards,
+            direction: RNNDirection::Forward,
             hidden_size: 0,
             linear_before_reset: false,
         }
@@ -3731,7 +3731,7 @@ impl<'a: 'b, 'b> GRUAttrsBuilder<'a, 'b> {
         self.fbb_.push_slot::<RNNDirection>(
             GRUAttrs::VT_DIRECTION,
             direction,
-            RNNDirection::Forwards,
+            RNNDirection::Forward,
         );
     }
     #[inline]
@@ -4041,7 +4041,7 @@ impl<'a> LSTMAttrs<'a> {
         // which contains a valid value in this slot
         unsafe {
             self._tab
-                .get::<RNNDirection>(LSTMAttrs::VT_DIRECTION, Some(RNNDirection::Forwards))
+                .get::<RNNDirection>(LSTMAttrs::VT_DIRECTION, Some(RNNDirection::Forward))
                 .unwrap()
         }
     }
@@ -4080,7 +4080,7 @@ impl<'a> Default for LSTMAttrsArgs {
     #[inline]
     fn default() -> Self {
         LSTMAttrsArgs {
-            direction: RNNDirection::Forwards,
+            direction: RNNDirection::Forward,
             hidden_size: 0,
         }
     }
@@ -4096,7 +4096,7 @@ impl<'a: 'b, 'b> LSTMAttrsBuilder<'a, 'b> {
         self.fbb_.push_slot::<RNNDirection>(
             LSTMAttrs::VT_DIRECTION,
             direction,
-            RNNDirection::Forwards,
+            RNNDirection::Forward,
         );
     }
     #[inline]


### PR DESCRIPTION
Fix an error when converting LSTM / GRU operators with a direction attribute of
"forward", or with no direction specified, as "forward" is the default. The
enum name was previously `Forwards`, so the conversion code expected an
attribute value of `forwards`.

The problem was spotted when converting the `decoder_iter.onnx` model from
https://github.com/xd009642/xd-tts/tree/master/models/tacotron2.
