### PR TITLE
Fix crash in `Erf`, `Tanh` operators under under pre-AVX2 x64 CPUs

### DIFF
--- a/rten-vecmath/src/erf.rs
+++ b/rten-vecmath/src/erf.rs
@@ -21,9 +21,7 @@ pub fn erf(x: f32) -> f32 {
 /// `libm::erff` as a source of truth.
 ///
 /// Safety: The caller must ensure the `SimdFloat` impl is usable on the current system.
-#[cfg_attr(target_arch = "x86_64", target_feature(enable = "avx2"))]
-#[cfg_attr(target_arch = "x86_64", target_feature(enable = "fma"))]
-#[inline]
+#[inline(always)]
 unsafe fn simd_erf<S: SimdFloat>(x: S) -> S {
     let neg_mask = x.lt(S::zero());
 

--- a/rten-vecmath/src/tanh.rs
+++ b/rten-vecmath/src/tanh.rs
@@ -10,9 +10,7 @@ pub fn tanh(x: f32) -> f32 {
     unsafe { simd_tanh(x) }
 }
 
-#[cfg_attr(target_arch = "x86_64", target_feature(enable = "avx2"))]
-#[cfg_attr(target_arch = "x86_64", target_feature(enable = "fma"))]
-#[inline]
+#[inline(always)]
 unsafe fn simd_tanh<S: SimdFloat>(x: S) -> S {
     let x_negative = x.le(S::zero());
     let abs_x = x.abs();


### PR DESCRIPTION
Remove the `#[target_feature]` attributes from the generic erf, tanh functions. Previously they were being compiled with AVX2 instructions even when called from the fallback (non-AVX2) dispatch.

This change follows the pattern established in
https://github.com/robertknight/rten/pull/131, which fixed the issue for Exp, Sigmoid and Softmax operators.

Downstream issue: https://github.com/robertknight/ocrs/issues/52 (see my notes here for steps to reproduce)

Together with https://github.com/robertknight/rten/pull/131, this should fix https://github.com/robertknight/rten/issues/35.