### PR TITLE
Revise SIMD traits to make working with masks more ergonomic/efficient

### DIFF
--- a/rten-vecmath/src/simd_vec/aarch64.rs
+++ b/rten-vecmath/src/simd_vec/aarch64.rs
@@ -1,16 +1,26 @@
 use std::arch::aarch64::{
-    float32x4_t, int32x4_t, uint32x4_t, vabsq_f32, vaddq_f32, vaddq_s32, vaddvq_f32, vbslq_f32,
-    vbslq_s32, vceqq_s32, vcgeq_f32, vcgeq_s32, vcgtq_s32, vcleq_f32, vcleq_s32, vcltq_f32,
-    vcltq_s32, vcvtq_s32_f32, vdivq_f32, vdupq_n_f32, vdupq_n_s32, vfmaq_f32, vld1q_f32, vld1q_s32,
-    vmaxq_f32, vmulq_f32, vreinterpretq_f32_s32, vreinterpretq_u32_s32, vshlq_n_s32, vst1q_f32,
-    vst1q_s32, vsubq_f32, vsubq_s32,
+    float32x4_t, int32x4_t, uint32x4_t, vabsq_f32, vaddq_f32, vaddq_s32, vaddvq_f32, vandq_u32,
+    vbslq_f32, vbslq_s32, vceqq_s32, vcgeq_f32, vcgeq_s32, vcgtq_s32, vcleq_f32, vcleq_s32,
+    vcltq_f32, vcltq_s32, vcvtq_s32_f32, vdivq_f32, vdupq_n_f32, vdupq_n_s32, vfmaq_f32, vld1q_f32,
+    vld1q_s32, vmaxq_f32, vmulq_f32, vreinterpretq_f32_s32, vreinterpretq_u32_s32, vshlq_n_s32,
+    vst1q_f32, vst1q_s32, vsubq_f32, vsubq_s32,
 };
 
-use crate::simd_vec::{SimdFloat, SimdInt};
+use crate::simd_vec::{SimdFloat, SimdInt, SimdMask, SimdVal};
+
+impl SimdMask for uint32x4_t {
+    #[inline]
+    unsafe fn and(self, other: Self) -> Self {
+        vandq_u32(self, other)
+    }
+}
+
+impl SimdVal for int32x4_t {
+    type Mask = uint32x4_t;
+}
 
 impl SimdInt for int32x4_t {
     type Float = float32x4_t;
-    type Mask = uint32x4_t;
 
     const LEN: usize = 4;
 
@@ -75,11 +85,6 @@ impl SimdInt for int32x4_t {
     }
 
     #[inline]
-    unsafe fn to_float_mask(self) -> <Self::Float as SimdFloat>::Mask {
-        vreinterpretq_u32_s32(self)
-    }
-
-    #[inline]
     unsafe fn load(ptr: *const i32) -> Self {
         vld1q_s32(ptr)
     }
@@ -90,9 +95,12 @@ impl SimdInt for int32x4_t {
     }
 }
 
+impl SimdVal for float32x4_t {
+    type Mask = uint32x4_t;
+}
+
 impl SimdFloat for float32x4_t {
     type Int = int32x4_t;
-    type Mask = uint32x4_t;
 
     const LEN: usize = 4;
 

--- a/rten-vecmath/src/simd_vec/wasm.rs
+++ b/rten-vecmath/src/simd_vec/wasm.rs
@@ -1,11 +1,11 @@
 use std::arch::wasm32::{
     f32x4_abs, f32x4_add, f32x4_div, f32x4_extract_lane, f32x4_ge, f32x4_le, f32x4_lt, f32x4_max,
     f32x4_mul, f32x4_splat, f32x4_sub, i32x4_add, i32x4_eq, i32x4_ge, i32x4_gt, i32x4_le, i32x4_lt,
-    i32x4_shl, i32x4_shuffle, i32x4_splat, i32x4_sub, i32x4_trunc_sat_f32x4, v128, v128_bitselect,
-    v128_load, v128_store,
+    i32x4_shl, i32x4_shuffle, i32x4_splat, i32x4_sub, i32x4_trunc_sat_f32x4, v128, v128_and,
+    v128_bitselect, v128_load, v128_store,
 };
 
-use crate::simd_vec::{SimdFloat, SimdInt};
+use crate::simd_vec::{SimdFloat, SimdInt, SimdMask, SimdVal};
 
 /// Wrapper around a WASM v128 type that marks it as containing integers.
 #[allow(non_camel_case_types)]
@@ -17,9 +17,19 @@ pub struct v128i(v128);
 #[derive(Copy, Clone, Debug)]
 pub struct v128f(v128);
 
+impl SimdMask for v128i {
+    #[inline]
+    unsafe fn and(self, other: Self) -> Self {
+        Self(v128_and(self.0, other.0))
+    }
+}
+
+impl SimdVal for v128i {
+    type Mask = v128i;
+}
+
 impl SimdInt for v128i {
     type Float = v128f;
-    type Mask = v128i;
 
     const LEN: usize = 4;
 
@@ -79,11 +89,6 @@ impl SimdInt for v128i {
     }
 
     #[inline]
-    unsafe fn to_float_mask(self) -> <Self::Float as SimdFloat>::Mask {
-        self
-    }
-
-    #[inline]
     unsafe fn load(ptr: *const i32) -> Self {
         Self(v128_load(ptr as *const v128))
     }
@@ -94,9 +99,12 @@ impl SimdInt for v128i {
     }
 }
 
+impl SimdVal for v128f {
+    type Mask = v128i;
+}
+
 impl SimdFloat for v128f {
     type Int = v128i;
-    type Mask = v128i;
 
     const LEN: usize = 4;
 


### PR DESCRIPTION
 - Add `SimdMask` trait for common operations on SIMD masks, eg. bitwise AND and OR.

 - Make an assumption that the SIMD mask type is always the same for a particular architecture and lane size. eg. Assume that i32xN and f32xN will use the same mask type. This avoids the need for casting masks.

 - Add `SimdVal` base trait which can house associated types and methods that are common to all SIMD vectors, regardless of element type.

   Initially this just defines the associated mask type, but in future it could also provide operations such as loading and storing values, and bitwise operations.