### PR TITLE
Reduce allocations / copies in `Graph::run`

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -450,7 +450,7 @@ impl Graph {
             });
 
             // Collect all or remaining inputs for the operator
-            let mut op_inputs: Vec<Option<Input>> = Vec::new();
+            let mut op_inputs: Vec<Option<Input>> = Vec::with_capacity(op_node.inputs.len());
             for node_id in op_node.inputs.iter() {
                 if in_place_input.is_some() && *node_id == in_place_input_id {
                     continue;
@@ -495,12 +495,10 @@ impl Graph {
             let op_result = if let Some(input) = in_place_input {
                 op_node
                     .operator
-                    .run_in_place(input, InputList::from_optional(&op_inputs))
+                    .run_in_place(input, InputList::from_optional(op_inputs))
                     .map(|out| [out].into())
             } else {
-                op_node
-                    .operator
-                    .run(InputList::from_optional(&op_inputs[..]))
+                op_node.operator.run(InputList::from_optional(op_inputs))
             };
 
             if record_timing {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -108,18 +108,6 @@ impl Node {
 /// ID of a node in a [Model](crate::Model) graph.
 pub type NodeId = usize;
 
-/// A graph defines how to produce output values from a set of dynamic input
-/// values and constants, by flowing the inputs through a series of computation
-/// steps (operators).
-///
-/// Graphs consists of three types of node, each of which has a numeric ID and a
-/// unique string name. A node in the graph is either a constant value such as
-/// weights produced during training, a dynamically supplied or produced input
-/// or output value, or a computation step.
-pub struct Graph {
-    nodes: Vec<Node>,
-}
-
 /// Reasons why a graph execution failed
 #[derive(Eq, PartialEq, Debug)]
 pub enum RunError {
@@ -235,6 +223,18 @@ pub struct RunOptions {
     /// including input shapes and execution time. This will slow down
     /// execution.
     pub verbose: bool,
+}
+
+/// A graph defines how to produce output values from a set of dynamic input
+/// values and constants, by flowing the inputs through a series of computation
+/// steps (operators).
+///
+/// Graphs consists of three types of node, each of which has a numeric ID and a
+/// unique string name. A node in the graph is either a constant value such as
+/// weights produced during training, a dynamically supplied or produced input
+/// or output value, or a computation step.
+pub struct Graph {
+    nodes: Vec<Node>,
 }
 
 impl Graph {

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -690,10 +690,8 @@ impl<'a> InputList<'a> {
         }
     }
 
-    pub fn from_optional<'b>(inputs: &'b [Option<Input<'b>>]) -> InputList<'b> {
-        InputList {
-            inputs: inputs.to_vec(),
-        }
+    pub fn from_optional(inputs: Vec<Option<Input>>) -> InputList {
+        InputList { inputs }
     }
 
     /// Get an optional input.

--- a/src/ops/resize.rs
+++ b/src/ops/resize.rs
@@ -725,13 +725,13 @@ mod tests {
                 mode: ResizeMode::Linear,
                 ..Resize::default()
             };
-            let inputs = [
+            let inputs = vec![
                 Some((&case.image).into()),
                 None, // `roi`
                 case.scales.as_ref().map(|t| t.into()),
                 case.sizes.as_ref().map(|t| t.into()),
             ];
-            let result = op.run(InputList::from_optional(&inputs));
+            let result = op.run(InputList::from_optional(inputs));
             match (case.expected, result) {
                 (CaseOutput::Shape(shape), Ok(out)) => {
                     let tensor = out[0].as_float_ref().unwrap();


### PR DESCRIPTION
This eliminates some unnecessary allocations and copies in `Graph::run`:

- Avoid an unnecessary clone of operator inputs when creating an `InputList` for an operator
- Use `with_capacity` to correctly size allocations up-front
- Avoid adding all the graph constants to a NodeId -> Input hash map at the start of each `Graph::run`. Instead look up the constant node and produce an `Input` just before the operator is called