### PR TITLE
Fix inconsistent outputs when beta == 0

### DIFF
--- a/src/gemm/kernels.rs
+++ b/src/gemm/kernels.rs
@@ -87,7 +87,8 @@ unsafe fn simd_gemv<S: SimdFloat, const NR_REGS: usize>(
             acc += *a_ptr.add(k) * *b_ptr.add(k * b_row_stride + c);
         }
         let out_el = out_ptr.add(c);
-        *out_el = (*out_el * beta) + acc * alpha;
+        let tmp = if beta == 0. { 0. } else { *out_el };
+        *out_el = beta * tmp + acc * alpha;
     }
 }
 


### PR DESCRIPTION
When `gemm` was called with `beta == 0`, the results could be inconsistent depending on the output location if the output buffer contained NaN or Inf before the call. Loops handling full tiles would skip reading the initial value from the output buffer if `beta == 0`, but loops handling non-full tiles would read the existing value and multiply by beta. This could produce Inf/Nan values. Fix the issue by always ignoring the initial value when beta is zero.

This choice is consistent with BLAS libraries [1] and is also necessary if we want to support using uninitialized output buffers, which may contain NaN/Inf bit patterns.

[1] See eg. https://community.intel.com/t5/Intel-oneAPI-Math-Kernel-Library/Vector-vector-product-cblas-sgemm-problem/td-p/785743