### PR TITLE
Implement RandomUniformLike, RandomNormal, RandomNormalLike

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,6 +105,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
 
 [[package]]
+name = "fastrand-contrib"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb6c045880cda8f657f4859baf534963ff0595e2dcce0de5f52dcdf3076c290b"
+dependencies = [
+ "fastrand",
+]
+
+[[package]]
 name = "fdeflate"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -298,6 +307,7 @@ name = "rten"
 version = "0.8.0"
 dependencies = [
  "fastrand",
+ "fastrand-contrib",
  "flatbuffers",
  "libm",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ smallvec = { version = "1.10.0", features = ["union", "const_generics", "const_n
 rten-tensor = { path = "./rten-tensor", version = "0.8.0" }
 rten-vecmath = { path = "./rten-vecmath", version = "0.8.0" }
 fastrand = { version = "2.0.2", optional = true }
+fastrand-contrib = { version = "0.1.0", optional = true }
 rustc-hash = "1.1.0"
 
 [dev-dependencies]
@@ -56,7 +57,7 @@ avx512 = ["rten-vecmath/avx512"]
 # Generate WebAssembly API using wasm-bindgen.
 wasm_api = []
 # Enable operators that generate random numbers.
-random = ["fastrand"]
+random = ["fastrand", "fastrand-contrib"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2.83"

--- a/rten-convert/rten_convert/converter.py
+++ b/rten-convert/rten_convert/converter.py
@@ -802,12 +802,29 @@ def op_node_from_onnx_operator(
             attrs = sg.OneHotAttrsT()
             attrs.axis = op_reader.get_attr("axis", "int", -1)
 
-        case "RandomUniform":
-            attrs = sg.RandomUniformAttrsT()
-            op_reader.check_attr("dtype", "int", 1)
+        case "RandomNormal" | "RandomNormalLike":
+            match op_type:
+                case "RandomNormal":
+                    attrs = sg.RandomNormalAttrsT()
+                    attrs.shape = op_reader.require_attr("shape", "ints")
+                case "RandomNormalLike":
+                    attrs = sg.RandomNormalLikeAttrsT()
 
+            op_reader.check_attr("dtype", "int", 1)
             attrs.seed = op_reader.get_attr("seed", "float", None)
-            attrs.shape = op_reader.require_attr("shape", "ints")
+            attrs.mean = op_reader.get_attr("mean", "float", 0.0)
+            attrs.scale = op_reader.get_attr("scale", "float", 1.0)
+
+        case "RandomUniform" | "RandomUniformLike":
+            match op_type:
+                case "RandomUniform":
+                    attrs = sg.RandomUniformAttrsT()
+                    attrs.shape = op_reader.require_attr("shape", "ints")
+                case "RandomUniformLike":
+                    attrs = sg.RandomUniformLikeAttrsT()
+
+            op_reader.check_attr("dtype", "int", 1)
+            attrs.seed = op_reader.get_attr("seed", "float", None)
             attrs.low = op_reader.get_attr("low", "float", 0.0)
             attrs.high = op_reader.get_attr("high", "float", 1.0)
 

--- a/rten-convert/rten_convert/schema_generated.py
+++ b/rten-convert/rten_convert/schema_generated.py
@@ -104,6 +104,9 @@ class OperatorType(object):
     ReduceSumSquare = 94
     RandomUniform = 95
     Elu = 96
+    RandomUniformLike = 97
+    RandomNormal = 98
+    RandomNormalLike = 99
 
 
 class RNNDirection(object):
@@ -174,6 +177,9 @@ class OperatorAttrs(object):
     LayerNormalizationAttrs = 30
     RandomUniformAttrs = 31
     EluAttrs = 32
+    RandomUniformLikeAttrs = 33
+    RandomNormalAttrs = 34
+    RandomNormalLikeAttrs = 35
 
 def OperatorAttrsCreator(unionType, table):
     from flatbuffers.table import Table
@@ -243,6 +249,12 @@ def OperatorAttrsCreator(unionType, table):
         return RandomUniformAttrsT.InitFromBuf(table.Bytes, table.Pos)
     if unionType == OperatorAttrs().EluAttrs:
         return EluAttrsT.InitFromBuf(table.Bytes, table.Pos)
+    if unionType == OperatorAttrs().RandomUniformLikeAttrs:
+        return RandomUniformLikeAttrsT.InitFromBuf(table.Bytes, table.Pos)
+    if unionType == OperatorAttrs().RandomNormalAttrs:
+        return RandomNormalAttrsT.InitFromBuf(table.Bytes, table.Pos)
+    if unionType == OperatorAttrs().RandomNormalLikeAttrs:
+        return RandomNormalLikeAttrsT.InitFromBuf(table.Bytes, table.Pos)
     return None
 
 
@@ -2760,6 +2772,267 @@ class OneHotAttrsT(object):
         return oneHotAttrs
 
 
+class RandomNormalAttrs(object):
+    __slots__ = ['_tab']
+
+    @classmethod
+    def GetRootAs(cls, buf, offset=0):
+        n = flatbuffers.encode.Get(flatbuffers.packer.uoffset, buf, offset)
+        x = RandomNormalAttrs()
+        x.Init(buf, n + offset)
+        return x
+
+    @classmethod
+    def GetRootAsRandomNormalAttrs(cls, buf, offset=0):
+        """This method is deprecated. Please switch to GetRootAs."""
+        return cls.GetRootAs(buf, offset)
+    @classmethod
+    def RandomNormalAttrsBufferHasIdentifier(cls, buf, offset, size_prefixed=False):
+        return flatbuffers.util.BufferHasIdentifier(buf, offset, b"\x52\x54\x45\x4E", size_prefixed=size_prefixed)
+
+    # RandomNormalAttrs
+    def Init(self, buf, pos):
+        self._tab = flatbuffers.table.Table(buf, pos)
+
+    # RandomNormalAttrs
+    def Mean(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
+        if o != 0:
+            return self._tab.Get(flatbuffers.number_types.Float32Flags, o + self._tab.Pos)
+        return 0.0
+
+    # RandomNormalAttrs
+    def Scale(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(6))
+        if o != 0:
+            return self._tab.Get(flatbuffers.number_types.Float32Flags, o + self._tab.Pos)
+        return 0.0
+
+    # RandomNormalAttrs
+    def Seed(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(8))
+        if o != 0:
+            return self._tab.Get(flatbuffers.number_types.Float32Flags, o + self._tab.Pos)
+        return None
+
+    # RandomNormalAttrs
+    def Shape(self, j):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(10))
+        if o != 0:
+            a = self._tab.Vector(o)
+            return self._tab.Get(flatbuffers.number_types.Uint32Flags, a + flatbuffers.number_types.UOffsetTFlags.py_type(j * 4))
+        return 0
+
+    # RandomNormalAttrs
+    def ShapeAsNumpy(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(10))
+        if o != 0:
+            return self._tab.GetVectorAsNumpy(flatbuffers.number_types.Uint32Flags, o)
+        return 0
+
+    # RandomNormalAttrs
+    def ShapeLength(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(10))
+        if o != 0:
+            return self._tab.VectorLen(o)
+        return 0
+
+    # RandomNormalAttrs
+    def ShapeIsNone(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(10))
+        return o == 0
+
+def RandomNormalAttrsStart(builder):
+    builder.StartObject(4)
+
+def RandomNormalAttrsAddMean(builder, mean):
+    builder.PrependFloat32Slot(0, mean, 0.0)
+
+def RandomNormalAttrsAddScale(builder, scale):
+    builder.PrependFloat32Slot(1, scale, 0.0)
+
+def RandomNormalAttrsAddSeed(builder, seed):
+    builder.PrependFloat32Slot(2, seed, None)
+
+def RandomNormalAttrsAddShape(builder, shape):
+    builder.PrependUOffsetTRelativeSlot(3, flatbuffers.number_types.UOffsetTFlags.py_type(shape), 0)
+
+def RandomNormalAttrsStartShapeVector(builder, numElems):
+    return builder.StartVector(4, numElems, 4)
+
+def RandomNormalAttrsEnd(builder):
+    return builder.EndObject()
+
+
+try:
+    from typing import List
+except:
+    pass
+
+class RandomNormalAttrsT(object):
+
+    # RandomNormalAttrsT
+    def __init__(self):
+        self.mean = 0.0  # type: float
+        self.scale = 0.0  # type: float
+        self.seed = None  # type: Optional[float]
+        self.shape = None  # type: List[int]
+
+    @classmethod
+    def InitFromBuf(cls, buf, pos):
+        randomNormalAttrs = RandomNormalAttrs()
+        randomNormalAttrs.Init(buf, pos)
+        return cls.InitFromObj(randomNormalAttrs)
+
+    @classmethod
+    def InitFromPackedBuf(cls, buf, pos=0):
+        n = flatbuffers.encode.Get(flatbuffers.packer.uoffset, buf, pos)
+        return cls.InitFromBuf(buf, pos+n)
+
+    @classmethod
+    def InitFromObj(cls, randomNormalAttrs):
+        x = RandomNormalAttrsT()
+        x._UnPack(randomNormalAttrs)
+        return x
+
+    # RandomNormalAttrsT
+    def _UnPack(self, randomNormalAttrs):
+        if randomNormalAttrs is None:
+            return
+        self.mean = randomNormalAttrs.Mean()
+        self.scale = randomNormalAttrs.Scale()
+        self.seed = randomNormalAttrs.Seed()
+        if not randomNormalAttrs.ShapeIsNone():
+            if np is None:
+                self.shape = []
+                for i in range(randomNormalAttrs.ShapeLength()):
+                    self.shape.append(randomNormalAttrs.Shape(i))
+            else:
+                self.shape = randomNormalAttrs.ShapeAsNumpy()
+
+    # RandomNormalAttrsT
+    def Pack(self, builder):
+        if self.shape is not None:
+            if np is not None and type(self.shape) is np.ndarray:
+                shape = builder.CreateNumpyVector(self.shape)
+            else:
+                RandomNormalAttrsStartShapeVector(builder, len(self.shape))
+                for i in reversed(range(len(self.shape))):
+                    builder.PrependUint32(self.shape[i])
+                shape = builder.EndVector()
+        RandomNormalAttrsStart(builder)
+        RandomNormalAttrsAddMean(builder, self.mean)
+        RandomNormalAttrsAddScale(builder, self.scale)
+        RandomNormalAttrsAddSeed(builder, self.seed)
+        if self.shape is not None:
+            RandomNormalAttrsAddShape(builder, shape)
+        randomNormalAttrs = RandomNormalAttrsEnd(builder)
+        return randomNormalAttrs
+
+
+class RandomNormalLikeAttrs(object):
+    __slots__ = ['_tab']
+
+    @classmethod
+    def GetRootAs(cls, buf, offset=0):
+        n = flatbuffers.encode.Get(flatbuffers.packer.uoffset, buf, offset)
+        x = RandomNormalLikeAttrs()
+        x.Init(buf, n + offset)
+        return x
+
+    @classmethod
+    def GetRootAsRandomNormalLikeAttrs(cls, buf, offset=0):
+        """This method is deprecated. Please switch to GetRootAs."""
+        return cls.GetRootAs(buf, offset)
+    @classmethod
+    def RandomNormalLikeAttrsBufferHasIdentifier(cls, buf, offset, size_prefixed=False):
+        return flatbuffers.util.BufferHasIdentifier(buf, offset, b"\x52\x54\x45\x4E", size_prefixed=size_prefixed)
+
+    # RandomNormalLikeAttrs
+    def Init(self, buf, pos):
+        self._tab = flatbuffers.table.Table(buf, pos)
+
+    # RandomNormalLikeAttrs
+    def Mean(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
+        if o != 0:
+            return self._tab.Get(flatbuffers.number_types.Float32Flags, o + self._tab.Pos)
+        return 0.0
+
+    # RandomNormalLikeAttrs
+    def Scale(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(6))
+        if o != 0:
+            return self._tab.Get(flatbuffers.number_types.Float32Flags, o + self._tab.Pos)
+        return 0.0
+
+    # RandomNormalLikeAttrs
+    def Seed(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(8))
+        if o != 0:
+            return self._tab.Get(flatbuffers.number_types.Float32Flags, o + self._tab.Pos)
+        return None
+
+def RandomNormalLikeAttrsStart(builder):
+    builder.StartObject(3)
+
+def RandomNormalLikeAttrsAddMean(builder, mean):
+    builder.PrependFloat32Slot(0, mean, 0.0)
+
+def RandomNormalLikeAttrsAddScale(builder, scale):
+    builder.PrependFloat32Slot(1, scale, 0.0)
+
+def RandomNormalLikeAttrsAddSeed(builder, seed):
+    builder.PrependFloat32Slot(2, seed, None)
+
+def RandomNormalLikeAttrsEnd(builder):
+    return builder.EndObject()
+
+
+
+class RandomNormalLikeAttrsT(object):
+
+    # RandomNormalLikeAttrsT
+    def __init__(self):
+        self.mean = 0.0  # type: float
+        self.scale = 0.0  # type: float
+        self.seed = None  # type: Optional[float]
+
+    @classmethod
+    def InitFromBuf(cls, buf, pos):
+        randomNormalLikeAttrs = RandomNormalLikeAttrs()
+        randomNormalLikeAttrs.Init(buf, pos)
+        return cls.InitFromObj(randomNormalLikeAttrs)
+
+    @classmethod
+    def InitFromPackedBuf(cls, buf, pos=0):
+        n = flatbuffers.encode.Get(flatbuffers.packer.uoffset, buf, pos)
+        return cls.InitFromBuf(buf, pos+n)
+
+    @classmethod
+    def InitFromObj(cls, randomNormalLikeAttrs):
+        x = RandomNormalLikeAttrsT()
+        x._UnPack(randomNormalLikeAttrs)
+        return x
+
+    # RandomNormalLikeAttrsT
+    def _UnPack(self, randomNormalLikeAttrs):
+        if randomNormalLikeAttrs is None:
+            return
+        self.mean = randomNormalLikeAttrs.Mean()
+        self.scale = randomNormalLikeAttrs.Scale()
+        self.seed = randomNormalLikeAttrs.Seed()
+
+    # RandomNormalLikeAttrsT
+    def Pack(self, builder):
+        RandomNormalLikeAttrsStart(builder)
+        RandomNormalLikeAttrsAddMean(builder, self.mean)
+        RandomNormalLikeAttrsAddScale(builder, self.scale)
+        RandomNormalLikeAttrsAddSeed(builder, self.seed)
+        randomNormalLikeAttrs = RandomNormalLikeAttrsEnd(builder)
+        return randomNormalLikeAttrs
+
+
 class RandomUniformAttrs(object):
     __slots__ = ['_tab']
 
@@ -2916,6 +3189,109 @@ class RandomUniformAttrsT(object):
         RandomUniformAttrsAddSeed(builder, self.seed)
         randomUniformAttrs = RandomUniformAttrsEnd(builder)
         return randomUniformAttrs
+
+
+class RandomUniformLikeAttrs(object):
+    __slots__ = ['_tab']
+
+    @classmethod
+    def GetRootAs(cls, buf, offset=0):
+        n = flatbuffers.encode.Get(flatbuffers.packer.uoffset, buf, offset)
+        x = RandomUniformLikeAttrs()
+        x.Init(buf, n + offset)
+        return x
+
+    @classmethod
+    def GetRootAsRandomUniformLikeAttrs(cls, buf, offset=0):
+        """This method is deprecated. Please switch to GetRootAs."""
+        return cls.GetRootAs(buf, offset)
+    @classmethod
+    def RandomUniformLikeAttrsBufferHasIdentifier(cls, buf, offset, size_prefixed=False):
+        return flatbuffers.util.BufferHasIdentifier(buf, offset, b"\x52\x54\x45\x4E", size_prefixed=size_prefixed)
+
+    # RandomUniformLikeAttrs
+    def Init(self, buf, pos):
+        self._tab = flatbuffers.table.Table(buf, pos)
+
+    # RandomUniformLikeAttrs
+    def High(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
+        if o != 0:
+            return self._tab.Get(flatbuffers.number_types.Float32Flags, o + self._tab.Pos)
+        return 0.0
+
+    # RandomUniformLikeAttrs
+    def Low(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(6))
+        if o != 0:
+            return self._tab.Get(flatbuffers.number_types.Float32Flags, o + self._tab.Pos)
+        return 0.0
+
+    # RandomUniformLikeAttrs
+    def Seed(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(8))
+        if o != 0:
+            return self._tab.Get(flatbuffers.number_types.Float32Flags, o + self._tab.Pos)
+        return None
+
+def RandomUniformLikeAttrsStart(builder):
+    builder.StartObject(3)
+
+def RandomUniformLikeAttrsAddHigh(builder, high):
+    builder.PrependFloat32Slot(0, high, 0.0)
+
+def RandomUniformLikeAttrsAddLow(builder, low):
+    builder.PrependFloat32Slot(1, low, 0.0)
+
+def RandomUniformLikeAttrsAddSeed(builder, seed):
+    builder.PrependFloat32Slot(2, seed, None)
+
+def RandomUniformLikeAttrsEnd(builder):
+    return builder.EndObject()
+
+
+
+class RandomUniformLikeAttrsT(object):
+
+    # RandomUniformLikeAttrsT
+    def __init__(self):
+        self.high = 0.0  # type: float
+        self.low = 0.0  # type: float
+        self.seed = None  # type: Optional[float]
+
+    @classmethod
+    def InitFromBuf(cls, buf, pos):
+        randomUniformLikeAttrs = RandomUniformLikeAttrs()
+        randomUniformLikeAttrs.Init(buf, pos)
+        return cls.InitFromObj(randomUniformLikeAttrs)
+
+    @classmethod
+    def InitFromPackedBuf(cls, buf, pos=0):
+        n = flatbuffers.encode.Get(flatbuffers.packer.uoffset, buf, pos)
+        return cls.InitFromBuf(buf, pos+n)
+
+    @classmethod
+    def InitFromObj(cls, randomUniformLikeAttrs):
+        x = RandomUniformLikeAttrsT()
+        x._UnPack(randomUniformLikeAttrs)
+        return x
+
+    # RandomUniformLikeAttrsT
+    def _UnPack(self, randomUniformLikeAttrs):
+        if randomUniformLikeAttrs is None:
+            return
+        self.high = randomUniformLikeAttrs.High()
+        self.low = randomUniformLikeAttrs.Low()
+        self.seed = randomUniformLikeAttrs.Seed()
+
+    # RandomUniformLikeAttrsT
+    def Pack(self, builder):
+        RandomUniformLikeAttrsStart(builder)
+        RandomUniformLikeAttrsAddHigh(builder, self.high)
+        RandomUniformLikeAttrsAddLow(builder, self.low)
+        RandomUniformLikeAttrsAddSeed(builder, self.seed)
+        randomUniformLikeAttrs = RandomUniformLikeAttrsEnd(builder)
+        return randomUniformLikeAttrs
 
 
 class ReduceMeanAttrs(object):
@@ -3989,7 +4365,7 @@ class OperatorNodeT(object):
     def __init__(self):
         self.type = 0  # type: int
         self.attrsType = 0  # type: int
-        self.attrs = None  # type: Union[None, ArgMaxAttrsT, AveragePoolAttrsT, BatchNormalizationAttrsT, CastAttrsT, ConcatAttrsT, ConstantOfShapeAttrsT, ConvAttrsT, ConvTransposeAttrsT, FlattenAttrsT, GatherAttrsT, GemmAttrsT, GRUAttrsT, LeakyReluAttrsT, LSTMAttrsT, MaxPoolAttrsT, ReduceMeanAttrsT, ReshapeAttrsT, ResizeAttrsT, SplitAttrsT, SoftmaxAttrsT, TransposeAttrsT, ModAttrsT, ScatterElementsAttrsT, OneHotAttrsT, TopKAttrsT, HardSigmoidAttrsT, TriluAttrsT, ScatterNDAttrsT, NonMaxSuppressionAttrsT, LayerNormalizationAttrsT, RandomUniformAttrsT, EluAttrsT]
+        self.attrs = None  # type: Union[None, ArgMaxAttrsT, AveragePoolAttrsT, BatchNormalizationAttrsT, CastAttrsT, ConcatAttrsT, ConstantOfShapeAttrsT, ConvAttrsT, ConvTransposeAttrsT, FlattenAttrsT, GatherAttrsT, GemmAttrsT, GRUAttrsT, LeakyReluAttrsT, LSTMAttrsT, MaxPoolAttrsT, ReduceMeanAttrsT, ReshapeAttrsT, ResizeAttrsT, SplitAttrsT, SoftmaxAttrsT, TransposeAttrsT, ModAttrsT, ScatterElementsAttrsT, OneHotAttrsT, TopKAttrsT, HardSigmoidAttrsT, TriluAttrsT, ScatterNDAttrsT, NonMaxSuppressionAttrsT, LayerNormalizationAttrsT, RandomUniformAttrsT, EluAttrsT, RandomUniformLikeAttrsT, RandomNormalAttrsT, RandomNormalLikeAttrsT]
         self.inputs = None  # type: List[int]
         self.outputs = None  # type: List[int]
 

--- a/src/model_builder.rs
+++ b/src/model_builder.rs
@@ -16,7 +16,7 @@ use crate::ops::{
 use crate::schema_generated as sg;
 
 #[cfg(feature = "random")]
-use crate::ops::RandomUniform;
+use crate::ops::{RandomNormal, RandomNormalLike, RandomUniform, RandomUniformLike};
 
 /// Enum of all the built-in operators
 pub enum OpType {
@@ -79,7 +79,13 @@ pub enum OpType {
     Pow,
 
     #[cfg(feature = "random")]
+    RandomNormal(RandomNormal),
+    #[cfg(feature = "random")]
+    RandomNormalLike(RandomNormalLike),
+    #[cfg(feature = "random")]
     RandomUniform(RandomUniform),
+    #[cfg(feature = "random")]
+    RandomUniformLike(RandomUniformLike),
 
     Range,
     Reciprocal,
@@ -565,6 +571,30 @@ impl<'a> ModelBuilder<'a> {
             OpType::Pow => op!(Pow),
 
             #[cfg(feature = "random")]
+            OpType::RandomNormal(args) => {
+                let shape = self.create_vec(Some(args.shape), |size| size as u32);
+                op_with_attrs!(RandomNormal, RandomNormalAttrs, {
+                    sg::RandomNormalAttrsArgs {
+                        mean: args.mean,
+                        scale: args.scale,
+                        seed: args.seed,
+                        shape,
+                    }
+                })
+            }
+
+            #[cfg(feature = "random")]
+            OpType::RandomNormalLike(args) => {
+                op_with_attrs!(RandomNormalLike, RandomNormalLikeAttrs, {
+                    sg::RandomNormalLikeAttrsArgs {
+                        mean: args.mean,
+                        scale: args.scale,
+                        seed: args.seed,
+                    }
+                })
+            }
+
+            #[cfg(feature = "random")]
             OpType::RandomUniform(args) => {
                 let shape = self.create_vec(Some(args.shape), |size| size as u32);
                 op_with_attrs!(RandomUniform, RandomUniformAttrs, {
@@ -573,6 +603,17 @@ impl<'a> ModelBuilder<'a> {
                         low: args.low,
                         seed: args.seed,
                         shape,
+                    }
+                })
+            }
+
+            #[cfg(feature = "random")]
+            OpType::RandomUniformLike(args) => {
+                op_with_attrs!(RandomUniformLike, RandomUniformLikeAttrs, {
+                    sg::RandomUniformLikeAttrsArgs {
+                        high: args.high,
+                        low: args.low,
+                        seed: args.seed,
                     }
                 })
             }

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -80,7 +80,7 @@ pub use pooling::{
 };
 
 #[cfg(feature = "random")]
-pub use random::RandomUniform;
+pub use random::{RandomNormal, RandomNormalLike, RandomUniform, RandomUniformLike};
 
 pub use reduce::{
     arg_max, arg_min, cum_sum, nonzero, reduce_l2, reduce_max, reduce_mean, reduce_min,

--- a/src/ops/operators.rs
+++ b/src/ops/operators.rs
@@ -6,8 +6,8 @@ use rten_tensor::{DynLayout, NdLayout, NdTensorView, Tensor, TensorBase, TensorV
 use crate::number::{Identities, IsInt};
 use crate::ops::OpError;
 use crate::ops::{
-    arg_max, div, matmul, mul, pad, reduce_l2, reduce_max, reduce_mean, reduce_min, resize_image,
-    softmax, topk,
+    arg_max, div, matmul, mul, pad, reduce_l2, reduce_max, reduce_mean, reduce_min, reduce_sum,
+    resize_image, softmax, topk,
 };
 use crate::tensor_pool::TensorPool;
 
@@ -66,6 +66,7 @@ pub trait FloatOperators {
     fn reduce_max(&self, axes: Option<&[i32]>, keep_dims: bool) -> Result<Tensor, OpError>;
     fn reduce_mean(&self, axes: Option<&[i32]>, keep_dims: bool) -> Result<Tensor, OpError>;
     fn reduce_min(&self, axes: Option<&[i32]>, keep_dims: bool) -> Result<Tensor, OpError>;
+    fn reduce_sum(&self, axes: Option<&[i32]>, keep_dims: bool) -> Result<Tensor, OpError>;
 
     /// Resize an NCHW image tensor to a given `[height, width]` using bilinear
     /// interpolation.
@@ -196,6 +197,10 @@ impl<S: AsRef<[f32]>> FloatOperators for TensorBase<f32, S, DynLayout> {
         reduce_mean(&TensorPool::new(), self.view(), axes, keep_dims)
     }
 
+    fn reduce_sum(&self, axes: Option<&[i32]>, keep_dims: bool) -> Result<Tensor, OpError> {
+        reduce_sum(&TensorPool::new(), self.view(), axes, keep_dims)
+    }
+
     fn resize_image(&self, size: [usize; 2]) -> Result<Tensor, OpError> {
         resize_image(self.view(), size)
     }
@@ -224,6 +229,10 @@ impl<S: AsRef<[f32]>, const N: usize> FloatOperators for TensorBase<f32, S, NdLa
 
     fn reduce_mean(&self, axes: Option<&[i32]>, keep_dims: bool) -> Result<Tensor, OpError> {
         reduce_mean(&TensorPool::new(), self.as_dyn(), axes, keep_dims)
+    }
+
+    fn reduce_sum(&self, axes: Option<&[i32]>, keep_dims: bool) -> Result<Tensor, OpError> {
+        reduce_sum(&TensorPool::new(), self.as_dyn(), axes, keep_dims)
     }
 
     fn resize_image(&self, size: [usize; 2]) -> Result<Tensor, OpError> {

--- a/src/ops/random.rs
+++ b/src/ops/random.rs
@@ -1,4 +1,6 @@
 use fastrand::Rng;
+use fastrand_contrib::RngExt;
+use rten_tensor::prelude::*;
 use rten_tensor::Tensor;
 
 use crate::ops::{InputList, IntoOpResult, OpError, Operator, Output};
@@ -40,15 +42,105 @@ impl Operator for RandomUniform {
     }
 }
 
+#[derive(Debug)]
+pub struct RandomUniformLike {
+    pub low: f32,
+    pub high: f32,
+
+    /// Random seed. See [RandomUniform::seed].
+    pub seed: Option<f32>,
+}
+
+impl Operator for RandomUniformLike {
+    fn name(&self) -> &str {
+        "RandomUniformLike"
+    }
+
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+        let input = inputs.require(0)?;
+        let op = RandomUniform {
+            low: self.low,
+            high: self.high,
+            seed: self.seed,
+            shape: input.shape().to_vec(),
+        };
+        op.run(pool, InputList::new())
+    }
+}
+
+#[derive(Debug)]
+pub struct RandomNormal {
+    pub mean: f32,
+    pub scale: f32,
+    pub shape: Vec<usize>,
+
+    /// Random seed.
+    ///
+    /// This unusually uses an `f32` value for consistency with the ONNX
+    /// specification.
+    pub seed: Option<f32>,
+}
+
+impl Operator for RandomNormal {
+    fn name(&self) -> &str {
+        "RandomNormal"
+    }
+
+    fn run(&self, pool: &TensorPool, _inputs: InputList) -> Result<Vec<Output>, OpError> {
+        let shape = self.shape.as_slice();
+
+        let mut rng = if let Some(seed) = self.seed {
+            Rng::with_seed(seed.to_bits() as u64)
+        } else {
+            Rng::new()
+        };
+
+        let len = shape.iter().product();
+        let mut data = pool.alloc(len);
+        data.extend(std::iter::from_fn(|| Some(rng.f32_normal(self.mean, self.scale))).take(len));
+
+        Tensor::from_data(shape, data).into_op_result()
+    }
+}
+
+#[derive(Debug)]
+pub struct RandomNormalLike {
+    pub mean: f32,
+    pub scale: f32,
+
+    /// Random seed. See [RandomUniform::seed].
+    pub seed: Option<f32>,
+}
+
+impl Operator for RandomNormalLike {
+    fn name(&self) -> &str {
+        "RandomNormalLike"
+    }
+
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+        let input = inputs.require(0)?;
+        let op = RandomNormal {
+            mean: self.mean,
+            scale: self.scale,
+            seed: self.seed,
+            shape: input.shape().to_vec(),
+        };
+        op.run(pool, InputList::new())
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use std::error::Error;
+
     use rten_tensor::prelude::*;
     use rten_tensor::Tensor;
 
-    use crate::ops::tests::new_pool;
+    use crate::ops::operators::FloatOperators;
+    use crate::ops::tests::{new_pool, run_op};
     use crate::ops::{InputList, Operator};
 
-    use super::RandomUniform;
+    use super::{RandomNormal, RandomNormalLike, RandomUniform, RandomUniformLike};
 
     #[test]
     fn test_random_uniform() {
@@ -151,5 +243,114 @@ mod tests {
                 assert_ne!(output, output_2);
             }
         }
+    }
+
+    #[test]
+    fn test_random_uniform_like() {
+        let input = Tensor::<f32>::zeros(&[5, 5]);
+        let op = RandomUniformLike {
+            low: 0.,
+            high: 2.,
+            seed: None,
+        };
+        let output: Tensor<f32> = run_op(&op, input.view()).unwrap();
+        assert_eq!(output.shape(), &[5, 5]);
+    }
+
+    #[test]
+    fn test_random_normal() -> Result<(), Box<dyn Error>> {
+        struct Case {
+            mean: f32,
+            scale: f32,
+            shape: Vec<usize>,
+            seed: Option<f32>,
+        }
+
+        let cases = [
+            // Default mean/scale values.
+            Case {
+                mean: 0.,
+                scale: 1.,
+                shape: vec![10, 10],
+                seed: None,
+            },
+            // Custom mean/scale values.
+            Case {
+                mean: 5.,
+                scale: 2.,
+                shape: vec![10, 10],
+                seed: None,
+            },
+            // Custom seed
+            Case {
+                mean: 0.,
+                scale: 1.,
+                shape: vec![10, 10],
+                seed: Some(0.5),
+            },
+        ];
+
+        for Case {
+            mean,
+            scale,
+            shape,
+            seed,
+        } in cases
+        {
+            let op = RandomNormal {
+                mean,
+                scale,
+                shape,
+                seed,
+            };
+            let output: Tensor = run_op(&op, InputList::new()).unwrap();
+            assert_eq!(output.shape(), op.shape);
+
+            // Test that outputs have expected distribution.
+            let mean = output
+                .reduce_mean(None, false /* keep_dims */)?
+                .item()
+                .copied()
+                .unwrap();
+            let delta = (mean - op.mean).abs();
+
+            // nb. This threshold is large because we're only generating a small
+            // number of values.
+            let threshold = 0.5;
+            assert!(delta <= threshold, "delta {delta} > {threshold}");
+
+            let var: f32 = output
+                .map(|x| (x - mean) * (x - mean))
+                .reduce_sum(None, false /* keep_dims */)?
+                .item()
+                .unwrap()
+                / output.len() as f32;
+            let std_dev = var.sqrt();
+            let delta = (std_dev - op.scale).abs();
+            assert!(delta <= threshold, "delta {delta} > {threshold}");
+
+            // Test that repeated generation produces the same output if the
+            // seed is fixed, or different output otherwise.
+            let output_2: Tensor = run_op(&op, InputList::new()).unwrap();
+            if let Some(_seed) = seed {
+                assert_eq!(output, output_2);
+            } else {
+                assert_ne!(output, output_2);
+            }
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_random_normal_like() {
+        let input = Tensor::<f32>::zeros(&[5, 5]);
+        let op = RandomNormalLike {
+            mean: 0.,
+            scale: 5.,
+            seed: None,
+        };
+        let output: Tensor<f32> = run_op(&op, input.view()).unwrap();
+        assert_eq!(output.shape(), &[5, 5]);
     }
 }

--- a/src/schema.fbs
+++ b/src/schema.fbs
@@ -107,6 +107,9 @@ enum OperatorType: ubyte {
   ReduceSumSquare,
   RandomUniform,
   Elu,
+  RandomUniformLike,
+  RandomNormal,
+  RandomNormalLike,
 }
 
 enum RNNDirection: ubyte {
@@ -182,6 +185,9 @@ union OperatorAttrs {
   LayerNormalizationAttrs,
   RandomUniformAttrs,
   EluAttrs,
+  RandomUniformLikeAttrs,
+  RandomNormalAttrs,
+  RandomNormalLikeAttrs,
 }
 
 table ArgMaxAttrs {
@@ -316,8 +322,27 @@ table OneHotAttrs {
   axis:int;
 }
 
+table RandomNormalAttrs {
+  mean:float;
+  scale:float;
+  seed:float = null;
+  shape:[uint];
+}
+
+table RandomNormalLikeAttrs {
+  mean:float;
+  scale:float;
+  seed:float = null;
+}
+
 table RandomUniformAttrs {
   shape:[uint];
+  high:float;
+  low:float;
+  seed:float = null;
+}
+
+table RandomUniformLikeAttrs {
   high:float;
   low:float;
   seed:float = null;

--- a/src/schema_generated.rs
+++ b/src/schema_generated.rs
@@ -18,13 +18,13 @@ pub const ENUM_MIN_OPERATOR_TYPE: u8 = 0;
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
-pub const ENUM_MAX_OPERATOR_TYPE: u8 = 96;
+pub const ENUM_MAX_OPERATOR_TYPE: u8 = 99;
 #[deprecated(
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 97] = [
+pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 100] = [
     OperatorType::Add,
     OperatorType::ArgMin,
     OperatorType::ArgMax,
@@ -122,6 +122,9 @@ pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 97] = [
     OperatorType::ReduceSumSquare,
     OperatorType::RandomUniform,
     OperatorType::Elu,
+    OperatorType::RandomUniformLike,
+    OperatorType::RandomNormal,
+    OperatorType::RandomNormalLike,
 ];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -226,9 +229,12 @@ impl OperatorType {
     pub const ReduceSumSquare: Self = Self(94);
     pub const RandomUniform: Self = Self(95);
     pub const Elu: Self = Self(96);
+    pub const RandomUniformLike: Self = Self(97);
+    pub const RandomNormal: Self = Self(98);
+    pub const RandomNormalLike: Self = Self(99);
 
     pub const ENUM_MIN: u8 = 0;
-    pub const ENUM_MAX: u8 = 96;
+    pub const ENUM_MAX: u8 = 99;
     pub const ENUM_VALUES: &'static [Self] = &[
         Self::Add,
         Self::ArgMin,
@@ -327,6 +333,9 @@ impl OperatorType {
         Self::ReduceSumSquare,
         Self::RandomUniform,
         Self::Elu,
+        Self::RandomUniformLike,
+        Self::RandomNormal,
+        Self::RandomNormalLike,
     ];
     /// Returns the variant's name or "" if unknown.
     pub fn variant_name(self) -> Option<&'static str> {
@@ -428,6 +437,9 @@ impl OperatorType {
             Self::ReduceSumSquare => Some("ReduceSumSquare"),
             Self::RandomUniform => Some("RandomUniform"),
             Self::Elu => Some("Elu"),
+            Self::RandomUniformLike => Some("RandomUniformLike"),
+            Self::RandomNormal => Some("RandomNormal"),
+            Self::RandomNormalLike => Some("RandomNormalLike"),
             _ => None,
         }
     }
@@ -1054,13 +1066,13 @@ pub const ENUM_MIN_OPERATOR_ATTRS: u8 = 0;
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
-pub const ENUM_MAX_OPERATOR_ATTRS: u8 = 32;
+pub const ENUM_MAX_OPERATOR_ATTRS: u8 = 35;
 #[deprecated(
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_OPERATOR_ATTRS: [OperatorAttrs; 33] = [
+pub const ENUM_VALUES_OPERATOR_ATTRS: [OperatorAttrs; 36] = [
     OperatorAttrs::NONE,
     OperatorAttrs::ArgMaxAttrs,
     OperatorAttrs::AveragePoolAttrs,
@@ -1094,6 +1106,9 @@ pub const ENUM_VALUES_OPERATOR_ATTRS: [OperatorAttrs; 33] = [
     OperatorAttrs::LayerNormalizationAttrs,
     OperatorAttrs::RandomUniformAttrs,
     OperatorAttrs::EluAttrs,
+    OperatorAttrs::RandomUniformLikeAttrs,
+    OperatorAttrs::RandomNormalAttrs,
+    OperatorAttrs::RandomNormalLikeAttrs,
 ];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -1134,9 +1149,12 @@ impl OperatorAttrs {
     pub const LayerNormalizationAttrs: Self = Self(30);
     pub const RandomUniformAttrs: Self = Self(31);
     pub const EluAttrs: Self = Self(32);
+    pub const RandomUniformLikeAttrs: Self = Self(33);
+    pub const RandomNormalAttrs: Self = Self(34);
+    pub const RandomNormalLikeAttrs: Self = Self(35);
 
     pub const ENUM_MIN: u8 = 0;
-    pub const ENUM_MAX: u8 = 32;
+    pub const ENUM_MAX: u8 = 35;
     pub const ENUM_VALUES: &'static [Self] = &[
         Self::NONE,
         Self::ArgMaxAttrs,
@@ -1171,6 +1189,9 @@ impl OperatorAttrs {
         Self::LayerNormalizationAttrs,
         Self::RandomUniformAttrs,
         Self::EluAttrs,
+        Self::RandomUniformLikeAttrs,
+        Self::RandomNormalAttrs,
+        Self::RandomNormalLikeAttrs,
     ];
     /// Returns the variant's name or "" if unknown.
     pub fn variant_name(self) -> Option<&'static str> {
@@ -1208,6 +1229,9 @@ impl OperatorAttrs {
             Self::LayerNormalizationAttrs => Some("LayerNormalizationAttrs"),
             Self::RandomUniformAttrs => Some("RandomUniformAttrs"),
             Self::EluAttrs => Some("EluAttrs"),
+            Self::RandomUniformLikeAttrs => Some("RandomUniformLikeAttrs"),
+            Self::RandomNormalAttrs => Some("RandomNormalAttrs"),
+            Self::RandomNormalLikeAttrs => Some("RandomNormalLikeAttrs"),
             _ => None,
         }
     }
@@ -4752,6 +4776,332 @@ impl core::fmt::Debug for OneHotAttrs<'_> {
         ds.finish()
     }
 }
+pub enum RandomNormalAttrsOffset {}
+#[derive(Copy, Clone, PartialEq)]
+
+pub struct RandomNormalAttrs<'a> {
+    pub _tab: flatbuffers::Table<'a>,
+}
+
+impl<'a> flatbuffers::Follow<'a> for RandomNormalAttrs<'a> {
+    type Inner = RandomNormalAttrs<'a>;
+    #[inline]
+    unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self {
+            _tab: flatbuffers::Table::new(buf, loc),
+        }
+    }
+}
+
+impl<'a> RandomNormalAttrs<'a> {
+    pub const VT_MEAN: flatbuffers::VOffsetT = 4;
+    pub const VT_SCALE: flatbuffers::VOffsetT = 6;
+    pub const VT_SEED: flatbuffers::VOffsetT = 8;
+    pub const VT_SHAPE: flatbuffers::VOffsetT = 10;
+
+    #[inline]
+    pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+        RandomNormalAttrs { _tab: table }
+    }
+    #[allow(unused_mut)]
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+        args: &'args RandomNormalAttrsArgs<'args>,
+    ) -> flatbuffers::WIPOffset<RandomNormalAttrs<'bldr>> {
+        let mut builder = RandomNormalAttrsBuilder::new(_fbb);
+        if let Some(x) = args.shape {
+            builder.add_shape(x);
+        }
+        if let Some(x) = args.seed {
+            builder.add_seed(x);
+        }
+        builder.add_scale(args.scale);
+        builder.add_mean(args.mean);
+        builder.finish()
+    }
+
+    #[inline]
+    pub fn mean(&self) -> f32 {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab
+                .get::<f32>(RandomNormalAttrs::VT_MEAN, Some(0.0))
+                .unwrap()
+        }
+    }
+    #[inline]
+    pub fn scale(&self) -> f32 {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab
+                .get::<f32>(RandomNormalAttrs::VT_SCALE, Some(0.0))
+                .unwrap()
+        }
+    }
+    #[inline]
+    pub fn seed(&self) -> Option<f32> {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe { self._tab.get::<f32>(RandomNormalAttrs::VT_SEED, None) }
+    }
+    #[inline]
+    pub fn shape(&self) -> Option<flatbuffers::Vector<'a, u32>> {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab
+                .get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u32>>>(
+                    RandomNormalAttrs::VT_SHAPE,
+                    None,
+                )
+        }
+    }
+}
+
+impl flatbuffers::Verifiable for RandomNormalAttrs<'_> {
+    #[inline]
+    fn run_verifier(
+        v: &mut flatbuffers::Verifier,
+        pos: usize,
+    ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+        use self::flatbuffers::Verifiable;
+        v.visit_table(pos)?
+            .visit_field::<f32>("mean", Self::VT_MEAN, false)?
+            .visit_field::<f32>("scale", Self::VT_SCALE, false)?
+            .visit_field::<f32>("seed", Self::VT_SEED, false)?
+            .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, u32>>>(
+                "shape",
+                Self::VT_SHAPE,
+                false,
+            )?
+            .finish();
+        Ok(())
+    }
+}
+pub struct RandomNormalAttrsArgs<'a> {
+    pub mean: f32,
+    pub scale: f32,
+    pub seed: Option<f32>,
+    pub shape: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u32>>>,
+}
+impl<'a> Default for RandomNormalAttrsArgs<'a> {
+    #[inline]
+    fn default() -> Self {
+        RandomNormalAttrsArgs {
+            mean: 0.0,
+            scale: 0.0,
+            seed: None,
+            shape: None,
+        }
+    }
+}
+
+pub struct RandomNormalAttrsBuilder<'a: 'b, 'b> {
+    fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+    start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b> RandomNormalAttrsBuilder<'a, 'b> {
+    #[inline]
+    pub fn add_mean(&mut self, mean: f32) {
+        self.fbb_
+            .push_slot::<f32>(RandomNormalAttrs::VT_MEAN, mean, 0.0);
+    }
+    #[inline]
+    pub fn add_scale(&mut self, scale: f32) {
+        self.fbb_
+            .push_slot::<f32>(RandomNormalAttrs::VT_SCALE, scale, 0.0);
+    }
+    #[inline]
+    pub fn add_seed(&mut self, seed: f32) {
+        self.fbb_
+            .push_slot_always::<f32>(RandomNormalAttrs::VT_SEED, seed);
+    }
+    #[inline]
+    pub fn add_shape(&mut self, shape: flatbuffers::WIPOffset<flatbuffers::Vector<'b, u32>>) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(RandomNormalAttrs::VT_SHAPE, shape);
+    }
+    #[inline]
+    pub fn new(
+        _fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+    ) -> RandomNormalAttrsBuilder<'a, 'b> {
+        let start = _fbb.start_table();
+        RandomNormalAttrsBuilder {
+            fbb_: _fbb,
+            start_: start,
+        }
+    }
+    #[inline]
+    pub fn finish(self) -> flatbuffers::WIPOffset<RandomNormalAttrs<'a>> {
+        let o = self.fbb_.end_table(self.start_);
+        flatbuffers::WIPOffset::new(o.value())
+    }
+}
+
+impl core::fmt::Debug for RandomNormalAttrs<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut ds = f.debug_struct("RandomNormalAttrs");
+        ds.field("mean", &self.mean());
+        ds.field("scale", &self.scale());
+        ds.field("seed", &self.seed());
+        ds.field("shape", &self.shape());
+        ds.finish()
+    }
+}
+pub enum RandomNormalLikeAttrsOffset {}
+#[derive(Copy, Clone, PartialEq)]
+
+pub struct RandomNormalLikeAttrs<'a> {
+    pub _tab: flatbuffers::Table<'a>,
+}
+
+impl<'a> flatbuffers::Follow<'a> for RandomNormalLikeAttrs<'a> {
+    type Inner = RandomNormalLikeAttrs<'a>;
+    #[inline]
+    unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self {
+            _tab: flatbuffers::Table::new(buf, loc),
+        }
+    }
+}
+
+impl<'a> RandomNormalLikeAttrs<'a> {
+    pub const VT_MEAN: flatbuffers::VOffsetT = 4;
+    pub const VT_SCALE: flatbuffers::VOffsetT = 6;
+    pub const VT_SEED: flatbuffers::VOffsetT = 8;
+
+    #[inline]
+    pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+        RandomNormalLikeAttrs { _tab: table }
+    }
+    #[allow(unused_mut)]
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+        args: &'args RandomNormalLikeAttrsArgs,
+    ) -> flatbuffers::WIPOffset<RandomNormalLikeAttrs<'bldr>> {
+        let mut builder = RandomNormalLikeAttrsBuilder::new(_fbb);
+        if let Some(x) = args.seed {
+            builder.add_seed(x);
+        }
+        builder.add_scale(args.scale);
+        builder.add_mean(args.mean);
+        builder.finish()
+    }
+
+    #[inline]
+    pub fn mean(&self) -> f32 {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab
+                .get::<f32>(RandomNormalLikeAttrs::VT_MEAN, Some(0.0))
+                .unwrap()
+        }
+    }
+    #[inline]
+    pub fn scale(&self) -> f32 {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab
+                .get::<f32>(RandomNormalLikeAttrs::VT_SCALE, Some(0.0))
+                .unwrap()
+        }
+    }
+    #[inline]
+    pub fn seed(&self) -> Option<f32> {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe { self._tab.get::<f32>(RandomNormalLikeAttrs::VT_SEED, None) }
+    }
+}
+
+impl flatbuffers::Verifiable for RandomNormalLikeAttrs<'_> {
+    #[inline]
+    fn run_verifier(
+        v: &mut flatbuffers::Verifier,
+        pos: usize,
+    ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+        use self::flatbuffers::Verifiable;
+        v.visit_table(pos)?
+            .visit_field::<f32>("mean", Self::VT_MEAN, false)?
+            .visit_field::<f32>("scale", Self::VT_SCALE, false)?
+            .visit_field::<f32>("seed", Self::VT_SEED, false)?
+            .finish();
+        Ok(())
+    }
+}
+pub struct RandomNormalLikeAttrsArgs {
+    pub mean: f32,
+    pub scale: f32,
+    pub seed: Option<f32>,
+}
+impl<'a> Default for RandomNormalLikeAttrsArgs {
+    #[inline]
+    fn default() -> Self {
+        RandomNormalLikeAttrsArgs {
+            mean: 0.0,
+            scale: 0.0,
+            seed: None,
+        }
+    }
+}
+
+pub struct RandomNormalLikeAttrsBuilder<'a: 'b, 'b> {
+    fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+    start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b> RandomNormalLikeAttrsBuilder<'a, 'b> {
+    #[inline]
+    pub fn add_mean(&mut self, mean: f32) {
+        self.fbb_
+            .push_slot::<f32>(RandomNormalLikeAttrs::VT_MEAN, mean, 0.0);
+    }
+    #[inline]
+    pub fn add_scale(&mut self, scale: f32) {
+        self.fbb_
+            .push_slot::<f32>(RandomNormalLikeAttrs::VT_SCALE, scale, 0.0);
+    }
+    #[inline]
+    pub fn add_seed(&mut self, seed: f32) {
+        self.fbb_
+            .push_slot_always::<f32>(RandomNormalLikeAttrs::VT_SEED, seed);
+    }
+    #[inline]
+    pub fn new(
+        _fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+    ) -> RandomNormalLikeAttrsBuilder<'a, 'b> {
+        let start = _fbb.start_table();
+        RandomNormalLikeAttrsBuilder {
+            fbb_: _fbb,
+            start_: start,
+        }
+    }
+    #[inline]
+    pub fn finish(self) -> flatbuffers::WIPOffset<RandomNormalLikeAttrs<'a>> {
+        let o = self.fbb_.end_table(self.start_);
+        flatbuffers::WIPOffset::new(o.value())
+    }
+}
+
+impl core::fmt::Debug for RandomNormalLikeAttrs<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut ds = f.debug_struct("RandomNormalLikeAttrs");
+        ds.field("mean", &self.mean());
+        ds.field("scale", &self.scale());
+        ds.field("seed", &self.seed());
+        ds.finish()
+    }
+}
 pub enum RandomUniformAttrsOffset {}
 #[derive(Copy, Clone, PartialEq)]
 
