### PR TITLE
Allocate buffers for prepacked matrices from pool

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -12,7 +12,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::env::env_flag;
 use crate::ops::{Input, InputList, OpError, Operator, Output};
-use crate::tensor_pool::TensorPool;
+use crate::tensor_pool::{ExtractBuffer, TensorPool};
 use crate::timer::Timer;
 use crate::timing::{InputShape, RunTiming, TimingRecord, TimingSort};
 
@@ -595,8 +595,8 @@ impl Graph {
                 if rc == Some(0) {
                     if let (true, Some(tensor)) = (use_pool, temp_values.remove(&node_id)) {
                         match tensor {
-                            Output::FloatTensor(t) => pool.add_tensor(t),
-                            Output::IntTensor(t) => pool.add_tensor(t),
+                            Output::FloatTensor(t) => pool.add(t.extract_buffer()),
+                            Output::IntTensor(t) => pool.add(t.extract_buffer()),
                         }
                     }
                 }

--- a/src/ops/conv.rs
+++ b/src/ops/conv.rs
@@ -453,10 +453,11 @@ pub fn conv(
 
         // Prepack kernel if we'll be able to reuse packed weights.
         let prepacked_kernel = if in_group.size(0) > 1 {
-            Some(gemm.prepack_a(kernel_mat))
+            Some(gemm.prepack_a_in(pool, kernel_mat).auto_return(pool))
         } else {
             None
         };
+        let prepacked_kernel = prepacked_kernel.as_deref();
 
         zip(out_group.axis_iter_mut(0), in_group.axis_iter(0))
             .par_bridge()
@@ -478,7 +479,6 @@ pub fn conv(
                     out_mat.data_mut().unwrap(),
                     out_row_stride,
                     prepacked_kernel
-                        .as_ref()
                         .map(GemmInputA::Packed)
                         .unwrap_or(GemmInputA::Unpacked(kernel_mat)),
                     GemmInputB::Virtual(&im2col),


### PR DESCRIPTION
- Generalize `PoolRef` and associated traits to work with data containers other than `TensorBase`. `PoolRef` now works with any container that impls `ExtractBuffer` to extract its buffer as a `Vec<T>`
- Support allocating prepacked matrices from, and return them to, a pool by adding `GemmExecutor::{prepack_a_in, prepack_b_in}` and implementing `ExtractBuffer` for `PackedAMatrix` and `PackedBMatrix`

Fixes https://github.com/robertknight/rten/issues/128