### PR TITLE
Add blocking / tiling for transpose operations

### DIFF
--- a/rten-bench/src/lib.rs
+++ b/rten-bench/src/lib.rs
@@ -1,4 +1,3 @@
-use std::fmt::Display;
 use std::time::Instant;
 
 /// Statistics from a benchmark run. All fields are durations in milliseconds.
@@ -20,9 +19,10 @@ pub struct BenchStats {
     pub var: f32,
 }
 
-/// Run a benchmark function `f` for `trials` iterations and print statistics
-/// about the run.
-pub fn run_bench<F: FnMut(), D: Display>(trials: usize, description: D, mut f: F) -> BenchStats {
+/// Run a benchmark function `f` for `trials` iterations and returns statistics.
+///
+/// Prints the statistics itself if `description` is provided.
+pub fn run_bench<F: FnMut()>(trials: usize, description: Option<&str>, mut f: F) -> BenchStats {
     if trials == 0 {
         return BenchStats::default();
     }
@@ -50,10 +50,12 @@ pub fn run_bench<F: FnMut(), D: Display>(trials: usize, description: D, mut f: F
     let mean = times.iter().sum::<f32>() / times.len() as f32;
     let var = times.iter().map(|x| (x - mean).abs()).sum::<f32>() / times.len() as f32;
 
-    println!(
-        "{}. mean {:.3}ms median {:.3} var {:.3} min {:.3} max {:.3}",
-        description, mean, median, var, min, max
-    );
+    if let Some(description) = description {
+        println!(
+            "{}. mean {:.3}ms median {:.3} var {:.3} min {:.3} max {:.3}",
+            description, mean, median, var, min, max
+        );
+    }
 
     BenchStats {
         max,

--- a/rten-imageproc/src/contours.rs
+++ b/rten-imageproc/src/contours.rs
@@ -465,7 +465,7 @@ mod tests {
         }
 
         let n_iters = 100;
-        run_bench(n_iters, "find_contours", || {
+        run_bench(n_iters, Some("find_contours"), || {
             let contours = find_contours(mask.view(), RetrievalMode::External);
             assert_eq!(contours.len(), (grid_rows * grid_cols) as usize);
         });

--- a/rten-tensor/src/transpose.rs
+++ b/rten-tensor/src/transpose.rs
@@ -1,41 +1,89 @@
+use std::mem::MaybeUninit;
+use std::ops::Range;
+
 use crate::{AsView, Layout};
-use crate::{NdTensorView, TensorView};
+use crate::{Matrix, MatrixLayout, MatrixMut, NdTensorView, NdTensorViewMut, TensorView};
 
-/// Call `f` with every element in `x` in logical order.
-///
-/// This is equivalent to `x.iter().for_each(f)` but is faster that Rust's
-/// standard iteration protocol when `x` is non-contiguous and has <= 4
-/// dimensions.
-fn fast_for_each_element<T, F: FnMut(&T)>(mut x: TensorView<T>, mut f: F) {
-    // Merge axes to increase the chance that we can use the fast path and
-    // also maximize the iteration count of the innermost loops.
-    x.merge_axes();
+/// Iterator returned by [range_chunks].
+pub struct RangeChunks {
+    remainder: Range<usize>,
+    chunk_size: usize,
+}
 
-    if x.ndim() > 4 {
-        x.iter().for_each(f)
-    } else {
-        while x.ndim() < 4 {
-            x.insert_axis(0);
+impl Iterator for RangeChunks {
+    type Item = Range<usize>;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if !self.remainder.is_empty() {
+            let start = self.remainder.start;
+            let end = (start + self.chunk_size).min(self.remainder.end);
+            self.remainder.start += self.chunk_size;
+            Some(start..end)
+        } else {
+            None
         }
+    }
 
-        let x_data = x.non_contiguous_data();
-        let x: NdTensorView<T, 4> = x.nd_view();
-        let shape = x.shape();
-        let strides = x.strides();
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.remainder.len().div_ceil(self.chunk_size);
+        (len, Some(len))
+    }
+}
 
-        assert!(x_data.len() >= x.layout().min_data_len());
+impl ExactSizeIterator for RangeChunks {}
 
-        for i0 in 0..shape[0] {
-            for i1 in 0..shape[1] {
-                for i2 in 0..shape[2] {
-                    for i3 in 0..shape[3] {
-                        let offset =
-                            i0 * strides[0] + i1 * strides[1] + i2 * strides[2] + i3 * strides[3];
+impl std::iter::FusedIterator for RangeChunks {}
 
-                        // Safety: We checked data length > max offset produced
-                        // by layout.
-                        let elt = unsafe { x_data.get_unchecked(offset) };
-                        f(elt)
+/// Return an iterator over sub-ranges of `range`. If `range.len()` is not a
+/// multiple of `chunk_size` then the final chunk will be shorter.
+#[inline]
+pub fn range_chunks(range: Range<usize>, chunk_size: usize) -> RangeChunks {
+    RangeChunks {
+        remainder: range,
+        chunk_size,
+    }
+}
+
+/// Tile size for blocked copy. A tile should fit in registers for 32-bit
+/// values.
+const TILE_SIZE: usize = 4;
+
+/// Block size for blocked copy. A source and dest block should fit in the cache
+/// for 32-bit values.
+const BLOCK_SIZE: usize = 64;
+
+/// Copy elements from `src` into `dest`.
+///
+/// `src` and `dest` must have the same shape but can (should) have different
+/// strides. This function uses blocking to avoid the cache conflicts that can
+/// arise in a naive copy if `src` is transposed.
+fn copy_blocked<T: Clone>(src: Matrix<T>, mut dest: MatrixMut<MaybeUninit<T>>) {
+    // Ensure src and dest have same index range.
+    assert!(src.shape() == dest.shape());
+
+    // Ensure tiles are always full.
+    assert!(dest.rows() % TILE_SIZE == 0);
+    assert!(dest.cols() % TILE_SIZE == 0);
+
+    for row_block in range_chunks(0..dest.rows(), BLOCK_SIZE) {
+        for col_block in range_chunks(0..dest.cols(), BLOCK_SIZE) {
+            for row_tile in range_chunks(row_block.clone(), TILE_SIZE) {
+                for col_tile in range_chunks(col_block.clone(), TILE_SIZE) {
+                    debug_assert!(row_tile.len() == TILE_SIZE);
+                    debug_assert!(col_tile.len() == TILE_SIZE);
+
+                    for y in 0..TILE_SIZE {
+                        for x in 0..TILE_SIZE {
+                            // Safety: Max values of `idx` are in-bounds for
+                            // `src` and `dest`.
+                            unsafe {
+                                let idx = [row_tile.start + y, col_tile.start + x];
+                                let src_el = src.get_unchecked(idx).clone();
+                                dest.get_unchecked_mut(idx).write(src_el);
+                            }
+                        }
                     }
                 }
             }
@@ -46,29 +94,87 @@ fn fast_for_each_element<T, F: FnMut(&T)>(mut x: TensorView<T>, mut f: F) {
 /// Return the elements of `src` as a contiguous vector, in the same order they
 /// would be yielded by `src.iter()`.
 ///
+/// This function assumes that the caller has already checked if `src` is
+/// contiguous and used more efficient methods to copy the data in that case.
+///
 /// This is equivalent to `src.iter().cloned().collect::<Vec<_>>()` but
 /// faster.
 pub fn contiguous_data<T: Clone>(src: TensorView<T>) -> Vec<T> {
     let src_len = src.len();
+    let mut result = Vec::with_capacity(src_len);
+    copy_contiguous(src, &mut result.spare_capacity_mut()[..src_len]);
 
-    // This is equivalent to `x.iter().cloned().collect::<Vec<_>>()` but uses a
-    // faster iteration method that is optimized for tensors with few (<= 4)
-    // dimensions.
-    let mut data = Vec::with_capacity(src.len());
-    let ptr: *mut T = data.as_mut_ptr();
+    // Safety: `copy_contiguous` initialized `src_len` elements of result.
+    unsafe { result.set_len(src_len) };
 
-    let mut offset = 0;
-    fast_for_each_element(src, |elt| {
-        // Safety: `fast_for_each_element` calls fn `self.len()` times,
-        // matching the buffer capacity.
-        unsafe { *ptr.add(offset) = elt.clone() };
-        offset += 1;
-    });
+    result
+}
 
-    // Safety: Length here matches capacity passed to `Vec::with_capacity`.
-    unsafe { data.set_len(src_len) }
+/// Copy elements of `src` into `dest` in contiguous order.
+///
+/// Returns `dest` as an initialized slice.
+pub fn copy_contiguous<'a, T: Clone>(
+    src: TensorView<T>,
+    dest: &'a mut [MaybeUninit<T>],
+) -> &'a [T] {
+    assert!(dest.len() == src.len());
 
-    data
+    // Merge axes to increase the chance that we can use the fast path and
+    // also maximize the iteration count of the innermost loops.
+    let mut src = src.clone();
+    src.merge_axes();
+
+    if src.ndim() > 4 {
+        for (dst, src) in dest.iter_mut().zip(src.iter()) {
+            dst.write(src.clone());
+        }
+        // Safety: Loop above initialized all elements of `dest`.
+        return unsafe { std::mem::transmute(dest) };
+    }
+
+    while src.ndim() < 4 {
+        src.insert_axis(0);
+    }
+
+    let src: NdTensorView<T, 4> = src.nd_view();
+
+    // As a heuristic, use a blocked copy if the source stride is likely to lead
+    // to cache conflicts. Otherwise a simple direct copy is probably going to
+    // be faster. With a better optimized blocked copy path, we might be able to
+    // use it all the time.
+    let use_blocked_copy = src.stride(3).count_ones() == 1
+        && src.stride(3) >= 32
+        && src.size(2) % TILE_SIZE == 0
+        && src.size(3) % TILE_SIZE == 0;
+
+    if use_blocked_copy {
+        let mut dest = NdTensorViewMut::from_data(src.shape(), dest);
+        for i0 in 0..src.size(0) {
+            for i1 in 0..src.size(1) {
+                let src = src.slice::<2, _>([i0, i1]);
+                let dest = dest.slice_mut::<2, _>([i0, i1]);
+                copy_blocked(src, dest);
+            }
+        }
+    } else {
+        let mut dest_offset = 0;
+        for i0 in 0..src.size(0) {
+            for i1 in 0..src.size(1) {
+                for i2 in 0..src.size(2) {
+                    for i3 in 0..src.size(3) {
+                        unsafe {
+                            let elt = src.get_unchecked([i0, i1, i2, i3]).clone();
+                            dest.get_unchecked_mut(dest_offset).write(elt);
+                            dest_offset += 1;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Safety: Loop above initialized all elements of `dest`.
+    unsafe { std::mem::transmute(dest) }
 }
 
 #[cfg(test)]
@@ -87,5 +193,19 @@ mod tests {
         let x = Tensor::from_data(&[1, 1, 1, 2, 2], vec![1, 2, 3, 4]);
         assert_eq!(contiguous_data(x.view()), [1, 2, 3, 4]);
         assert_eq!(contiguous_data(x.transposed()), [1, 3, 2, 4]);
+
+        // Transposed matrices of varying sizes. This includes:
+        //
+        // - Zero
+        // - Powers of 2
+        // - Non-powers of 2
+        // - Values above and below threshold for using blocked copy
+        for size in [0usize, 2, 4, 8, 15, 16, 32, 64, 65, 68] {
+            let x = Tensor::<i32>::arange(0, (size * size) as i32, None);
+            let x = x.reshaped([size, size]);
+            let transposed = contiguous_data(x.transposed().as_dyn());
+            let expected = x.transposed().iter().copied().collect::<Vec<_>>();
+            assert_eq!(transposed, expected);
+        }
     }
 }

--- a/rten-tensor/src/transpose.rs
+++ b/rten-tensor/src/transpose.rs
@@ -7,6 +7,10 @@ use crate::{NdTensorView, TensorView};
 /// standard iteration protocol when `x` is non-contiguous and has <= 4
 /// dimensions.
 fn fast_for_each_element<T, F: FnMut(&T)>(mut x: TensorView<T>, mut f: F) {
+    // Merge axes to increase the chance that we can use the fast path and
+    // also maximize the iteration count of the innermost loops.
+    x.merge_axes();
+
     if x.ndim() > 4 {
         x.iter().for_each(f)
     } else {

--- a/src/gemm.rs
+++ b/src/gemm.rs
@@ -1782,11 +1782,15 @@ mod tests {
         let iters = 1000;
         let a = NdTensor::rand([m, n], &mut rng);
 
-        run_bench(10, &format!("m {} n {} iters {}", m, n, iters), || {
-            for _i in 0..iters {
-                gemm.prepack_a(a.view());
-            }
-        });
+        run_bench(
+            10,
+            Some(&format!("m {} n {} iters {}", m, n, iters)),
+            || {
+                for _i in 0..iters {
+                    gemm.prepack_a(a.view());
+                }
+            },
+        );
     }
 
     // TODO - Add a set of tests for use with Miri. These should exercise all

--- a/src/ops/conv.rs
+++ b/src/ops/conv.rs
@@ -1334,7 +1334,7 @@ mod tests {
             &mut rng,
         );
 
-        run_bench(100, "col2im", || {
+        run_bench(100, Some("col2im"), || {
             col2im(
                 &mut output.view_mut(),
                 &columns.view(),

--- a/src/ops/matmul.rs
+++ b/src/ops/matmul.rs
@@ -522,7 +522,7 @@ mod tests {
                 let desc = format!(
                     "matmul [{a_batch},{a_rows},{a_cols}] x [{a_cols},{b_cols}], strategy={strategy:?}",
                 );
-                run_bench(trials, &desc, || {
+                run_bench(trials, Some(&desc), || {
                     matmul_impl(a.view(), b.view(), strategy).unwrap();
                 });
             };


### PR DESCRIPTION
Before this PR the transpose operation had a naive implementation which used nested for loops to generate all valid indices and the source/dest offsets, then copied the value from the permuted/transposed source view to the destination.

This actually worked quite well except for cases where the strides after permuting/transposing the source were a multiple of the cache line size, especially powers of 2. In that case cache conflicts caused performance to be much worse. Transposing a 1024x1024 matrix was ~8x slower than copying the data (excluding the time taken for memory allocation), whereas for a 1023x1023 matrix it was only ~1.5x.

This PR fixes the issue by adding a simple implementation of blocking and tiling for transpose operations. Initially this is only enabled for cases where the last stride of the transposed tensor is a power of 2 greater than 32. Also the layout of the permuted tensor is simplified to minimize the number of dimensions before performing the copy. This maximizes the iteration count of each loop.

Some numbers from the `bench_transpose` benchmark comparing copy vs naive/reference transpose vs blocked transpose:

```
transpose shape [512, 512] perm [0, 1] copy 0.045ms ref transpose 0.042ms opt transpose 0.039ms overhead 0
transpose shape [128, 128] perm [1, 0] copy 0.002ms ref transpose 0.010ms opt transpose 0.009ms overhead 4.532522
transpose shape [256, 256] perm [1, 0] copy 0.010ms ref transpose 0.065ms opt transpose 0.041ms overhead 2.8640494
transpose shape [512, 512] perm [1, 0] copy 0.045ms ref transpose 0.393ms opt transpose 0.172ms overhead 1.6292478
transpose shape [1024, 1024] perm [1, 0] copy 0.210ms ref transpose 2.202ms opt transpose 0.703ms overhead 1.8715324
transpose shape [127, 127] perm [1, 0] copy 0.001ms ref transpose 0.006ms opt transpose 0.006ms overhead 3.6574275
transpose shape [255, 255] perm [1, 0] copy 0.007ms ref transpose 0.020ms opt transpose 0.019ms overhead 1.4803344
transpose shape [513, 513] perm [1, 0] copy 0.038ms ref transpose 0.087ms opt transpose 0.085ms overhead 0.4125464
transpose shape [1023, 1023] perm [1, 0] copy 0.230ms ref transpose 0.729ms opt transpose 0.646ms overhead 1.6150845
transpose shape [4, 1500, 8, 64] perm [0, 2, 1, 3] copy 1.012ms ref transpose 1.488ms opt transpose 1.455ms overhead 0.33376133
transpose shape [4, 8, 1500, 64] perm [0, 2, 1, 3] copy 1.023ms ref transpose 1.023ms opt transpose 1.008ms overhead 0
transpose shape [1, 1500, 8, 64] perm [0, 2, 3, 1] copy 0.118ms ref transpose 1.097ms opt transpose 0.452ms overhead 2.439674
transpose shape [1, 288, 8, 64] perm [0, 2, 1, 3] copy 0.022ms ref transpose 0.031ms opt transpose 0.029ms overhead 0.0066960254
```

Fixes https://github.com/robertknight/rten/issues/66.