### PR TITLE
Add buffer pool/arena to enable re-use of temporary buffers during graph execution

### DIFF
--- a/rten-examples/src/jina_similarity.rs
+++ b/rten-examples/src/jina_similarity.rs
@@ -3,7 +3,7 @@ use std::error::Error;
 use std::fs;
 
 use rten::ops::concat;
-use rten::{FloatOperators, Input, Model, NodeId, Operators};
+use rten::{FloatOperators, Input, Model, NodeId, Operators, TensorPool};
 use rten_tensor::prelude::*;
 use rten_tensor::{NdTensor, Tensor};
 use rten_text::tokenizers::{EncodeOptions, Tokenizer};
@@ -161,7 +161,8 @@ fn embed_sentence_batch(
             view
         })
         .collect();
-    let mean_pooled: NdTensor<f32, 2> = concat(&mean_pooled_views, 0)?.try_into()?;
+    let pool = TensorPool::new();
+    let mean_pooled: NdTensor<f32, 2> = concat(&pool, &mean_pooled_views, 0)?.try_into()?;
     Ok(mean_pooled)
 }
 

--- a/rten-tensor/src/lib.rs
+++ b/rten-tensor/src/lib.rs
@@ -62,7 +62,8 @@ pub use iterators::{
     IterMut, Lanes, LanesMut, Offsets,
 };
 pub use layout::{
-    is_valid_permutation, DynLayout, Layout, MatrixLayout, MutLayout, NdLayout, OverlapPolicy,
+    is_valid_permutation, DynLayout, IntoLayout, Layout, MatrixLayout, MutLayout, NdLayout,
+    OverlapPolicy,
 };
 pub use slice_range::{to_slice_items, DynSliceItems, IntoSliceItems, SliceItem, SliceRange};
 

--- a/rten-tensor/src/tensor.rs
+++ b/rten-tensor/src/tensor.rs
@@ -675,6 +675,12 @@ impl<T, L: Clone + MutLayout> TensorBase<T, Vec<T>, L> {
         }
     }
 
+    /// Consume self and return the underlying data in whatever order the
+    /// elements are currently stored.
+    pub fn into_non_contiguous_data(self) -> Vec<T> {
+        self.data
+    }
+
     /// Consume self and return a new contiguous tensor with the given shape.
     ///
     /// This avoids copying the data if it is already contiguous.
