### PR TITLE
Remove redundant `a_cols` argument from `prepack_b`

### DIFF
--- a/src/ops/matmul.rs
+++ b/src/ops/matmul.rs
@@ -176,7 +176,7 @@ fn matmul_impl(a: TensorView, b: TensorView, strategy: MatmulStrategy) -> Result
     });
     let prepacked_b = (num_a_matrices > 1 && num_b_matrices == 1 && a_rows > 1).then(|| {
         let b_matrix = b.inner_iter::<2>().next().unwrap();
-        gemm.prepack_b(b_matrix, a_cols)
+        gemm.prepack_b(b_matrix)
     });
 
     a_broadcast

--- a/src/ops/rnn.rs
+++ b/src/ops/rnn.rs
@@ -211,7 +211,6 @@ fn extract_weights_and_bias<'a>(
     gate_index: usize,
     sequence_len: usize,
 ) -> GateWeightsAndBias<'a> {
-    let input_size = weights.size(2);
     let hidden_size = weights.size(1) / num_gates;
     let weights = extract_matrix(weights, dir, num_gates, gate_index).transposed();
     let recurrent_weights =
@@ -229,12 +228,12 @@ fn extract_weights_and_bias<'a>(
     let prepack = sequence_len > 4;
 
     let weights = if prepack {
-        GateWeights::Packed(gemm.prepack_b(weights, input_size))
+        GateWeights::Packed(gemm.prepack_b(weights))
     } else {
         GateWeights::Unpacked(weights)
     };
     let recurrent_weights = if prepack {
-        GateWeights::Packed(gemm.prepack_b(recurrent_weights, hidden_size))
+        GateWeights::Packed(gemm.prepack_b(recurrent_weights))
     } else {
         GateWeights::Unpacked(recurrent_weights)
     };


### PR DESCRIPTION
When packing the RHS input for matrix multiplication, `b.rows()` is the same as `a.cols()`, so this argument is redundant. More importantly, it removes an apparent dependence on knowing the size of the LHS matrix when prepacking the RHS.