### PR TITLE
Convert unary operators to allocate from pool

### DIFF
--- a/src/ops/norm.rs
+++ b/src/ops/norm.rs
@@ -270,7 +270,8 @@ pub fn layer_normalization(
         Some(normalized_axes.as_slice()),
         true, /* keep_dims */
     )?;
-    let inverse_std_dev = var.map(|x| 1. / (x + epsilon).sqrt());
+    let inverse_std_dev_buf = pool.alloc_vec(var.len());
+    let inverse_std_dev = var.map_buf(inverse_std_dev_buf, |x| 1. / (x + epsilon).sqrt());
     let normalized = mul(&pool, d.view(), inverse_std_dev.view())?;
 
     // Second step: Shift and scale input.


### PR DESCRIPTION
Add a `TensorBase::map_buf` API as a variant of `TensorBase::map` which allows an output buffer to be passed, and use it to convert unary operators to allocate from the pool.