@@ -2177,6 +2183,17 @@ mod tests {
     fn test_into_data() {
         let tensor = NdTensor::from_data([2], vec![2., 3.]);
         assert_eq!(tensor.into_data(), vec![2., 3.]);
+
+        let mut tensor = NdTensor::from_data([2, 2], vec![1., 2., 3., 4.]);
+        tensor.transpose();
+        assert_eq!(tensor.into_data(), vec![1., 3., 2., 4.]);
+    }
+
+    #[test]
+    fn test_into_non_contiguous_data() {
+        let mut tensor = NdTensor::from_data([2, 2], vec![1., 2., 3., 4.]);
+        tensor.transpose();
+        assert_eq!(tensor.into_non_contiguous_data(), vec![1., 2., 3., 4.]);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@ mod model;
 mod model_metadata;
 mod number;
 mod slice_reductions;
+mod tensor_pool;
 mod timer;
 mod timing;
 
@@ -67,6 +68,7 @@ pub use graph::{Dimension, NodeId, RunOptions};
 pub use model::{DefaultOperatorFactory, Model, ModelLoadError, NodeInfo, OpRegistry, ReadOpError};
 pub use model_metadata::ModelMetadata;
 pub use ops::{FloatOperators, Input, Operators, Output};
+pub use tensor_pool::TensorPool;
 pub use timer::Timer;
 pub use timing::TimingSort;
 

--- a/src/ops/gather.rs
+++ b/src/ops/gather.rs
@@ -8,6 +8,7 @@ use crate::ops::reduce::{cmp_nan_greater, cmp_nan_less};
 use crate::ops::{
     resolve_axis, resolve_index, Input, InputList, IntoOpResult, OpError, Operator, Output,
 };
+use crate::tensor_pool::TensorPool;
 
 /// Gather elements from `input` specified by `indices`.
 ///
@@ -76,7 +77,7 @@ impl Operator for Gather {
         "Gather"
     }
 
-    fn run(&self, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, _pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
         let input = inputs.require(0)?;
         let indices = inputs.require_as::<i32>(1)?;
         match input {
@@ -216,7 +217,7 @@ impl Operator for GatherElements {
         "GatherElements"
     }
 
-    fn run(&self, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, _pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
         let input = inputs.require(0)?;
         let indices = inputs.require_as::<i32>(1)?;
         match input {
@@ -323,7 +324,7 @@ impl Operator for ScatterElements {
         "ScatterElements"
     }
 
-    fn run(&self, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, _pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
         let data = inputs.require(0)?;
         let indices = inputs.require_as::<i32>(1)?;
         let updates = inputs.require(2)?;
@@ -418,7 +419,7 @@ impl Operator for ScatterND {
         "ScatterND"
     }
 
-    fn run(&self, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, _pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
         let data = inputs.require(0)?;
         let indices = inputs.require_as::<i32>(1)?;
         let updates = inputs.require(2)?;

--- a/src/ops/identity.rs
+++ b/src/ops/identity.rs
@@ -1,6 +1,7 @@
 use rten_tensor::prelude::*;
 
 use crate::ops::{Input, InputList, IntoOpResult, OpError, Operator, Output};
+use crate::tensor_pool::TensorPool;
 
 #[derive(Debug)]
 pub struct Identity {}
@@ -10,7 +11,7 @@ impl Operator for Identity {
         "Identity"
     }
 
-    fn run(&self, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, _pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
         let input = inputs.require(0)?;
         let result: Output = match input {
             Input::IntTensor(t) => t.to_tensor().into(),
@@ -35,15 +36,17 @@ mod tests {
     use rten_tensor::test_util::expect_equal;
     use rten_tensor::Tensor;
 
+    use crate::ops::tests::new_pool;
     use crate::ops::{Identity, Operator};
 
     #[test]
     fn test_identity() -> Result<(), Box<dyn Error>> {
+        let pool = new_pool();
         let id_op = Identity {};
 
         let int_input = Tensor::from_vec(vec![1, 2, 3]);
         let result = id_op
-            .run((&int_input).into())
+            .run(&pool, (&int_input).into())
             .unwrap()
             .remove(0)
             .into_int()
@@ -52,7 +55,7 @@ mod tests {
 
         let float_input = Tensor::from_vec(vec![1.0, 2.0, 3.0]);
         let result = id_op
-            .run((&float_input).into())
+            .run(&pool, (&float_input).into())
             .unwrap()
             .remove(0)
             .into_float()

--- a/src/ops/matmul.rs
+++ b/src/ops/matmul.rs
@@ -8,6 +8,7 @@ use crate::gemm::{gemm, GemmExecutor, GemmInputA, GemmInputB};
 use crate::ops::binary_elementwise::broadcast_shapes;
 use crate::ops::layout::expand_to;
 use crate::ops::{InputList, IntoOpResult, OpError, Operator, Output};
+use crate::tensor_pool::TensorPool;
 
 #[derive(Debug)]
 pub struct Gemm {
@@ -70,7 +71,7 @@ impl Operator for Gemm {
         "Gemm"
     }
 
-    fn run(&self, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, _pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
         let a = inputs.require_as(0)?;
         let b = inputs.require_as(1)?;
         let c = inputs.get_as(2)?;
@@ -220,7 +221,7 @@ impl Operator for MatMul {
         "MatMul"
     }
 
-    fn run(&self, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, _pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
         let a = inputs.require_as(0)?;
         let b = inputs.require_as(1)?;
         matmul(a, b).into_op_result()

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -21,6 +21,8 @@ use smallvec::SmallVec;
 use rten_tensor::prelude::*;
 use rten_tensor::{DynLayout, NdTensor, NdTensorView, Tensor, TensorView};
 
+use crate::tensor_pool::TensorPool;
+
 mod binary_elementwise;
 mod concat;
 mod conv;
@@ -634,7 +636,7 @@ pub trait Operator: Debug {
     fn name(&self) -> &str;
 
     /// Execute the operator with the given inputs.
-    fn run(&self, input: InputList) -> Result<Vec<Output>, OpError>;
+    fn run(&self, pool: &TensorPool, input: InputList) -> Result<Vec<Output>, OpError>;
 
     /// Return true if this operator supports in-place execution via
     /// `run_in_place`.
@@ -824,6 +826,16 @@ mod tests {
     use rten_tensor::NdTensor;
 
     use super::Input;
+
+    use crate::tensor_pool::TensorPool;
+
+    /// Create an empty tensor pool.
+    ///
+    /// This is a wrapper that provides a place to customize the behavior of
+    /// the pool in tests.
+    pub fn new_pool() -> TensorPool {
+        TensorPool::new()
+    }
 
     /// Compare two f32 tensors with a higher absolute tolerance (1e-4) than
     /// the default (1e-5).

--- a/src/ops/non_max_suppression.rs
+++ b/src/ops/non_max_suppression.rs
@@ -3,6 +3,7 @@ use rten_tensor::{NdTensor, NdTensorView};
 
 use crate::ops::{InputList, IntoOpResult, OpError, Operator, Output};
 use crate::static_dims;
+use crate::tensor_pool::TensorPool;
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum BoxOrder {
@@ -190,7 +191,7 @@ impl Operator for NonMaxSuppression {
         "NonMaxSuppression"
     }
 
-    fn run(&self, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, _pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
         let boxes = inputs.require_as(0)?;
         let boxes = static_dims!(boxes, 3, "ND4")?;
 

--- a/src/ops/operators.rs
+++ b/src/ops/operators.rs
@@ -1,3 +1,4 @@
+use std::any::Any;
 use std::fmt::Debug;
 
 use rten_tensor::prelude::*;
@@ -9,6 +10,7 @@ use crate::ops::{
     arg_max, div, matmul, mul, pad, reduce_l2, reduce_max, reduce_mean, reduce_min, resize_image,
     softmax, topk,
 };
+use crate::tensor_pool::TensorPool;
 
 /// Trait which exposes ONNX operators as methods of tensors.
 ///
@@ -24,7 +26,8 @@ pub trait Operators {
 
     fn div(&self, other: TensorView<Self::Elem>) -> Result<Tensor<Self::Elem>, OpError>
     where
-        Self::Elem: Copy
+        Self::Elem: Any
+            + Copy
             + Debug
             + Default
             + std::ops::Mul<Output = Self::Elem>
@@ -34,7 +37,7 @@ pub trait Operators {
 
     fn mul(&self, other: TensorView<Self::Elem>) -> Result<Tensor<Self::Elem>, OpError>
     where
-        Self::Elem: Copy + Debug + Default + std::ops::Mul<Output = Self::Elem>;
+        Self::Elem: Any + Copy + Debug + Default + std::ops::Mul<Output = Self::Elem>;
 
     fn pad(
         &self,
@@ -84,7 +87,8 @@ impl<T, S: AsRef<[T]>> Operators for TensorBase<T, S, DynLayout> {
 
     fn div(&self, other: TensorView<Self::Elem>) -> Result<Tensor<Self::Elem>, OpError>
     where
-        Self::Elem: Copy
+        Self::Elem: Any
+            + Copy
             + Debug
             + Default
             + std::ops::Mul<Output = Self::Elem>
@@ -92,14 +96,14 @@ impl<T, S: AsRef<[T]>> Operators for TensorBase<T, S, DynLayout> {
             + IsInt
             + Identities,
     {
-        div(self.view(), other)
+        div(&TensorPool::new(), self.view(), other)
     }
 
     fn mul(&self, other: TensorView<T>) -> Result<Tensor<T>, OpError>
     where
-        T: Copy + Debug + Default + std::ops::Mul<Output = T>,
+        T: Any + Copy + Debug + Default + std::ops::Mul<Output = T>,
     {
-        mul(self.view(), other)
+        mul(&TensorPool::new(), self.view(), other)
     }
 
     fn pad(&self, padding: NdTensorView<i32, 1>, val: T) -> Result<Tensor<Self::Elem>, OpError>
@@ -135,7 +139,8 @@ impl<T, S: AsRef<[T]>, const N: usize> Operators for TensorBase<T, S, NdLayout<N
 
     fn div(&self, other: TensorView<Self::Elem>) -> Result<Tensor<Self::Elem>, OpError>
     where
-        Self::Elem: Copy
+        Self::Elem: Any
+            + Copy
             + Debug
             + Default
             + std::ops::Mul<Output = Self::Elem>
@@ -143,14 +148,14 @@ impl<T, S: AsRef<[T]>, const N: usize> Operators for TensorBase<T, S, NdLayout<N
             + IsInt
             + Identities,
     {
-        div(self.as_dyn(), other)
+        div(&TensorPool::new(), self.as_dyn(), other)
     }
 
     fn mul(&self, other: TensorView<T>) -> Result<Tensor<T>, OpError>
     where
-        T: Copy + Debug + Default + std::ops::Mul<Output = T>,
+        T: Any + Copy + Debug + Default + std::ops::Mul<Output = T>,
     {
-        mul(self.as_dyn(), other)
+        mul(&TensorPool::new(), self.as_dyn(), other)
     }
 
     fn pad(&self, padding: NdTensorView<i32, 1>, val: T) -> Result<Tensor<Self::Elem>, OpError>

--- a/src/ops/reduce.rs
+++ b/src/ops/reduce.rs
@@ -11,6 +11,7 @@ use crate::ops::{
     resolve_axes, resolve_axis, Input, InputList, IntoOpResult, OpError, Operator, Output,
 };
 use crate::slice_reductions::slice_sum;
+use crate::tensor_pool::TensorPool;
 
 /// Compute the indices of the max elements along an axis, according to a
 /// comparison function `compare`.
@@ -75,7 +76,7 @@ impl Operator for ArgMax {
         "ArgMax"
     }
 
-    fn run(&self, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, _pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
         let input = inputs.require_as::<f32>(0)?;
         arg_max(input, self.axis, self.keep_dims).into_op_result()
     }
@@ -106,7 +107,7 @@ impl Operator for ArgMin {
         "ArgMin"
     }
 
-    fn run(&self, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, _pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
         let input = inputs.require_as::<f32>(0)?;
         arg_min(input, self.axis, self.keep_dims).into_op_result()
     }
@@ -142,7 +143,7 @@ impl Operator for CumSum {
         "CumSum"
     }
 
-    fn run(&self, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, _pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
         let input = inputs.require(0)?;
         let axis: i32 = inputs.require_as_scalar(1)?;
         match input {
@@ -184,7 +185,7 @@ impl Operator for NonZero {
         "NonZero"
     }
 
-    fn run(&self, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, _pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
         let input = inputs.require(0)?;
         match input {
             Input::IntTensor(input) => nonzero(input).into_op_result(),
@@ -345,7 +346,7 @@ impl Operator for ReduceMean {
         "ReduceMean"
     }
 
-    fn run(&self, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, _pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
         let input = inputs.require_as(0)?;
         reduce_mean(
             input,
@@ -383,7 +384,7 @@ impl Operator for ReduceL2 {
         "ReduceL2"
     }
 
-    fn run(&self, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, _pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
         let input = inputs.require_as(0)?;
         reduce_l2(
             input,
@@ -480,7 +481,7 @@ impl Operator for ReduceMin {
         "ReduceMin"
     }
 
-    fn run(&self, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, _pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
         let input = inputs.require(0)?;
         dispatch_reduce_op!(input, reduce_min, self.axes, self.keep_dims)
     }
@@ -505,7 +506,7 @@ impl Operator for ReduceMax {
         "ReduceMax"
     }
 
-    fn run(&self, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, _pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
         let input = inputs.require(0)?;
         dispatch_reduce_op!(input, reduce_max, self.axes, self.keep_dims)
     }
@@ -536,7 +537,7 @@ impl Operator for ReduceProd {
         "ReduceProd"
     }
 
-    fn run(&self, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, _pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
         let input = inputs.require(0)?;
         dispatch_reduce_op!(input, reduce_prod, self.axes, self.keep_dims)
     }
@@ -567,7 +568,7 @@ impl Operator for ReduceSum {
         "ReduceSum"
     }
 
-    fn run(&self, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, _pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
         let input = inputs.require(0)?;
         dispatch_reduce_op!(input, reduce_sum, self.axes, self.keep_dims)
     }
@@ -598,7 +599,7 @@ impl Operator for ReduceSumSquare {
         "ReduceSumSquare"
     }
 
-    fn run(&self, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, _pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
         let input = inputs.require(0)?;
         dispatch_reduce_op!(input, reduce_sum_square, self.axes, self.keep_dims)
     }
@@ -687,7 +688,7 @@ impl Operator for TopK {
         "TopK"
     }
 
-    fn run(&self, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, _pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
         let values = inputs.require(0)?;
         let k = inputs.require_as_scalar::<i32>(1).and_then(|k| {
             if k < 0 {

--- a/src/ops/slice.rs
+++ b/src/ops/slice.rs
@@ -5,6 +5,7 @@ use rten_tensor::{NdTensorView, SliceItem, SliceRange, Tensor, TensorView};
 
 use crate::ops::{resolve_axis, Input, InputList, IntoOpResult, OpError, Operator, Output};
 use crate::static_dims;
+use crate::tensor_pool::TensorPool;
 
 /// Compute the effective starts, ends and steps for each input dimension in
 /// a Slice operation.
@@ -98,7 +99,7 @@ impl Operator for Slice {
         "Slice"
     }
 
-    fn run(&self, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, _pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
         let input = inputs.require(0)?;
 
         let starts = inputs.require_as::<i32>(1)?;
@@ -154,7 +155,7 @@ impl Operator for Slice {
                 let mut inputs: Vec<_> = vec![(&input).into()];
                 inputs.extend(other.iter());
                 return self
-                    .run(InputList::from(&inputs))
+                    .run(&TensorPool::new(), InputList::from(&inputs))
                     .map(|mut outputs| outputs.remove(0));
             }
         }

--- a/src/ops/trilu.rs
+++ b/src/ops/trilu.rs
@@ -2,6 +2,7 @@ use rten_tensor::prelude::*;
 use rten_tensor::{Tensor, TensorView};
 
 use crate::ops::{Input, InputList, IntoOpResult, OpError, Operator, Output};
+use crate::tensor_pool::TensorPool;
 
 pub fn trilu<T: Copy + Default>(
     input: TensorView<T>,
@@ -41,7 +42,7 @@ impl Operator for Trilu {
         "Trilu"
     }
 
-    fn run(&self, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, _pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
         let input = inputs.require(0)?;
         let k = inputs.get_as_scalar(1)?.unwrap_or(0);
 

--- a/src/ops/variadic_elementwise.rs
+++ b/src/ops/variadic_elementwise.rs
@@ -6,6 +6,7 @@ use rten_tensor::{Tensor, TensorView};
 use crate::ops::binary_elementwise::broadcast_shapes;
 use crate::ops::reduce::{cmp_nan_greater, cmp_nan_less};
 use crate::ops::{Input, InputList, IntoOpResult, OpError, Operator, Output};
+use crate::tensor_pool::TensorPool;
 
 /// Apply an elementwise reduction to a sequence of tensors.
 ///
@@ -107,7 +108,7 @@ impl Operator for Max {
         "Max"
     }
 
-    fn run(&self, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, _pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
         run_typed_op!(inputs)
     }
 }
@@ -126,7 +127,7 @@ impl Operator for Mean {
         "Mean"
     }
 
-    fn run(&self, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, _pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
         let inputs: Vec<TensorView<f32>> = typed_views(&inputs)?;
         mean(&inputs).into_op_result()
     }
@@ -149,7 +150,7 @@ impl Operator for Min {
         "Min"
     }
 
-    fn run(&self, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, _pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
         run_typed_op!(inputs)
     }
 }
@@ -168,7 +169,7 @@ impl Operator for Sum {
         "Sum"
     }
 
-    fn run(&self, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, _pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
         run_typed_op!(inputs)
     }
 }

--- a/src/tensor_pool.rs
+++ b/src/tensor_pool.rs
@@ -1,0 +1,223 @@
+use std::any::Any;
+use std::cell::RefCell;
+use std::mem::MaybeUninit;
+
+use rten_tensor::prelude::*;
+use rten_tensor::{IntoLayout, MutLayout, TensorBase};
+
+/// A pool which enables reuse of tensor data buffers.
+///
+/// Reusing buffers for operator outputs, as opposed to allocating a fresh
+/// buffer from the global allocator and freeing it when no longer needed,
+/// can provide a significant performance improvement.
+///
+/// Tensors are allocated from the pool using [`alloc`](TensorPool::alloc)
+/// and returned to the pool after use using [`add`](TensorPool::add). If
+/// an allocation request cannot be satisfied by the pool, it will fall back
+/// to the global allocator.
+///
+/// To simplify the implementation, the pool is limited to working with
+/// buffers of `Copy + 'static` types.
+pub struct TensorPool {
+    /// List of buffers currently in the pool. Each is a
+    /// `Vec<MaybeUninit<T>>` where `T` is a `Copy` type.
+    items: RefCell<Vec<Box<dyn Any>>>,
+
+    /// Number of allocation requests received.
+    alloc_count: RefCell<usize>,
+
+    /// Number of allocation requests fulfilled from the pool.
+    hit_count: RefCell<usize>,
+}
+
+impl TensorPool {
+    /// Return a new, empty pool.
+    ///
+    /// This is a cheap operation that does not allocate, so it can be used
+    /// to create a temporary pool to pass to a function that requires one,
+    /// if the caller does not have a pool otherwise available.
+    pub fn new() -> TensorPool {
+        TensorPool {
+            items: RefCell::new(Vec::new()),
+            alloc_count: RefCell::new(0),
+            hit_count: RefCell::new(0),
+        }
+    }
+
+    /// Allocate a tensor from the pool if possible, or fall back to the
+    /// global allocator otherwise.
+    ///
+    /// The contents of the returned tensor are uninitialized. After
+    /// initializing its contents, [`assume_init`](Tensor::assume_init) can
+    /// be used to mark it as initialized.
+    ///
+    /// When it is no longer needed, the tensor can be returned to the pool
+    /// using [`add`](TensorPool::add) to make it available for subsequent
+    /// allocations.
+    pub fn alloc<T: Copy + Any, S: IntoLayout>(
+        &self,
+        shape: S,
+    ) -> TensorBase<MaybeUninit<T>, Vec<MaybeUninit<T>>, S::Layout> {
+        *self.alloc_count.borrow_mut() += 1;
+
+        let required_len: usize = shape.as_ref().iter().product();
+
+        // Find best fit item that matches the requested type and size with
+        // the least excess capacity.
+        let best_fit =
+            self.items
+                .borrow()
+                .iter()
+                .enumerate()
+                .fold(None, |best_fit, (idx, tensor)| {
+                    let Some(tensor) = tensor.downcast_ref::<Vec<MaybeUninit<T>>>() else {
+                        return best_fit;
+                    };
+
+                    let len = tensor.capacity();
+                    if len < required_len {
+                        return best_fit;
+                    }
+                    let overhead = len - required_len;
+
+                    if let Some((best_fit_idx, best_fit_overhead)) = best_fit {
+                        if overhead >= best_fit_overhead {
+                            return Some((best_fit_idx, best_fit_overhead));
+                        }
+                    }
+
+                    Some((idx, overhead))
+                });
+
+        let layout = shape.into_layout();
+        let Some((best_fit, _overhead)) = best_fit else {
+            // No match :( - Fall back to the global allocator.
+            return TensorBase::uninit(layout.shape());
+        };
+
+        *self.hit_count.borrow_mut() += 1;
+
+        let item = self.items.borrow_mut().remove(best_fit);
+        let mut data: Vec<MaybeUninit<T>> = *item.downcast().expect("buffer type mismatch");
+
+        // Safety: Changing the length of a `MaybeUninit<T>` is safe since items
+        // are de-facto "initialized".
+        unsafe {
+            assert!(layout.len() <= data.capacity());
+            data.set_len(layout.len());
+        }
+
+        TensorBase::from_data(layout.shape(), data)
+    }
+
+    /// Allocate a tensor using [`alloc`](TensorPool::alloc) and fill all
+    /// entries with zero.
+    pub fn alloc_zeroed<T: Copy + Any + Default, S: IntoLayout>(
+        &self,
+        shape: S,
+    ) -> TensorBase<T, Vec<T>, S::Layout> {
+        let mut tensor = self.alloc(shape);
+        tensor.fill(MaybeUninit::new(T::default()));
+
+        // Safety: We just populated all the elements.
+        unsafe { tensor.assume_init() }
+    }
+
+    /// Add the data buffer from a tensor into the pool, so it can be used
+    /// to satisfy future calls to [`alloc`](TensorPool::alloc).
+    ///
+    /// This method expects `T` to be an initialized type (ie. not an
+    /// uninitialized tensor as returned by `Tensor::uninit`).
+    pub fn add<T: Any, L: MutLayout>(&self, tensor: TensorBase<T, Vec<T>, L>) {
+        let data = tensor.into_non_contiguous_data();
+
+        // Safety: We assume casting `Vec<T>` => `Vec<MaybeUninit<T>>` is safe
+        // for `Copy` types.
+        let data: Vec<MaybeUninit<T>> = unsafe { std::mem::transmute(data) };
+
+        self.items.borrow_mut().insert(0, Box::new(data));
+    }
+
+    /// Return the total number of allocation requests.
+    pub fn alloc_count(&self) -> usize {
+        *self.alloc_count.borrow()
+    }
+
+    /// Return the number of allocation requests that were fulfilled using
+    /// items in the pool.
+    pub fn hit_count(&self) -> usize {
+        *self.hit_count.borrow()
+    }
+}
+
+impl Default for TensorPool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rten_tensor::prelude::*;
+
+    use super::TensorPool;
+
+    #[test]
+    fn test_pool_alloc() {
+        let pool = TensorPool::new();
+
+        // nb. These tests use `alloc_zeroed` because `TensorPool::add` expects
+        // an initialized tensor.
+
+        // Initial alloc. There is nothing in the pool so this will use the
+        // system allocator.
+        let tensor = pool.alloc_zeroed::<f32, _>([2, 2]);
+        assert_eq!(tensor.shape(), [2, 2]);
+        assert_eq!(pool.alloc_count(), 1);
+        assert_eq!(pool.hit_count(), 0);
+        let ptr = tensor.data().unwrap().as_ptr();
+
+        pool.add(tensor);
+
+        // Alloc with an exact size match. This will be fulfilled from the pool.
+        let tensor = pool.alloc_zeroed::<f32, _>([2, 2]);
+        assert_eq!(tensor.shape(), [2, 2]);
+        assert_eq!(pool.alloc_count(), 2);
+        assert_eq!(pool.hit_count(), 1);
+
+        // Check we really did get the same data back.
+        assert_eq!(tensor.data().unwrap().as_ptr(), ptr);
+
+        pool.add(tensor);
+
+        // Alloc with a smaller size. This will be fulfilled from the pool.
+        let tensor = pool.alloc_zeroed::<f32, _>([2, 1]);
+        assert_eq!(tensor.shape(), [2, 1]);
+        assert_eq!(pool.alloc_count(), 3);
+        assert_eq!(pool.hit_count(), 2);
+
+        pool.add(tensor);
+
+        // Alloc with a larger size. This will return a new tensor.
+        let tensor = pool.alloc_zeroed::<f32, _>([2, 3]);
+        assert_eq!(tensor.shape(), [2, 3]);
+        assert_eq!(pool.alloc_count(), 4);
+        assert_eq!(pool.hit_count(), 2);
+
+        // Alloc with a size that matches the item in the pool, but a different
+        // type. This will return a new tensor.
+        let int_tensor = pool.alloc_zeroed::<i32, _>([2, 2]);
+        assert_eq!(int_tensor.shape(), [2, 2]);
+        assert_eq!(pool.alloc_count(), 5);
+        assert_eq!(pool.hit_count(), 2);
+
+        pool.add(int_tensor);
+
+        // Alloc that matches the tensor we just freed. This will return the
+        // item just added to the pool.
+        let int_tensor = pool.alloc_zeroed::<i32, _>([2, 2]);
+        assert_eq!(int_tensor.shape(), [2, 2]);
+        assert_eq!(pool.alloc_count(), 6);
+        assert_eq!(pool.hit_count(), 3);
+    }
+}


### PR DESCRIPTION
Graph execution often spends a significant amount of time allocating or freeing large buffers using the system allocator. So far this is mitigated for some operators by running them in-place on the first input, however there are many important operations which cannot run in-place, and many cases where operators that can run in place do not because an input is needed by a subsequent operation.

This PR introduces a tensor buffer pool (`TensorPool`), which is created at the start of the graph run, and used by operators as an allocator for their outputs. Once a value is no longer needed by subsequent steps of graph execution, the buffer is added to the pool and made available for use by subsequent steps. New output has been added to the timing report enabled by `RTEN_TIMING`, reporting the total number of allocation requests to the pool and the hit rate (how often buffer requests were fulfilled from the pool). 

The pool is disabled by default and enabled by setting the `RTEN_USE_POOL` env var. It will be enabled once the majority of operators are converted to allocate from the pool.

To verify this works, a subset of operators have been converted to allocate from the pool, based on ops used by the YOLOv8 example. In this example, this reduces execution times on my laptop from 210-220ms to 180-190ms, and this may improve further when additional operators are converted to use pool allocation.

Most operators do not yet allocate from the pool, and they will be converted in subsequent commits.

**TODO:**

- [x] Tests for new `Tensor*` methods
- [x] Tests for `TensorPool`
- [x] Add feature flag to make the pool opt-in until more operators are converted to use it