### PR TITLE
Refactor operator attribute deserialization

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@ pub mod ctc;
 pub mod ops;
 
 pub use graph::{Dimension, NodeId, RunOptions};
-pub use model::{DefaultOperatorFactory, Model, ModelLoadError, NodeInfo, OpRegistry, ReadOpError};
+pub use model::{Model, ModelLoadError, NodeInfo, OpRegistry, ReadOp, ReadOpError};
 pub use model_metadata::ModelMetadata;
 pub use ops::{FloatOperators, Input, Operators, Output};
 pub use tensor_pool::TensorPool;


### PR DESCRIPTION
Refactor deserialization of operators to reduce boilerplate.

Combine the separate `DefaultOperatorFactory` trait and function for deserializing the `schema_generate::OperatorNode` struct. There is now a single `ReadOp` trait with a method for deserializing an `OperatorNode`.