### PR TITLE
Support `Elu` operator, reading axes list from inputs rather than attribute in `Reduce*` ops

### DIFF
--- a/rten-convert/rten_convert/converter.py
+++ b/rten-convert/rten_convert/converter.py
@@ -703,6 +703,10 @@ def op_node_from_onnx_operator(
             op_reader.check_attr("exclusive", "int", 0)
             op_reader.check_attr("reverse", "int", 0)
 
+        case "Elu":
+            attrs = sg.EluAttrsT()
+            attrs.alpha = op_reader.get_attr("alpha", "float", 1.0)
+
         case "Flatten":
             attrs = sg.FlattenAttrsT()
             attrs.axis = op_reader.get_attr("axis", "int", 1)

--- a/rten-convert/rten_convert/schema_generated.py
+++ b/rten-convert/rten_convert/schema_generated.py
@@ -103,6 +103,7 @@ class OperatorType(object):
     LayerNormalization = 93
     ReduceSumSquare = 94
     RandomUniform = 95
+    Elu = 96
 
 
 class RNNDirection(object):
@@ -172,6 +173,7 @@ class OperatorAttrs(object):
     NonMaxSuppressionAttrs = 29
     LayerNormalizationAttrs = 30
     RandomUniformAttrs = 31
+    EluAttrs = 32
 
 def OperatorAttrsCreator(unionType, table):
     from flatbuffers.table import Table
@@ -239,6 +241,8 @@ def OperatorAttrsCreator(unionType, table):
         return LayerNormalizationAttrsT.InitFromBuf(table.Bytes, table.Pos)
     if unionType == OperatorAttrs().RandomUniformAttrs:
         return RandomUniformAttrsT.InitFromBuf(table.Bytes, table.Pos)
+    if unionType == OperatorAttrs().EluAttrs:
+        return EluAttrsT.InitFromBuf(table.Bytes, table.Pos)
     return None
 
 
@@ -1492,6 +1496,83 @@ class ConvTransposeAttrsT(object):
             ConvTransposeAttrsAddStrides(builder, strides)
         convTransposeAttrs = ConvTransposeAttrsEnd(builder)
         return convTransposeAttrs
+
+
+class EluAttrs(object):
+    __slots__ = ['_tab']
+
+    @classmethod
+    def GetRootAs(cls, buf, offset=0):
+        n = flatbuffers.encode.Get(flatbuffers.packer.uoffset, buf, offset)
+        x = EluAttrs()
+        x.Init(buf, n + offset)
+        return x
+
+    @classmethod
+    def GetRootAsEluAttrs(cls, buf, offset=0):
+        """This method is deprecated. Please switch to GetRootAs."""
+        return cls.GetRootAs(buf, offset)
+    @classmethod
+    def EluAttrsBufferHasIdentifier(cls, buf, offset, size_prefixed=False):
+        return flatbuffers.util.BufferHasIdentifier(buf, offset, b"\x52\x54\x45\x4E", size_prefixed=size_prefixed)
+
+    # EluAttrs
+    def Init(self, buf, pos):
+        self._tab = flatbuffers.table.Table(buf, pos)
+
+    # EluAttrs
+    def Alpha(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
+        if o != 0:
+            return self._tab.Get(flatbuffers.number_types.Float32Flags, o + self._tab.Pos)
+        return 0.0
+
+def EluAttrsStart(builder):
+    builder.StartObject(1)
+
+def EluAttrsAddAlpha(builder, alpha):
+    builder.PrependFloat32Slot(0, alpha, 0.0)
+
+def EluAttrsEnd(builder):
+    return builder.EndObject()
+
+
+
+class EluAttrsT(object):
+
+    # EluAttrsT
+    def __init__(self):
+        self.alpha = 0.0  # type: float
+
+    @classmethod
+    def InitFromBuf(cls, buf, pos):
+        eluAttrs = EluAttrs()
+        eluAttrs.Init(buf, pos)
+        return cls.InitFromObj(eluAttrs)
+
+    @classmethod
+    def InitFromPackedBuf(cls, buf, pos=0):
+        n = flatbuffers.encode.Get(flatbuffers.packer.uoffset, buf, pos)
+        return cls.InitFromBuf(buf, pos+n)
+
+    @classmethod
+    def InitFromObj(cls, eluAttrs):
+        x = EluAttrsT()
+        x._UnPack(eluAttrs)
+        return x
+
+    # EluAttrsT
+    def _UnPack(self, eluAttrs):
+        if eluAttrs is None:
+            return
+        self.alpha = eluAttrs.Alpha()
+
+    # EluAttrsT
+    def Pack(self, builder):
+        EluAttrsStart(builder)
+        EluAttrsAddAlpha(builder, self.alpha)
+        eluAttrs = EluAttrsEnd(builder)
+        return eluAttrs
 
 
 class FlattenAttrs(object):
@@ -3908,7 +3989,7 @@ class OperatorNodeT(object):
     def __init__(self):
         self.type = 0  # type: int
         self.attrsType = 0  # type: int
-        self.attrs = None  # type: Union[None, ArgMaxAttrsT, AveragePoolAttrsT, BatchNormalizationAttrsT, CastAttrsT, ConcatAttrsT, ConstantOfShapeAttrsT, ConvAttrsT, ConvTransposeAttrsT, FlattenAttrsT, GatherAttrsT, GemmAttrsT, GRUAttrsT, LeakyReluAttrsT, LSTMAttrsT, MaxPoolAttrsT, ReduceMeanAttrsT, ReshapeAttrsT, ResizeAttrsT, SplitAttrsT, SoftmaxAttrsT, TransposeAttrsT, ModAttrsT, ScatterElementsAttrsT, OneHotAttrsT, TopKAttrsT, HardSigmoidAttrsT, TriluAttrsT, ScatterNDAttrsT, NonMaxSuppressionAttrsT, LayerNormalizationAttrsT, RandomUniformAttrsT]
+        self.attrs = None  # type: Union[None, ArgMaxAttrsT, AveragePoolAttrsT, BatchNormalizationAttrsT, CastAttrsT, ConcatAttrsT, ConstantOfShapeAttrsT, ConvAttrsT, ConvTransposeAttrsT, FlattenAttrsT, GatherAttrsT, GemmAttrsT, GRUAttrsT, LeakyReluAttrsT, LSTMAttrsT, MaxPoolAttrsT, ReduceMeanAttrsT, ReshapeAttrsT, ResizeAttrsT, SplitAttrsT, SoftmaxAttrsT, TransposeAttrsT, ModAttrsT, ScatterElementsAttrsT, OneHotAttrsT, TopKAttrsT, HardSigmoidAttrsT, TriluAttrsT, ScatterNDAttrsT, NonMaxSuppressionAttrsT, LayerNormalizationAttrsT, RandomUniformAttrsT, EluAttrsT]
         self.inputs = None  # type: List[int]
         self.outputs = None  # type: List[int]
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -468,6 +468,7 @@ impl_default_factory!(ConvTranspose, read_conv_transpose_op);
 impl_default_factory!(Cos);
 impl_default_factory!(CumSum);
 impl_default_factory!(Div);
+impl_default_factory!(Elu, read_elu_op);
 impl_default_factory!(Equal);
 impl_default_factory!(Erf);
 impl_default_factory!(Exp);
@@ -627,6 +628,7 @@ impl OpRegistry {
         register_op!(Cos);
         register_op!(CumSum);
         register_op!(Div);
+        register_op!(Elu);
         register_op!(Equal);
         register_op!(Erf);
         register_op!(Exp);
@@ -851,6 +853,13 @@ fn read_conv_transpose_op(node: &OperatorNode) -> ReadOpResult {
         .map(|stride| array_from_iter(stride.iter().map(|x| x as usize)))
         .unwrap_or([1, 1]);
     Ok(Box::new(ops::ConvTranspose { strides }))
+}
+
+fn read_elu_op(node: &OperatorNode) -> ReadOpResult {
+    let attrs = node.attrs_as_elu_attrs().ok_or(ReadOpError::AttrError)?;
+    Ok(Box::new(ops::Elu {
+        alpha: attrs.alpha(),
+    }))
 }
 
 read_axis_op!(read_flatten_op, attrs_as_flatten_attrs, Flatten);
@@ -1482,6 +1491,7 @@ mod tests {
         add_operator!(ConvTranspose, [input_node, kernel], { strides: [2, 2] });
         add_operator!(Cos, [input_node]);
         add_operator!(Div, [input_node, input_node]);
+        add_operator!(Elu, [input_node], { alpha: 1.0 });
         add_operator!(Equal, [input_node, input_node]);
         add_operator!(Erf, [input_node]);
         add_operator!(Exp, [input_node]);

--- a/src/model_builder.rs
+++ b/src/model_builder.rs
@@ -7,7 +7,7 @@ use rten_tensor::Tensor;
 use crate::graph::Dimension;
 use crate::ops::{
     ArgMax, ArgMin, AveragePool, BatchNormalization, BoxOrder, Cast, Concat, ConstantOfShape, Conv,
-    ConvTranspose, CoordTransformMode, DataType, Flatten, Gather, GatherElements, Gemm,
+    ConvTranspose, CoordTransformMode, DataType, Elu, Flatten, Gather, GatherElements, Gemm,
     HardSigmoid, InstanceNormalization, LayerNormalization, LeakyRelu, LogSoftmax, MaxPool, Mod,
     NearestMode, NonMaxSuppression, OneHot, Padding, ReduceMax, ReduceMean, ReduceMin, ReduceProd,
     ReduceSum, ReduceSumSquare, Reshape, Resize, ResizeMode, Scalar, ScatterElements,
@@ -39,6 +39,7 @@ pub enum OpType {
     ConvTranspose(ConvTranspose),
     Cos,
     Div,
+    Elu(Elu),
     Equal,
     Erf,
     Exp,
@@ -433,6 +434,9 @@ impl<'a> ModelBuilder<'a> {
             }),
             OpType::Cos => op!(Cos),
             OpType::Div => op!(Div),
+            OpType::Elu(args) => {
+                op_with_attrs!(Elu, EluAttrs, sg::EluAttrsArgs { alpha: args.alpha })
+            }
             OpType::Equal => op!(Equal),
             OpType::Erf => op!(Erf),
             OpType::Exp => op!(Exp),

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -96,14 +96,14 @@ pub use split::{split, Split};
 pub use trilu::{trilu, Trilu};
 pub use unary_elementwise::{
     abs, abs_in_place, acos, acos_in_place, asin, asin_in_place, atan, atan_in_place, ceil,
-    ceil_in_place, clip, clip_in_place, cos, cos_in_place, erf, erf_in_place, exp, exp_in_place,
-    floor, floor_in_place, hard_sigmoid, hard_sigmoid_in_place, hard_swish, hard_swish_in_place,
-    leaky_relu, leaky_relu_in_place, log, log_in_place, neg, neg_in_place, not, not_in_place,
-    reciprocal, reciprocal_in_place, relu, relu_in_place, round, round_in_place, sigmoid,
-    sigmoid_in_place, sign, sign_in_place, sin, sin_in_place, sqrt, sqrt_in_place, tan,
-    tan_in_place, tanh, tanh_in_place, Abs, Acos, Asin, Atan, Ceil, Clip, Cos, Erf, Exp, Floor,
-    HardSigmoid, HardSwish, LeakyRelu, Log, Neg, Not, Reciprocal, Relu, Round, Sigmoid, Sign, Sin,
-    Sqrt, Tan, Tanh,
+    ceil_in_place, clip, clip_in_place, cos, cos_in_place, elu, elu_in_place, erf, erf_in_place,
+    exp, exp_in_place, floor, floor_in_place, hard_sigmoid, hard_sigmoid_in_place, hard_swish,
+    hard_swish_in_place, leaky_relu, leaky_relu_in_place, log, log_in_place, neg, neg_in_place,
+    not, not_in_place, reciprocal, reciprocal_in_place, relu, relu_in_place, round, round_in_place,
+    sigmoid, sigmoid_in_place, sign, sign_in_place, sin, sin_in_place, sqrt, sqrt_in_place, tan,
+    tan_in_place, tanh, tanh_in_place, Abs, Acos, Asin, Atan, Ceil, Clip, Cos, Elu, Erf, Exp,
+    Floor, HardSigmoid, HardSwish, LeakyRelu, Log, Neg, Not, Reciprocal, Relu, Round, Sigmoid,
+    Sign, Sin, Sqrt, Tan, Tanh,
 };
 pub use variadic_elementwise::{max, mean, min, sum, Max, Mean, Min, Sum};
 

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -838,8 +838,7 @@ mod tests {
     use rten_tensor::test_util::{expect_equal_with_tolerance, ExpectEqualError};
     use rten_tensor::NdTensor;
 
-    use super::Input;
-
+    use super::{Input, InputList, OpError, Operator, Output};
     use crate::tensor_pool::TensorPool;
 
     /// Create an empty tensor pool.
@@ -860,6 +859,22 @@ mod tests {
         expected: &V,
     ) -> Result<(), ExpectEqualError> {
         expect_equal_with_tolerance(result, expected, 1e-4, 0.)
+    }
+
+    /// Utility to simplify running a single-output [Operator] with a list of
+    /// typed inputs.
+    ///
+    /// Usage is:
+    ///
+    /// ```text
+    /// let result: NdTensor<f32, 2> = run_op(&op, (data.view(), arg.view()))
+    /// ```
+    pub fn run_op<'a, I: Into<InputList<'a>>, O: TryFrom<Output, Error = OpError>>(
+        op: &dyn Operator,
+        inputs: I,
+    ) -> Result<O, OpError> {
+        let pool = new_pool();
+        op.run(&pool, inputs.into())?.remove(0).try_into()
     }
 
     #[test]

--- a/src/schema.fbs
+++ b/src/schema.fbs
@@ -106,6 +106,7 @@ enum OperatorType: ubyte {
   LayerNormalization,
   ReduceSumSquare,
   RandomUniform,
+  Elu,
 }
 
 enum RNNDirection: ubyte {
@@ -180,6 +181,7 @@ union OperatorAttrs {
   NonMaxSuppressionAttrs,
   LayerNormalizationAttrs,
   RandomUniformAttrs,
+  EluAttrs,
 }
 
 table ArgMaxAttrs {
@@ -241,6 +243,10 @@ table ConvAttrs {
 
 table ConvTransposeAttrs {
   strides:[uint];
+}
+
+table EluAttrs {
+  alpha:float;
 }
 
 table FlattenAttrs {

--- a/src/schema_generated.rs
+++ b/src/schema_generated.rs
@@ -18,13 +18,13 @@ pub const ENUM_MIN_OPERATOR_TYPE: u8 = 0;
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
-pub const ENUM_MAX_OPERATOR_TYPE: u8 = 95;
+pub const ENUM_MAX_OPERATOR_TYPE: u8 = 96;
 #[deprecated(
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 96] = [
+pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 97] = [
     OperatorType::Add,
     OperatorType::ArgMin,
     OperatorType::ArgMax,
@@ -121,6 +121,7 @@ pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 96] = [
     OperatorType::LayerNormalization,
     OperatorType::ReduceSumSquare,
     OperatorType::RandomUniform,
+    OperatorType::Elu,
 ];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -224,9 +225,10 @@ impl OperatorType {
     pub const LayerNormalization: Self = Self(93);
     pub const ReduceSumSquare: Self = Self(94);
     pub const RandomUniform: Self = Self(95);
+    pub const Elu: Self = Self(96);
 
     pub const ENUM_MIN: u8 = 0;
-    pub const ENUM_MAX: u8 = 95;
+    pub const ENUM_MAX: u8 = 96;
     pub const ENUM_VALUES: &'static [Self] = &[
         Self::Add,
         Self::ArgMin,
@@ -324,6 +326,7 @@ impl OperatorType {
         Self::LayerNormalization,
         Self::ReduceSumSquare,
         Self::RandomUniform,
+        Self::Elu,
     ];
     /// Returns the variant's name or "" if unknown.
     pub fn variant_name(self) -> Option<&'static str> {
@@ -424,6 +427,7 @@ impl OperatorType {
             Self::LayerNormalization => Some("LayerNormalization"),
             Self::ReduceSumSquare => Some("ReduceSumSquare"),
             Self::RandomUniform => Some("RandomUniform"),
+            Self::Elu => Some("Elu"),
             _ => None,
         }
     }
@@ -1050,13 +1054,13 @@ pub const ENUM_MIN_OPERATOR_ATTRS: u8 = 0;
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
-pub const ENUM_MAX_OPERATOR_ATTRS: u8 = 31;
+pub const ENUM_MAX_OPERATOR_ATTRS: u8 = 32;
 #[deprecated(
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_OPERATOR_ATTRS: [OperatorAttrs; 32] = [
+pub const ENUM_VALUES_OPERATOR_ATTRS: [OperatorAttrs; 33] = [
     OperatorAttrs::NONE,
     OperatorAttrs::ArgMaxAttrs,
     OperatorAttrs::AveragePoolAttrs,
@@ -1089,6 +1093,7 @@ pub const ENUM_VALUES_OPERATOR_ATTRS: [OperatorAttrs; 32] = [
     OperatorAttrs::NonMaxSuppressionAttrs,
     OperatorAttrs::LayerNormalizationAttrs,
     OperatorAttrs::RandomUniformAttrs,
+    OperatorAttrs::EluAttrs,
 ];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -1128,9 +1133,10 @@ impl OperatorAttrs {
     pub const NonMaxSuppressionAttrs: Self = Self(29);
     pub const LayerNormalizationAttrs: Self = Self(30);
     pub const RandomUniformAttrs: Self = Self(31);
+    pub const EluAttrs: Self = Self(32);
 
     pub const ENUM_MIN: u8 = 0;
-    pub const ENUM_MAX: u8 = 31;
+    pub const ENUM_MAX: u8 = 32;
     pub const ENUM_VALUES: &'static [Self] = &[
         Self::NONE,
         Self::ArgMaxAttrs,
@@ -1164,6 +1170,7 @@ impl OperatorAttrs {
         Self::NonMaxSuppressionAttrs,
         Self::LayerNormalizationAttrs,
         Self::RandomUniformAttrs,
+        Self::EluAttrs,
     ];
     /// Returns the variant's name or "" if unknown.
     pub fn variant_name(self) -> Option<&'static str> {
@@ -1200,6 +1207,7 @@ impl OperatorAttrs {
             Self::NonMaxSuppressionAttrs => Some("NonMaxSuppressionAttrs"),
             Self::LayerNormalizationAttrs => Some("LayerNormalizationAttrs"),
             Self::RandomUniformAttrs => Some("RandomUniformAttrs"),
+            Self::EluAttrs => Some("EluAttrs"),
             _ => None,
         }
     }
@@ -3132,6 +3140,103 @@ impl core::fmt::Debug for ConvTransposeAttrs<'_> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let mut ds = f.debug_struct("ConvTransposeAttrs");
         ds.field("strides", &self.strides());
+        ds.finish()
+    }
+}
+pub enum EluAttrsOffset {}
+#[derive(Copy, Clone, PartialEq)]
+
+pub struct EluAttrs<'a> {
+    pub _tab: flatbuffers::Table<'a>,
+}
+
+impl<'a> flatbuffers::Follow<'a> for EluAttrs<'a> {
+    type Inner = EluAttrs<'a>;
+    #[inline]
+    unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self {
+            _tab: flatbuffers::Table::new(buf, loc),
+        }
+    }
+}
+
+impl<'a> EluAttrs<'a> {
+    pub const VT_ALPHA: flatbuffers::VOffsetT = 4;
+
+    #[inline]
+    pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+        EluAttrs { _tab: table }
+    }
+    #[allow(unused_mut)]
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+        args: &'args EluAttrsArgs,
+    ) -> flatbuffers::WIPOffset<EluAttrs<'bldr>> {
+        let mut builder = EluAttrsBuilder::new(_fbb);
+        builder.add_alpha(args.alpha);
+        builder.finish()
+    }
+
+    #[inline]
+    pub fn alpha(&self) -> f32 {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe { self._tab.get::<f32>(EluAttrs::VT_ALPHA, Some(0.0)).unwrap() }
+    }
+}
+
+impl flatbuffers::Verifiable for EluAttrs<'_> {
+    #[inline]
+    fn run_verifier(
+        v: &mut flatbuffers::Verifier,
+        pos: usize,
+    ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+        use self::flatbuffers::Verifiable;
+        v.visit_table(pos)?
+            .visit_field::<f32>("alpha", Self::VT_ALPHA, false)?
+            .finish();
+        Ok(())
+    }
+}
+pub struct EluAttrsArgs {
+    pub alpha: f32,
+}
+impl<'a> Default for EluAttrsArgs {
+    #[inline]
+    fn default() -> Self {
+        EluAttrsArgs { alpha: 0.0 }
+    }
+}
+
+pub struct EluAttrsBuilder<'a: 'b, 'b> {
+    fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+    start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b> EluAttrsBuilder<'a, 'b> {
+    #[inline]
+    pub fn add_alpha(&mut self, alpha: f32) {
+        self.fbb_.push_slot::<f32>(EluAttrs::VT_ALPHA, alpha, 0.0);
+    }
+    #[inline]
+    pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> EluAttrsBuilder<'a, 'b> {
+        let start = _fbb.start_table();
+        EluAttrsBuilder {
+            fbb_: _fbb,
+            start_: start,
+        }
+    }
+    #[inline]
+    pub fn finish(self) -> flatbuffers::WIPOffset<EluAttrs<'a>> {
+        let o = self.fbb_.end_table(self.start_);
+        flatbuffers::WIPOffset::new(o.value())
+    }
+}
+
+impl core::fmt::Debug for EluAttrs<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut ds = f.debug_struct("EluAttrs");
+        ds.field("alpha", &self.alpha());
         ds.finish()
     }
 }
