### PR TITLE
Implement Softplus op

### DIFF
--- a/rten-convert/rten_convert/schema_generated.py
+++ b/rten-convert/rten_convert/schema_generated.py
@@ -107,6 +107,7 @@ class OperatorType(object):
     RandomUniformLike = 97
     RandomNormal = 98
     RandomNormalLike = 99
+    Softplus = 100
 
 
 class RNNDirection(object):

--- a/src/model.rs
+++ b/src/model.rs
@@ -883,6 +883,7 @@ impl_read_op!(Sin);
 impl_read_op!(Size);
 impl_read_op!(Slice);
 impl_read_op!(Softmax, axis, attrs_as_softmax_attrs);
+impl_read_op!(Softplus);
 impl_read_op!(Split, axis, attrs_as_split_attrs);
 impl_read_op!(Sqrt);
 impl_read_op!(Squeeze);
@@ -1074,6 +1075,7 @@ impl OpRegistry {
         register_op!(Size);
         register_op!(Slice);
         register_op!(Softmax);
+        register_op!(Softplus);
         register_op!(Split);
         register_op!(Sqrt);
         register_op!(Squeeze);
@@ -1680,6 +1682,7 @@ mod tests {
         let const_1 = builder.add_int_constant(&Tensor::from_data(&[1], vec![1]));
         add_operator!(Slice, [input_node, const_0, const_1, const_0]);
 
+        add_operator!(Softplus, [input_node]);
         add_operator!(Softmax, [input_node], { axis: 1 });
         add_operator!(Sqrt, [input_node]);
         add_operator!(Squeeze, [input_node]);

--- a/src/model_builder.rs
+++ b/src/model_builder.rs
@@ -107,6 +107,7 @@ pub enum OpType {
     Size,
     Slice,
     Softmax(Softmax),
+    Softplus,
     Split(Split),
     Sqrt,
     Squeeze,
@@ -695,6 +696,7 @@ impl<'a> ModelBuilder<'a> {
                     axis: args.axis as i32,
                 }
             ),
+            OpType::Softplus => op!(Softplus),
             OpType::Split(args) => op_with_attrs!(Split, SplitAttrs, {
                 sg::SplitAttrsArgs {
                     axis: args.axis as i32,

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -100,10 +100,10 @@ pub use unary_elementwise::{
     exp, exp_in_place, floor, floor_in_place, hard_sigmoid, hard_sigmoid_in_place, hard_swish,
     hard_swish_in_place, leaky_relu, leaky_relu_in_place, log, log_in_place, neg, neg_in_place,
     not, not_in_place, reciprocal, reciprocal_in_place, relu, relu_in_place, round, round_in_place,
-    sigmoid, sigmoid_in_place, sign, sign_in_place, sin, sin_in_place, sqrt, sqrt_in_place, tan,
-    tan_in_place, tanh, tanh_in_place, Abs, Acos, Asin, Atan, Ceil, Clip, Cos, Elu, Erf, Exp,
-    Floor, HardSigmoid, HardSwish, LeakyRelu, Log, Neg, Not, Reciprocal, Relu, Round, Sigmoid,
-    Sign, Sin, Sqrt, Tan, Tanh,
+    sigmoid, sigmoid_in_place, sign, sign_in_place, sin, sin_in_place, softplus, softplus_in_place,
+    sqrt, sqrt_in_place, tan, tan_in_place, tanh, tanh_in_place, Abs, Acos, Asin, Atan, Ceil, Clip,
+    Cos, Elu, Erf, Exp, Floor, HardSigmoid, HardSwish, LeakyRelu, Log, Neg, Not, Reciprocal, Relu,
+    Round, Sigmoid, Sign, Sin, Softplus, Sqrt, Tan, Tanh,
 };
 pub use variadic_elementwise::{max, mean, min, sum, Max, Mean, Min, Sum};
 

--- a/src/ops/unary_elementwise.rs
+++ b/src/ops/unary_elementwise.rs
@@ -626,6 +626,9 @@ pub fn sign_in_place<T: Signum>(mut input: TensorViewMut<T>) {
 
 unary_numeric_op!(Sign, sign, sign_in_place);
 unary_float_op!(Sqrt, sqrt, sqrt_in_place, |val: f32| val.sqrt());
+unary_float_op!(Softplus, softplus, softplus_in_place, |val: f32| {
+    val.exp().ln_1p()
+});
 unary_float_op!(Tan, tan, tan_in_place, |val: f32| val.tan());
 parallel_unary_float_op!(
     Tanh,
@@ -651,8 +654,8 @@ mod tests {
         clip_in_place, cos, cos_in_place, elu, elu_in_place, erf, erf_in_place, exp, exp_in_place,
         floor, hard_sigmoid, hard_swish, leaky_relu, leaky_relu_in_place, log, log_in_place, neg,
         neg_in_place, not, not_in_place, reciprocal, relu, relu_in_place, round, round_in_place,
-        sigmoid, sigmoid_in_place, sign, sign_in_place, sin, sin_in_place, sqrt, sqrt_in_place,
-        tan, tan_in_place, tanh, tanh_in_place,
+        sigmoid, sigmoid_in_place, sign, sign_in_place, sin, sin_in_place, softplus,
+        softplus_in_place, sqrt, sqrt_in_place, tan, tan_in_place, tanh, tanh_in_place,
     };
 
     /// Define a test for a simple unary operator which applies the function
@@ -1112,6 +1115,9 @@ mod tests {
 
     test_unary_op!(test_sign, sign, sign_in_place, |x: &f32| x.signum());
     test_unary_op!(test_sin, sin, sin_in_place, |x: &f32| x.sin());
+    test_unary_op!(test_softplus, softplus, softplus_in_place, |x: &f32| {
+        x.exp().ln_1p()
+    });
 
     #[test]
     fn test_sqrt() -> Result<(), Box<dyn Error>> {

--- a/src/schema.fbs
+++ b/src/schema.fbs
@@ -110,6 +110,7 @@ enum OperatorType: ubyte {
   RandomUniformLike,
   RandomNormal,
   RandomNormalLike,
+  Softplus,
 }
 
 enum RNNDirection: ubyte {

--- a/src/schema_generated.rs
+++ b/src/schema_generated.rs
@@ -18,13 +18,13 @@ pub const ENUM_MIN_OPERATOR_TYPE: u8 = 0;
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
-pub const ENUM_MAX_OPERATOR_TYPE: u8 = 99;
+pub const ENUM_MAX_OPERATOR_TYPE: u8 = 100;
 #[deprecated(
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 100] = [
+pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 101] = [
     OperatorType::Add,
     OperatorType::ArgMin,
     OperatorType::ArgMax,
@@ -125,6 +125,7 @@ pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 100] = [
     OperatorType::RandomUniformLike,
     OperatorType::RandomNormal,
     OperatorType::RandomNormalLike,
+    OperatorType::Softplus,
 ];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -232,9 +233,10 @@ impl OperatorType {
     pub const RandomUniformLike: Self = Self(97);
     pub const RandomNormal: Self = Self(98);
     pub const RandomNormalLike: Self = Self(99);
+    pub const Softplus: Self = Self(100);
 
     pub const ENUM_MIN: u8 = 0;
-    pub const ENUM_MAX: u8 = 99;
+    pub const ENUM_MAX: u8 = 100;
     pub const ENUM_VALUES: &'static [Self] = &[
         Self::Add,
         Self::ArgMin,
@@ -336,6 +338,7 @@ impl OperatorType {
         Self::RandomUniformLike,
         Self::RandomNormal,
         Self::RandomNormalLike,
+        Self::Softplus,
     ];
     /// Returns the variant's name or "" if unknown.
     pub fn variant_name(self) -> Option<&'static str> {
@@ -440,6 +443,7 @@ impl OperatorType {
             Self::RandomUniformLike => Some("RandomUniformLike"),
             Self::RandomNormal => Some("RandomNormal"),
             Self::RandomNormalLike => Some("RandomNormalLike"),
+            Self::Softplus => Some("Softplus"),
             _ => None,
         }
     }


### PR DESCRIPTION
The ONNX spec states that the input must be 1D tensor, but that looks like a mistake [1] and the restriction is not implemented here.

The corresponding PyTorch operator [2] reverts to a linear function for inputs above a threshold, but the ONNX spec makes no mention of this and ONNX Runtime doesn't, so that is not implemented here either.

[1] https://github.com/onnx/onnx/issues/2563
[2] https://pytorch.org/docs/stable/generated/torch.nn.Softplus.html