### PR TITLE
Support AVX-512 for SIMD unary operators, softmax

### DIFF
--- a/rten-vecmath/src/exp.rs
+++ b/rten-vecmath/src/exp.rs
@@ -69,9 +69,7 @@ pub fn exp(val: f32) -> f32 {
 /// library.
 ///
 /// Safety: The caller must ensure the `SimdFloat` impl is usable on the current system.
-#[cfg_attr(target_arch = "x86_64", target_feature(enable = "avx2"))]
-#[cfg_attr(target_arch = "x86_64", target_feature(enable = "fma"))]
-#[inline]
+#[inline(always)]
 pub(crate) unsafe fn simd_exp<S: SimdFloat>(x: S) -> S {
     // Load constants
     let inv_log_2 = S::splat(INV_LOG2);
@@ -142,9 +140,7 @@ pub(crate) unsafe fn simd_exp<S: SimdFloat>(x: S) -> S {
 /// using `1. / (1. + (-x).exp())`.
 ///
 /// Safety: The caller must ensure the `SimdFloat` impl is usable on the current system.
-#[cfg_attr(target_arch = "x86_64", target_feature(enable = "avx2"))]
-#[cfg_attr(target_arch = "x86_64", target_feature(enable = "fma"))]
-#[inline]
+#[inline(always)]
 unsafe fn simd_sigmoid<S: SimdFloat>(x: S) -> S {
     // 1. + exp(-x)
     let denom = S::one().add(simd_exp(x.neg()));

--- a/rten-vecmath/src/simd_vec.rs
+++ b/rten-vecmath/src/simd_vec.rs
@@ -24,6 +24,25 @@ use crate::MAX_LEN;
 
 /// Trait for SIMD vectors containing 32-bit integers.
 ///
+/// ## Inlining and target features
+///
+/// Correct use of inlining and target features, in impls of these traits and
+/// generic functions using them, are critical to getting the performance
+/// benefits. If an intrinic is not inlined, the function call overhead can
+/// negate the benefits of using SIMD in the first place.
+///
+/// Implementations of this trait should add `#[inline]` and
+/// `#[target_feature(enable = "feature"]` attributes, where the feature names
+/// match the wrapped architecture-specific intrinics. An exception is for
+/// intrinsics which are always available in a given build configuration (eg.
+/// we assume SSE is always available under x86_64 and Neon under Arm).
+///
+/// Generic functions which use this trait must have `#[inline(always)]`
+/// annotations, including on any closures in their bodies. These generic
+/// functions must then be wrapped in target feature-specific wrappers which
+/// have `#[target_feature]`s that are a union of all those used in the
+/// implementation.
+///
 /// # Safety
 ///
 /// The caller must ensure that the SIMD instructions used by a type
@@ -120,6 +139,11 @@ pub trait SimdInt: Copy + Sized {
 }
 
 /// Trait for SIMD vectors containing single-precision floats.
+///
+/// ## Inlining and target features
+///
+/// See the comments for [SimdInt] on use of `#[inline]` and `#[target_feature]`
+/// attributes.
 ///
 /// # Safety
 ///

--- a/rten-vecmath/src/simd_vec/x86_64.rs
+++ b/rten-vecmath/src/simd_vec/x86_64.rs
@@ -19,88 +19,84 @@ impl SimdInt for __m256i {
 
     #[inline]
     #[target_feature(enable = "avx2")]
-    #[target_feature(enable = "fma")]
     unsafe fn zero() -> Self {
         _mm256_setzero_si256()
     }
 
     #[inline]
     #[target_feature(enable = "avx2")]
-    #[target_feature(enable = "fma")]
     unsafe fn splat(val: i32) -> Self {
         _mm256_set1_epi32(val)
     }
 
     #[inline]
+    #[target_feature(enable = "avx2")]
     unsafe fn ge(self, other: Self) -> Self::Mask {
         _mm256_or_si256(self.gt(other), self.eq(other))
     }
 
     #[inline]
+    #[target_feature(enable = "avx2")]
     unsafe fn le(self, other: Self) -> Self::Mask {
         _mm256_or_si256(self.lt(other), self.eq(other))
     }
 
     #[inline]
+    #[target_feature(enable = "avx2")]
     unsafe fn lt(self, other: Self) -> Self::Mask {
         other.gt(self)
     }
 
     #[inline]
+    #[target_feature(enable = "avx2")]
     unsafe fn eq(self, other: Self) -> Self::Mask {
         _mm256_cmpeq_epi32(self, other)
     }
 
     #[inline]
     #[target_feature(enable = "avx2")]
-    #[target_feature(enable = "fma")]
     unsafe fn gt(self, other: Self) -> Self::Mask {
         _mm256_cmpgt_epi32(self, other)
     }
 
     #[inline]
     #[target_feature(enable = "avx2")]
-    #[target_feature(enable = "fma")]
     unsafe fn blend(self, other: Self, mask: Self::Mask) -> Self {
         _mm256_blendv_epi8(self, other, mask)
     }
 
     #[inline]
     #[target_feature(enable = "avx2")]
-    #[target_feature(enable = "fma")]
     unsafe fn add(self, rhs: Self) -> Self {
         _mm256_add_epi32(self, rhs)
     }
 
     #[inline]
     #[target_feature(enable = "avx2")]
-    #[target_feature(enable = "fma")]
     unsafe fn sub(self, rhs: Self) -> Self {
         _mm256_sub_epi32(self, rhs)
     }
 
     #[inline]
     #[target_feature(enable = "avx2")]
-    #[target_feature(enable = "fma")]
     unsafe fn shl<const COUNT: i32>(self) -> Self {
         _mm256_slli_epi32(self, COUNT)
     }
 
     #[inline]
     #[target_feature(enable = "avx2")]
-    #[target_feature(enable = "fma")]
     unsafe fn reinterpret_as_float(self) -> Self::Float {
         _mm256_castsi256_ps(self)
     }
 
     #[inline]
+    #[target_feature(enable = "avx2")]
     unsafe fn to_float_mask(self) -> <Self::Float as SimdFloat>::Mask {
         self.reinterpret_as_float()
     }
 
     #[inline]
     #[target_feature(enable = "avx2")]
-    #[target_feature(enable = "fma")]
     unsafe fn load(ptr: *const i32) -> Self {
         // Cast is OK because instruction does not require alignment.
         _mm256_loadu_si256(ptr as *const __m256i)
@@ -108,7 +104,6 @@ impl SimdInt for __m256i {
 
     #[inline]
     #[target_feature(enable = "avx2")]
-    #[target_feature(enable = "fma")]
     unsafe fn store(self, ptr: *mut i32) {
         // Cast is OK because instruction does not require alignment.
         _mm256_storeu_si256(ptr as *mut __m256i, self)
@@ -123,14 +118,12 @@ impl SimdFloat for __m256 {
 
     #[inline]
     #[target_feature(enable = "avx2")]
-    #[target_feature(enable = "fma")]
     unsafe fn splat(val: f32) -> Self {
         _mm256_set1_ps(val)
     }
 
     #[inline]
     #[target_feature(enable = "avx2")]
-    #[target_feature(enable = "fma")]
     unsafe fn abs(self) -> Self {
         // https://stackoverflow.com/q/63599391/434243
         let sign_bit = _mm256_set1_ps(-0.0);
@@ -138,7 +131,6 @@ impl SimdFloat for __m256 {
     }
 
     #[inline]
-    #[target_feature(enable = "avx2")]
     #[target_feature(enable = "fma")]
     unsafe fn mul_add(self, a: Self, b: Self) -> Self {
         _mm256_fmadd_ps(self, a, b)
@@ -146,94 +138,84 @@ impl SimdFloat for __m256 {
 
     #[inline]
     #[target_feature(enable = "avx2")]
-    #[target_feature(enable = "fma")]
     unsafe fn sub(self, rhs: Self) -> Self {
         _mm256_sub_ps(self, rhs)
     }
 
     #[inline]
     #[target_feature(enable = "avx2")]
-    #[target_feature(enable = "fma")]
     unsafe fn add(self, rhs: Self) -> Self {
         _mm256_add_ps(self, rhs)
     }
 
     #[inline]
     #[target_feature(enable = "avx2")]
-    #[target_feature(enable = "fma")]
     unsafe fn to_int_trunc(self) -> Self::Int {
         _mm256_cvttps_epi32(self)
     }
 
     #[inline]
     #[target_feature(enable = "avx2")]
-    #[target_feature(enable = "fma")]
     unsafe fn mul(self, rhs: Self) -> Self {
         _mm256_mul_ps(self, rhs)
     }
 
     #[inline]
     #[target_feature(enable = "avx2")]
-    #[target_feature(enable = "fma")]
     unsafe fn div(self, rhs: Self) -> Self {
         _mm256_div_ps(self, rhs)
     }
 
     #[inline]
     #[target_feature(enable = "avx2")]
-    #[target_feature(enable = "fma")]
     unsafe fn ge(self, rhs: Self::Mask) -> Self {
         _mm256_cmp_ps(self, rhs, _CMP_GE_OQ)
     }
 
     #[inline]
     #[target_feature(enable = "avx2")]
-    #[target_feature(enable = "fma")]
     unsafe fn le(self, rhs: Self::Mask) -> Self {
         _mm256_cmp_ps(self, rhs, _CMP_LE_OQ)
     }
 
     #[inline]
     #[target_feature(enable = "avx2")]
-    #[target_feature(enable = "fma")]
     unsafe fn lt(self, rhs: Self::Mask) -> Self {
         _mm256_cmp_ps(self, rhs, _CMP_LT_OQ)
     }
 
     #[inline]
     #[target_feature(enable = "avx2")]
-    #[target_feature(enable = "fma")]
     unsafe fn max(self, rhs: Self) -> Self {
         _mm256_max_ps(self, rhs)
     }
 
     #[inline]
     #[target_feature(enable = "avx2")]
-    #[target_feature(enable = "fma")]
     unsafe fn blend(self, rhs: Self, mask: Self::Mask) -> Self {
         _mm256_blendv_ps(self, rhs, mask)
     }
 
     #[inline]
     #[target_feature(enable = "avx2")]
-    #[target_feature(enable = "fma")]
     unsafe fn load(ptr: *const f32) -> Self {
         _mm256_loadu_ps(ptr)
     }
 
     #[inline]
+    #[target_feature(enable = "avx2")]
     unsafe fn gather_mask(ptr: *const f32, offsets: Self::Int, mask: Self::Mask) -> Self {
         _mm256_mask_i32gather_ps::<4>(Self::zero(), ptr, offsets, mask)
     }
 
     #[inline]
     #[target_feature(enable = "avx2")]
-    #[target_feature(enable = "fma")]
     unsafe fn store(self, ptr: *mut f32) {
         _mm256_storeu_ps(ptr, self)
     }
 
     #[inline]
+    #[target_feature(enable = "avx2")]
     unsafe fn sum(self) -> f32 {
         // See https://stackoverflow.com/a/13222410/434243
         let hi_4 = _mm256_extractf128_ps(self, 1);
@@ -280,77 +262,92 @@ impl SimdInt for __m512i {
     const LEN: usize = 16;
 
     #[inline]
+    #[target_feature(enable = "avx512f")]
     unsafe fn zero() -> Self {
         _mm512_setzero_si512()
     }
 
     #[inline]
+    #[target_feature(enable = "avx512f")]
     unsafe fn splat(val: i32) -> Self {
         _mm512_set1_epi32(val)
     }
 
     #[inline]
+    #[target_feature(enable = "avx512f")]
     unsafe fn eq(self, other: Self) -> Self::Mask {
         _mm512_cmp_epi32_mask(self, other, _MM_CMPINT_EQ)
     }
 
     #[inline]
+    #[target_feature(enable = "avx512f")]
     unsafe fn le(self, other: Self) -> Self::Mask {
         _mm512_cmp_epi32_mask(self, other, _MM_CMPINT_LE)
     }
 
     #[inline]
+    #[target_feature(enable = "avx512f")]
     unsafe fn lt(self, other: Self) -> Self::Mask {
         _mm512_cmp_epi32_mask(self, other, _MM_CMPINT_LT)
     }
 
     #[inline]
+    #[target_feature(enable = "avx512f")]
     unsafe fn ge(self, other: Self) -> Self::Mask {
         other.le(self)
     }
 
     #[inline]
+    #[target_feature(enable = "avx512f")]
     unsafe fn gt(self, other: Self) -> Self::Mask {
         other.lt(self)
     }
 
     #[inline]
+    #[target_feature(enable = "avx512f")]
     unsafe fn blend(self, other: Self, mask: Self::Mask) -> Self {
         _mm512_mask_blend_epi32(mask, self, other)
     }
 
     #[inline]
+    #[target_feature(enable = "avx512f")]
     unsafe fn add(self, rhs: Self) -> Self {
         _mm512_add_epi32(self, rhs)
     }
 
     #[inline]
+    #[target_feature(enable = "avx512f")]
     unsafe fn sub(self, rhs: Self) -> Self {
         _mm512_sub_epi32(self, rhs)
     }
 
     #[inline]
+    #[target_feature(enable = "avx512f")]
     unsafe fn shl<const COUNT: i32>(self) -> Self {
         let count = Self::splat(COUNT);
         _mm512_sllv_epi32(self, count)
     }
 
     #[inline]
+    #[target_feature(enable = "avx512f")]
     unsafe fn reinterpret_as_float(self) -> Self::Float {
         _mm512_castsi512_ps(self)
     }
 
     #[inline]
+    #[target_feature(enable = "avx512f")]
     unsafe fn to_float_mask(self) -> <Self::Float as SimdFloat>::Mask {
         self.eq(Self::splat(-1))
     }
 
     #[inline]
+    #[target_feature(enable = "avx512f")]
     unsafe fn load(ptr: *const i32) -> Self {
         _mm512_loadu_si512(ptr)
     }
 
     #[inline]
+    #[target_feature(enable = "avx512f")]
     unsafe fn store(self, ptr: *mut i32) {
         _mm512_storeu_si512(ptr, self)
     }
@@ -364,81 +361,97 @@ impl SimdFloat for __m512 {
     const LEN: usize = 16;
 
     #[inline]
+    #[target_feature(enable = "avx512f")]
     unsafe fn splat(val: f32) -> Self {
         _mm512_set1_ps(val)
     }
 
     #[inline]
+    #[target_feature(enable = "avx512f")]
     unsafe fn abs(self) -> Self {
         _mm512_abs_ps(self)
     }
 
     #[inline]
+    #[target_feature(enable = "avx512f")]
     unsafe fn mul_add(self, a: Self, b: Self) -> Self {
         _mm512_fmadd_ps(self, a, b)
     }
 
     #[inline]
+    #[target_feature(enable = "avx512f")]
     unsafe fn sub(self, rhs: Self) -> Self {
         _mm512_sub_ps(self, rhs)
     }
 
     #[inline]
+    #[target_feature(enable = "avx512f")]
     unsafe fn add(self, rhs: Self) -> Self {
         _mm512_add_ps(self, rhs)
     }
 
     #[inline]
+    #[target_feature(enable = "avx512f")]
     unsafe fn to_int_trunc(self) -> Self::Int {
         _mm512_cvttps_epi32(self)
     }
 
     #[inline]
+    #[target_feature(enable = "avx512f")]
     unsafe fn mul(self, rhs: Self) -> Self {
         _mm512_mul_ps(self, rhs)
     }
 
     #[inline]
+    #[target_feature(enable = "avx512f")]
     unsafe fn div(self, rhs: Self) -> Self {
         _mm512_div_ps(self, rhs)
     }
 
     #[inline]
+    #[target_feature(enable = "avx512f")]
     unsafe fn ge(self, rhs: Self) -> Self::Mask {
         _mm512_cmp_ps_mask(self, rhs, _CMP_GE_OQ)
     }
 
     #[inline]
+    #[target_feature(enable = "avx512f")]
     unsafe fn le(self, rhs: Self) -> Self::Mask {
         _mm512_cmp_ps_mask(self, rhs, _CMP_LE_OQ)
     }
 
     #[inline]
+    #[target_feature(enable = "avx512f")]
     unsafe fn lt(self, rhs: Self) -> Self::Mask {
         _mm512_cmp_ps_mask(self, rhs, _CMP_LT_OQ)
     }
 
     #[inline]
+    #[target_feature(enable = "avx512f")]
     unsafe fn max(self, rhs: Self) -> Self {
         _mm512_max_ps(self, rhs)
     }
 
     #[inline]
+    #[target_feature(enable = "avx512f")]
     unsafe fn blend(self, rhs: Self, mask: Self::Mask) -> Self {
         _mm512_mask_blend_ps(mask, self, rhs)
     }
 
     #[inline]
+    #[target_feature(enable = "avx512f")]
     unsafe fn load(ptr: *const f32) -> Self {
         _mm512_loadu_ps(ptr)
     }
 
     #[inline]
+    #[target_feature(enable = "avx512f")]
     unsafe fn store(self, ptr: *mut f32) {
         _mm512_storeu_ps(ptr, self)
     }
 
     #[inline]
+    #[target_feature(enable = "avx512f")]
     unsafe fn gather_mask(ptr: *const f32, offsets: Self::Int, mask: Self::Mask) -> Self {
         _mm512_mask_i32gather_ps::<4>(Self::zero(), mask, offsets, ptr as *const u8)
     }
@@ -454,6 +467,7 @@ impl SimdFloat for __m512 {
     }
 
     #[inline]
+    #[target_feature(enable = "avx512f")]
     unsafe fn sum(self) -> f32 {
         _mm512_reduce_add_ps(self)
     }


### PR DESCRIPTION
Support AVX-512 for Exp, Sigmoid, Tanh, Erf, Softmax and other operators which use SIMD-accelerated implementations in rten-vecmath.

The performance benefit is small because these operations are limited by memory bandwidth, but doing this revealed some issues with supporting different instruction sets on the same architecture. Usage of `#[inline]` and `#[target_feature]` had to be corrected to ensure that SIMD intrinics are actually inlined reliably. Otherwise the function call overhead negates the benefits of SIMD entirely.

The `SimdInt` and `SimdFloat` docs have been updated to explain the rules around inlining and target features.