### PR TITLE
Accelerate im2col transform using SIMD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,8 @@ wasm-all: wasm wasm-nosimd
 
 .PHONY: wasm-tests
 wasm-tests:
-	cargo build --tests -p rten
+	rm -f target/wasm32-wasi/debug/deps/rten-*.wasm
+	RUSTFLAGS="-C target-feature=+simd128" cargo build --target wasm32-wasi --tests -p rten
 	wasmtime --dir . target/wasm32-wasi/debug/deps/rten-*.wasm
 
 src/schema_generated.rs: src/schema.fbs

--- a/rten-cli/Cargo.toml
+++ b/rten-cli/Cargo.toml
@@ -15,6 +15,10 @@ rten = { path = "../", version = "0.7.0", features=["random"] }
 rten-tensor = { path = "../rten-tensor", version = "0.7.0" }
 lexopt = "0.3.0"
 
+[features]
+# Use AVX-512 instructions if available. Requires nightly Rust for AVX-512 intrinsics.
+avx512 = ["rten/avx512"]
+
 [[bin]]
 name = "rten"
 path = "src/main.rs"

--- a/rten-examples/Cargo.toml
+++ b/rten-examples/Cargo.toml
@@ -21,6 +21,10 @@ rten-imageproc = { path = "../rten-imageproc" }
 rten-tensor = { path = "../rten-tensor" }
 rten-text = { path = "../rten-text" }
 
+[features]
+# Use AVX-512 instructions if available. Requires nightly Rust for AVX-512 intrinsics.
+avx512 = ["rten/avx512"]
+
 [lints.clippy]
 # Allows use of `..Default::default()` for future compatibility even when not
 # currently needed.

--- a/rten-vecmath/src/lib.rs
+++ b/rten-vecmath/src/lib.rs
@@ -107,7 +107,7 @@ pub fn is_avx512_supported() -> bool {
     }
 }
 
-/// Maximum SIMD vector size supported by this library, in units of 32-byte lanes.
+/// Maximum SIMD vector size supported by this library, in units of 32-bit lanes.
 ///
 /// Chosen as 16 to match AVX-512.
 const MAX_LEN: usize = 16;

--- a/rten-vecmath/src/lib.rs
+++ b/rten-vecmath/src/lib.rs
@@ -39,6 +39,74 @@ use simd_vec::SimdFloat;
 pub use softmax::{vec_softmax, vec_softmax_in_place};
 pub use tanh::{tanh, vec_tanh, vec_tanh_in_place};
 
+/// Detect availability of AVX-512 on macOS, where `is_x86_feature_detected`
+/// can return false even if AVX-512 is available.
+///
+/// See https://github.com/golang/go/issues/43089. Go chose to use the
+/// `commpage` to get the info. We use `sysctlbyname` instead since it is
+/// a documented API.
+#[cfg(feature = "avx512")]
+#[cfg(target_os = "macos")]
+fn test_for_avx512_on_macos() -> bool {
+    use std::ffi::CStr;
+    use std::os::raw::{c_char, c_int, c_void};
+    use std::sync::OnceLock;
+
+    #[link(name = "c")]
+    extern "C" {
+        /// See https://developer.apple.com/documentation/kernel/1387446-sysctlbyname.
+        fn sysctlbyname(
+            name: *const c_char,
+            oldp: *mut c_void,
+            oldlenp: *mut usize,
+            newp: *const c_void,
+            newlen: usize,
+        ) -> c_int;
+    }
+
+    static AVX512_AVAILABLE: OnceLock<bool> = OnceLock::new();
+
+    *AVX512_AVAILABLE.get_or_init(|| {
+        unsafe {
+            let mut ret = 0u64;
+            let mut size = std::mem::size_of::<u64>();
+
+            // We test only for avx512vl, as this implies avx512f.
+            let sysctl_ret = sysctlbyname(
+                CStr::from_bytes_with_nul(b"hw.optional.avx512vl\0")
+                    .unwrap()
+                    .as_ptr(),
+                std::mem::transmute(&mut ret),
+                &mut size,
+                std::ptr::null(),
+                0,
+            );
+            sysctl_ret == 0 && ret == 1
+        }
+    })
+}
+
+/// Test if the current system has basic AVX-512 support (AVX-512 F, AVX-512 VL).
+///
+/// This is unfortunately not as simple as using `is_x86_feature_detected`
+/// because that can return incorrect results on macOS.
+#[cfg(feature = "avx512")]
+#[cfg(target_arch = "x86_64")]
+pub fn is_avx512_supported() -> bool {
+    if is_x86_feature_detected!("avx512f") && is_x86_feature_detected!("avx512vl") {
+        true
+    } else {
+        #[cfg(target_os = "macos")]
+        {
+            test_for_avx512_on_macos()
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            false
+        }
+    }
+}
+
 /// Maximum SIMD vector size supported by this library, in units of 32-byte lanes.
 ///
 /// Chosen as 16 to match AVX-512.

