### PR TITLE
Tweak vector-matrix microkernel

### DIFF
--- a/src/gemm/kernels.rs
+++ b/src/gemm/kernels.rs
@@ -42,7 +42,7 @@ unsafe fn simd_gemv<S: SimdFloat, const NR_REGS: usize>(
     let mut b_tiles = range_chunks_exact(0..b.cols(), NR_REGS * S::LEN);
     for b_tile in b_tiles.by_ref() {
         let mut acc = [S::zero(); NR_REGS];
-        for k in 0..a.len() {
+        unroll_loop!(0..a.len(), k, 4, {
             let a_elt = *a_ptr.add(k);
             let a_elts = S::splat(a_elt);
 
@@ -50,7 +50,7 @@ unsafe fn simd_gemv<S: SimdFloat, const NR_REGS: usize>(
                 let b_elts = S::load(b_ptr.add(k * b_row_stride + b_tile.start + i * S::LEN));
                 acc[i] = a_elts.mul_add(b_elts, acc[i]);
             }
-        }
+        });
 
         if alpha != 1. {
             let alpha_vec = S::splat(alpha);

--- a/src/gemm/kernels/aarch64.rs
+++ b/src/gemm/kernels/aarch64.rs
@@ -77,7 +77,7 @@ unsafe impl Kernel for ArmNeonKernel {
     fn gemv_kernel(&self, out: &mut [f32], a: &[f32], b: Matrix, alpha: f32, beta: f32) {
         // Safety - float32x4_t is supported if this kernel was constructed.
         unsafe {
-            simd_gemv::<float32x4_t, 2>(out, a, b, alpha, beta);
+            simd_gemv::<float32x4_t, 4>(out, a, b, alpha, beta);
         }
     }
 }

--- a/src/gemm/kernels/x86_64.rs
+++ b/src/gemm/kernels/x86_64.rs
@@ -117,7 +117,7 @@ unsafe impl Kernel for FmaKernel {
         #[target_feature(enable = "avx2")]
         #[target_feature(enable = "fma")]
         unsafe fn gemv_kernel_impl(out: &mut [f32], a: &[f32], b: Matrix, alpha: f32, beta: f32) {
-            simd_gemv::<__m256, 2>(out, a, b, alpha, beta);
+            simd_gemv::<__m256, 4>(out, a, b, alpha, beta);
         }
         // Safety: Kernel can only be constructed if supported.
         unsafe {


### PR DESCRIPTION
Make some simple optimizations to vector-matrix product microkernels:

 - Unroll the inner loop over depth
 - Increase the number of accumulator registers from 2 to 4 for AVX2 and Arm Neon

Tested on AWS c6g.xlarge and c6i.xlarge instances, this improved GFLOPS on the `bench_gemm` matrix-vector product case by 2-3 GFLOPS. In a Whisper decoder benchmark, this reduced decoding time by ~2.5%.