### PR TITLE
Allocate from pool if needed in `Operator::run_in_place` impls

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -515,7 +515,7 @@ impl Graph {
             let op_result = if let Some(input) = in_place_input {
                 op_node
                     .operator
-                    .run_in_place(input, InputList::from_optional(op_inputs))
+                    .run_in_place(&pool, input, InputList::from_optional(op_inputs))
                     .map(|out| [out].into())
             } else {
                 op_node
@@ -925,12 +925,17 @@ mod tests {
             self.inner.run(pool, inputs)
         }
 
-        fn run_in_place(&self, output: Output, inputs: InputList) -> Result<Output, OpError> {
+        fn run_in_place(
+            &self,
+            pool: &TensorPool,
+            output: Output,
+            inputs: InputList,
+        ) -> Result<Output, OpError> {
             {
                 let mut m = self.metrics.lock().unwrap();
                 m.run_in_place_count += 1;
             }
-            self.inner.run_in_place(output, inputs)
+            self.inner.run_in_place(pool, output, inputs)
         }
     }
 
@@ -1355,7 +1360,12 @@ mod tests {
             input.to_tensor().into_op_result()
         }
 
-        fn run_in_place(&self, input: Output, _other: InputList) -> Result<Output, OpError> {
+        fn run_in_place(
+            &self,
+            _pool: &TensorPool,
+            input: Output,
+            _other: InputList,
+        ) -> Result<Output, OpError> {
             let mut output = input.into_float().unwrap();
             for x in output.iter_mut() {
                 *x = *x + 1.0;

--- a/src/ops/concat.rs
+++ b/src/ops/concat.rs
@@ -248,7 +248,12 @@ impl Operator for Tile {
         true
     }
 
-    fn run_in_place(&self, output: Output, inputs: InputList) -> Result<Output, OpError> {
+    fn run_in_place(
+        &self,
+        pool: &TensorPool,
+        output: Output,
+        inputs: InputList,
+    ) -> Result<Output, OpError> {
         let repeats = inputs.require_as::<i32>(0)?;
         let repeats = static_dims!(repeats, 1)?;
 
@@ -256,10 +261,9 @@ impl Operator for Tile {
             return Ok(output);
         }
 
-        let pool = TensorPool::new();
         match output {
-            Output::IntTensor(input) => tile(&pool, input.view(), repeats).map(|t| t.into()),
-            Output::FloatTensor(input) => tile(&pool, input.view(), repeats).map(|t| t.into()),
+            Output::IntTensor(input) => tile(pool, input.view(), repeats).map(|t| t.into()),
+            Output::FloatTensor(input) => tile(pool, input.view(), repeats).map(|t| t.into()),
         }
     }
 }

--- a/src/ops/convert.rs
+++ b/src/ops/convert.rs
@@ -38,12 +38,17 @@ impl Operator for Cast {
         true
     }
 
-    fn run_in_place(&self, input: Output, _: InputList) -> Result<Output, OpError> {
+    fn run_in_place(
+        &self,
+        pool: &TensorPool,
+        input: Output,
+        _: InputList,
+    ) -> Result<Output, OpError> {
         match (input, self.to) {
             (Output::IntTensor(t), DataType::Int32) => Ok(t.into()),
             (Output::FloatTensor(t), DataType::Float) => Ok(t.into()),
             (input, _) => self
-                .run(&TensorPool::new(), InputList::from(&[(&input).into()]))
+                .run(pool, InputList::from(&[(&input).into()]))
                 .map(|mut outputs| outputs.remove(0)),
         }
     }

--- a/src/ops/identity.rs
+++ b/src/ops/identity.rs
@@ -32,7 +32,12 @@ impl Operator for Identity {
         true
     }
 
-    fn run_in_place(&self, input: Output, _: InputList) -> Result<Output, OpError> {
+    fn run_in_place(
+        &self,
+        _pool: &TensorPool,
+        input: Output,
+        _: InputList,
+    ) -> Result<Output, OpError> {
         Ok(input)
     }
 }

--- a/src/ops/layout.rs
+++ b/src/ops/layout.rs
@@ -106,7 +106,12 @@ impl Operator for Expand {
         true
     }
 
-    fn run_in_place(&self, input: Output, inputs: InputList) -> Result<Output, OpError> {
+    fn run_in_place(
+        &self,
+        pool: &TensorPool,
+        input: Output,
+        inputs: InputList,
+    ) -> Result<Output, OpError> {
         let shape = inputs.require_as(0)?;
         let shape = static_dims!(shape, 1)?;
 
@@ -115,10 +120,9 @@ impl Operator for Expand {
             return Ok(input);
         }
 
-        let pool = TensorPool::new();
         let output: Output = match input {
-            Output::FloatTensor(input) => expand_to(&pool, input.view(), &out_shape).into(),
-            Output::IntTensor(input) => expand_to(&pool, input.view(), &out_shape).into(),
+            Output::FloatTensor(input) => expand_to(pool, input.view(), &out_shape).into(),
+            Output::IntTensor(input) => expand_to(pool, input.view(), &out_shape).into(),
         };
         Ok(output)
     }
@@ -172,7 +176,14 @@ impl Operator for Flatten {
         true
     }
 
-    fn run_in_place(&self, input: Output, _: InputList) -> Result<Output, OpError> {
+    fn run_in_place(
+        &self,
+        _pool: &TensorPool,
+        input: Output,
+        _: InputList,
+    ) -> Result<Output, OpError> {
+        // TODO - `flatten_in_place` should allocate from the pool if a copy is
+        // required.
         match input {
             Output::IntTensor(mut output) => {
                 flatten_in_place(&mut output, self.axis)?;
@@ -307,7 +318,15 @@ impl Operator for Reshape {
         true
     }
 
-    fn run_in_place(&self, input: Output, other: InputList) -> Result<Output, OpError> {
+    fn run_in_place(
+        &self,
+        _pool: &TensorPool,
+        input: Output,
+        other: InputList,
+    ) -> Result<Output, OpError> {
+        // TODO - `reshape_in_place` should allocate from the pool if a copy is
+        // required.
+
         let shape = other.require_as(0)?;
         let shape = static_dims!(shape, 1)?;
 
@@ -437,7 +456,12 @@ impl Operator for Squeeze {
         true
     }
 
-    fn run_in_place(&self, input: Output, other: InputList) -> Result<Output, OpError> {
+    fn run_in_place(
+        &self,
+        _pool: &TensorPool,
+        input: Output,
+        other: InputList,
+    ) -> Result<Output, OpError> {
         let axes = other.get_as(0)?;
         let axes = axes.map(|axes| static_dims!(axes, 1)).transpose()?;
 
@@ -554,7 +578,12 @@ impl Operator for Unsqueeze {
         true
     }
 
-    fn run_in_place(&self, output: Output, inputs: InputList) -> Result<Output, OpError> {
+    fn run_in_place(
+        &self,
+        _pool: &TensorPool,
+        output: Output,
+        inputs: InputList,
+    ) -> Result<Output, OpError> {
         let axes = inputs.require_as(0)?;
         let axes = static_dims!(axes, 1)?;
 

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -636,6 +636,9 @@ pub trait Operator: Debug {
     fn name(&self) -> &str;
 
     /// Execute the operator with the given inputs.
+    ///
+    /// The output, and any large intermediate buffers used by the operation,
+    /// should be allocated from `pool`.
     fn run(&self, pool: &TensorPool, input: InputList) -> Result<Vec<Output>, OpError>;
 
     /// Return true if this operator supports in-place execution via
@@ -663,7 +666,17 @@ pub trait Operator: Debug {
     ///
     /// `input` is the first input, which the implementation may modify and
     /// return as the output. `other` are the remaining inputs.
-    fn run_in_place(&self, _input: Output, _other: InputList) -> Result<Output, OpError> {
+    ///
+    /// Operators may fall back to allocating a new output if some property of
+    /// the input data or shapes means in-place operation is not possible. In
+    /// that case they should allocate the output from `pool`. The pool should
+    /// also be used for any temporary buffers created during execution.
+    fn run_in_place(
+        &self,
+        _pool: &TensorPool,
+        _input: Output,
+        _other: InputList,
+    ) -> Result<Output, OpError> {
         unimplemented!("in-place execution not supported")
     }
 }

--- a/src/ops/norm.rs
+++ b/src/ops/norm.rs
@@ -102,7 +102,12 @@ impl Operator for BatchNormalization {
         true
     }
 
-    fn run_in_place(&self, input: Output, other: InputList) -> Result<Output, OpError> {
+    fn run_in_place(
+        &self,
+        _pool: &TensorPool,
+        input: Output,
+        other: InputList,
+    ) -> Result<Output, OpError> {
         let mut output = input.into_float().ok_or(OpError::IncorrectInputType)?;
         let scale = other.require_as(0)?;
         let scale = static_dims!(scale, 1)?;
@@ -218,7 +223,12 @@ impl Operator for InstanceNormalization {
         true
     }
 
-    fn run_in_place(&self, output: Output, inputs: InputList) -> Result<Output, OpError> {
+    fn run_in_place(
+        &self,
+        _pool: &TensorPool,
+        output: Output,
+        inputs: InputList,
+    ) -> Result<Output, OpError> {
         let mut output = output.into_float().ok_or(OpError::IncorrectInputType)?;
 
         let scale = inputs.require_as(0)?;
@@ -406,7 +416,12 @@ impl Operator for LogSoftmax {
         true
     }
 
-    fn run_in_place(&self, input: Output, _other: InputList) -> Result<Output, OpError> {
+    fn run_in_place(
+        &self,
+        _pool: &TensorPool,
+        input: Output,
+        _other: InputList,
+    ) -> Result<Output, OpError> {
         let mut output = input.into_float().ok_or(OpError::IncorrectInputType)?;
         log_softmax_in_place(&mut output, self.axis)?;
         Ok(output.into())
@@ -444,7 +459,12 @@ impl Operator for Softmax {
         true
     }
 
-    fn run_in_place(&self, input: Output, _other: InputList) -> Result<Output, OpError> {
+    fn run_in_place(
+        &self,
+        _pool: &TensorPool,
+        input: Output,
+        _other: InputList,
+    ) -> Result<Output, OpError> {
         let mut output = input.into_float().ok_or(OpError::IncorrectInputType)?;
         softmax_in_place(&mut output, self.axis)?;
         Ok(output.into())

--- a/src/ops/slice.rs
+++ b/src/ops/slice.rs
@@ -137,7 +137,12 @@ impl Operator for Slice {
         true
     }
 
-    fn run_in_place(&self, input: Output, other: InputList) -> Result<Output, OpError> {
+    fn run_in_place(
+        &self,
+        pool: &TensorPool,
+        input: Output,
+        other: InputList,
+    ) -> Result<Output, OpError> {
         let starts = other.require_as::<i32>(0)?;
         let starts = static_dims!(starts, 1)?;
 
@@ -159,7 +164,7 @@ impl Operator for Slice {
                 let mut inputs: Vec<_> = vec![(&input).into()];
                 inputs.extend(other.iter());
                 return self
-                    .run(&TensorPool::new(), InputList::from(&inputs))
+                    .run(pool, InputList::from(&inputs))
                     .map(|mut outputs| outputs.remove(0));
             }
         }

--- a/src/ops/unary_elementwise.rs
+++ b/src/ops/unary_elementwise.rs
@@ -52,7 +52,12 @@ impl<Op: UnaryFloatOp + Debug> Operator for Op {
         true
     }
 
-    fn run_in_place(&self, input: Output, _: InputList) -> Result<Output, OpError> {
+    fn run_in_place(
+        &self,
+        _pool: &TensorPool,
+        input: Output,
+        _: InputList,
+    ) -> Result<Output, OpError> {
         let mut output = input.into_float().ok_or(OpError::IncorrectInputType)?;
         self.apply(output.view_mut());
         Ok(output.into())
@@ -86,7 +91,12 @@ macro_rules! unary_numeric_op {
                 true
             }
 
-            fn run_in_place(&self, input: Output, _: InputList) -> Result<Output, OpError> {
+            fn run_in_place(
+                &self,
+                _pool: &TensorPool,
+                input: Output,
+                _: InputList,
+            ) -> Result<Output, OpError> {
                 match input {
                     Output::FloatTensor(mut input) => {
                         $mut_impl(input.view_mut());
@@ -198,7 +208,12 @@ macro_rules! parallel_unary_float_op {
                 $func_name(pool, inputs.require_as(0)?).into_op_result()
             }
 
-            fn run_in_place(&self, input: Output, _: InputList) -> Result<Output, OpError> {
+            fn run_in_place(
+                &self,
+                _pool: &TensorPool,
+                input: Output,
+                _: InputList,
+            ) -> Result<Output, OpError> {
                 let mut tensor = input.into_float().ok_or(OpError::IncorrectInputType)?;
                 $in_place_func_name(tensor.view_mut());
                 Ok(tensor.into())
@@ -348,7 +363,12 @@ impl Operator for Clip {
         true
     }
 
-    fn run_in_place(&self, input: Output, other: InputList) -> Result<Output, OpError> {
+    fn run_in_place(
+        &self,
+        _pool: &TensorPool,
+        input: Output,
+        other: InputList,
+    ) -> Result<Output, OpError> {
         match input {
             Output::FloatTensor(mut input) => {
                 let min = other.get_as_scalar(0)?;
@@ -495,7 +515,12 @@ impl Operator for Not {
         true
     }
 
-    fn run_in_place(&self, input: Output, _: InputList) -> Result<Output, OpError> {
+    fn run_in_place(
+        &self,
+        _pool: &TensorPool,
+        input: Output,
+        _: InputList,
+    ) -> Result<Output, OpError> {
         let mut output = input.into_int().ok_or(OpError::IncorrectInputType)?;
         not_in_place(output.view_mut());
         Ok(output.into())


### PR DESCRIPTION
When an operator's `run_in_place` impl falls back to allocating a new tensor instead of mutating the input, allocate the new output buffer from the pool.

This was straightforward for most operators, but I left `TODO`s for a couple of the layout operations where modifying the fallback to use the pool is a bit more involved.

Part of https://github.com/robertknight/rten/issues/109.