### PR TITLE
Add `include` field to Cargo.toml files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ license = "MIT OR Apache-2.0"
 homepage = "https://github.com/robertknight/rten"
 repository = "https://github.com/robertknight/rten"
 resolver = "2"
+include = ["/src", "/CHANGELOG.md", "/README.md"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/rten-cli/Cargo.toml
+++ b/rten-cli/Cargo.toml
@@ -7,6 +7,7 @@ description = "CLI tool for inspecting and running RTen models"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/robertknight/rten"
 repository = "https://github.com/robertknight/rten"
+include = ["/src", "/README.md"]
 
 [dependencies]
 fastrand = "2.0.2"

--- a/rten-imageio/Cargo.toml
+++ b/rten-imageio/Cargo.toml
@@ -7,6 +7,7 @@ description = "Utilities for loading images for use with RTen"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/robertknight/rten"
 repository = "https://github.com/robertknight/rten"
+include = ["/src", "/README.md"]
 
 [dependencies]
 image = { version = "0.24.6", default-features = false, features = ["png", "jpeg", "jpeg_rayon", "webp"] }

--- a/rten-imageproc/Cargo.toml
+++ b/rten-imageproc/Cargo.toml
@@ -7,6 +7,7 @@ description = "Image tensor processing and geometry functions"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/robertknight/rten"
 repository = "https://github.com/robertknight/rten"
+include = ["/src", "/README.md"]
 
 [dependencies]
 rten-tensor = { path = "../rten-tensor", version = "0.6.0" }

--- a/rten-tensor/Cargo.toml
+++ b/rten-tensor/Cargo.toml
@@ -7,6 +7,7 @@ description = "Tensor library for the RTen machine learning runtime"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/robertknight/rten"
 repository = "https://github.com/robertknight/rten"
+include = ["/src", "/README.md"]
 
 [dependencies]
 smallvec = { version = "1.10.0", features=["union", "const_generics", "const_new"] }

--- a/rten-text/Cargo.toml
+++ b/rten-text/Cargo.toml
@@ -7,6 +7,7 @@ description = "Text tokenization and other ML pre/post-processing functions"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/robertknight/rten"
 repository = "https://github.com/robertknight/rten"
+include = ["/src", "/README.md"]
 
 [lib]
 crate-type = ["lib"]

--- a/rten-vecmath/Cargo.toml
+++ b/rten-vecmath/Cargo.toml
@@ -7,6 +7,7 @@ description = "SIMD vectorized implementations of various math functions used in
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/robertknight/rten"
 repository = "https://github.com/robertknight/rten"
+include = ["/src", "/README.md"]
 
 [dev-dependencies]
 fastrand = "2.0.2"


### PR DESCRIPTION
This prevents inclusion of test data and other scripts in the generated package.

Fixes https://github.com/robertknight/rten/issues/76