@@ -6585,6 +6690,21 @@ impl<'a> OperatorNode<'a> {
             None
         }
     }
+
+    #[inline]
+    #[allow(non_snake_case)]
+    pub fn attrs_as_elu_attrs(&self) -> Option<EluAttrs<'a>> {
+        if self.attrs_type() == OperatorAttrs::EluAttrs {
+            self.attrs().map(|t| {
+                // Safety:
+                // Created from a valid Table for this object
+                // Which contains a valid union in this slot
+                unsafe { EluAttrs::init_from_table(t) }
+            })
+        } else {
+            None
+        }
+    }
 }
 
 impl flatbuffers::Verifiable for OperatorNode<'_> {
@@ -6629,6 +6749,7 @@ impl flatbuffers::Verifiable for OperatorNode<'_> {
           OperatorAttrs::NonMaxSuppressionAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<NonMaxSuppressionAttrs>>("OperatorAttrs::NonMaxSuppressionAttrs", pos),
           OperatorAttrs::LayerNormalizationAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<LayerNormalizationAttrs>>("OperatorAttrs::LayerNormalizationAttrs", pos),
           OperatorAttrs::RandomUniformAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<RandomUniformAttrs>>("OperatorAttrs::RandomUniformAttrs", pos),
+          OperatorAttrs::EluAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<EluAttrs>>("OperatorAttrs::EluAttrs", pos),
           _ => Ok(()),
         }
      })?