--- a/rten-vecmath/src/simd_vec/aarch64.rs
+++ b/rten-vecmath/src/simd_vec/aarch64.rs
@@ -1,8 +1,9 @@
 use std::arch::aarch64::{
     float32x4_t, int32x4_t, uint32x4_t, vabsq_f32, vaddq_f32, vaddq_s32, vaddvq_f32, vbslq_f32,
-    vbslq_s32, vcgeq_f32, vcgtq_s32, vcleq_f32, vcltq_f32, vcvtq_s32_f32, vdivq_f32, vdupq_n_f32,
-    vdupq_n_s32, vfmaq_f32, vld1q_f32, vld1q_s32, vmaxq_f32, vmulq_f32, vreinterpretq_f32_s32,
-    vshlq_n_s32, vst1q_f32, vst1q_s32, vsubq_f32, vsubq_s32,
+    vbslq_s32, vceqq_s32, vcgeq_f32, vcgeq_s32, vcgtq_s32, vcleq_f32, vcleq_s32, vcltq_f32,
+    vcltq_s32, vcvtq_s32_f32, vdivq_f32, vdupq_n_f32, vdupq_n_s32, vfmaq_f32, vld1q_f32, vld1q_s32,
+    vmaxq_f32, vmulq_f32, vreinterpretq_f32_s32, vreinterpretq_u32_s32, vshlq_n_s32, vst1q_f32,
+    vst1q_s32, vsubq_f32, vsubq_s32,
 };
 
 use crate::simd_vec::{SimdFloat, SimdInt};
@@ -24,8 +25,28 @@ impl SimdInt for int32x4_t {
     }
 
     #[inline]
+    unsafe fn eq(self, other: Self) -> Self::Mask {
+        vceqq_s32(self, other)
+    }
+
+    #[inline]
+    unsafe fn le(self, other: Self) -> Self::Mask {
+        vcleq_s32(self, other)
+    }
+
+    #[inline]
+    unsafe fn ge(self, other: Self) -> Self::Mask {
+        vcgeq_s32(self, other)
+    }
+
+    #[inline]
     unsafe fn gt(self, other: Self) -> Self::Mask {
         vcgtq_s32(self, other)
+    }
+
+    #[inline]
+    unsafe fn lt(self, other: Self) -> Self::Mask {
+        vcltq_s32(self, other)
     }
 
     #[inline]