@@ -4924,6 +5274,154 @@ impl core::fmt::Debug for RandomUniformAttrs<'_> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let mut ds = f.debug_struct("RandomUniformAttrs");
         ds.field("shape", &self.shape());
+        ds.field("high", &self.high());
+        ds.field("low", &self.low());
+        ds.field("seed", &self.seed());
+        ds.finish()
+    }
+}
+pub enum RandomUniformLikeAttrsOffset {}
+#[derive(Copy, Clone, PartialEq)]
+
+pub struct RandomUniformLikeAttrs<'a> {
+    pub _tab: flatbuffers::Table<'a>,
+}
+
+impl<'a> flatbuffers::Follow<'a> for RandomUniformLikeAttrs<'a> {
+    type Inner = RandomUniformLikeAttrs<'a>;
+    #[inline]
+    unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self {
+            _tab: flatbuffers::Table::new(buf, loc),
+        }
+    }
+}
+
+impl<'a> RandomUniformLikeAttrs<'a> {
+    pub const VT_HIGH: flatbuffers::VOffsetT = 4;
+    pub const VT_LOW: flatbuffers::VOffsetT = 6;
+    pub const VT_SEED: flatbuffers::VOffsetT = 8;
+
+    #[inline]
+    pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+        RandomUniformLikeAttrs { _tab: table }
+    }
+    #[allow(unused_mut)]
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+        args: &'args RandomUniformLikeAttrsArgs,
+    ) -> flatbuffers::WIPOffset<RandomUniformLikeAttrs<'bldr>> {
+        let mut builder = RandomUniformLikeAttrsBuilder::new(_fbb);
+        if let Some(x) = args.seed {
+            builder.add_seed(x);
+        }
+        builder.add_low(args.low);
+        builder.add_high(args.high);
+        builder.finish()
+    }
+
+    #[inline]
+    pub fn high(&self) -> f32 {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab
+                .get::<f32>(RandomUniformLikeAttrs::VT_HIGH, Some(0.0))
+                .unwrap()
+        }
+    }
+    #[inline]
+    pub fn low(&self) -> f32 {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab
+                .get::<f32>(RandomUniformLikeAttrs::VT_LOW, Some(0.0))
+                .unwrap()
+        }
+    }
+    #[inline]
+    pub fn seed(&self) -> Option<f32> {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe { self._tab.get::<f32>(RandomUniformLikeAttrs::VT_SEED, None) }
+    }
+}
+
+impl flatbuffers::Verifiable for RandomUniformLikeAttrs<'_> {
+    #[inline]
+    fn run_verifier(
+        v: &mut flatbuffers::Verifier,
+        pos: usize,
+    ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+        use self::flatbuffers::Verifiable;
+        v.visit_table(pos)?
+            .visit_field::<f32>("high", Self::VT_HIGH, false)?
+            .visit_field::<f32>("low", Self::VT_LOW, false)?
+            .visit_field::<f32>("seed", Self::VT_SEED, false)?
+            .finish();
+        Ok(())
+    }
+}
+pub struct RandomUniformLikeAttrsArgs {
+    pub high: f32,
+    pub low: f32,
+    pub seed: Option<f32>,
+}
+impl<'a> Default for RandomUniformLikeAttrsArgs {
+    #[inline]
+    fn default() -> Self {
+        RandomUniformLikeAttrsArgs {
+            high: 0.0,
+            low: 0.0,
+            seed: None,
+        }
+    }
+}
+
+pub struct RandomUniformLikeAttrsBuilder<'a: 'b, 'b> {
+    fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+    start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b> RandomUniformLikeAttrsBuilder<'a, 'b> {
+    #[inline]
+    pub fn add_high(&mut self, high: f32) {
+        self.fbb_
+            .push_slot::<f32>(RandomUniformLikeAttrs::VT_HIGH, high, 0.0);
+    }
+    #[inline]
+    pub fn add_low(&mut self, low: f32) {
+        self.fbb_
+            .push_slot::<f32>(RandomUniformLikeAttrs::VT_LOW, low, 0.0);
+    }
+    #[inline]
+    pub fn add_seed(&mut self, seed: f32) {
+        self.fbb_
+            .push_slot_always::<f32>(RandomUniformLikeAttrs::VT_SEED, seed);
+    }
+    #[inline]
+    pub fn new(
+        _fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+    ) -> RandomUniformLikeAttrsBuilder<'a, 'b> {
+        let start = _fbb.start_table();
+        RandomUniformLikeAttrsBuilder {
+            fbb_: _fbb,
+            start_: start,
+        }
+    }
+    #[inline]
+    pub fn finish(self) -> flatbuffers::WIPOffset<RandomUniformLikeAttrs<'a>> {
+        let o = self.fbb_.end_table(self.start_);
+        flatbuffers::WIPOffset::new(o.value())
+    }
+}
+
+impl core::fmt::Debug for RandomUniformLikeAttrs<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut ds = f.debug_struct("RandomUniformLikeAttrs");
         ds.field("high", &self.high());
         ds.field("low", &self.low());
         ds.field("seed", &self.seed());
