### PR TITLE
Convert Gemm, Expand ops to use pool

### DIFF
--- a/src/gemm.rs
+++ b/src/gemm.rs
@@ -230,6 +230,7 @@ impl<'a> GemmInputB<'a> {
 ///
 /// This computes `output = alpha * (a @ b) + beta * output` where `@` is
 /// matrix multiplication.
+#[allow(unused)]
 pub fn gemm(
     out_data: &mut [f32],
     out_row_stride: usize,


### PR DESCRIPTION
While converting the Gemm operator, also modify it to avoid redundant zeroing of the output buffer if `beta` is zero. The same optimization was applied to the MatMul operator previously.