### PR TITLE
Refine tensor pool APIs and usage

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -595,8 +595,8 @@ impl Graph {
                 if rc == Some(0) {
                     if let (true, Some(tensor)) = (use_pool, temp_values.remove(&node_id)) {
                         match tensor {
-                            Output::FloatTensor(t) => pool.add(t),
-                            Output::IntTensor(t) => pool.add(t),
+                            Output::FloatTensor(t) => pool.add_tensor(t),
+                            Output::IntTensor(t) => pool.add_tensor(t),
                         }
                     }
                 }

--- a/src/ops/binary_elementwise.rs
+++ b/src/ops/binary_elementwise.rs
@@ -169,7 +169,7 @@ fn binary_op<T: Copy + Debug, R: Default, F: Fn(T, T) -> R>(
         if let Some((cycles, repeats)) = fast_broadcast_cycles_repeats(b.shape(), a.shape()) {
             assert!(cycles * b_data.len() * repeats == a.len());
 
-            let mut output = pool.alloc(out_shape.as_slice());
+            let mut output = Tensor::uninit_in(pool, &out_shape);
 
             // Unsafe access used to skip bounds checks in inner loop.
             let out_data = output.data_mut().unwrap();

--- a/src/ops/binary_elementwise.rs
+++ b/src/ops/binary_elementwise.rs
@@ -802,7 +802,7 @@ pub fn where_op<T: Copy>(
     let can_cycle = cond_cycles.is_some() && x_cycles.is_some() && y_cycles.is_some();
 
     let out_len = result_shape.iter().product();
-    let mut out_data = pool.alloc_vec(out_len);
+    let mut out_data = pool.alloc(out_len);
 
     if let (true, Some(cond_data), Some(x_data), Some(y_data)) =
         (can_cycle, cond.data(), x.data(), y.data())

--- a/src/ops/concat.rs
+++ b/src/ops/concat.rs
@@ -205,7 +205,7 @@ pub fn tile<T: Copy>(
         .zip(repeats.iter())
         .map(|(size, repeat)| size * repeat)
         .collect();
-    let mut output = pool.alloc(out_shape.as_slice());
+    let mut output = Tensor::uninit_in(pool, &out_shape);
 
     if !output.is_empty() {
         tile_inner(

--- a/src/ops/concat.rs
+++ b/src/ops/concat.rs
@@ -81,7 +81,7 @@ pub fn concat<T: Copy>(
     for other in &inputs[1..] {
         out_shape[axis] += other.size(axis);
     }
-    let mut out_data: Vec<T> = pool.alloc_vec(out_shape.iter().product());
+    let mut out_data: Vec<T> = pool.alloc(out_shape.iter().product());
 
     let mut input_iters: Vec<TensorChunks<'_, T>> = inputs
         .iter()

--- a/src/ops/conv.rs
+++ b/src/ops/conv.rs
@@ -603,7 +603,7 @@ pub fn conv_transpose(
     let mut output = if let Some(bias) = bias {
         init_tensor_with_channel_bias(pool, &[batch, out_c, out_h, out_w], 1, &bias)
     } else {
-        pool.alloc_zeroed([batch, out_c, out_h, out_w].as_slice())
+        Tensor::zeros_in(pool, [batch, out_c, out_h, out_w].as_slice())
     };
 
     // Ensure input and kernel are contiguous to support reshaping.

--- a/src/ops/conv.rs
+++ b/src/ops/conv.rs
@@ -676,6 +676,7 @@ mod tests {
     use crate::ops::tests::expect_eq_1e4;
     use crate::ops::tests::new_pool;
     use crate::ops::{conv, conv_transpose, Conv, OpError, Operator, Padding};
+    use crate::tensor_pool::AutoReturn;
 
     /// Un-optimized reference implementation of convolution.
     ///
@@ -1293,7 +1294,7 @@ mod tests {
         let start = std::time::Instant::now();
         for _ in 0..iters {
             for stride in [1, 1, 2] {
-                let result = conv(
+                conv(
                     &pool,
                     input.view(),
                     kernel.view(),
@@ -1303,9 +1304,8 @@ mod tests {
                     &[stride, stride],
                     &dilations,
                 )
-                .unwrap();
-
-                pool.add(result);
+                .unwrap()
+                .auto_return(&pool);
             }
         }
         let elapsed = start.elapsed().as_secs_f32() * 1000.0;

--- a/src/ops/conv.rs
+++ b/src/ops/conv.rs
@@ -54,7 +54,7 @@ fn init_tensor_with_channel_bias(
     chan_dim: usize,
     bias: &NdTensorView<f32, 1>,
 ) -> Tensor {
-    let mut out_data = pool.alloc_vec(shape.iter().product());
+    let mut out_data = pool.alloc(shape.iter().product());
 
     let chan_elts: usize = shape[chan_dim + 1..].iter().product();
     let all_chan_elts: usize = chan_elts * shape[chan_dim];

--- a/src/ops/gather.rs
+++ b/src/ops/gather.rs
@@ -49,7 +49,7 @@ pub fn gather<T: Copy + Default>(
         &input.shape()[axis + 1..],
     ]
     .concat();
-    let mut output = pool.alloc_zeroed::<T, _>(out_shape.as_slice());
+    let mut output = Tensor::zeros_in(pool, &out_shape);
 
     let mut in_range = full_range(input.ndim());
     let mut out_range = full_range(output.ndim());
@@ -168,7 +168,7 @@ pub fn gather_elements<T: Copy + Default>(
         ));
     }
     let axis = resolve_axis(input.ndim(), axis)?;
-    let mut output = pool.alloc_zeroed::<T, _>(indices.shape());
+    let mut output = Tensor::zeros_in(pool, indices.shape());
 
     // For the common case of tensors with <= 4 dims, expand input to 4 dims
     // and then use a fast path for static-rank tensors.

--- a/src/ops/generate.rs
+++ b/src/ops/generate.rs
@@ -17,7 +17,7 @@ pub fn constant_of_shape<T: Copy>(
 ) -> Tensor<T> {
     let shape: Vec<_> = shape.iter().map(|el| *el as usize).collect();
     let len = shape.iter().product();
-    let mut data = pool.alloc_vec(len);
+    let mut data = pool.alloc(len);
     data.resize(len, value);
     Tensor::from_data(&shape, data)
 }
@@ -58,7 +58,7 @@ pub fn onehot<T: Copy + Default + PartialEq>(
     out_shape.insert(onehot_axis, depth);
 
     let len = out_shape.iter().product();
-    let mut data = pool.alloc_vec(len);
+    let mut data = pool.alloc(len);
     data.resize(len, off_value);
     let mut output = Tensor::from_data(&out_shape, data);
 

--- a/src/ops/layout.rs
+++ b/src/ops/layout.rs
@@ -376,7 +376,7 @@ impl Operator for Size {
 
         // Allocate output from pool for consistency with other operators,
         // even though the buffer is tiny, so there is no performance benefit.
-        let mut output = pool.alloc_zeroed([]);
+        let mut output = Tensor::zeros_in(pool, &[]);
         output[[]] = len;
 
         output.into_op_result()

--- a/src/ops/layout.rs
+++ b/src/ops/layout.rs
@@ -42,7 +42,7 @@ pub(crate) fn expand_to<T: Copy>(
         (Some(in_data), Some((cycles, repeats))) => {
             assert!(out_len == input.len() * cycles * repeats);
 
-            let mut out_data: Vec<T> = pool.alloc_vec(out_len);
+            let mut out_data: Vec<T> = pool.alloc(out_len);
             let mut out_ptr = out_data.as_mut_ptr();
             for _ in 0..cycles {
                 if repeats == 1 {
@@ -354,7 +354,7 @@ impl Operator for Shape {
 
         // Allocate output from pool for consistency with other operators,
         // even though the buffer is tiny, so there is no performance benefit.
-        let mut data = pool.alloc_vec(input.ndim());
+        let mut data = pool.alloc(input.ndim());
         data.extend(input.shape().iter().map(|&el| el as i32));
 
         let shape = Tensor::from_data(&[input.ndim()], data);

--- a/src/ops/layout.rs
+++ b/src/ops/layout.rs
@@ -278,7 +278,7 @@ pub fn reshape<T: Copy>(
     allow_zero: bool,
 ) -> Result<Tensor<T>, OpError> {
     let out_shape = resolve_shape(input.shape(), shape, allow_zero)?;
-    let mut output = pool.alloc(input.shape()).init_from(&input);
+    let mut output = Tensor::uninit_in(pool, input.shape()).init_from(&input);
     output.reshape(&out_shape);
     Ok(output)
 }
@@ -493,7 +493,7 @@ pub fn transpose<T: Copy>(
             transposed.transpose();
         }
     };
-    let output = pool.alloc(transposed.shape());
+    let output = Tensor::uninit_in(pool, transposed.shape());
     Ok(output.init_from(&transposed))
 }
 

--- a/src/ops/matmul.rs
+++ b/src/ops/matmul.rs
@@ -63,7 +63,7 @@ pub fn gemm_op(
             output
         }
         _ => {
-            let mut output = pool.alloc(out_shape);
+            let mut output = Tensor::uninit_in(pool, out_shape);
             let out_row_stride = output.stride(0);
             gemm.gemm_uninit(
                 output.data_mut().unwrap(),
@@ -168,7 +168,7 @@ fn matmul_impl(
         return Ok(output);
     }
 
-    let mut output = pool.alloc(out_shape.as_slice());
+    let mut output = Tensor::uninit_in(pool, out_shape);
     if output.is_empty() {
         // nb. We don't need to alloc from the pool here, since the buffer
         // is already empty.

--- a/src/ops/matmul.rs
+++ b/src/ops/matmul.rs
@@ -262,6 +262,7 @@ mod tests {
 
     use crate::gemm::gemm;
     use crate::ops::tests::new_pool;
+    use crate::tensor_pool::AutoReturn;
 
     use super::{gemm_op, matmul, matmul_impl, MatmulStrategy, OpError};
 
@@ -581,8 +582,9 @@ mod tests {
                 );
                 let pool = new_pool();
                 run_bench(trials, Some(&desc), || {
-                    let output = matmul_impl(&pool, a.view(), b.view(), strategy).unwrap();
-                    pool.add(output);
+                    matmul_impl(&pool, a.view(), b.view(), strategy)
+                        .unwrap()
+                        .auto_return(&pool);
                 });
             };
 

--- a/src/ops/non_max_suppression.rs
+++ b/src/ops/non_max_suppression.rs
@@ -170,7 +170,7 @@ pub fn non_max_suppression(
         });
     }
 
-    let mut selected_indices = pool.alloc_zeroed::<i32, _>([selected.len(), 3]);
+    let mut selected_indices = NdTensor::zeros_in(pool, [selected.len(), 3]);
     for (i, nms_box) in selected.into_iter().enumerate() {
         selected_indices.slice_mut(i).assign_array([
             nms_box.batch_index as i32,

--- a/src/ops/pad.rs
+++ b/src/ops/pad.rs
@@ -30,7 +30,6 @@ pub fn pad<T: Copy>(
             start_pad + size + end_pad
         })
         .collect();
-    let out_len = out_shape.iter().product();
 
     let non_pad_region: Vec<SliceItem> = input
         .shape()
@@ -42,10 +41,7 @@ pub fn pad<T: Copy>(
         })
         .collect();
 
-    let mut data = pool.alloc_vec(out_len);
-    data.resize(out_len, const_val);
-
-    let mut output = Tensor::from_data(&out_shape, data);
+    let mut output = Tensor::full_in(pool, &out_shape, const_val);
     output
         .slice_mut_dyn(non_pad_region.as_slice())
         .copy_from(&input);

--- a/src/ops/random.rs
+++ b/src/ops/random.rs
@@ -33,7 +33,7 @@ impl Operator for RandomUniform {
         };
 
         let len = shape.iter().product();
-        let mut data = pool.alloc_vec(len);
+        let mut data = pool.alloc(len);
         data.extend(std::iter::from_fn(|| Some(scale_value(rng.f32()))).take(len));
 
         Tensor::from_data(shape, data).into_op_result()

--- a/src/ops/reduce.rs
+++ b/src/ops/reduce.rs
@@ -650,8 +650,8 @@ pub fn topk<T: Copy + Default + PartialOrd>(
         .enumerate()
         .map(|(dim, size)| if dim == axis { k } else { *size })
         .collect();
-    let mut out_values = pool.alloc_zeroed::<T, _>(out_shape.as_slice());
-    let mut indices = pool.alloc_zeroed::<i32, _>(out_shape.as_slice());
+    let mut out_values = Tensor::zeros_in(pool, &out_shape);
+    let mut indices = Tensor::zeros_in(pool, &out_shape);
 
     // Handle edge case early to simplify main loop.
     if k == 0 {

--- a/src/ops/reduce.rs
+++ b/src/ops/reduce.rs
@@ -124,7 +124,7 @@ pub fn cum_sum<T: Copy + Default + Identities + std::ops::AddAssign>(
     axis: isize,
 ) -> Result<Tensor<T>, OpError> {
     let resolved_axis = resolve_axis(input.ndim(), axis)?;
-    let mut output = pool.alloc::<T, _>(input.shape());
+    let mut output = Tensor::uninit_in(pool, input.shape());
 
     let mut n_init = 0;
     if !input.is_empty() {

--- a/src/ops/reduce.rs
+++ b/src/ops/reduce.rs
@@ -35,7 +35,7 @@ fn select_max_index<T, Cmp: Fn(&T, &T) -> std::cmp::Ordering>(
         .enumerate()
         .map(|(dim, &size)| if resolved_axis == dim { 1 } else { size })
         .collect();
-    let mut reduced_data = pool.alloc_vec(reduced_shape.iter().product());
+    let mut reduced_data = pool.alloc(reduced_shape.iter().product());
 
     if !input.is_empty() {
         for slice in input.lanes(resolved_axis) {
@@ -264,7 +264,7 @@ fn reduce<T: Copy, R: Reducer<T>>(
             }
         })
         .collect();
-    let mut reduced_data = pool.alloc_vec(reduced_shape.iter().product());
+    let mut reduced_data = pool.alloc(reduced_shape.iter().product());
 
     match (reduced_inner_dims, input.data()) {
         (Some(ndims), Some(input_data)) => {

--- a/src/ops/resize.rs
+++ b/src/ops/resize.rs
@@ -259,7 +259,7 @@ pub fn resize(
     }
 
     let sizes_usize: Vec<_> = sizes.iter().map(|size| *size as usize).collect();
-    let mut output = pool.alloc(sizes_usize.as_slice());
+    let mut output = Tensor::uninit_in(pool, &sizes_usize);
 
     if output.is_empty() {
         // Safety: Empty output is already initialized.

--- a/src/ops/slice.rs
+++ b/src/ops/slice.rs
@@ -72,7 +72,7 @@ pub fn slice<T: Copy>(
         .enumerate()
         .map(|(dim, range)| range.steps(input.size(dim)))
         .collect();
-    let mut sliced_data = pool.alloc_vec(sliced_shape.iter().product());
+    let mut sliced_data = pool.alloc(sliced_shape.iter().product());
     sliced_data.extend(input.slice_iter(&items).copied());
 
     Ok(Tensor::from_data(&sliced_shape, sliced_data))

--- a/src/ops/split.rs
+++ b/src/ops/split.rs
@@ -40,9 +40,7 @@ pub fn split<T: Copy>(
 
             split_start += split_size;
 
-            let slice = input.slice_dyn(slice_range.as_slice());
-            let output = pool.alloc(slice.shape());
-            output.init_from(&slice)
+            input.slice_dyn(slice_range.as_slice()).to_tensor_in(pool)
         })
         .collect();
 

--- a/src/ops/trilu.rs
+++ b/src/ops/trilu.rs
@@ -14,7 +14,7 @@ pub fn trilu<T: Copy + Default>(
         return Err(OpError::InvalidValue("Input must have >= 2 dims"));
     }
 
-    let mut output = pool.alloc_zeroed(input.shape());
+    let mut output = Tensor::zeros_in(pool, input.shape());
 
     for (mut out_mat, in_mat) in output.inner_iter_mut::<2>().zip(input.inner_iter::<2>()) {
         let [rows, cols] = out_mat.shape();

--- a/src/ops/unary_elementwise.rs
+++ b/src/ops/unary_elementwise.rs
@@ -160,7 +160,7 @@ fn par_unary_op<
     op: F,
 ) -> Tensor<T> {
     let input = input.to_contiguous();
-    let mut output = pool.alloc(input.shape());
+    let mut output = Tensor::uninit_in(pool, input.shape());
 
     let in_chunks = input.data().unwrap().par_chunks(CHUNK_SIZE);
     let out_chunks = output.data_mut().unwrap().par_chunks_mut(CHUNK_SIZE);

--- a/src/ops/variadic_elementwise.rs
+++ b/src/ops/variadic_elementwise.rs
@@ -26,7 +26,7 @@ fn reduce_elementwise<T: Copy, R: Fn(&[T]) -> T>(
                 ));
             };
 
-            let mut result = pool.alloc(out_shape.as_slice());
+            let mut result = Tensor::uninit_in(pool, &out_shape);
             for (out, (&a, &b)) in zip(
                 result.iter_mut(),
                 zip(a.broadcast_iter(&out_shape), b.broadcast_iter(&out_shape)),
@@ -54,7 +54,7 @@ fn reduce_elementwise<T: Copy, R: Fn(&[T]) -> T>(
                 .map(|view| view.broadcast_iter(&out_shape))
                 .collect();
             let mut elts = Vec::with_capacity(inputs.len());
-            let mut output = pool.alloc(out_shape.as_slice());
+            let mut output = Tensor::uninit_in(pool, &out_shape);
 
             for out in output.iter_mut() {
                 elts.extend(iters.iter_mut().map(|it| it.next().unwrap()));


### PR DESCRIPTION
This PR refines the APIs and use of the tensor pool for allocations:

- The `TensorPool::{alloc, alloc_zeroed}` methods have been removed in favor of more `_in`-suffixed APIs on `TensorBase`: `zeros_in`, `uninit_in`, `full_in`
- Some uses of `TensorPool::add` have been replaced with `tensor.auto_return`, which is more ergonomic to use
- The docs and tests have been updated to reflect the now-preferred usage patterns 