@@ -7014,6 +7135,16 @@ impl core::fmt::Debug for OperatorNode<'_> {
             }
             OperatorAttrs::RandomUniformAttrs => {
                 if let Some(x) = self.attrs_as_random_uniform_attrs() {
+                    ds.field("attrs", &x)
+                } else {
+                    ds.field(
+                        "attrs",
+                        &"InvalidFlatbuffer: Union discriminant does not match value.",
+                    )
+                }
+            }
+            OperatorAttrs::EluAttrs => {
+                if let Some(x) = self.attrs_as_elu_attrs() {
                     ds.field("attrs", &x)
                 } else {
                     ds.field(

--- a/tools/ort-infer.py
+++ b/tools/ort-infer.py
@@ -39,6 +39,7 @@ def run_model(model_path: str, n_evals: int = 10, enable_profiling=False):
     for node in session.get_inputs():
         type_map = {
             "tensor(float)": np.float32,
+            "tensor(float16)": np.float16,
         }
         value = np.random.rand(*node.shape).astype(type_map[node.type])
         inputs[node.name] = value


### PR DESCRIPTION
This addresses a few issues I found while playing around with ONNX models from openpilot:

- Support the `Elu` activation operator
- The latest versions of the `Reduce*` operators take `axes` as a dynamic input rather than static attribute.
- Enable the `ort-infer.py` script to run with models that have `float16` inputs

For RTen, the original `supercombo.onnx` model fails to convert because the weights are in float16 format. However this hack works (at least for getting the model to run, I haven't verified the outputs):

```diff
diff --git a/rten-convert/rten_convert/converter.py b/rten-convert/rten_convert/converter.py
index 42b427a6..d4fe5f4e 100644
--- a/rten-convert/rten_convert/converter.py
+++ b/rten-convert/rten_convert/converter.py
@@ -426,6 +426,9 @@ def constant_node_from_onnx_initializer(
         case "float32" | "int32":
             pass
 
+        case "float16":
+            data = data.astype(np.float32)
+
         # Int types that can be widened to int32
         case "bool" | "int8" | "int16":
             data = data.astype(np.int32)
```

TODO:

- [x] Tests for Elu op
- [x] Tests for `Reduce` operator change