### PR TITLE
Convert tensor copies to allocate from pool

### DIFF
--- a/src/ops/identity.rs
+++ b/src/ops/identity.rs
@@ -1,7 +1,15 @@
+use std::any::Any;
+
 use rten_tensor::prelude::*;
+use rten_tensor::{Tensor, TensorView};
 
 use crate::ops::{Input, InputList, IntoOpResult, OpError, Operator, Output};
 use crate::tensor_pool::TensorPool;
+
+fn identity<T: Any + Copy>(pool: &TensorPool, src: TensorView<T>) -> Tensor<T> {
+    let buf = pool.alloc_vec(src.len());
+    src.to_tensor_buf(buf)
+}
 
 #[derive(Debug)]
 pub struct Identity {}
@@ -11,11 +19,11 @@ impl Operator for Identity {
         "Identity"
     }
 
-    fn run(&self, _pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
         let input = inputs.require(0)?;
         let result: Output = match input {
-            Input::IntTensor(t) => t.to_tensor().into(),
-            Input::FloatTensor(t) => t.to_tensor().into(),
+            Input::IntTensor(t) => identity(pool, t).into(),
+            Input::FloatTensor(t) => identity(pool, t).into(),
         };
         result.into_op_result()
     }

--- a/src/ops/operators.rs
+++ b/src/ops/operators.rs
@@ -205,7 +205,7 @@ impl<S: AsRef<[f32]>> FloatOperators for TensorBase<f32, S, DynLayout> {
     }
 
     fn softmax(&self, axis: isize) -> Result<Tensor, OpError> {
-        softmax(self.view(), axis)
+        softmax(&TensorPool::new(), self.view(), axis)
     }
 }
 
@@ -235,6 +235,6 @@ impl<S: AsRef<[f32]>, const N: usize> FloatOperators for TensorBase<f32, S, NdLa
     }
 
     fn softmax(&self, axis: isize) -> Result<Tensor, OpError> {
-        softmax(self.as_dyn(), axis)
+        softmax(&TensorPool::new(), self.as_dyn(), axis)
     }
 }


### PR DESCRIPTION
Add `TensorBase::to_tensor_buf` API that makes it possible to create a contiguous copy of a tensor/view with a pre-allocated output buffer, and use it to convert the `Identity`, `BatchNormalization`, `Slice`, `Softmax`, `LogSoftmax` and `InstanceNormalization` ops to allocate from the pool.