### PR TITLE
Avoid zeroing output buffer for MatMul operator

### DIFF
--- a/src/gemm.rs
+++ b/src/gemm.rs
@@ -436,6 +436,10 @@ impl GemmExecutor {
     ///
     /// This computes `output = alpha * (a @ b) + beta * output` where `@` is
     /// matrix multiplication.
+    ///
+    /// As a special case, when beta is `0.0`, the computation is simplified to
+    /// `output = alpha * (a @ b)`. ie. existing values in `output` are not
+    /// used. This matters if the existing values include infinities or NaNs.
     pub fn gemm(
         &self,
         out_data: &mut [f32],


### PR DESCRIPTION
Following the fix in https://github.com/robertknight/rten/pull/81, it is now possible to skip zeroing the output buffer for the MatMul operator. In the process add some APIs to `Tensor` to support working with uninitialized buffers. This makes the Whisper ASR demo mentioned in https://github.com/robertknight/rten/issues/42 about ~4% faster.

In the process, fix an issue where `gemm` did not initialize outputs if the `K` dimension is zero.