@@ -6705,6 +7203,51 @@ impl<'a> OperatorNode<'a> {
             None
         }
     }
+
+    #[inline]
+    #[allow(non_snake_case)]
+    pub fn attrs_as_random_uniform_like_attrs(&self) -> Option<RandomUniformLikeAttrs<'a>> {
+        if self.attrs_type() == OperatorAttrs::RandomUniformLikeAttrs {
+            self.attrs().map(|t| {
+                // Safety:
+                // Created from a valid Table for this object
+                // Which contains a valid union in this slot
+                unsafe { RandomUniformLikeAttrs::init_from_table(t) }
+            })
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    #[allow(non_snake_case)]
+    pub fn attrs_as_random_normal_attrs(&self) -> Option<RandomNormalAttrs<'a>> {
+        if self.attrs_type() == OperatorAttrs::RandomNormalAttrs {
+            self.attrs().map(|t| {
+                // Safety:
+                // Created from a valid Table for this object
+                // Which contains a valid union in this slot
+                unsafe { RandomNormalAttrs::init_from_table(t) }
+            })
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    #[allow(non_snake_case)]
+    pub fn attrs_as_random_normal_like_attrs(&self) -> Option<RandomNormalLikeAttrs<'a>> {
+        if self.attrs_type() == OperatorAttrs::RandomNormalLikeAttrs {
+            self.attrs().map(|t| {
+                // Safety:
+                // Created from a valid Table for this object
+                // Which contains a valid union in this slot
+                unsafe { RandomNormalLikeAttrs::init_from_table(t) }
+            })
+        } else {
+            None
+        }
+    }
 }
 
 impl flatbuffers::Verifiable for OperatorNode<'_> {
