### PR TITLE
Support matrices with non-unit column stride in vector-matrix products

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,11 @@ wasm-nosimd:
 .PHONY: wasm-all
 wasm-all: wasm wasm-nosimd
 
+.PHONY: wasm-tests
+wasm-tests:
+	cargo build --tests -p rten
+	wasmtime --dir . target/wasm32-wasi/debug/deps/rten-*.wasm
+
 src/schema_generated.rs: src/schema.fbs
 	flatc -o src/ --rust src/schema.fbs
 	cargo fmt

--- a/rten-vecmath/src/simd_vec.rs
+++ b/rten-vecmath/src/simd_vec.rs
@@ -200,6 +200,12 @@ pub trait SimdFloat: Copy + Sized {
         y.mul(self)
     }
 
+    /// Sum all the lanes in this vector.
+    ///
+    /// The ordering of the summation is not specified. This can lead to small
+    /// differences in results depending on the architecture.
+    unsafe fn sum(self) -> f32;
+
     /// Load `Self::LEN` floats from the memory address at `ptr`.
     ///
     /// Implementations must not require `ptr` to be aligned.
@@ -395,5 +401,10 @@ impl SimdFloat for f32 {
     #[inline]
     unsafe fn store(self, ptr: *mut f32) {
         *ptr = self;
+    }
+
+    #[inline]
+    unsafe fn sum(self) -> f32 {
+        self
     }
 }

--- a/rten-vecmath/src/simd_vec/aarch64.rs
+++ b/rten-vecmath/src/simd_vec/aarch64.rs
@@ -1,8 +1,8 @@
 use std::arch::aarch64::{
-    float32x4_t, int32x4_t, uint32x4_t, vabsq_f32, vaddq_f32, vaddq_s32, vbslq_f32, vbslq_s32,
-    vcgeq_f32, vcgtq_s32, vcleq_f32, vcltq_f32, vcvtq_s32_f32, vdivq_f32, vdupq_n_f32, vdupq_n_s32,
-    vfmaq_f32, vld1q_f32, vld1q_s32, vmaxq_f32, vmulq_f32, vreinterpretq_f32_s32, vshlq_n_s32,
-    vst1q_f32, vst1q_s32, vsubq_f32, vsubq_s32,
+    float32x4_t, int32x4_t, uint32x4_t, vabsq_f32, vaddq_f32, vaddq_s32, vaddvq_f32, vbslq_f32,
+    vbslq_s32, vcgeq_f32, vcgtq_s32, vcleq_f32, vcltq_f32, vcvtq_s32_f32, vdivq_f32, vdupq_n_f32,
+    vdupq_n_s32, vfmaq_f32, vld1q_f32, vld1q_s32, vmaxq_f32, vmulq_f32, vreinterpretq_f32_s32,
+    vshlq_n_s32, vst1q_f32, vst1q_s32, vsubq_f32, vsubq_s32,
 };
 
 use crate::simd_vec::{SimdFloat, SimdInt};
@@ -143,5 +143,10 @@ impl SimdFloat for float32x4_t {
     #[inline]
     unsafe fn store(self, ptr: *mut f32) {
         vst1q_f32(ptr, self)
+    }
+
+    #[inline]
+    unsafe fn sum(self) -> f32 {
+        vaddvq_f32(self)
     }
 }

