### PR TITLE
Enable `RTEN_USE_POOL` by default

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -1,0 +1,20 @@
+/// Interpret a string value such as "1" or "no" as a boolean.
+pub fn str_as_bool(s: &str) -> bool {
+    match s {
+        "1" | "true" | "t" | "yes" | "y" => true,
+        "0" | "false" | "f" | "no" | "n" => false,
+        _ => {
+            eprintln!("Unrecognized boolean value \"{}\"", s);
+            false
+        }
+    }
+}
+
+/// Return whether a feature flag controlled by an environment variable is
+/// enabled.
+pub fn env_flag(name: &str, default: bool) -> bool {
+    std::env::var(name)
+        .as_ref()
+        .map(|s| str_as_bool(s))
+        .unwrap_or(default)
+}

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,4 +1,3 @@
-use std::env;
 use std::error::Error;
 use std::fmt;
 use std::iter::zip;
@@ -11,6 +10,7 @@ use rten_tensor::Tensor;
 // Instead we want faster hashing.
 use rustc_hash::{FxHashMap, FxHashSet};
 
+use crate::env::env_flag;
 use crate::ops::{Input, InputList, OpError, Operator, Output};
 use crate::tensor_pool::TensorPool;
 use crate::timer::Timer;
@@ -409,7 +409,7 @@ impl Graph {
         // release buffers back into it, so all allocations use the system
         // allocator.
         let pool = TensorPool::new();
-        let use_pool = env::var_os("RTEN_USE_POOL").is_some();
+        let use_pool = env_flag("RTEN_USE_POOL", true);
 
         // Execute the plan
         let mut temp_values: FxHashMap<NodeId, Output> = FxHashMap::default();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,7 @@
 #[allow(unused)] // Docs only
 use rten_tensor::{NdTensor, Tensor};
 
+mod env;
 mod gemm;
 mod graph;
 mod iter_util;

--- a/src/model.rs
+++ b/src/model.rs
@@ -8,6 +8,7 @@ use std::fmt::{Display, Formatter};
 use rten_tensor::Tensor;
 use smallvec::smallvec;
 
+use crate::env::str_as_bool;
 use crate::graph::{Dimension, Graph, Node, NodeId, RunError, RunOptions};
 use crate::model_metadata::ModelMetadata;
 use crate::ops;
@@ -89,15 +90,6 @@ impl<'a> NodeInfo<'a> {
 /// This env var is a space-separated sequence of `key=value` pairs.
 fn parse_timing_config(config: &str, opts: &mut RunOptions) {
     opts.timing = true;
-
-    let str_as_bool = |s: &str| match s {
-        "1" | "true" | "t" | "yes" | "y" => true,
-        "0" | "false" | "f" | "no" | "n" => false,
-        _ => {
-            eprintln!("Unrecognized boolean value \"{}\"", s);
-            false
-        }
-    };
 
     for token in config.split_ascii_whitespace() {
         if let Some((key, val)) = token.split_once('=') {


### PR DESCRIPTION
Extract a helper function for testing the state of feature flags in env vars, and change the default for `RTEN_USE_POOL` to true.

The flag has been kept around rather than removing it entirely to make it convenient to measure its impact.

This is the last part of https://github.com/robertknight/rten/issues/109.