### PR TITLE
Convert operators to use tensor pool, part 2

### DIFF
--- a/src/ops/concat.rs
+++ b/src/ops/concat.rs
@@ -1,5 +1,4 @@
 use std::any::Any;
-use std::mem::MaybeUninit;
 
 use rten_tensor::prelude::*;
 use rten_tensor::{Iter, NdTensorView, Tensor, TensorView};
@@ -82,10 +81,7 @@ pub fn concat<T: Any + Copy>(
     for other in &inputs[1..] {
         out_shape[axis] += other.size(axis);
     }
-    let out: Tensor<MaybeUninit<T>> = pool.alloc(out_shape.as_slice());
-    let mut out_data = out.into_data();
-    out_data.clear();
-    let mut out_data: Vec<T> = unsafe { std::mem::transmute(out_data) };
+    let mut out_data: Vec<T> = pool.alloc_vec(out_shape.iter().product());
 
     let mut input_iters: Vec<TensorChunks<'_, T>> = inputs
         .iter()

--- a/src/ops/concat.rs
+++ b/src/ops/concat.rs
@@ -1,4 +1,5 @@
 use std::any::Any;
+use std::mem::MaybeUninit;
 
 use rten_tensor::prelude::*;
 use rten_tensor::{Iter, NdTensorView, Tensor, TensorView};
@@ -128,18 +129,38 @@ impl Operator for Concat {
     }
 }
 
+/// Copied from `std::MaybeUninit::write_slice` in nightly std.
+fn write_slice<'a, T>(dest: &'a mut [MaybeUninit<T>], src: &[T]) -> &'a mut [T]
+where
+    T: Copy,
+{
+    // SAFETY: &[T] and &[MaybeUninit<T>] have the same layout
+    let uninit_src: &[MaybeUninit<T>] = unsafe { std::mem::transmute(src) };
+
+    dest.copy_from_slice(uninit_src);
+
+    // SAFETY: Valid elements have just been copied into `this` so it is initialized
+    unsafe { std::mem::transmute(dest) }
+}
+
 /// Recursively tile (ie. repeatly copy) chunks of `input` to `output`.
 ///
 /// `input_shape` and `repeats` are equal-length slices specifying the size
 /// of each dimension and the number of times to repeat that dim. All input
 /// dim sizes and repeats must be >= 1 (ie. input and output must be non-empty).
