### PR TITLE
Separate out the parallel part of depthwise conv into a separate function

### DIFF
--- a/src/ops/conv.rs
+++ b/src/ops/conv.rs
@@ -1,4 +1,5 @@
 use std::iter::zip;
+use std::mem::MaybeUninit;
 
 use std::ops::Range;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -227,6 +228,83 @@ fn conv_2d_pointwise(
     unsafe { output.assume_init() }
 }
 
+/// Compute depthwise convolution for the block of channels from `input`
+/// specified by `chan_range` into `out_chans`.
+///
+/// `col_range_for_kernel_x` is a precomputed map of kernel X coordinate to
+/// `(in_range, out_range)` of column ranges that are valid for the input and
+/// output.
+///
+/// When this function returns, all elements of `out_chans` will have been
+/// initialized.
+fn conv_2d_depthwise_block(
+    mut output: NdTensorViewMut<MaybeUninit<f32>, 3>, // C, H, W
+    chan_range: Range<usize>,
+    input: NdTensorView<f32, 3>,  // C, H, W
+    kernel: NdTensorView<f32, 4>, // C, _, Kh, Kw
+    bias: Option<NdTensorView<f32, 1>>,
+    padding: [usize; 4],
+    strides: [usize; 2],
+    dilations: [usize; 2],
+    col_range_for_kernel_x: &[(Range<usize>, Range<usize>)],
+) {
+    let [_, out_h, _out_w] = output.shape();
+    let [_, _, k_h, _k_w] = kernel.shape();
+    let [_, in_h, _in_w] = input.shape();
+    let [stride_h, stride_w] = strides;
+    let [pad_top, _pad_left, _pad_bottom, _pad_right] = padding;
+    let [dilation_y, _dilation_x] = dilations;
+
+    for c in chan_range.clone() {
+        let kernel_view = kernel.slice([c, 0]).weakly_checked_view();
+
+        // For efficiency, use manual slicing in the inner loops to extract
+        // input/output rows.
+        let mut out_chan = output.slice_mut::<2, _>([c - chan_range.start]);
+        let out_row_stride = out_chan.stride(0);
+        let out_chan_data = out_chan.data_mut().unwrap();
+
+        let in_chan = input.slice::<2, _>([c]);
+        let in_row_stride = in_chan.stride(0);
+        let in_chan_data = in_chan.data().unwrap();
+
+        let init_value = if let Some(bias) = bias { bias[[c]] } else { 0. };
+
+        // The loops here are ordered so that the inner-most loop is as
+        // efficient as possible and runs for as long as possible over a
+        // contiguous slice of memory.
+        for out_y in 0..out_h {
+            let out_row = &mut out_chan_data[out_y * out_row_stride..][..out_row_stride];
+
+            // Initialize output row.
+            for x in out_row.iter_mut() {
+                x.write(init_value);
+            }
+            let out_row: &mut [f32] = unsafe { std::mem::transmute(out_row) };
+
+            for k_y in 0..k_h {
+                let in_y = out_y * stride_h + k_y * dilation_y;
+                if in_y < pad_top || in_y >= in_h + pad_top {
+                    continue;
+                }
+
+                let in_row_y = in_y - pad_top;
+                let in_row = &in_chan_data[in_row_y * in_row_stride..][..in_row_stride];
+
+                for (k_x, (in_range, out_range)) in col_range_for_kernel_x.iter().enumerate() {
+                    add_scaled_vector(
+                        &mut out_row[out_range.clone()],
+                        &in_row[in_range.clone()],
+                        1,        /* dest_stride */
+                        stride_w, /* src_stride */
+                        kernel_view[[k_y, k_x]],
+                    );
+                }
+            }
+        }
+    }
+}
+
 /// Specialization of conv_2d for depthwise convolutions.
 ///
 /// Depthwise convolutions operate over a single input/output channel at