@@ -6750,6 +7293,9 @@ impl flatbuffers::Verifiable for OperatorNode<'_> {
           OperatorAttrs::LayerNormalizationAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<LayerNormalizationAttrs>>("OperatorAttrs::LayerNormalizationAttrs", pos),
           OperatorAttrs::RandomUniformAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<RandomUniformAttrs>>("OperatorAttrs::RandomUniformAttrs", pos),
           OperatorAttrs::EluAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<EluAttrs>>("OperatorAttrs::EluAttrs", pos),
+          OperatorAttrs::RandomUniformLikeAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<RandomUniformLikeAttrs>>("OperatorAttrs::RandomUniformLikeAttrs", pos),
+          OperatorAttrs::RandomNormalAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<RandomNormalAttrs>>("OperatorAttrs::RandomNormalAttrs", pos),
+          OperatorAttrs::RandomNormalLikeAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<RandomNormalLikeAttrs>>("OperatorAttrs::RandomNormalLikeAttrs", pos),
           _ => Ok(()),
         }
      })?
@@ -7145,6 +7691,36 @@ impl core::fmt::Debug for OperatorNode<'_> {
             }
             OperatorAttrs::EluAttrs => {
                 if let Some(x) = self.attrs_as_elu_attrs() {
+                    ds.field("attrs", &x)
+                } else {
+                    ds.field(
+                        "attrs",
+                        &"InvalidFlatbuffer: Union discriminant does not match value.",
+                    )
+                }
+            }
+            OperatorAttrs::RandomUniformLikeAttrs => {
+                if let Some(x) = self.attrs_as_random_uniform_like_attrs() {
+                    ds.field("attrs", &x)
+                } else {
+                    ds.field(
+                        "attrs",
+                        &"InvalidFlatbuffer: Union discriminant does not match value.",
+                    )
+                }
+            }
+            OperatorAttrs::RandomNormalAttrs => {
+                if let Some(x) = self.attrs_as_random_normal_attrs() {
+                    ds.field("attrs", &x)
+                } else {
+                    ds.field(
+                        "attrs",
+                        &"InvalidFlatbuffer: Union discriminant does not match value.",
+                    )
+                }
+            }
+            OperatorAttrs::RandomNormalLikeAttrs => {
+                if let Some(x) = self.attrs_as_random_normal_like_attrs() {
                     ds.field("attrs", &x)
                 } else {
                     ds.field(


### PR DESCRIPTION
`RandomNormal` uses the `RngExt::f32_normal` implementation from `fastrand-contrib`, which uses the Box-Muller transform [1] algorithm.

[1] https://en.wikipedia.org/wiki/Box–Muller_transform

**TODO:**

- [x] Actually verify that outputs of `RandomNormal*` ops are approximately normally distributed