@@ -51,6 +72,11 @@ impl SimdInt for int32x4_t {
     #[inline]
     unsafe fn reinterpret_as_float(self) -> Self::Float {
         vreinterpretq_f32_s32(self)
+    }
+
+    #[inline]
+    unsafe fn to_float_mask(self) -> <Self::Float as SimdFloat>::Mask {
+        vreinterpretq_u32_s32(self)
     }
 
     #[inline]
@@ -138,6 +164,18 @@ impl SimdFloat for float32x4_t {
     #[inline]
     unsafe fn load(ptr: *const f32) -> Self {
         vld1q_f32(ptr)
+    }
+
+    #[inline]
+    unsafe fn gather_mask(src: *const f32, offsets: Self::Int, mask: Self::Mask) -> Self {
+        // Set offset to zero where masked out. `src` is required to point to
+        // a non-empty buffer, so index zero can be loaded as a dummy.
+        let offsets = Self::Int::splat(0).blend(offsets, mask);
+        let mut offset_array = [0; 4];
+        offsets.store(offset_array.as_mut_ptr());
+
+        let values: [f32; 4] = std::array::from_fn(|i| *src.add(offset_array[i] as usize));
+        Self::splat(0.).blend(Self::load(values.as_ptr()), mask)
     }
 
     #[inline]

--- a/src/gemm.rs
+++ b/src/gemm.rs
@@ -398,6 +398,13 @@ impl GemmExecutor {
         }
     }
 
+    /// Return the panel width used when packing the "B" matrix.
+    ///
+    /// This information is useful for implementations of [VirtualMatrix].
+    pub fn b_panel_width(&self) -> usize {
+        self.kernel.nr()
+    }
+
     /// Prepack a matrix for use as the right-hand or "B" matrix input.
     pub fn prepack_b(&self, b: Matrix) -> PackedBMatrix {
         let nc = col_block_size(b.cols(), self.kernel.nr());

--- a/src/gemm/kernels/x86_64.rs
+++ b/src/gemm/kernels/x86_64.rs
@@ -8,6 +8,9 @@ use std::arch::x86_64::__m512;
 use rten_tensor::Matrix;
 use rten_vecmath::simd_vec::SimdFloat;
 
+#[cfg(feature = "avx512")]
+use rten_vecmath::is_avx512_supported;
+
 use super::{simd_gemm, simd_gemv, Kernel};
 use crate::gemm::packing::{pack_a_block, pack_b_block};
 
@@ -126,53 +129,6 @@ unsafe impl Kernel for FmaKernel {
     }
 }
 
-/// Detect availability of AVX-512 on macOS, where `is_x86_feature_detected`
-/// can return false even if AVX-512 is available.
-///
-/// See https://github.com/golang/go/issues/43089. Go chose to use the
-/// `commpage` to get the info. We use `sysctlbyname` instead since it is
-/// a documented API.
-#[cfg(feature = "avx512")]
-#[cfg(target_os = "macos")]
-fn test_for_avx512_on_macos() -> bool {
-    use std::ffi::CStr;
-    use std::os::raw::{c_char, c_int, c_void};
-    use std::sync::OnceLock;
-
-    #[link(name = "c")]
-    extern "C" {
-        /// See https://developer.apple.com/documentation/kernel/1387446-sysctlbyname.
-        fn sysctlbyname(
-            name: *const c_char,
-            oldp: *mut c_void,
-            oldlenp: *mut usize,
-            newp: *const c_void,
-            newlen: usize,
-        ) -> c_int;
-    }
-
-    static AVX512_AVAILABLE: OnceLock<bool> = OnceLock::new();
-
-    *AVX512_AVAILABLE.get_or_init(|| {
-        unsafe {
-            let mut ret = 0u64;
-            let mut size = std::mem::size_of::<u64>();
-
-            // We test only for avx512vl, as this implies avx512f.
-            let sysctl_ret = sysctlbyname(
-                CStr::from_bytes_with_nul(b"hw.optional.avx512vl\0")
-                    .unwrap()
-                    .as_ptr(),
-                std::mem::transmute(&mut ret),
-                &mut size,
-                std::ptr::null(),
-                0,
-            );
-            sysctl_ret == 0 && ret == 1
-        }
-    })
-}
-
 /// Optimized kernel for x64 CPUs that support AVX 512 instructions.
 #[cfg(feature = "avx512")]
 #[derive(Default)]
@@ -197,21 +153,7 @@ impl Avx512Kernel {
 #[cfg(feature = "avx512")]
 unsafe impl Kernel for Avx512Kernel {
     fn new() -> Option<Self> {
-        let supported = {
-            if is_x86_feature_detected!("avx512f") && is_x86_feature_detected!("avx512vl") {
-                true
-            } else {
-                #[cfg(target_os = "macos")]
-                {
-                    test_for_avx512_on_macos()
-                }
-                #[cfg(not(target_os = "macos"))]
-                {
-                    false
-                }
-            }
-        };
-        supported.then_some(Avx512Kernel { _private: () })
+        is_avx512_supported().then_some(Avx512Kernel { _private: () })
     }
 
     fn name(&self) -> &'static str {

--- a/src/ops/conv/im2col.rs
+++ b/src/ops/conv/im2col.rs
@@ -1,0 +1,309 @@
+use std::ops::Range;
+
+use rten_tensor::prelude::*;
+use rten_tensor::NdTensorView;
+use rten_vecmath::simd_vec::{SimdFloat, SimdInt};
+
+#[cfg(feature = "avx512")]
+use rten_vecmath::is_avx512_supported;
+
+use crate::gemm::{round_up, KernelType, VirtualMatrix};
+use crate::ops::pooling::calc_output_size_and_padding;
+use crate::ops::Padding;
+
+struct RowOffsets {
+    /// Map of channel index to `channel * channel_stride`.
+    chan: Vec<i32>,
+
+    /// Map of row index to `row * row_stride`.
+    y: Vec<i32>,
+
+    /// Map of col index to `col * col_stride`.
+    x: Vec<i32>,
+}
+
+struct ColOffsets {
+    /// Map of column index to `row * row_stride`.
+    y: Vec<i32>,
+
+    /// Map of column index to `col * col_stride`.
+    x: Vec<i32>,
+}
+
+/// Unrolls patches of an image as columns of a virtual matrix.
+///
+/// The input image has shape [C,H,W] and is transformed into a matrix with
+/// shape [C * Kh * kW, Oh * Ow] where Kh/Kw are convolution kernel sizes and
+/// Oh/Ow are the number of patches in the Y and X directions.
+///
+/// The transform is virtual because the matrix is not actually materialized
+/// in memory. Instead blocks of it are produced on-demand during a matrix
+/// multiplication operation.
+pub struct VirtualIm2Col<'a> {
+    image: NdTensorView<'a, f32, 3>,
+
+    /// Map of im2col row index to input image coordinate, premultiplied with
+    /// the corresponding stride.
+    row_offsets: RowOffsets,
+
+    /// Map of im2col column index to input image coordinate, premultiplied with
+    /// the corresponding stride. The length of `col_offsets` is rounded up
+    /// to the nearest multiple of the panel width. `n_cols` contains the
+    /// number of columns in the virtual matrix.
+    col_offsets: ColOffsets,
+
+    /// Number of columns in the im2col matrix.
+    n_cols: usize,
+
+    /// Maximum valid sum of `row_offsets.y + col_offsets.y`. Values above this
+    /// correspond to the padding region.
+    max_y_offset: i32,
+
+    /// Maximum valid sum of `row_offsets.x + col_offsets.x`. Values above this
+    /// correspond to the padding region.
+    max_x_offset: i32,
+
+    /// Gemm kernel that is going to be used.
+    gemm_kernel: KernelType,
+}
+
+impl<'a> VirtualIm2Col<'a> {
+    /// Create a virtual im2col matrix from a [C, H, W] input tensor and
+    /// convolution parameters.
+    pub fn new(
+        gemm_kernel: KernelType,
+        image: NdTensorView<'a, f32, 3>,
+        kernel: [usize; 2],
+        padding: [usize; 4],
+        strides: [usize; 2],
+        dilations: [usize; 2],
+        panel_width: usize,
+    ) -> VirtualIm2Col {
+        // Ensure image has at least one cell.
+        assert!(image.len() > 0);
+
+        let [chans, h, w] = image.shape();
+        let [k_h, k_w] = kernel;
+        let [stride_h, stride_w] = strides;
+        let [dilation_y, dilation_x] = dilations;
+        let [pad_top, pad_left, _pad_bottom, _pad_right] = padding;
+        let (y_patches, x_patches, _) = calc_output_size_and_padding(
+            (h, w),
+            (k_h, k_w),
+            (stride_h, stride_w),
+            Padding::Fixed(padding.into()),
+            Some((dilation_y, dilation_x)),
+        )
+        .expect("invalid im2col params");
+
+        let [im_stride_c, im_stride_h, im_stride_w]: [i32; 3] =
+            image.strides().map(|s| s.try_into().unwrap());
+
+        // Build lookup table of row index in the virtual im2col matrix to
+        // offsets in the image.
+        let n_rows = chans * k_h * k_w;
+        let row_offsets = (0..n_rows).map(|row| {
+            let in_chan = row as i32 / (k_h * k_w) as i32;
+            let kernel_element = row as i32 % (k_h * k_w) as i32;
+            let k_y = kernel_element / k_w as i32;
+            let k_x = kernel_element % k_w as i32;
+
+            // Offset to image channel
+            (
+                in_chan * im_stride_c,
+                // Offset from top-left corner of patch
+                (
+                    im_stride_h * k_y * dilation_y as i32,
+                    im_stride_w * k_x * dilation_x as i32,
+                ),
+            )
+        });
+        let (row_chan_offsets, row_yx_offsets): (Vec<i32>, Vec<(i32, i32)>) = row_offsets.unzip();
+        let (row_y_offsets, row_x_offsets) = row_yx_offsets.into_iter().unzip();
+
+        // Build lookup table of column index in the virtual im2col matrix to
+        // offsets in the image.
+        let n_cols = x_patches * y_patches;
+        let n_cols_padded = round_up(n_cols, panel_width);
+
+        let col_offsets = (0..n_cols_padded).map(|col| {
+            let patch_y = col as i32 / x_patches as i32;
+            let patch_x = col as i32 % x_patches as i32;
+            let img_x = (patch_x * stride_w as i32) - pad_left as i32;
+            let img_y = (patch_y * stride_h as i32) - pad_top as i32;
+            (img_y * im_stride_h, img_x * im_stride_w)
+        });
+        let (col_y_offsets, col_x_offsets): (Vec<i32>, Vec<i32>) = col_offsets.unzip();
+
+        // Compute max valid X / Y offsets for testing whether an element is in
+        // the padding region or not.
+        let max_y_offset: i32 = ((image.size(1) - 1) * image.stride(1))
+            .try_into()
+            .expect("invalid im2col params");
+        let max_x_offset: i32 = ((image.size(2) - 1) * image.stride(2))
+            .try_into()
+            .expect("invalid im2col params");
+
+        VirtualIm2Col {
+            gemm_kernel,
+            image,
+            row_offsets: RowOffsets {
+                chan: row_chan_offsets,
+                y: row_y_offsets,
+                x: row_x_offsets,
+            },
+            col_offsets: ColOffsets {
+                y: col_y_offsets,
+                x: col_x_offsets,
+            },
+            n_cols,
+
+            max_y_offset,
+            max_x_offset,
+        }
+    }
+
+    /// Pack part of an image according to the requirements of
+    /// [VirtualMatrix::pack_b].
+    ///
+    /// `NR_REGS` specifies the width of each column panel in terms of the width
+    /// of vector registers (`S::LEN`). ie. `panel_width` must exactly equal
+    /// `NR_REGS * S::LEN`.
+    #[inline(always)]
+    unsafe fn pack_b_impl<S: SimdFloat, const NR_REGS: usize>(
+        &self,
+        out: &mut [f32],
+        panel_width: usize,
+        rows: Range<usize>,
+        cols: Range<usize>,
+    ) {
+        assert_eq!(panel_width, S::LEN * NR_REGS);
+
+        let col_range = cols.start..round_up(cols.end, panel_width);
+        assert!(out.len() >= rows.len() * col_range.len());
+
+        let col_y_offsets = &self.col_offsets.y[col_range.clone()];
+        let col_x_offsets = &self.col_offsets.x[col_range.clone()];
+        let row_chan_offsets = &self.row_offsets.chan[rows.clone()];
+        let row_y_offsets = &self.row_offsets.y[rows.clone()];
+        let row_x_offsets = &self.row_offsets.x[rows.clone()];
+
+        let img_data = self.image.non_contiguous_data();
+
+        // Loop over column panels, then rows, then `S::LEN`-wide column groups
+        // within each panel.
+        let out_ptr = out.as_mut_ptr();
+        let mut out_offset = 0;
+
+        for start_col in (0..col_y_offsets.len()).step_by(S::LEN * NR_REGS) {
+            let col_y_offset: [S::Int; NR_REGS] = std::array::from_fn(|i| {
+                S::Int::load(col_y_offsets.as_ptr().add(start_col + S::LEN * i))
+            });
+            let col_x_offset: [S::Int; NR_REGS] = std::array::from_fn(|i| {
+                S::Int::load(col_x_offsets.as_ptr().add(start_col + S::LEN * i))
+            });
+            let max_x_offset = S::Int::splat(self.max_x_offset);
+            let max_y_offset = S::Int::splat(self.max_y_offset);
+
+            for ((&row_chan_offset, &row_y_offset), &row_x_offset) in row_chan_offsets
+                .iter()
+                .zip(row_y_offsets.iter())
+                .zip(row_x_offsets.iter())
+            {
+                let row_chan_offset = S::Int::splat(row_chan_offset);
+                let row_y_offset = S::Int::splat(row_y_offset);
+                let row_x_offset = S::Int::splat(row_x_offset);
+
+                for i in 0..NR_REGS {
+                    let y_offset = col_y_offset[i].add(row_y_offset);
+                    let x_offset = col_x_offset[i].add(row_x_offset);
+                    let offsets = row_chan_offset.add(y_offset).add(x_offset);
+
+                    // Create mask to specify offsets which are valid. Others
+                    // correspond to the padding region.
+                    let zero = S::Int::zero();
+                    let pad_mask = S::Int::splat(-1)
+                        .blend(zero, y_offset.lt(zero))
+                        .blend(zero, y_offset.gt(max_y_offset))
+                        .blend(zero, x_offset.lt(zero))
+                        .blend(zero, x_offset.gt(max_x_offset));
+
+                    let elts = S::gather_mask(img_data.as_ptr(), offsets, pad_mask.to_float_mask());
+
+                    elts.store(out_ptr.add(out_offset));
+                    out_offset += S::LEN;
+                }
+            }
+        }
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[target_feature(enable = "avx2")]
+    #[target_feature(enable = "fma")]
+    unsafe fn pack_b_impl_avx(
+        &self,
+        out: &mut [f32],
+        panel_width: usize,
+        rows: Range<usize>,
+        cols: Range<usize>,
+    ) {
+        use std::arch::x86_64::__m256;
+        self.pack_b_impl::<__m256, 2>(out, panel_width, rows.clone(), cols.clone());
+    }
+
+    #[cfg(feature = "avx512")]
+    #[cfg(target_arch = "x86_64")]
+    #[target_feature(enable = "avx512f")]
+    #[target_feature(enable = "avx512vl")]
+    unsafe fn pack_b_impl_avx512(
+        &self,
+        out: &mut [f32],
+        panel_width: usize,
+        rows: Range<usize>,
+        cols: Range<usize>,
+    ) {
+        use std::arch::x86_64::__m512;
+        self.pack_b_impl::<__m512, 2>(out, panel_width, rows.clone(), cols.clone());
+    }
+}
+
+impl<'a> VirtualMatrix for VirtualIm2Col<'a> {
+    fn rows(&self) -> usize {
+        self.row_offsets.chan.len()
+    }
+
+    fn cols(&self) -> usize {
+        self.n_cols
+    }
+
+    fn pack_b(&self, out: &mut [f32], panel_width: usize, rows: Range<usize>, cols: Range<usize>) {
+        match self.gemm_kernel {
+            #[cfg(feature = "avx512")]
+            #[cfg(target_arch = "x86_64")]
+            KernelType::Avx512 => unsafe {
+                assert!(is_avx512_supported());
+                self.pack_b_impl_avx512(out, panel_width, rows.clone(), cols.clone());
+            },
+            #[cfg(target_arch = "x86_64")]
+            KernelType::Fma => unsafe {
+                assert!(is_x86_feature_detected!("avx2"));
+                self.pack_b_impl_avx(out, panel_width, rows.clone(), cols.clone());
+            },
+            #[cfg(target_arch = "aarch64")]
+            KernelType::ArmNeon => unsafe {
+                // Safety: Neon is always available.
+                use std::arch::aarch64::float32x4_t;
+                self.pack_b_impl::<float32x4_t, 2>(out, panel_width, rows, cols);
+            },
+            #[cfg(target_arch = "wasm32")]
+            KernelType::Wasm => unsafe {
+                // Safety: SIMD support is checked when WASM binary is loaded.
+                use rten_vecmath::simd_vec::wasm::v128f;
+                self.pack_b_impl::<v128f, 2>(out, panel_width, rows, cols);
+            },
+            KernelType::Base => unsafe {
+                self.pack_b_impl::<f32, 4>(out, panel_width, rows, cols);
+            },
+        }
+    }
+}


### PR DESCRIPTION
Re-implement the fused im2col transform (`VirtualIm2Col`) used by convolutions, with SIMD operations. This helps by:

 1. Computing the source offsets, gathering and storing multiple elements at once.
 2. Eliminating unpredictable branches to determine whether an element is in the padding region or not. Instead predication is used.
 3. Enabling the compiler to unroll inner loops by providing statically known loop counts.

On an Intel i5, this reduced time in im2col operations in Ocrs by about 35%, of which 10% comes from (3). The remaining time is almost all in copying memory. It might be possible to reduce that with prefetching.

---

*TODO:*

- [x] Test performance on Arm (eg. using the YOLOv8 example)
- [x] Test performance on server x64