@@ -241,11 +319,11 @@ fn conv_2d_depthwise(
     dilations: [usize; 2],
     out_hw: [usize; 2],
 ) -> Tensor {
-    let [batch, _in_c, in_h, in_w]: [usize; 4] = input.shape();
-    let [out_c, _, k_h, k_w]: [usize; 4] = kernel.shape();
-    let [pad_top, pad_left, _pad_bottom, _pad_right] = padding;
-    let [stride_h, stride_w] = strides;
-    let [dilation_y, dilation_x] = dilations;
+    let [batch, _in_c, _in_h, in_w]: [usize; 4] = input.shape();
+    let [out_c, _, _k_h, k_w]: [usize; 4] = kernel.shape();
+    let [_pad_top, pad_left, _pad_bottom, _pad_right] = padding;
+    let [_stride_h, stride_w] = strides;
+    let [_dilation_y, dilation_x] = dilations;
     let [out_h, out_w] = out_hw;
 
     let mut output = NdTensor::uninit([batch, out_c, out_h, out_w]);
@@ -288,59 +366,19 @@ fn conv_2d_depthwise(
             .zip(range_chunks(0..out_c, channel_chunk_size))
             .par_bridge()
             .for_each(|(mut out_chans, chan_range)| {
-                for c in chan_range.clone() {
-                    let kernel_view = kernel.slice([c, 0]).weakly_checked_view();
+                conv_2d_depthwise_block(
+                    out_chans.nd_view_mut(),
+                    chan_range,
+                    input,
+                    kernel.view(),
+                    bias,
+                    padding,
+                    strides,
+                    dilations,
+                    &col_range_for_kernel_x,
+                );
 
-                    // For efficiency, use manual slicing in the inner loops to extract
-                    // input/output rows.
-                    let mut out_chan = out_chans.slice_mut::<2, _>([c - chan_range.start]);
-                    let out_row_stride = out_chan.stride(0);
-                    let out_chan_data = out_chan.data_mut().unwrap();
-
-                    let in_chan = input.slice::<2, _>([c]);
-                    let in_row_stride = in_chan.stride(0);
-                    let in_chan_data = in_chan.data().unwrap();
-
-                    let init_value = if let Some(bias) = bias { bias[[c]] } else { 0. };
-
-                    // The loops here are ordered so that the inner-most loop is as
-                    // efficient as possible and runs for as long as possible over a
-                    // contiguous slice of memory.
-                    for out_y in 0..out_h {
-                        let out_row =
-                            &mut out_chan_data[out_y * out_row_stride..][..out_row_stride];
-
-                        // Initialize output row.
-                        for x in out_row.iter_mut() {
-                            x.write(init_value);
-                        }
-                        let out_row: &mut [f32] = unsafe { std::mem::transmute(out_row) };
-
-                        for k_y in 0..k_h {
-                            let in_y = out_y * stride_h + k_y * dilation_y;
-                            if in_y < pad_top || in_y >= in_h + pad_top {
-                                continue;
-                            }
-
-                            let in_row_y = in_y - pad_top;
-                            let in_row = &in_chan_data[in_row_y * in_row_stride..][..in_row_stride];
-
-                            for (k_x, (in_range, out_range)) in
-                                col_range_for_kernel_x.iter().enumerate()
-                            {
-                                add_scaled_vector(
-                                    &mut out_row[out_range.clone()],
-                                    &in_row[in_range.clone()],
-                                    1,        /* dest_stride */
-                                    stride_w, /* src_stride */
-                                    kernel_view[[k_y, k_x]],
-                                );
-                            }
-                        }
-                    }
-
-                    n_init.fetch_add(out_h * out_w, Ordering::SeqCst);
-                }
+                n_init.fetch_add(out_chans.len(), Ordering::SeqCst);
             });
     }
 


### PR DESCRIPTION
The main motivation is to give this block of code a more readable name in the profiler/debugger etc, as it runs on a separate thread from the setup code in `conv_2d_depthwise`. It also makes the parent function a bit easier to follow.