--- a/rten-vecmath/src/simd_vec/x86_64.rs
+++ b/rten-vecmath/src/simd_vec/x86_64.rs
@@ -1,10 +1,11 @@
 use std::arch::x86_64::{
     __m256, __m256i, _mm256_add_epi32, _mm256_add_ps, _mm256_andnot_ps, _mm256_blendv_epi8,
-    _mm256_blendv_ps, _mm256_castsi256_ps, _mm256_cmp_ps, _mm256_cmpgt_epi32, _mm256_cvttps_epi32,
-    _mm256_div_ps, _mm256_fmadd_ps, _mm256_loadu_ps, _mm256_loadu_si256, _mm256_max_ps,
-    _mm256_mul_ps, _mm256_set1_epi32, _mm256_set1_ps, _mm256_setzero_si256, _mm256_slli_epi32,
-    _mm256_storeu_ps, _mm256_storeu_si256, _mm256_sub_epi32, _mm256_sub_ps, _mm_prefetch,
-    _CMP_GE_OQ, _CMP_LE_OQ, _CMP_LT_OQ, _MM_HINT_ET0, _MM_HINT_T0,
+    _mm256_blendv_ps, _mm256_castps256_ps128, _mm256_castsi256_ps, _mm256_cmp_ps,
+    _mm256_cmpgt_epi32, _mm256_cvttps_epi32, _mm256_div_ps, _mm256_extractf128_ps, _mm256_fmadd_ps,
+    _mm256_loadu_ps, _mm256_loadu_si256, _mm256_max_ps, _mm256_mul_ps, _mm256_set1_epi32,
+    _mm256_set1_ps, _mm256_setzero_si256, _mm256_slli_epi32, _mm256_storeu_ps, _mm256_storeu_si256,
+    _mm256_sub_epi32, _mm256_sub_ps, _mm_add_ps, _mm_cvtss_f32, _mm_movehl_ps, _mm_prefetch,
+    _mm_shuffle_ps, _CMP_GE_OQ, _CMP_LE_OQ, _CMP_LT_OQ, _MM_HINT_ET0, _MM_HINT_T0,
 };
 
 use crate::simd_vec::{SimdFloat, SimdInt};
@@ -201,6 +202,21 @@ impl SimdFloat for __m256 {
         _mm256_storeu_ps(ptr, self)
     }
 
