### PR TITLE
Optimize node ID hashing, `DynLayout` construction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,6 +305,7 @@ dependencies = [
  "rten-bench",
  "rten-tensor",
  "rten-vecmath",
+ "rustc-hash",
  "serde_json",
  "smallvec",
  "wasm-bindgen",
@@ -382,6 +383,12 @@ dependencies = [
  "fastrand",
  "libm",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ smallvec = { version = "1.10.0", features = ["union", "const_generics", "const_n
 rten-tensor = { path = "./rten-tensor", version = "0.7.0" }
 rten-vecmath = { path = "./rten-vecmath", version = "0.7.0" }
 fastrand = { version = "2.0.2", optional = true }
+rustc-hash = "1.1.0"
 
 [dev-dependencies]
 rten = { path = ".", features = ["random"] }

--- a/rten-tensor/src/layout.rs
+++ b/rten-tensor/src/layout.rs
@@ -1081,6 +1081,7 @@ pub trait IntoLayout: AsRef<[usize]> {
 impl<const N: usize> IntoLayout for [usize; N] {
     type Layout = NdLayout<N>;
 
+    #[inline]
     fn into_layout(self) -> NdLayout<N> {
         NdLayout::from_shape(self)
     }
@@ -1089,6 +1090,7 @@ impl<const N: usize> IntoLayout for [usize; N] {
 impl<'a> IntoLayout for &'a [usize] {
     type Layout = DynLayout;
 
+    #[inline]
     fn into_layout(self) -> DynLayout {
         DynLayout::from_shape(self)
     }

--- a/rten-tensor/src/layout.rs
+++ b/rten-tensor/src/layout.rs
@@ -840,11 +840,12 @@ impl DynLayout {
 
     /// Create a shape-and-strides array for a contiguous layout.
     fn contiguous_shape_and_strides(shape: &[usize]) -> SmallVec<[usize; 8]> {
-        let mut strides_and_shape = SmallVec::with_capacity(shape.len() * 2);
-        strides_and_shape.extend_from_slice(shape);
-        for i in 0..shape.len() {
-            let stride = shape[i + 1..].iter().product();
-            strides_and_shape.push(stride);
+        let mut strides_and_shape: SmallVec<[usize; 8]> = SmallVec::from_slice(shape);
+        strides_and_shape.resize(shape.len() * 2, 0);
+        let mut stride = 1;
+        for i in (0..shape.len()).rev() {
+            strides_and_shape[shape.len() + i] = stride;
+            stride *= shape[i];
         }
         strides_and_shape
     }


### PR DESCRIPTION
This is a collection of small optimizations for graph executions with many operations relative to compute. These were found by profiling main-thread execution time of the [whisper-rs](https://github.com/igor-yusupov/comparisons-rten/tree/main/whisper/whisper-rs) demo.