### PR TITLE
Avoid zero-initialization of packing buffers

### DIFF
--- a/src/gemm/packing.rs
+++ b/src/gemm/packing.rs
@@ -1,3 +1,4 @@
+use std::mem::MaybeUninit;
 use std::ops::Range;
 
 use rten_tensor::{Matrix, MatrixLayout};
@@ -11,7 +12,17 @@ use super::Kernel;
 /// row panels. Each row panel has size `K::MR * cols.len()` and uses
 /// column-major order. If `rows.len()` is not a multiple of `K::MR`, the
 /// final panel is zero-padded.
-pub fn pack_a_block<K: Kernel>(out: &mut [f32], a: Matrix, rows: Range<usize>, cols: Range<usize>) {
+///
+/// # Safety
+///
+/// When this function returns, all elements of `out` will have been initialized
+/// either to a value from `a`, or zero.
+pub fn pack_a_block<K: Kernel>(
+    out: &mut [MaybeUninit<f32>],
+    a: Matrix,
+    rows: Range<usize>,
+    cols: Range<usize>,
+) {
     let a_rows = rows.len();
     let a_cols = cols.len();
 
@@ -40,8 +51,8 @@ pub fn pack_a_block<K: Kernel>(out: &mut [f32], a: Matrix, rows: Range<usize>, c
                     for row in 0..K::MR {
                         // Safety: Indexes are less than lengths asserted above.
                         unsafe {
-                            *out.get_unchecked_mut(panel_offset + col * K::MR + row) =
-                                *a_data.get_unchecked(a_offset + row * row_stride + col);
+                            out.get_unchecked_mut(panel_offset + col * K::MR + row)
+                                .write(*a_data.get_unchecked(a_offset + row * row_stride + col));
                         }
                     }
                 }
@@ -50,8 +61,12 @@ pub fn pack_a_block<K: Kernel>(out: &mut [f32], a: Matrix, rows: Range<usize>, c
                     for row in 0..K::MR {
                         // Safety: Indexes are less than lengths asserted above.
                         unsafe {
-                            *out.get_unchecked_mut(panel_offset + col * K::MR + row) = *a_data
-                                .get_unchecked(a_offset + row * row_stride + col * col_stride);
+                            out.get_unchecked_mut(panel_offset + col * K::MR + row)
+                                .write(
+                                    *a_data.get_unchecked(
+                                        a_offset + row * row_stride + col * col_stride,
+                                    ),
+                                );
                         }
                     }
                 }
@@ -62,14 +77,20 @@ pub fn pack_a_block<K: Kernel>(out: &mut [f32], a: Matrix, rows: Range<usize>, c
                 let out_col_offset = panel_offset + col * K::MR;
                 for row in 0..K::MR {
                     let a_row = rows.start + panel_start_row + row;
-                    out[out_col_offset + row] = if a_row < rows.end {
+                    out[out_col_offset + row].write(if a_row < rows.end {
                         a_data[a_row * row_stride + (cols.start + col) * col_stride]
                     } else {
                         0.0
-                    };
+                    });
                 }
             }
         }
+    }
+
+    // Initialize any spare capacity in the buffer.
+    let n_init = n_panels * a_cols * K::MR;
+    for x in &mut out[n_init..] {
+        x.write(0.);
     }
 }
 
@@ -79,7 +100,17 @@ pub fn pack_a_block<K: Kernel>(out: &mut [f32], a: Matrix, rows: Range<usize>, c
 /// K::NR)` column panels. Each column panel has size `rows.len() *
 /// K::NR` and uses row-major order. If `cols.len()` is not a multiple of
 /// `K::NR`, the final panel is zero-padded.
-pub fn pack_b_block<K: Kernel>(out: &mut [f32], b: Matrix, rows: Range<usize>, cols: Range<usize>) {
+///
+/// # Safety
+///
+/// When this function returns, all elements of `out` will have been initialized
+/// either to a value from `b`, or zero.
+pub fn pack_b_block<K: Kernel>(
+    out: &mut [MaybeUninit<f32>],
+    b: Matrix,
+    rows: Range<usize>,
+    cols: Range<usize>,
+) {
     let b_cols = cols.len();
     let b_rows = rows.len();
     let b_row_stride = b.row_stride();
@@ -113,8 +144,8 @@ pub fn pack_b_block<K: Kernel>(out: &mut [f32], b: Matrix, rows: Range<usize>, c
                     for col in 0..K::NR {
                         // Safety: Indexes are less than lengths asserted above.
                         unsafe {
-                            *out.get_unchecked_mut(out_offset + col) =
-                                *b_data.get_unchecked(in_offset + col);
+                            out.get_unchecked_mut(out_offset + col)
+                                .write(*b_data.get_unchecked(in_offset + col));
                         }
                     }
                 }
@@ -125,8 +156,8 @@ pub fn pack_b_block<K: Kernel>(out: &mut [f32], b: Matrix, rows: Range<usize>, c
                     for col in 0..K::NR {
                         // Safety: Indexes are less than lengths asserted above.
                         unsafe {
-                            *out.get_unchecked_mut(out_offset + col) =
-                                *b_data.get_unchecked(in_offset + col * b_col_stride);
+                            out.get_unchecked_mut(out_offset + col)
+                                .write(*b_data.get_unchecked(in_offset + col * b_col_stride));
                         }
                     }
                 }
@@ -142,13 +173,19 @@ pub fn pack_b_block<K: Kernel>(out: &mut [f32], b: Matrix, rows: Range<usize>, c
                     let b_offset =
                         b_row_offset + (cols.start + panel_start_col + col) * b_col_stride;
 
-                    out[out_row_offset + col] = if out_col < b_cols {
+                    out[out_row_offset + col].write(if out_col < b_cols {
                         b_data[b_offset]
                     } else {
                         0.0
-                    };
+                    });
                 }
             }
         }
+    }
+
+    // Initialize any spare capacity in the buffer.
+    let n_init = n_panels * b_rows * K::NR;
+    for x in &mut out[n_init..] {
+        x.write(0.);
     }
 }


### PR DESCRIPTION
Avoid overhead from zeroing memory when prepacking matrix inputs by allowing the packing functions to write to uninitialized memory. The packing functions guarantee that the entire buffer passed to them is initialized when they return.

In a TTS demo using Tacotron2 [^1], which uses an LSTM-based decoder, this reduces the "real-time factor" (degree of slowdown over real-time generation) from ~1.9x to ~1.65x.

TODO:
- [x] Make sure only the portion of buffers that we expect to use is passed to packing functions. `Vec::spare_capacity_mut` can in theory return a larger capacity than we asked for.
- [x] Review the safety comments

[^1]: https://github.com/robertknight/xd-tts