### PR TITLE
Overhaul tensor APIs that take an output buffer

### DIFF
--- a/rten-tensor/src/lib.rs
+++ b/rten-tensor/src/lib.rs
@@ -56,6 +56,39 @@ pub trait RandomSource<T> {
     fn next(&mut self) -> T;
 }
 
+/// Storage allocation trait.
+///
+/// This is used by various methods on [TensorBase] with an `_in` suffix,
+/// which allow the caller to control the allocation of the data buffer for
+/// the returned owned tensor.
+pub trait Alloc {
+    /// Allocate storage for an owned tensor.
+    ///
+    /// The returned `Vec` should be empty but have the given capacity.
+    fn alloc<T>(&self, capacity: usize) -> Vec<T>;
+}
+
+impl<A: Alloc> Alloc for &A {
+    fn alloc<T>(&self, capacity: usize) -> Vec<T> {
+        A::alloc(self, capacity)
+    }
+}
+
+/// Implementation of [Alloc] which wraps the global allocator.
+pub struct GlobalAlloc {}
+
+impl GlobalAlloc {
+    pub const fn new() -> GlobalAlloc {
+        GlobalAlloc {}
+    }
+}
+
+impl Alloc for GlobalAlloc {
+    fn alloc<T>(&self, capacity: usize) -> Vec<T> {
+        Vec::with_capacity(capacity)
+    }
+}
+
 pub use index_iterator::{DynIndices, Indices, NdIndices};
 pub use iterators::{
     AxisChunks, AxisChunksMut, AxisIter, AxisIterMut, BroadcastIter, InnerIter, InnerIterMut, Iter,

--- a/src/ops/binary_elementwise.rs
+++ b/src/ops/binary_elementwise.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 use std::fmt::Debug;
 use std::iter::{repeat, zip};
 
@@ -155,7 +154,7 @@ fn fast_broadcast_cycles(from_shape: &[usize], to_shape: &[usize]) -> Option<usi
 /// Compute the result of applying the binary operation `op` to corresponding
 /// elements of `a` and `b`. The shapes of `a` and `b` are broadcast to a
 /// matching shape if necessary.
-fn binary_op<T: Copy + Debug, R: Any + Copy + Default, F: Fn(T, T) -> R>(
+fn binary_op<T: Copy + Debug, R: Default, F: Fn(T, T) -> R>(
     pool: &TensorPool,
     a: TensorView<T>,
     b: TensorView<T>,
@@ -266,7 +265,7 @@ fn binary_op_in_place<T: Copy + Debug, F: Fn(T, T) -> T>(
 /// operands can be swapped without affecting the result. In this case we
 /// can make the larger of the two operands the LHS and benefit from
 /// optimizations in `binary_op` that assume this.
-fn binary_commutative_op<T: Any + Copy + Debug + Default, F: Fn(T, T) -> T>(
+fn binary_commutative_op<T: Copy + Debug + Default, F: Fn(T, T) -> T>(
     pool: &TensorPool,
     a: TensorView<T>,
     b: TensorView<T>,
@@ -331,7 +330,7 @@ macro_rules! run_typed_op_in_place {
 }
 
 /// Perform elementwise addition of two tensors.
-pub fn add<T: Copy + Any + Debug + Default + std::ops::Add<Output = T>>(
+pub fn add<T: Copy + Debug + Default + std::ops::Add<Output = T>>(
     pool: &TensorPool,
     a: TensorView<T>,
     b: TensorView<T>,
@@ -340,7 +339,7 @@ pub fn add<T: Copy + Any + Debug + Default + std::ops::Add<Output = T>>(
 }
 
 /// Perform in-place elementwise addition of two tensors.
-pub fn add_in_place<T: Any + Copy + Debug + std::ops::Add<Output = T>>(
+pub fn add_in_place<T: Copy + Debug + std::ops::Add<Output = T>>(
     a: TensorViewMut<T>,
     b: TensorView<T>,
 ) {
@@ -382,7 +381,7 @@ impl Operator for Add {
 /// These accept two i32 tensors and produce an i32 result.
 macro_rules! logical_boolean_op {
     ($op:ident, $op_fn:ident, $expr:expr) => {
-        pub fn $op_fn<T: AsBool + Any + Copy + Debug>(
+        pub fn $op_fn<T: AsBool + Copy + Debug>(
             pool: &TensorPool,
             a: TensorView<T>,
             b: TensorView<T>,
@@ -421,8 +420,7 @@ logical_boolean_op!(Xor, xor, |x, y| x ^ y);
 
 /// Perform elementwise division of two tensors.
 pub fn div<
-    T: Any
-        + Copy
+    T: Copy
         + Debug
         + Default
         + std::ops::Mul<Output = T>
@@ -490,7 +488,7 @@ enum BooleanOp {
     GreaterOrEqual,
 }
 
-fn boolean_op<T: Any + Copy + Debug + PartialEq + PartialOrd>(
+fn boolean_op<T: Copy + Debug + PartialEq + PartialOrd>(
     pool: &TensorPool,
     a: TensorView<T>,
     b: TensorView<T>,
@@ -511,7 +509,7 @@ fn boolean_op<T: Any + Copy + Debug + PartialEq + PartialOrd>(
 /// types.
 macro_rules! boolean_cmp_op {
     ($name:ident, $func:ident) => {
-        pub fn $func<T: Any + Copy + Debug + PartialEq + PartialOrd>(
+        pub fn $func<T: Copy + Debug + PartialEq + PartialOrd>(
             pool: &TensorPool,
             a: TensorView<T>,
             b: TensorView<T>,
@@ -581,13 +579,7 @@ pub enum DivMode {
 
 /// Return the elementwise remainder of dividing `a / b`.
 pub fn mod_op<
-    T: Any
-        + Copy
-        + Debug
-        + Default
-        + PartialOrd
-        + std::ops::Add<Output = T>
-        + std::ops::Rem<Output = T>,
+    T: Copy + Debug + Default + PartialOrd + std::ops::Add<Output = T> + std::ops::Rem<Output = T>,
 >(
     pool: &TensorPool,
     a: TensorView<T>,
@@ -639,7 +631,7 @@ impl Operator for Mod {
 }
 
 /// Multiply two tensors elementwise.
-pub fn mul<T: Any + Copy + Debug + Default + std::ops::Mul<Output = T>>(
+pub fn mul<T: Copy + Debug + Default + std::ops::Mul<Output = T>>(
     pool: &TensorPool,
     a: TensorView<T>,
     b: TensorView<T>,
@@ -751,7 +743,7 @@ impl Operator for Pow {
 }
 
 /// Perform elementwise subtraction of two tensors.
-pub fn sub<T: Any + Copy + Debug + Default + std::ops::Sub<Output = T>>(
+pub fn sub<T: Copy + Debug + Default + std::ops::Sub<Output = T>>(
     pool: &TensorPool,
     a: TensorView<T>,
     b: TensorView<T>,
@@ -793,7 +785,7 @@ impl Operator for Sub {
     }
 }
 
-pub fn where_op<T: Any + Copy>(
+pub fn where_op<T: Copy>(
     pool: &TensorPool,
     cond: TensorView<i32>,
     x: TensorView<T>,

--- a/src/ops/concat.rs
+++ b/src/ops/concat.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 use std::mem::MaybeUninit;
 
 use rten_tensor::prelude::*;
@@ -54,7 +53,7 @@ impl<'a, T: Copy> TensorChunks<'a, T> {
     }
 }
 
-pub fn concat<T: Any + Copy>(
+pub fn concat<T: Copy>(
     pool: &TensorPool,
     inputs: &[TensorView<T>],
     axis: isize,
@@ -190,7 +189,7 @@ fn tile_inner<T: Copy>(
     assert!(n_init == output.len());
 }
 
-pub fn tile<T: Any + Copy>(
+pub fn tile<T: Copy>(
     pool: &TensorPool,
     input: TensorView<T>,
     repeats: NdTensorView<i32, 1>,

--- a/src/ops/convert.rs
+++ b/src/ops/convert.rs
@@ -16,20 +16,14 @@ impl Operator for Cast {
     fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
         let input = inputs.require(0)?;
         let result: Output = match self.to {
-            DataType::Int32 => {
-                let buf: Vec<i32> = pool.alloc_vec(input.len());
-                match input {
-                    Input::IntTensor(t) => t.map_buf(buf, |x| *x).into(),
-                    Input::FloatTensor(t) => t.map_buf(buf, |x| *x as i32).into(),
-                }
-            }
-            DataType::Float => {
-                let buf: Vec<f32> = pool.alloc_vec(input.len());
-                match input {
-                    Input::FloatTensor(t) => t.map_buf(buf, |x| *x).into(),
-                    Input::IntTensor(t) => t.map_buf(buf, |x| *x as f32).into(),
-                }
-            }
+            DataType::Int32 => match input {
+                Input::IntTensor(t) => t.map_in(pool, |x| *x).into(),
+                Input::FloatTensor(t) => t.map_in(pool, |x| *x as i32).into(),
+            },
+            DataType::Float => match input {
+                Input::FloatTensor(t) => t.map_in(pool, |x| *x).into(),
+                Input::IntTensor(t) => t.map_in(pool, |x| *x as f32).into(),
+            },
         };
         result.into_op_result()
     }

--- a/src/ops/gather.rs
+++ b/src/ops/gather.rs
@@ -296,8 +296,7 @@ pub fn scatter_elements<
     }
     let axis = resolve_axis(data.ndim(), axis)?;
 
-    let buf = pool.alloc_vec(data.len());
-    let mut output = data.to_tensor_buf(buf);
+    let mut output = data.to_tensor_in(pool);
     for (index, update) in zip(updates.indices(), updates.iter()) {
         let target_index: SmallVec<[usize; 5]> = index
             .iter()
@@ -398,8 +397,7 @@ pub fn scatter_nd<
         .unwrap()
         .chunks(indices.size(indices.ndim() - 1));
 
-    let buf = pool.alloc_vec(data.len());
-    let mut output = data.to_tensor_buf(buf);
+    let mut output = data.to_tensor_in(pool);
     for (index, update_slice) in index_slices.zip(update_slices) {
         let mut output_slice_offset = 0;
         for (i, (size, stride)) in index

--- a/src/ops/gather.rs
+++ b/src/ops/gather.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 use std::iter::zip;
 
 use rten_tensor::prelude::*;
@@ -17,7 +16,7 @@ use crate::tensor_pool::TensorPool;
 /// is very similar to `numpy.take`. See
 /// <https://numpy.org/doc/stable/reference/generated/numpy.take.html> for
 /// additional explanation.
-pub fn gather<T: Any + Copy + Default>(
+pub fn gather<T: Copy + Default>(
     pool: &TensorPool,
     input: TensorView<T>,
     axis: isize,
@@ -157,7 +156,7 @@ fn unsqueeze_n<T>(mut view: TensorView<T>, n: usize) -> TensorView<T> {
     view
 }
 
-pub fn gather_elements<T: Any + Copy + Default>(
+pub fn gather_elements<T: Copy + Default>(
     pool: &TensorPool,
     input: TensorView<T>,
     indices: TensorView<i32>,
@@ -275,7 +274,7 @@ fn scatter_reduce<T: Copy + PartialOrd + std::ops::Add<Output = T> + std::ops::M
 }
 
 pub fn scatter_elements<
-    T: Any + Copy + Default + PartialOrd + std::ops::Add<Output = T> + std::ops::Mul<Output = T>,
+    T: Copy + Default + PartialOrd + std::ops::Add<Output = T> + std::ops::Mul<Output = T>,
 >(
     pool: &TensorPool,
     data: TensorView<T>,
@@ -350,7 +349,7 @@ impl Operator for ScatterElements {
 }
 
 pub fn scatter_nd<
-    T: Any + Copy + Default + PartialOrd + std::ops::Add<Output = T> + std::ops::Mul<Output = T>,
+    T: Copy + Default + PartialOrd + std::ops::Add<Output = T> + std::ops::Mul<Output = T>,
 >(
     pool: &TensorPool,
     data: TensorView<T>,

--- a/src/ops/generate.rs
+++ b/src/ops/generate.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 use std::iter::zip;
 use std::ops;
 
@@ -11,7 +10,7 @@ use crate::ops::{
 use crate::static_dims;
 use crate::tensor_pool::TensorPool;
 
-pub fn constant_of_shape<T: Any + Copy>(
+pub fn constant_of_shape<T: Copy>(
     pool: &TensorPool,
     value: T,
     shape: &NdTensorView<i32, 1>,
@@ -44,7 +43,7 @@ impl Operator for ConstantOfShape {
     }
 }
 
-pub fn onehot<T: Any + Copy + Default + PartialEq>(
+pub fn onehot<T: Copy + Default + PartialEq>(
     pool: &TensorPool,
     indices: TensorView<i32>,
     onehot_axis: isize,

--- a/src/ops/identity.rs
+++ b/src/ops/identity.rs
@@ -7,8 +7,7 @@ use crate::ops::{Input, InputList, IntoOpResult, OpError, Operator, Output};
 use crate::tensor_pool::TensorPool;
 
 fn identity<T: Any + Copy>(pool: &TensorPool, src: TensorView<T>) -> Tensor<T> {
-    let buf = pool.alloc_vec(src.len());
-    src.to_tensor_buf(buf)
+    src.to_tensor_in(pool)
 }
 
 #[derive(Debug)]

--- a/src/ops/identity.rs
+++ b/src/ops/identity.rs
@@ -1,12 +1,10 @@
-use std::any::Any;
-
 use rten_tensor::prelude::*;
 use rten_tensor::{Tensor, TensorView};
 
 use crate::ops::{Input, InputList, IntoOpResult, OpError, Operator, Output};
 use crate::tensor_pool::TensorPool;
 
-fn identity<T: Any + Copy>(pool: &TensorPool, src: TensorView<T>) -> Tensor<T> {
+fn identity<T: Copy>(pool: &TensorPool, src: TensorView<T>) -> Tensor<T> {
     src.to_tensor_in(pool)
 }
 

--- a/src/ops/layout.rs
+++ b/src/ops/layout.rs
@@ -1,6 +1,5 @@
 //! Operators which query or change the shape of a tensor, or copy/move/reorder
 //! elements.
-use std::any::Any;
 use std::iter::zip;
 
 use rten_tensor::prelude::*;
@@ -27,7 +26,7 @@ fn expand_output_shape(
 
 /// Broadcast `input` to `out_shape`. This assumes that `out_shape` has already
 /// been verified to be a valid broadcast target.
-pub(crate) fn expand_to<T: Any + Copy>(
+pub(crate) fn expand_to<T: Copy>(
     pool: &TensorPool,
     input: TensorView<T>,
     out_shape: &[usize],
@@ -72,7 +71,7 @@ pub(crate) fn expand_to<T: Any + Copy>(
     }
 }
 
-pub fn expand<T: Any + Copy>(
+pub fn expand<T: Copy>(
     pool: &TensorPool,
     input: TensorView<T>,
     shape: &NdTensorView<i32, 1>,
@@ -135,7 +134,7 @@ fn flattened_shape(shape: &[usize], axis: isize) -> Result<[usize; 2], OpError> 
     Ok([outer_size, inner_size])
 }
 
-pub fn flatten<T: Any + Copy>(
+pub fn flatten<T: Copy>(
     pool: &TensorPool,
     input: TensorView<T>,
     axis: isize,
@@ -146,7 +145,7 @@ pub fn flatten<T: Any + Copy>(
     Ok(output)
 }
 
-pub fn flatten_in_place<T: Any + Copy>(
+pub fn flatten_in_place<T: Copy>(
     pool: &TensorPool,
     input: &mut Tensor<T>,
     axis: isize,
@@ -272,7 +271,7 @@ fn resolve_shape(
         .collect())
 }
 
-pub fn reshape<T: Any + Copy>(
+pub fn reshape<T: Copy>(
     pool: &TensorPool,
     input: TensorView<T>,
     shape: &NdTensorView<i32, 1>,
@@ -284,7 +283,7 @@ pub fn reshape<T: Any + Copy>(
     Ok(output)
 }
 
-pub fn reshape_in_place<T: Any + Copy>(
+pub fn reshape_in_place<T: Copy>(
     pool: &TensorPool,
     input: &mut Tensor<T>,
     shape: &NdTensorView<i32, 1>,
@@ -421,7 +420,7 @@ pub fn squeeze_in_place<T: Clone>(
     Ok(())
 }
 
-pub fn squeeze<T: Any + Copy>(
+pub fn squeeze<T: Copy>(
     pool: &TensorPool,
     input: TensorView<T>,
     axes: Option<NdTensorView<i32, 1>>,
@@ -477,7 +476,7 @@ impl Operator for Squeeze {
     }
 }
 
-pub fn transpose<T: Any + Copy>(
+pub fn transpose<T: Copy>(
     pool: &TensorPool,
     input: TensorView<T>,
     permutation: Option<&[usize]>,
@@ -544,7 +543,7 @@ pub fn unsqueeze_in_place<T: Clone>(
     Ok(input)
 }
 
-pub fn unsqueeze<T: Any + Copy>(
+pub fn unsqueeze<T: Copy>(
     pool: &TensorPool,
     input: TensorView<T>,
     axes: &NdTensorView<i32, 1>,

--- a/src/ops/operators.rs
+++ b/src/ops/operators.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 use std::fmt::Debug;
 
 use rten_tensor::prelude::*;
@@ -22,12 +21,11 @@ pub trait Operators {
 
     fn arg_max(&self, axis: isize, keep_dims: bool) -> Result<Tensor<i32>, OpError>
     where
-        Self::Elem: Any + Copy + PartialOrd;
+        Self::Elem: Copy + PartialOrd;
 
     fn div(&self, other: TensorView<Self::Elem>) -> Result<Tensor<Self::Elem>, OpError>
     where
-        Self::Elem: Any
-            + Copy
+        Self::Elem: Copy
             + Debug
             + Default
             + std::ops::Mul<Output = Self::Elem>
@@ -37,7 +35,7 @@ pub trait Operators {
 
     fn mul(&self, other: TensorView<Self::Elem>) -> Result<Tensor<Self::Elem>, OpError>
     where
-        Self::Elem: Any + Copy + Debug + Default + std::ops::Mul<Output = Self::Elem>;
+        Self::Elem: Copy + Debug + Default + std::ops::Mul<Output = Self::Elem>;
 
     fn pad(
         &self,
@@ -45,7 +43,7 @@ pub trait Operators {
         val: Self::Elem,
     ) -> Result<Tensor<Self::Elem>, OpError>
     where
-        Self::Elem: Any + Copy;
+        Self::Elem: Copy;
 
     fn topk(
         &self,
@@ -55,7 +53,7 @@ pub trait Operators {
         sorted: bool,
     ) -> Result<(Tensor<Self::Elem>, Tensor<i32>), OpError>
     where
-        Self::Elem: Any + Copy + Default + PartialOrd;
+        Self::Elem: Copy + Default + PartialOrd;
 }
 
 /// Trait which exposes ONNX operators as methods of tensors.
@@ -80,15 +78,14 @@ impl<T, S: AsRef<[T]>> Operators for TensorBase<T, S, DynLayout> {
 
     fn arg_max(&self, axis: isize, keep_dims: bool) -> Result<Tensor<i32>, OpError>
     where
-        T: Any + Copy + PartialOrd,
+        T: Copy + PartialOrd,
     {
         arg_max(&TensorPool::new(), self.view(), axis, keep_dims)
     }
 
     fn div(&self, other: TensorView<Self::Elem>) -> Result<Tensor<Self::Elem>, OpError>
     where
-        Self::Elem: Any
-            + Copy
+        Self::Elem: Copy
             + Debug
             + Default
             + std::ops::Mul<Output = Self::Elem>
@@ -101,14 +98,14 @@ impl<T, S: AsRef<[T]>> Operators for TensorBase<T, S, DynLayout> {
 
     fn mul(&self, other: TensorView<T>) -> Result<Tensor<T>, OpError>
     where
-        T: Any + Copy + Debug + Default + std::ops::Mul<Output = T>,
+        T: Copy + Debug + Default + std::ops::Mul<Output = T>,
     {
         mul(&TensorPool::new(), self.view(), other)
     }
 
     fn pad(&self, padding: NdTensorView<i32, 1>, val: T) -> Result<Tensor<Self::Elem>, OpError>
     where
-        Self::Elem: Any + Copy,
+        Self::Elem: Copy,
     {
         pad(&TensorPool::new(), self.view(), &padding, val)
     }
@@ -121,7 +118,7 @@ impl<T, S: AsRef<[T]>> Operators for TensorBase<T, S, DynLayout> {
         sorted: bool,
     ) -> Result<(Tensor<Self::Elem>, Tensor<i32>), OpError>
     where
-        T: Any + Copy + Default + PartialOrd,
+        T: Copy + Default + PartialOrd,
     {
         topk(&TensorPool::new(), self.view(), k, axis, largest, sorted)
     }
@@ -132,15 +129,14 @@ impl<T, S: AsRef<[T]>, const N: usize> Operators for TensorBase<T, S, NdLayout<N
 
     fn arg_max(&self, axis: isize, keep_dims: bool) -> Result<Tensor<i32>, OpError>
     where
-        T: Any + Copy + PartialOrd,
+        T: Copy + PartialOrd,
     {
         arg_max(&TensorPool::new(), self.as_dyn(), axis, keep_dims)
     }
 
     fn div(&self, other: TensorView<Self::Elem>) -> Result<Tensor<Self::Elem>, OpError>
     where
-        Self::Elem: Any
-            + Copy
+        Self::Elem: Copy
             + Debug
             + Default
             + std::ops::Mul<Output = Self::Elem>
@@ -153,14 +149,14 @@ impl<T, S: AsRef<[T]>, const N: usize> Operators for TensorBase<T, S, NdLayout<N
 
     fn mul(&self, other: TensorView<T>) -> Result<Tensor<T>, OpError>
     where
-        T: Any + Copy + Debug + Default + std::ops::Mul<Output = T>,
+        T: Copy + Debug + Default + std::ops::Mul<Output = T>,
     {
         mul(&TensorPool::new(), self.as_dyn(), other)
     }
 
     fn pad(&self, padding: NdTensorView<i32, 1>, val: T) -> Result<Tensor<Self::Elem>, OpError>
     where
-        Self::Elem: Any + Copy,
+        Self::Elem: Copy,
     {
         pad(&TensorPool::new(), self.as_dyn(), &padding, val)
     }
@@ -173,7 +169,7 @@ impl<T, S: AsRef<[T]>, const N: usize> Operators for TensorBase<T, S, NdLayout<N
         sorted: bool,
     ) -> Result<(Tensor<Self::Elem>, Tensor<i32>), OpError>
     where
-        T: Any + Copy + Default + PartialOrd,
+        T: Copy + Default + PartialOrd,
     {
         topk(&TensorPool::new(), self.as_dyn(), k, axis, largest, sorted)
     }

--- a/src/ops/pad.rs
+++ b/src/ops/pad.rs
@@ -1,5 +1,3 @@
-use std::any::Any;
-
 use rten_tensor::prelude::*;
 use rten_tensor::{NdTensorView, SliceItem, Tensor, TensorView};
 
@@ -7,7 +5,7 @@ use crate::ops::{Input, InputList, IntoOpResult, OpError, Operator, Output};
 use crate::static_dims;
 use crate::tensor_pool::TensorPool;
 
-pub fn pad<T: Any + Copy>(
+pub fn pad<T: Copy>(
     pool: &TensorPool,
     input: TensorView<T>,
     padding: &NdTensorView<i32, 1>,

--- a/src/ops/reduce.rs
+++ b/src/ops/reduce.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 use std::cmp::Ordering;
 use std::iter::zip;
 
@@ -59,7 +58,7 @@ fn select_max_index<T, Cmp: Fn(&T, &T) -> std::cmp::Ordering>(
 /// Return the index of the maximum value along a given axis.
 ///
 /// NaN values are propagated by treating NaNs as greater than other values.
-pub fn arg_max<T: Any + Copy + PartialOrd>(
+pub fn arg_max<T: Copy + PartialOrd>(
     pool: &TensorPool,
     input: TensorView<T>,
     axis: isize,
@@ -88,7 +87,7 @@ impl Operator for ArgMax {
 /// Return the index of the minimum value along a given axis.
 ///
 /// NaN values are propagated by treating NaNs as smaller than other values.
-pub fn arg_min<T: Any + Copy + PartialOrd>(
+pub fn arg_min<T: Copy + PartialOrd>(
     pool: &TensorPool,
     input: TensorView<T>,
     axis: isize,
@@ -119,7 +118,7 @@ impl Operator for ArgMin {
     }
 }
 
-pub fn cum_sum<T: Any + Copy + Default + Identities + std::ops::AddAssign>(
+pub fn cum_sum<T: Copy + Default + Identities + std::ops::AddAssign>(
     pool: &TensorPool,
     input: TensorView<T>,
     axis: isize,
@@ -222,7 +221,7 @@ trait Reducer<T> {
     }
 }
 
-fn reduce<T: Any + Copy, R: Reducer<T>>(
+fn reduce<T: Copy, R: Reducer<T>>(
     pool: &TensorPool,
     input: TensorView<T>,
     axes: Option<&[i32]>,
@@ -465,7 +464,7 @@ pub fn cmp_nan_less<T: PartialOrd>(a: T, b: T) -> std::cmp::Ordering {
     }
 }
 
-fn reduce_min_max<T: Any + Copy + PartialOrd>(
+fn reduce_min_max<T: Copy + PartialOrd>(
     pool: &TensorPool,
     input: TensorView<T>,
     axes: Option<&[i32]>,
@@ -488,7 +487,7 @@ fn reduce_min_max<T: Any + Copy + PartialOrd>(
     reduce(pool, input, axes, keep_dims, MinMaxReducer { max })
 }
 
-pub fn reduce_min<T: Any + Copy + PartialOrd>(
+pub fn reduce_min<T: Copy + PartialOrd>(
     pool: &TensorPool,
     input: TensorView<T>,
     axes: Option<&[i32]>,
@@ -514,7 +513,7 @@ impl Operator for ReduceMin {
     }
 }
 
-pub fn reduce_max<T: Any + Copy + PartialOrd>(
+pub fn reduce_max<T: Copy + PartialOrd>(
     pool: &TensorPool,
     input: TensorView<T>,
     axes: Option<&[i32]>,
@@ -540,7 +539,7 @@ impl Operator for ReduceMax {
     }
 }
 
-pub fn reduce_prod<T: Any + Copy + std::iter::Product>(
+pub fn reduce_prod<T: Copy + std::iter::Product>(
     pool: &TensorPool,
     input: TensorView<T>,
     axes: Option<&[i32]>,
@@ -572,7 +571,7 @@ impl Operator for ReduceProd {
     }
 }
 
-pub fn reduce_sum<T: Any + Copy + std::iter::Sum>(
+pub fn reduce_sum<T: Copy + std::iter::Sum>(
     pool: &TensorPool,
     input: TensorView<T>,
     axes: Option<&[i32]>,
@@ -604,7 +603,7 @@ impl Operator for ReduceSum {
     }
 }
 
-pub fn reduce_sum_square<T: Any + Copy + std::ops::Mul<T, Output = T> + std::iter::Sum>(
+pub fn reduce_sum_square<T: Copy + std::ops::Mul<T, Output = T> + std::iter::Sum>(
     pool: &TensorPool,
     input: TensorView<T>,
     axes: Option<&[i32]>,
@@ -636,7 +635,7 @@ impl Operator for ReduceSumSquare {
     }
 }
 
-pub fn topk<T: Any + Copy + Default + PartialOrd>(
+pub fn topk<T: Copy + Default + PartialOrd>(
     pool: &TensorPool,
     values: TensorView<T>,
     k: usize,

--- a/src/ops/slice.rs
+++ b/src/ops/slice.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 use std::iter::zip;
 
 use rten_tensor::prelude::*;
@@ -48,7 +47,7 @@ fn slice_ranges(
 }
 
 /// Return a copy of a tensor which only retains a subset of a given dimension.
-pub fn slice<T: Any + Copy>(
+pub fn slice<T: Copy>(
     pool: &TensorPool,
     input: TensorView<T>,
     starts: &NdTensorView<i32, 1>,

--- a/src/ops/split.rs
+++ b/src/ops/split.rs
@@ -1,5 +1,3 @@
-use std::any::Any;
-
 use rten_tensor::prelude::*;
 use rten_tensor::{NdTensorView, SliceItem, Tensor, TensorView};
 
@@ -7,7 +5,7 @@ use crate::ops::{resolve_axis, InputList, OpError, Operator, Output};
 use crate::static_dims;
 use crate::tensor_pool::TensorPool;
 
-pub fn split<T: Any + Copy>(
+pub fn split<T: Copy>(
     pool: &TensorPool,
     input: TensorView<T>,
     axis: isize,

--- a/src/ops/trilu.rs
+++ b/src/ops/trilu.rs
@@ -1,12 +1,10 @@
-use std::any::Any;
-
 use rten_tensor::prelude::*;
 use rten_tensor::{Tensor, TensorView};
 
 use crate::ops::{Input, InputList, IntoOpResult, OpError, Operator, Output};
 use crate::tensor_pool::TensorPool;
 
-pub fn trilu<T: Any + Copy + Default>(
+pub fn trilu<T: Copy + Default>(
     pool: &TensorPool,
     input: TensorView<T>,
     k: i32,

--- a/src/ops/unary_elementwise.rs
+++ b/src/ops/unary_elementwise.rs
@@ -2,7 +2,6 @@ extern crate libm;
 
 use rayon::prelude::*;
 
-use std::any::Any;
 use std::fmt::Debug;
 use std::mem::MaybeUninit;
 
@@ -153,7 +152,7 @@ const CHUNK_SIZE: usize = 32 * 1024;
 
 /// Apply a unary operation in parallel to contiguous slices of `input`.
 fn par_unary_op<
-    T: Any + Copy + Default + Send + Sync,
+    T: Copy + Default + Send + Sync,
     F: Fn(&[T], &mut [MaybeUninit<T>]) + Send + Sync,
 >(
     pool: &TensorPool,
@@ -245,7 +244,7 @@ impl AbsValue for i32 {
     }
 }
 
-pub fn abs<T: Any + AbsValue + Copy>(pool: &TensorPool, input: TensorView<T>) -> Tensor<T> {
+pub fn abs<T: AbsValue>(pool: &TensorPool, input: TensorView<T>) -> Tensor<T> {
     input.map_in(pool, |x| x.abs())
 }
 
@@ -312,7 +311,7 @@ impl Clamp for f32 {
     }
 }
 
-pub fn clip<T: Any + Copy + Clamp>(
+pub fn clip<T: Copy + Clamp>(
     pool: &TensorPool,
     input: TensorView<T>,
     min: Option<T>,
@@ -472,7 +471,7 @@ impl UnaryFloatOp for LeakyRelu {
 
 unary_float_op!(Log, log, log_in_place, |val: f32| val.ln());
 
-pub fn neg<T: Any + Copy + std::ops::Neg<Output = T>>(
+pub fn neg<T: Copy + std::ops::Neg<Output = T>>(
     pool: &TensorPool,
     input: TensorView<T>,
 ) -> Tensor<T> {
@@ -581,7 +580,7 @@ macro_rules! impl_signum {
 impl_signum!(i32);
 impl_signum!(f32);
 
-pub fn sign<T: Any + Signum>(pool: &TensorPool, input: TensorView<T>) -> Tensor<T> {
+pub fn sign<T: Signum>(pool: &TensorPool, input: TensorView<T>) -> Tensor<T> {
     input.map_in(pool, |x| x.signum())
 }
 

--- a/src/ops/unary_elementwise.rs
+++ b/src/ops/unary_elementwise.rs
@@ -28,8 +28,7 @@ pub trait UnaryFloatOp {
 
     /// Apply the operator to all elements in `input`.
     fn map(&self, pool: &TensorPool, input: TensorView) -> Tensor {
-        let buf = pool.alloc_vec(input.len());
-        input.map_buf(buf, |val| self.map_element(*val))
+        input.map_in(pool, |val| self.map_element(*val))
     }
 
     /// Apply the operator to all elements in `input`.
@@ -247,8 +246,7 @@ impl AbsValue for i32 {
 }
 
 pub fn abs<T: Any + AbsValue + Copy>(pool: &TensorPool, input: TensorView<T>) -> Tensor<T> {
-    let buf = pool.alloc_vec(input.len());
-    input.map_buf(buf, |x| x.abs())
+    input.map_in(pool, |x| x.abs())
 }
 
 pub fn abs_in_place<T: AbsValue>(mut input: TensorViewMut<T>) {
@@ -322,8 +320,7 @@ pub fn clip<T: Any + Copy + Clamp>(
 ) -> Tensor<T> {
     let min = min.unwrap_or(T::min_val());
     let max = max.unwrap_or(T::max_val());
-    let buf = pool.alloc_vec(input.len());
-    input.map_buf(buf, |x| x.clamp(min, max))
+    input.map_in(pool, |x| x.clamp(min, max))
 }
 
 pub fn clip_in_place<T: Copy + Clamp>(input: &mut Tensor<T>, min: Option<T>, max: Option<T>) {
@@ -479,8 +476,7 @@ pub fn neg<T: Any + Copy + std::ops::Neg<Output = T>>(
     pool: &TensorPool,
     input: TensorView<T>,
 ) -> Tensor<T> {
-    let buf = pool.alloc_vec(input.len());
-    input.map_buf(buf, |x| x.neg())
+    input.map_in(pool, |x| x.neg())
 }
 
 pub fn neg_in_place<T: Copy + std::ops::Neg<Output = T>>(mut input: TensorViewMut<T>) {
@@ -490,8 +486,7 @@ pub fn neg_in_place<T: Copy + std::ops::Neg<Output = T>>(mut input: TensorViewMu
 unary_numeric_op!(Neg, neg, neg_in_place);
 
 pub fn not<T: AsBool + PartialEq>(pool: &TensorPool, input: TensorView<T>) -> Tensor<i32> {
-    let buf = pool.alloc_vec(input.len());
-    input.map_buf(buf, |x| i32::from(!x.as_bool()))
+    input.map_in(pool, |x| i32::from(!x.as_bool()))
 }
 
 pub fn not_in_place(mut input: TensorViewMut<i32>) {
@@ -587,8 +582,7 @@ impl_signum!(i32);
 impl_signum!(f32);
 
 pub fn sign<T: Any + Signum>(pool: &TensorPool, input: TensorView<T>) -> Tensor<T> {
-    let buf = pool.alloc_vec(input.len());
-    input.map_buf(buf, |x| x.signum())
+    input.map_in(pool, |x| x.signum())
 }
 
 pub fn sign_in_place<T: Signum>(mut input: TensorViewMut<T>) {

--- a/src/ops/variadic_elementwise.rs
+++ b/src/ops/variadic_elementwise.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 use std::iter::zip;
 
 use rten_tensor::prelude::*;
@@ -12,7 +11,7 @@ use crate::tensor_pool::TensorPool;
 /// Apply an elementwise reduction to a sequence of tensors.
 ///
 /// All inputs must be broadcastable to the same shape.
-fn reduce_elementwise<T: Any + Copy, R: Fn(&[T]) -> T>(
+fn reduce_elementwise<T: Copy, R: Fn(&[T]) -> T>(
     pool: &TensorPool,
     inputs: &[TensorView<T>],
     reduce: &R,
@@ -80,7 +79,7 @@ where
     })
 }
 
-pub fn max<T: Any + Copy + PartialOrd>(
+pub fn max<T: Copy + PartialOrd>(
     pool: &TensorPool,
     inputs: &[TensorView<T>],
 ) -> Result<Tensor<T>, OpError> {
@@ -141,7 +140,7 @@ impl Operator for Mean {
     }
 }
 
-pub fn min<T: Any + Copy + PartialOrd>(
+pub fn min<T: Copy + PartialOrd>(
     pool: &TensorPool,
     inputs: &[TensorView<T>],
 ) -> Result<Tensor<T>, OpError> {
@@ -166,7 +165,7 @@ impl Operator for Min {
     }
 }
 
-pub fn sum<T: Any + Copy + std::iter::Sum>(
+pub fn sum<T: Copy + std::iter::Sum>(
     pool: &TensorPool,
     inputs: &[TensorView<T>],
 ) -> Result<Tensor<T>, OpError> {


### PR DESCRIPTION
Overhaul the TensorPool implementation and related APIs to fix unsoundness, remove `Any` bounds that infected all the operators, and align more closely with how allocator APIs work in nightly std.

 - Change TensorBase methods to have an `_in` suffix rather than `_buf` and take an
   allocator as an argument rather than a buffer. The allocator is needed for
   methods which conditionally allocate, and it avoids repeated code for other
   cases to have the method determine the allocation size rather than the caller.

 - Rework TensorPool for better soundness and more flexibility, by removing the
   `T: Any + Copy` constraint.

   Instead of storing `Vec<MaybeUninit<T>>`s in `Box<dyn Any>` wrappers in the
   pool, extract the underlying parts of the `Vec` and store those in a `Buffer`
   struct. When dropped, `Buffer`  reconstitutes the `Vec` and drops it. This
   avoids the unsoundness of transmuting `Vec<T>` -> `Vec<U>`. Instead we're
   transmuting only the pointer when fulfilling an allocation request.