+    #[inline]
+    unsafe fn sum(self) -> f32 {
+        // See https://stackoverflow.com/a/13222410/434243
+        let hi_4 = _mm256_extractf128_ps(self, 1);
+        let lo_4 = _mm256_castps256_ps128(self);
+        let sum_4 = _mm_add_ps(lo_4, hi_4);
+        let lo_2 = sum_4;
+        let hi_2 = _mm_movehl_ps(sum_4, sum_4);
+        let sum_2 = _mm_add_ps(lo_2, hi_2);
+        let lo = sum_2;
+        let hi = _mm_shuffle_ps(sum_2, sum_2, 0x1);
+        let sum = _mm_add_ps(lo, hi);
+        _mm_cvtss_f32(sum)
+    }
+
     /// Prefetch the cache line containing `data`, for reading.
     #[inline]
     unsafe fn prefetch(data: *const f32) {
@@ -219,8 +235,8 @@ use std::arch::x86_64::{
     __m512, __m512i, __mmask16, _mm512_abs_ps, _mm512_add_epi32, _mm512_add_ps,
     _mm512_castsi512_ps, _mm512_cmp_epi32_mask, _mm512_cmp_ps_mask, _mm512_cvttps_epi32,
     _mm512_div_ps, _mm512_fmadd_ps, _mm512_loadu_ps, _mm512_loadu_si512, _mm512_mask_blend_epi32,
-    _mm512_mask_blend_ps, _mm512_max_ps, _mm512_mul_ps, _mm512_set1_epi32, _mm512_set1_ps,
-    _mm512_setzero_si512, _mm512_sllv_epi32, _mm512_storeu_ps, _mm512_storeu_si512,
+    _mm512_mask_blend_ps, _mm512_max_ps, _mm512_mul_ps, _mm512_reduce_add_ps, _mm512_set1_epi32,
+    _mm512_set1_ps, _mm512_setzero_si512, _mm512_sllv_epi32, _mm512_storeu_ps, _mm512_storeu_si512,
     _mm512_sub_epi32, _mm512_sub_ps, _MM_CMPINT_LT,
 };
 
@@ -375,5 +391,10 @@ impl SimdFloat for __m512 {
     #[inline]
     unsafe fn prefetch_write(data: *mut f32) {
         _mm_prefetch(data as *const i8, _MM_HINT_ET0);
+    }
+
+    #[inline]
+    unsafe fn sum(self) -> f32 {
+        _mm512_reduce_add_ps(self)
     }
 }

--- a/src/gemm.rs
+++ b/src/gemm.rs
@@ -1710,6 +1710,14 @@ mod tests {
                 b_strides: Strides::Transposed,
                 ..Default::default()
             },
+            // Transposed matrix with alpha != 1
+            Case {
+                n: 20,
+                k: 20,
+                alpha: 0.5,
+                b_strides: Strides::Transposed,
+                ..Default::default()
+            },
             // Matrix with non-unit strides
             Case {
                 n: 21,
@@ -1722,6 +1730,14 @@ mod tests {
                 n: 21,
                 k: 21,
                 beta: 0.5,
+                b_strides: Strides::Other,
+                ..Default::default()
+            },
+            // Matrix with non-unit strides, alpha != 1
+            Case {
+                n: 21,
+                k: 21,
+                alpha: 0.5,
                 b_strides: Strides::Other,
                 ..Default::default()
             },

--- a/src/gemm.rs
+++ b/src/gemm.rs
@@ -633,8 +633,6 @@ fn gemv(
     beta: f32,
     bias: Option<f32>,
 ) {
-    assert!(a.is_contiguous());
-    assert!(b.is_contiguous());
     assert!(output_mat.is_contiguous());
 
     let a_cols = a.size(0);
@@ -644,19 +642,21 @@ fn gemv(
     let b_block_size = 256;
     let k_block_size = 256;
 
+    let a = a.to_contiguous();
+    let a_data = a.data().unwrap();
+
     // Partition the matrix and vector into blocks, to achieve effective
     // cache usage and enable parallelism.
     range_chunks(0..b_cols, b_block_size)
         .zip(out_data.chunks_mut(b_block_size))
         .par_bridge()
-        .for_each(|(b_block, out_chunk)| {
-            let a_data = a.data().unwrap();
+        .for_each(|(col_block, out_chunk)| {
             let mut effective_beta = beta;
 
-            for k_block in range_chunks(0..a_cols, k_block_size) {
-                let a_block = &a_data[k_block.clone()];
-                let b_block = b.slice::<2, _>((k_block, b_block.clone()));
-
+            for (k_block, a_block) in
+                range_chunks(0..a_cols, k_block_size).zip(a_data.chunks(k_block_size))
+            {
+                let b_block = b.slice::<2, _>((k_block, col_block.clone()));
                 kernel.gemv_kernel(out_chunk, a_block, b_block, alpha, effective_beta);
 
                 // Reset `beta` so that subsequent updates for each column
@@ -743,19 +743,17 @@ fn gemm_impl(
 
     // Use optimized path for vector-matrix products.
     if let (1, GemmInputA::Unpacked(a), GemmInputB::Unpacked(b)) = (a.rows(), a, b) {
-        if let (Some(_), Some(_)) = (a.data(), b.data()) {
-            gemv(
-                kernel,
-                a.slice::<1, _>(0),
-                b,
-                output_mat.view_mut(),
-                alpha,
-                beta,
-                // nb. We checked above that, if present, the bias length matches `a.rows()`.
-                bias.map(|b| b[0]),
-            );
-            return;
-        }
+        gemv(
+            kernel,
+            a.slice::<1, _>(0),
+            b,
+            output_mat.view_mut(),
+            alpha,
+            beta,
+            // nb. We checked above that, if present, the bias length matches `a.rows()`.
+            bias.map(|b| b[0]),
+        );
+        return;
     }
 
     let output_tiles = OutputTiles::new(output_mat, kernel.mr(), kernel.nr());
@@ -1598,12 +1596,32 @@ mod tests {
 
     #[test]
     fn test_gemv() -> Result<(), Box<dyn Error>> {
+        enum Strides {
+            Contiguous,
+            Transposed,
+            Other,
+        }
+
         struct Case {
             n: usize,
             k: usize,
             alpha: f32,
             beta: f32,
             bias: Option<f32>,
+            b_strides: Strides,
+        }
+
+        impl Default for Case {
+            fn default() -> Case {
+                Case {
+                    n: 16,
+                    k: 16,
+                    alpha: 1.,
+                    beta: 0.,
+                    bias: None,
+                    b_strides: Strides::Contiguous,
+                }
+            }
         }
 
         let cases = [
@@ -1611,88 +1629,101 @@ mod tests {
             Case {
                 n: 0,
                 k: 1,
-                alpha: 1.,
-                beta: 0.,
-                bias: None,
+                ..Default::default()
             },
             Case {
                 n: 1,
                 k: 0,
-                alpha: 1.,
-                beta: 0.,
-                bias: None,
+                ..Default::default()
             },
             // Smallest possible input
             Case {
                 n: 1,
                 k: 1,
-                alpha: 1.,
-                beta: 0.,
-                bias: None,
+                ..Default::default()
             },
             // n is a multiple of the tile size (16 for AVX 2 / FMA)
             Case {
                 n: 16,
                 k: 16,
-                alpha: 1.,
-                beta: 0.,
-                bias: None,
+                ..Default::default()
             },
             // n is not an exact multiple of the tile size
             Case {
                 n: 20,
                 k: 16,
-                alpha: 1.,
-                beta: 1.,
-                bias: None,
+                ..Default::default()
             },
             // n exceeds column block size
             Case {
                 n: 300,
                 k: 16,
-                alpha: 1.,
-                beta: 1.,
-                bias: None,
+                ..Default::default()
             },
             // k exceeds depth block size
             Case {
                 n: 20,
                 k: 300,
-                alpha: 1.,
-                beta: 1.,
-                bias: None,
+                ..Default::default()
             },
             // beta value = 0.
             Case {
                 n: 20,
                 k: 300,
-                alpha: 1.,
                 beta: 0.,
-                bias: None,
+                ..Default::default()
             },
             // Non-standard beta value
             Case {
                 n: 20,
                 k: 300,
-                alpha: 1.,
                 beta: 0.5,
-                bias: None,
+                ..Default::default()
             },
             // Non-standard alpha value
             Case {
                 n: 20,
                 k: 20,
                 alpha: 0.5,
-                beta: 1.,
-                bias: None,
+                ..Default::default()
             },
             // Test with bias
             Case {
                 n: 20,
                 k: 20,
-                alpha: 1.,
-                beta: 0.,
                 bias: Some(0.5),
+                ..Default::default()
+            },
+            // Transposed matrix. Note both `n` and `k` are chosen to not be
+            // an exact multiple of column or depth tile sizes.
+            Case {
+                n: 21,
+                k: 21,
+                b_strides: Strides::Transposed,
+                ..Default::default()
+            },
+            // Transposed matrix with beta != 0
+            Case {
+                n: 21,
+                k: 21,
+                beta: 1.,
+                b_strides: Strides::Transposed,
+                ..Default::default()
+            },
+            // Matrix with non-unit strides
+            Case {
+                n: 21,
+                k: 21,
+                b_strides: Strides::Other,
+                ..Default::default()
+            },
+            // Matrix with non-unit strides, beta != 0
+            Case {
+                n: 21,
+                k: 21,
+                beta: 0.5,
+                b_strides: Strides::Other,
+                ..Default::default()
             },
         ];
 
@@ -1704,11 +1735,23 @@ mod tests {
             alpha,
             beta,
             bias,
+            b_strides,
         } in cases
         {
             let a = Tensor::rand(&[1, k], &mut rng);
-            let b = Tensor::rand(&[k, n], &mut rng);
-            let mut result = Tensor::zeros(&[1, n]);
+            let mut b = Tensor::rand(&[k, n], &mut rng);
+            match b_strides {
+                Strides::Contiguous => {}
+                Strides::Transposed => {
+                    b.transpose();
+                }
+                Strides::Other => {
+                    b = Tensor::from_data_with_strides(&[k, n / 2], b.to_vec(), &[b.stride(0), 2])
+                        .unwrap();
+                }
+            }
+
+            let mut result = Tensor::zeros(&[1, b.size(1)]);
             let bias_array = bias.map(|b| [b]);
 
             run_gemm(


### PR DESCRIPTION
Add an alternate case where the matrix is transposed (unit row stride, non-unit column stride) as well as a general case when neither the row nor column strides are 1.

The immediate use case is a model which runs LSTM ops with a sequence length of 1. This results in a vector-matrix product operation where the weight matrix is transposed.

- Add `SimdFloat::sum` to horizontally sum SIMD vectors
- Generalize the vector-matrix product path to support B matrices with arbitrary strides. This is split into two cases, one for a transposed matrix, and one for when neither the row nor column stride is 1