-fn tile_inner<T: Copy>(input: &[T], output: &mut [T], input_shape: &[usize], repeats: &[usize]) {
+fn tile_inner<T: Copy>(
+    input: &[T],
+    output: &mut [MaybeUninit<T>],
+    input_shape: &[usize],
+    repeats: &[usize],
+) {
+    let mut n_init = 0;
     match (input_shape, repeats) {
         ([size], [repeats]) => {
             assert!(input.len() == *size);
             assert!(input.len() * repeats == output.len());
             for out_chunk in output.chunks_mut(input.len()) {
-                out_chunk.copy_from_slice(input);
+                n_init += write_slice(out_chunk, input).len();
             }
         }
         ([size, inner_size @ ..], [repeats, inner_repeats @ ..]) => {
@@ -156,18 +177,21 @@ fn tile_inner<T: Copy>(input: &[T], output: &mut [T], input_shape: &[usize], rep
                     .zip(out_chunk.chunks_mut(inner_output_len))
                 {
                     tile_inner(inner_input, inner_output, inner_size, inner_repeats);
+                    n_init += inner_output.len();
                 }
             }
         }
         ([], []) => {
             // Input is a scalar.
-            output.copy_from_slice(input);
+            n_init += write_slice(output, input).len();
         }
         _ => panic!("input_shape.len() != repeats.len()"),
     }
+    assert!(n_init == output.len());
 }
 
-pub fn tile<T: Copy + Default>(
+pub fn tile<T: Any + Copy>(
+    pool: &TensorPool,
     input: TensorView<T>,
     repeats: NdTensorView<i32, 1>,
 ) -> Result<Tensor<T>, OpError> {
@@ -182,18 +206,20 @@ pub fn tile<T: Copy + Default>(
         .zip(repeats.iter())
         .map(|(size, repeat)| size * repeat)
         .collect();
-    let mut output = Tensor::zeros(&out_shape);
+    let mut output = pool.alloc(out_shape.as_slice());
 
-    if output.is_empty() {
-        return Ok(output);
+    if !output.is_empty() {
+        tile_inner(
+            input.to_contiguous().data().unwrap(),
+            output.data_mut().unwrap(),
+            input.shape(),
+            &repeats,
+        );
     }
 
-    tile_inner(
-        input.to_contiguous().data().unwrap(),
-        output.data_mut().unwrap(),
-        input.shape(),
-        &repeats,
-    );
+    // Safety - `tile_inner` initialized all output elements, or the tensor
+    // is empty.
+    let output = unsafe { output.assume_init() };
 
     Ok(output)
 }
@@ -206,14 +232,14 @@ impl Operator for Tile {
         "Tile"
     }
 
-    fn run(&self, _pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
         let input = inputs.require(0)?;
         let repeats = inputs.require_as::<i32>(1)?;
         let repeats = static_dims!(repeats, 1)?;
 
         match input {
-            Input::IntTensor(input) => tile(input, repeats).into_op_result(),
-            Input::FloatTensor(input) => tile(input, repeats).into_op_result(),
+            Input::IntTensor(input) => tile(pool, input, repeats).into_op_result(),
+            Input::FloatTensor(input) => tile(pool, input, repeats).into_op_result(),
         }
     }
 
@@ -230,9 +256,10 @@ impl Operator for Tile {
             return Ok(output);
         }
 
+        let pool = TensorPool::new();
         match output {
-            Output::IntTensor(input) => tile(input.view(), repeats).map(|t| t.into()),
-            Output::FloatTensor(input) => tile(input.view(), repeats).map(|t| t.into()),
+            Output::IntTensor(input) => tile(&pool, input.view(), repeats).map(|t| t.into()),
+            Output::FloatTensor(input) => tile(&pool, input.view(), repeats).map(|t| t.into()),
         }
     }
 }
@@ -321,29 +348,31 @@ mod tests {
 
     #[test]
     fn test_tile() {
+        let pool = new_pool();
+
         // Empty
         let input = Tensor::<f32>::zeros(&[3, 4, 5]);
         let repeats = tensor!([4, 0, 1]);
-        let result = tile(input.view(), repeats.nd_view()).unwrap();
+        let result = tile(&pool, input.view(), repeats.nd_view()).unwrap();
         assert_eq!(result.shape(), &[12, 0, 5]);
         assert!(result.is_empty());
 
         // Scalar
         let input = tensor!(5.);
         let repeats = tensor!([]);
-        let result = tile(input.view(), repeats.nd_view()).unwrap();
+        let result = tile(&pool, input.view(), repeats.nd_view()).unwrap();
         assert_eq!(result, tensor!(5.));
 
         // 1D tile
         let input = tensor!([1, 2, 3, 4]);
         let repeats = tensor!([3]);
-        let result = tile(input.view(), repeats.nd_view()).unwrap();
+        let result = tile(&pool, input.view(), repeats.nd_view()).unwrap();
         assert_eq!(result, tensor!([1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4]));
 
         // 2D tile
         let input = tensor!((1, 1); [3.]);
         let repeats = tensor!([3, 2]);
-        let result = tile(input.view(), repeats.nd_view()).unwrap();
+        let result = tile(&pool, input.view(), repeats.nd_view()).unwrap();
         assert_eq!(
             result,
             tensor!(
@@ -359,25 +388,25 @@ mod tests {
         // Noop tile
         let input = tensor!([1, 2, 3, 4]);
         let repeats = tensor!([1]);
-        let result = tile(input.view(), repeats.nd_view()).unwrap();
+        let result = tile(&pool, input.view(), repeats.nd_view()).unwrap();
         assert_eq!(input, result);
 
         // Repeat inner dim of a 2D tensor
         let input = Tensor::from([[1, 2], [3, 4]]);
         let repeats = tensor!([1, 2]);
-        let result = tile(input.view(), repeats.nd_view()).unwrap();
+        let result = tile(&pool, input.view(), repeats.nd_view()).unwrap();
         assert_eq!(result, Tensor::from([[1, 2, 1, 2], [3, 4, 3, 4]]));
 
         // Repeat outer dim of a 2D tensor
         let input = Tensor::from([[1, 2], [3, 4]]);
         let repeats = tensor!([2, 1]);
-        let result = tile(input.view(), repeats.nd_view()).unwrap();
+        let result = tile(&pool, input.view(), repeats.nd_view()).unwrap();
         assert_eq!(result, Tensor::from([[1, 2], [3, 4], [1, 2], [3, 4]]));
 
         // Repeat inner and outer dims of a 2D tensor
         let input = Tensor::from([[1, 2], [3, 4]]);
         let repeats = tensor!([2, 2]);
-        let result = tile(input.view(), repeats.nd_view()).unwrap();
+        let result = tile(&pool, input.view(), repeats.nd_view()).unwrap();
         assert_eq!(
             result,
             Tensor::from([[1, 2, 1, 2], [3, 4, 3, 4], [1, 2, 1, 2], [3, 4, 3, 4]])
@@ -386,16 +415,18 @@ mod tests {
 
     #[test]
     fn test_tile_invalid_repeats() {
+        let pool = new_pool();
+
         // Repeats length does not match input ndim.
         let input = tensor!([1, 2, 3]);
         let repeats = tensor!([1, 2]);
-        let result = tile(input.view(), repeats.nd_view());
+        let result = tile(&pool, input.view(), repeats.nd_view());
         assert_eq!(result, Err(OpError::InvalidValue("invalid repeats")));
 
         // Negative repeats
         let input = tensor!([1, 2, 3]);
         let repeats = tensor!([-1]);
-        let result = tile(input.view(), repeats.nd_view());
+        let result = tile(&pool, input.view(), repeats.nd_view());
         assert_eq!(result, Err(OpError::InvalidValue("invalid repeats")));
     }
 }

--- a/src/ops/conv.rs
+++ b/src/ops/conv.rs
@@ -49,11 +49,12 @@ fn min_max_out_x_coords(
 /// This is slightly more efficient than creating a zero-filled tensor and then
 /// adding the appropriate bias to each element.
 fn init_tensor_with_channel_bias(
+    pool: &TensorPool,
     shape: &[usize],
     chan_dim: usize,
     bias: &NdTensorView<f32, 1>,
 ) -> Tensor {
-    let mut out_data = Vec::with_capacity(shape.iter().product());
+    let mut out_data = pool.alloc_vec(shape.iter().product());
 
     let chan_elts: usize = shape[chan_dim + 1..].iter().product();
     let all_chan_elts: usize = chan_elts * shape[chan_dim];
@@ -577,6 +578,7 @@ fn col2im(
 /// `input` has dimensions NCHW and `kernel` has dimensions COHW where `O` is
 /// the number of output channels.
 pub fn conv_transpose(
+    pool: &TensorPool,
     input: TensorView,
     kernel: TensorView,
     bias: Option<TensorView>,
@@ -599,9 +601,9 @@ pub fn conv_transpose(
     let out_w = (in_w - 1) * stride_w + k_w;
 
     let mut output = if let Some(bias) = bias {
-        init_tensor_with_channel_bias(&[batch, out_c, out_h, out_w], 1, &bias)
+        init_tensor_with_channel_bias(pool, &[batch, out_c, out_h, out_w], 1, &bias)
     } else {
-        Tensor::zeros(&[batch, out_c, out_h, out_w])
+        pool.alloc_zeroed([batch, out_c, out_h, out_w].as_slice())
     };
 
     // Ensure input and kernel are contiguous to support reshaping.
@@ -653,11 +655,11 @@ impl Operator for ConvTranspose {
         "ConvTranspose"
     }
 
-    fn run(&self, _pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
         let input = inputs.require_as(0)?;
         let weight = inputs.require_as(1)?;
         let bias = inputs.get_as(2)?;
-        conv_transpose(input, weight, bias, self.strides).into_op_result()
+        conv_transpose(pool, input, weight, bias, self.strides).into_op_result()
     }
 }
 
@@ -1236,6 +1238,7 @@ mod tests {
 
     #[test]
     fn test_conv_transpose() -> Result<(), Box<dyn Error>> {
+        let pool = new_pool();
         let input = Tensor::from_data(&[1, 1, 2, 2], vec![1.0, 2.0, 3.0, 4.0]);
         let kernel = Tensor::from_data(&[1, 1, 2, 2], vec![0.1, 0.2, 0.3, 0.4]);
         let expected = Tensor::from_data(
@@ -1246,7 +1249,7 @@ mod tests {
             ],
         );
 
-        let result = conv_transpose(input.view(), kernel.view(), None, [2, 2]).unwrap();
+        let result = conv_transpose(&pool, input.view(), kernel.view(), None, [2, 2]).unwrap();
         expect_equal(&result, &expected)?;
 
         let mut expected_with_bias = Tensor::from_data(expected.shape().into(), expected.to_vec());
@@ -1254,8 +1257,14 @@ mod tests {
             *eb += 1.234;
         }
         let bias = Tensor::from_data(&[1], vec![1.234]);
-        let result =
-            conv_transpose(input.view(), kernel.view(), Some(bias.view()), [2, 2]).unwrap();
+        let result = conv_transpose(
+            &pool,
+            input.view(),
+            kernel.view(),
+            Some(bias.view()),
+            [2, 2],
+        )
+        .unwrap();
         expect_equal(&result, &expected_with_bias)?;
 
         Ok(())

--- a/src/ops/operators.rs
+++ b/src/ops/operators.rs
@@ -181,7 +181,7 @@ impl<T, S: AsRef<[T]>, const N: usize> Operators for TensorBase<T, S, NdLayout<N
 
 impl<S: AsRef<[f32]>> FloatOperators for TensorBase<f32, S, DynLayout> {
     fn matmul(&self, other: TensorView) -> Result<Tensor, OpError> {
-        matmul(self.view(), other)
+        matmul(&TensorPool::new(), self.view(), other)
     }
 
     fn reduce_l2(&self, axes: Option<&[i32]>, keep_dims: bool) -> Result<Tensor, OpError> {
@@ -211,7 +211,7 @@ impl<S: AsRef<[f32]>> FloatOperators for TensorBase<f32, S, DynLayout> {
 
 impl<S: AsRef<[f32]>, const N: usize> FloatOperators for TensorBase<f32, S, NdLayout<N>> {
     fn matmul(&self, other: TensorView) -> Result<Tensor, OpError> {
-        matmul(self.as_dyn(), other)
+        matmul(&TensorPool::new(), self.as_dyn(), other)
     }
 
     fn reduce_l2(&self, axes: Option<&[i32]>, keep_dims: bool) -> Result<Tensor, OpError> {

--- a/src/tensor_pool.rs
+++ b/src/tensor_pool.rs
@@ -58,9 +58,38 @@ impl TensorPool {
         &self,
         shape: S,
     ) -> TensorBase<MaybeUninit<T>, Vec<MaybeUninit<T>>, S::Layout> {
-        *self.alloc_count.borrow_mut() += 1;
+        let layout = shape.into_layout();
+        TensorBase::from_data(layout.shape(), self.alloc_buf(layout.len()))
+    }
 
-        let required_len: usize = shape.as_ref().iter().product();
+    /// Allocate a tensor using [`alloc`](TensorPool::alloc) and fill all
+    /// entries with zero.
+    pub fn alloc_zeroed<T: Copy + Any + Default, S: IntoLayout>(
+        &self,
+        shape: S,
+    ) -> TensorBase<T, Vec<T>, S::Layout> {
+        let mut tensor = self.alloc(shape);
+        tensor.fill(MaybeUninit::new(T::default()));
+
+        // Safety: We just populated all the elements.
+        unsafe { tensor.assume_init() }
+    }
+
+    /// Allocate an empty vec with a given capacity from the pool.
+    ///
+    /// This is useful for scenarios where the data buffer for a tensor is
+    /// built up and then passed to `Tensor::from_data`.
+    pub fn alloc_vec<T: Copy + Any>(&self, capacity: usize) -> Vec<T> {
+        let mut buf = self.alloc_buf::<T>(capacity);
+        buf.clear();
+
+        // Safety: Since the vec is empty, it is fully initialized and we
+        // can convert `Vec<MaybeUninit<T>>` -> `Vec<T>`.
+        unsafe { std::mem::transmute(buf) }
+    }
+
+    fn alloc_buf<T: Copy + Any>(&self, required_len: usize) -> Vec<MaybeUninit<T>> {
+        *self.alloc_count.borrow_mut() += 1;
 
         // Find best fit item that matches the requested type and size with
         // the least excess capacity.
@@ -89,38 +118,24 @@ impl TensorPool {
                     Some((idx, overhead))
                 });
 
-        let layout = shape.into_layout();
-        let Some((best_fit, _overhead)) = best_fit else {
+        let mut data = if let Some((best_fit, _overhead)) = best_fit {
+            *self.hit_count.borrow_mut() += 1;
+
+            let item = self.items.borrow_mut().remove(best_fit);
+            *item.downcast().expect("buffer type mismatch")
+        } else {
             // No match :( - Fall back to the global allocator.
-            return TensorBase::uninit(layout.shape());
+            Vec::with_capacity(required_len)
         };
-
-        *self.hit_count.borrow_mut() += 1;
-
-        let item = self.items.borrow_mut().remove(best_fit);
-        let mut data: Vec<MaybeUninit<T>> = *item.downcast().expect("buffer type mismatch");
 
         // Safety: Changing the length of a `MaybeUninit<T>` is safe since items
         // are de-facto "initialized".
         unsafe {
-            assert!(layout.len() <= data.capacity());
-            data.set_len(layout.len());
+            assert!(required_len <= data.capacity());
+            data.set_len(required_len);
         }
 
-        TensorBase::from_data(layout.shape(), data)
-    }
-
-    /// Allocate a tensor using [`alloc`](TensorPool::alloc) and fill all
-    /// entries with zero.
-    pub fn alloc_zeroed<T: Copy + Any + Default, S: IntoLayout>(
-        &self,
-        shape: S,
-    ) -> TensorBase<T, Vec<T>, S::Layout> {
-        let mut tensor = self.alloc(shape);
-        tensor.fill(MaybeUninit::new(T::default()));
-
-        // Safety: We just populated all the elements.
-        unsafe { tensor.assume_init() }
+        data
     }
 
     /// Add the data buffer from a tensor into the pool, so it can be used
@@ -129,11 +144,18 @@ impl TensorPool {
     /// This method expects `T` to be an initialized type (ie. not an
     /// uninitialized tensor as returned by `Tensor::uninit`).
     pub fn add<T: Any + Copy, L: MutLayout>(&self, tensor: TensorBase<T, Vec<T>, L>) {
-        let data = tensor.into_non_contiguous_data();
+        self.add_vec(tensor.into_non_contiguous_data());
+    }
 
-        // Safety: We assume casting `Vec<T>` => `Vec<MaybeUninit<T>>` is safe
-        // for `Copy` types.
-        let data: Vec<MaybeUninit<T>> = unsafe { std::mem::transmute(data) };
+    /// Add a data buffer to the pool.
+    ///
+    /// This is like [`add`](TensorPool::add) but takes a buffer directly,
+    /// instead of a tensor from which a buffer can be extracted.
+    pub fn add_vec<T: Any + Copy>(&self, mut vec: Vec<T>) {
+        vec.clear();
+
+        // The buffer is now empty, so we can mark it uninitialized.
+        let data: Vec<MaybeUninit<T>> = unsafe { std::mem::transmute(vec) };
 
         self.items.borrow_mut().insert(0, Box::new(data));
     }
@@ -219,5 +241,24 @@ mod tests {
         assert_eq!(int_tensor.shape(), [2, 2]);
         assert_eq!(pool.alloc_count(), 6);
         assert_eq!(pool.hit_count(), 3);
+    }
+
+    #[test]
+    fn test_pool_alloc_vec() {
+        let pool = TensorPool::new();
+
+        let vec = pool.alloc_vec::<f32>(128);
+        assert_eq!(vec.capacity(), 128);
+        assert_eq!(vec.len(), 0);
+        assert_eq!(pool.alloc_count(), 1);
+        assert_eq!(pool.hit_count(), 0);
+
+        pool.add_vec(vec);
+
+        let vec = pool.alloc_vec::<f32>(64);
+        assert_eq!(vec.capacity(), 128);
+        assert_eq!(vec.len(), 0);
+        assert_eq!(pool.alloc_count(), 2);
+        assert_eq!(pool.hit_count(), 1);
     }
 }

--- a/src/tensor_pool.rs
+++ b/src/tensor_pool.rs
@@ -128,7 +128,7 @@ impl TensorPool {
     ///
     /// This method expects `T` to be an initialized type (ie. not an
     /// uninitialized tensor as returned by `Tensor::uninit`).
-    pub fn add<T: Any, L: MutLayout>(&self, tensor: TensorBase<T, Vec<T>, L>) {
+    pub fn add<T: Any + Copy, L: MutLayout>(&self, tensor: TensorBase<T, Vec<T>, L>) {
         let data = tensor.into_non_contiguous_data();
 
         // Safety: We assume casting `Vec<T>` => `Vec<MaybeUninit<T>>` is safe

--- a/src/wasm_api.rs
+++ b/src/wasm_api.rs
@@ -9,6 +9,7 @@ use wasm_bindgen::prelude::*;
 use crate::graph::Dimension;
 use crate::model;
 use crate::ops::{matmul, Input, Output};
+use crate::tensor_pool::TensorPool;
 
 #[wasm_bindgen]
 pub struct Model {
@@ -201,7 +202,8 @@ impl Tensor {
     pub fn matmul(&self, other: &Tensor) -> Result<Tensor, String> {
         let a = self.as_float()?;
         let b = other.as_float()?;
-        let out = matmul(a, b).map_err(|e| e.to_string())?;
+        let pool = TensorPool::new();
+        let out = matmul(&pool, a, b).map_err(|e| e.to_string())?;
         Ok(Tensor::from_output(out.into()))
     }
 }


### PR DESCRIPTION
Convert the `Reshape`, `MatMul`, `Where`, `Tile` and `ConvTranspose` operators to allocate from the shared pool.

In the process, add some general new facilities to `TensorPool`:

- The ability to allocate an empty `Vec` with a given capacity
- A `PoolRef` smart pointer which wraps a tensor and returns it to the pool when it goes out of scope. This is useful for temporary buffers allocate within operators, such as the col2im matrix in `ConvTranspose`.