### PR TITLE
Add blanket `IntoStorage` impl for `T: Storage`

### DIFF
--- a/rten-tensor/src/storage.rs
+++ b/rten-tensor/src/storage.rs
@@ -99,7 +99,7 @@ pub trait IntoStorage {
     fn into_storage(self) -> Self::Output;
 }
 
-impl<T> IntoStorage for Vec<T> {
+impl<T: Storage> IntoStorage for T {
     type Output = Self;
 
     fn into_storage(self) -> Self {


### PR DESCRIPTION
This provides the missing `IntoStorage` impl for `Cow<'a, [T]>`, found while updating Ocrs for recent RTen API changes.