### PR TITLE
Implement `GatherND` operator

### DIFF
--- a/rten-convert/rten_convert/converter.py
+++ b/rten-convert/rten_convert/converter.py
@@ -715,6 +715,10 @@ def op_node_from_onnx_operator(
             attrs = sg.GatherAttrsT()
             attrs.axis = op_reader.get_attr("axis", "int", 0)
 
+        case "GatherND":
+            attrs = sg.GatherNDAttrsT()
+            attrs.batchDims = op_reader.get_attr("batch_dims", "int", 0)
+
         case "Gemm":
             attrs = sg.GemmAttrsT()
             attrs.alpha = op_reader.get_attr("alpha", "float", 1.0)

--- a/rten-convert/rten_convert/schema_generated.py
+++ b/rten-convert/rten_convert/schema_generated.py
@@ -108,6 +108,7 @@ class OperatorType(object):
     RandomNormal = 98
     RandomNormalLike = 99
     Softplus = 100
+    GatherND = 101
 
 
 class RNNDirection(object):
@@ -181,6 +182,7 @@ class OperatorAttrs(object):
     RandomUniformLikeAttrs = 33
     RandomNormalAttrs = 34
     RandomNormalLikeAttrs = 35
+    GatherNDAttrs = 36
 
 def OperatorAttrsCreator(unionType, table):
     from flatbuffers.table import Table
@@ -256,6 +258,8 @@ def OperatorAttrsCreator(unionType, table):
         return RandomNormalAttrsT.InitFromBuf(table.Bytes, table.Pos)
     if unionType == OperatorAttrs().RandomNormalLikeAttrs:
         return RandomNormalLikeAttrsT.InitFromBuf(table.Bytes, table.Pos)
+    if unionType == OperatorAttrs().GatherNDAttrs:
+        return GatherNDAttrsT.InitFromBuf(table.Bytes, table.Pos)
     return None
 
 
@@ -1830,6 +1834,83 @@ class GatherAttrsT(object):
         GatherAttrsAddAxis(builder, self.axis)
         gatherAttrs = GatherAttrsEnd(builder)
         return gatherAttrs
+
+
+class GatherNDAttrs(object):
+    __slots__ = ['_tab']
+
+    @classmethod
+    def GetRootAs(cls, buf, offset=0):
+        n = flatbuffers.encode.Get(flatbuffers.packer.uoffset, buf, offset)
+        x = GatherNDAttrs()
+        x.Init(buf, n + offset)
+        return x
+
+    @classmethod
+    def GetRootAsGatherNDAttrs(cls, buf, offset=0):
+        """This method is deprecated. Please switch to GetRootAs."""
+        return cls.GetRootAs(buf, offset)
+    @classmethod
+    def GatherNDAttrsBufferHasIdentifier(cls, buf, offset, size_prefixed=False):
+        return flatbuffers.util.BufferHasIdentifier(buf, offset, b"\x52\x54\x45\x4E", size_prefixed=size_prefixed)
+
+    # GatherNDAttrs
+    def Init(self, buf, pos):
+        self._tab = flatbuffers.table.Table(buf, pos)
+
+    # GatherNDAttrs
+    def BatchDims(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
+        if o != 0:
+            return self._tab.Get(flatbuffers.number_types.Int32Flags, o + self._tab.Pos)
+        return 0
+
+def GatherNDAttrsStart(builder):
+    builder.StartObject(1)
+
+def GatherNDAttrsAddBatchDims(builder, batchDims):
+    builder.PrependInt32Slot(0, batchDims, 0)
+
+def GatherNDAttrsEnd(builder):
+    return builder.EndObject()
+
+
+
+class GatherNDAttrsT(object):
+
+    # GatherNDAttrsT
+    def __init__(self):
+        self.batchDims = 0  # type: int
+
+    @classmethod
+    def InitFromBuf(cls, buf, pos):
+        gatherNdattrs = GatherNDAttrs()
+        gatherNdattrs.Init(buf, pos)
+        return cls.InitFromObj(gatherNdattrs)
+
+    @classmethod
+    def InitFromPackedBuf(cls, buf, pos=0):
+        n = flatbuffers.encode.Get(flatbuffers.packer.uoffset, buf, pos)
+        return cls.InitFromBuf(buf, pos+n)
+
+    @classmethod
+    def InitFromObj(cls, gatherNdattrs):
+        x = GatherNDAttrsT()
+        x._UnPack(gatherNdattrs)
+        return x
+
+    # GatherNDAttrsT
+    def _UnPack(self, gatherNdattrs):
+        if gatherNdattrs is None:
+            return
+        self.batchDims = gatherNdattrs.BatchDims()
+
+    # GatherNDAttrsT
+    def Pack(self, builder):
+        GatherNDAttrsStart(builder)
+        GatherNDAttrsAddBatchDims(builder, self.batchDims)
+        gatherNdattrs = GatherNDAttrsEnd(builder)
+        return gatherNdattrs
 
 
 class GemmAttrs(object):
@@ -4366,7 +4447,7 @@ class OperatorNodeT(object):
     def __init__(self):
         self.type = 0  # type: int
         self.attrsType = 0  # type: int
-        self.attrs = None  # type: Union[None, ArgMaxAttrsT, AveragePoolAttrsT, BatchNormalizationAttrsT, CastAttrsT, ConcatAttrsT, ConstantOfShapeAttrsT, ConvAttrsT, ConvTransposeAttrsT, FlattenAttrsT, GatherAttrsT, GemmAttrsT, GRUAttrsT, LeakyReluAttrsT, LSTMAttrsT, MaxPoolAttrsT, ReduceMeanAttrsT, ReshapeAttrsT, ResizeAttrsT, SplitAttrsT, SoftmaxAttrsT, TransposeAttrsT, ModAttrsT, ScatterElementsAttrsT, OneHotAttrsT, TopKAttrsT, HardSigmoidAttrsT, TriluAttrsT, ScatterNDAttrsT, NonMaxSuppressionAttrsT, LayerNormalizationAttrsT, RandomUniformAttrsT, EluAttrsT, RandomUniformLikeAttrsT, RandomNormalAttrsT, RandomNormalLikeAttrsT]
+        self.attrs = None  # type: Union[None, ArgMaxAttrsT, AveragePoolAttrsT, BatchNormalizationAttrsT, CastAttrsT, ConcatAttrsT, ConstantOfShapeAttrsT, ConvAttrsT, ConvTransposeAttrsT, FlattenAttrsT, GatherAttrsT, GemmAttrsT, GRUAttrsT, LeakyReluAttrsT, LSTMAttrsT, MaxPoolAttrsT, ReduceMeanAttrsT, ReshapeAttrsT, ResizeAttrsT, SplitAttrsT, SoftmaxAttrsT, TransposeAttrsT, ModAttrsT, ScatterElementsAttrsT, OneHotAttrsT, TopKAttrsT, HardSigmoidAttrsT, TriluAttrsT, ScatterNDAttrsT, NonMaxSuppressionAttrsT, LayerNormalizationAttrsT, RandomUniformAttrsT, EluAttrsT, RandomUniformLikeAttrsT, RandomNormalAttrsT, RandomNormalLikeAttrsT, GatherNDAttrsT]
         self.inputs = None  # type: List[int]
         self.outputs = None  # type: List[int]
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -618,6 +618,15 @@ impl_read_op!(Flatten, axis, attrs_as_flatten_attrs);
 impl_read_op!(Floor);
 impl_read_op!(Gather, axis, attrs_as_gather_attrs);
 impl_read_op!(GatherElements, axis, attrs_as_gather_attrs);
+impl_read_op!(
+    GatherND,
+    attrs_as_gather_ndattrs,
+    |attrs: sg::GatherNDAttrs| {
+        Ok(ops::GatherND {
+            batch_dims: attrs.batch_dims() as usize,
+        })
+    }
+);
 impl_read_op!(Gemm, attrs_as_gemm_attrs, |attrs: sg::GemmAttrs| {
     Ok(ops::Gemm {
         alpha: attrs.alpha(),
@@ -1010,6 +1019,7 @@ impl OpRegistry {
         register_op!(Floor);
         register_op!(Gather);
         register_op!(GatherElements);
+        register_op!(GatherND);
         register_op!(Gemm);
         register_op!(GlobalAveragePool);
         register_op!(Greater);

--- a/src/model_builder.rs
+++ b/src/model_builder.rs
@@ -5,10 +5,10 @@ use rten_tensor::Tensor;
 use crate::graph::Dimension;
 use crate::ops::{
     ArgMax, ArgMin, AveragePool, BatchNormalization, BoxOrder, Cast, Concat, ConstantOfShape, Conv,
-    ConvTranspose, CoordTransformMode, DataType, Elu, Flatten, Gather, GatherElements, Gemm,
-    HardSigmoid, InstanceNormalization, LayerNormalization, LeakyRelu, LogSoftmax, MaxPool, Mod,
-    NearestMode, NonMaxSuppression, OneHot, Padding, ReduceMax, ReduceMean, ReduceMin, ReduceProd,
-    ReduceSum, ReduceSumSquare, Reshape, Resize, ResizeMode, Scalar, ScatterElements,
+    ConvTranspose, CoordTransformMode, DataType, Elu, Flatten, Gather, GatherElements, GatherND,
+    Gemm, HardSigmoid, InstanceNormalization, LayerNormalization, LeakyRelu, LogSoftmax, MaxPool,
+    Mod, NearestMode, NonMaxSuppression, OneHot, Padding, ReduceMax, ReduceMean, ReduceMin,
+    ReduceProd, ReduceSum, ReduceSumSquare, Reshape, Resize, ResizeMode, Scalar, ScatterElements,
     ScatterReduction, Softmax, Split, TopK, Transpose, Trilu,
 };
 use crate::schema_generated as sg;
@@ -46,6 +46,7 @@ pub enum OpType {
     Floor,
     Gather(Gather),
     GatherElements(GatherElements),
+    GatherND(GatherND),
     Gemm(Gemm),
     GlobalAveragePool,
     Greater,
@@ -466,6 +467,13 @@ impl<'a> ModelBuilder<'a> {
                 GatherAttrs,
                 sg::GatherAttrsArgs {
                     axis: args.axis as i32,
+                }
+            ),
+            OpType::GatherND(args) => op_with_attrs!(
+                GatherND,
+                GatherNDAttrs,
+                sg::GatherNDAttrsArgs {
+                    batch_dims: args.batch_dims as i32,
                 }
             ),
             OpType::Gemm(args) => op_with_attrs!(

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -59,8 +59,8 @@ pub use concat::{concat, tile, Concat, Tile};
 pub use conv::{conv, conv_transpose, Conv, ConvTranspose};
 pub use convert::Cast;
 pub use gather::{
-    gather, gather_elements, scatter_elements, scatter_nd, Gather, GatherElements, ScatterElements,
-    ScatterND, ScatterReduction,
+    gather, gather_elements, gather_nd, scatter_elements, scatter_nd, Gather, GatherElements,
+    GatherND, ScatterElements, ScatterND, ScatterReduction,
 };
 pub use generate::{constant_of_shape, onehot, range, ConstantOfShape, OneHot, Range};
 pub use identity::Identity;

--- a/src/schema.fbs
+++ b/src/schema.fbs
@@ -111,6 +111,7 @@ enum OperatorType: ubyte {
   RandomNormal,
   RandomNormalLike,
   Softplus,
+  GatherND,
 }
 
 enum RNNDirection: ubyte {
@@ -189,6 +190,7 @@ union OperatorAttrs {
   RandomUniformLikeAttrs,
   RandomNormalAttrs,
   RandomNormalLikeAttrs,
+  GatherNDAttrs,
 }
 
 table ArgMaxAttrs {
@@ -267,6 +269,10 @@ table LayerNormalizationAttrs {
 
 table GatherAttrs {
   axis:int;
+}
+
+table GatherNDAttrs {
+  batch_dims:int;
 }
 
 table GemmAttrs {

--- a/src/schema_generated.rs
+++ b/src/schema_generated.rs
@@ -18,13 +18,13 @@ pub const ENUM_MIN_OPERATOR_TYPE: u8 = 0;
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
-pub const ENUM_MAX_OPERATOR_TYPE: u8 = 100;
+pub const ENUM_MAX_OPERATOR_TYPE: u8 = 101;
 #[deprecated(
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 101] = [
+pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 102] = [
     OperatorType::Add,
     OperatorType::ArgMin,
     OperatorType::ArgMax,
@@ -126,6 +126,7 @@ pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 101] = [
     OperatorType::RandomNormal,
     OperatorType::RandomNormalLike,
     OperatorType::Softplus,
+    OperatorType::GatherND,
 ];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -234,9 +235,10 @@ impl OperatorType {
     pub const RandomNormal: Self = Self(98);
     pub const RandomNormalLike: Self = Self(99);
     pub const Softplus: Self = Self(100);
+    pub const GatherND: Self = Self(101);
 
     pub const ENUM_MIN: u8 = 0;
-    pub const ENUM_MAX: u8 = 100;
+    pub const ENUM_MAX: u8 = 101;
     pub const ENUM_VALUES: &'static [Self] = &[
         Self::Add,
         Self::ArgMin,
@@ -339,6 +341,7 @@ impl OperatorType {
         Self::RandomNormal,
         Self::RandomNormalLike,
         Self::Softplus,
+        Self::GatherND,
     ];
     /// Returns the variant's name or "" if unknown.
     pub fn variant_name(self) -> Option<&'static str> {
@@ -444,6 +447,7 @@ impl OperatorType {
             Self::RandomNormal => Some("RandomNormal"),
             Self::RandomNormalLike => Some("RandomNormalLike"),
             Self::Softplus => Some("Softplus"),
+            Self::GatherND => Some("GatherND"),
             _ => None,
         }
     }
@@ -1070,13 +1074,13 @@ pub const ENUM_MIN_OPERATOR_ATTRS: u8 = 0;
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
-pub const ENUM_MAX_OPERATOR_ATTRS: u8 = 35;
+pub const ENUM_MAX_OPERATOR_ATTRS: u8 = 36;
 #[deprecated(
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_OPERATOR_ATTRS: [OperatorAttrs; 36] = [
+pub const ENUM_VALUES_OPERATOR_ATTRS: [OperatorAttrs; 37] = [
     OperatorAttrs::NONE,
     OperatorAttrs::ArgMaxAttrs,
     OperatorAttrs::AveragePoolAttrs,
@@ -1113,6 +1117,7 @@ pub const ENUM_VALUES_OPERATOR_ATTRS: [OperatorAttrs; 36] = [
     OperatorAttrs::RandomUniformLikeAttrs,
     OperatorAttrs::RandomNormalAttrs,
     OperatorAttrs::RandomNormalLikeAttrs,
+    OperatorAttrs::GatherNDAttrs,
 ];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -1156,9 +1161,10 @@ impl OperatorAttrs {
     pub const RandomUniformLikeAttrs: Self = Self(33);
     pub const RandomNormalAttrs: Self = Self(34);
     pub const RandomNormalLikeAttrs: Self = Self(35);
+    pub const GatherNDAttrs: Self = Self(36);
 
     pub const ENUM_MIN: u8 = 0;
-    pub const ENUM_MAX: u8 = 35;
+    pub const ENUM_MAX: u8 = 36;
     pub const ENUM_VALUES: &'static [Self] = &[
         Self::NONE,
         Self::ArgMaxAttrs,
@@ -1196,6 +1202,7 @@ impl OperatorAttrs {
         Self::RandomUniformLikeAttrs,
         Self::RandomNormalAttrs,
         Self::RandomNormalLikeAttrs,
+        Self::GatherNDAttrs,
     ];
     /// Returns the variant's name or "" if unknown.
     pub fn variant_name(self) -> Option<&'static str> {
@@ -1236,6 +1243,7 @@ impl OperatorAttrs {
             Self::RandomUniformLikeAttrs => Some("RandomUniformLikeAttrs"),
             Self::RandomNormalAttrs => Some("RandomNormalAttrs"),
             Self::RandomNormalLikeAttrs => Some("RandomNormalLikeAttrs"),
+            Self::GatherNDAttrs => Some("GatherNDAttrs"),
             _ => None,
         }
     }
@@ -3591,6 +3599,108 @@ impl core::fmt::Debug for GatherAttrs<'_> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let mut ds = f.debug_struct("GatherAttrs");
         ds.field("axis", &self.axis());
+        ds.finish()
+    }
+}
+pub enum GatherNDAttrsOffset {}
+#[derive(Copy, Clone, PartialEq)]
+
+pub struct GatherNDAttrs<'a> {
+    pub _tab: flatbuffers::Table<'a>,
+}
+
+impl<'a> flatbuffers::Follow<'a> for GatherNDAttrs<'a> {
+    type Inner = GatherNDAttrs<'a>;
+    #[inline]
+    unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self {
+            _tab: flatbuffers::Table::new(buf, loc),
+        }
+    }
+}
+
+impl<'a> GatherNDAttrs<'a> {
+    pub const VT_BATCH_DIMS: flatbuffers::VOffsetT = 4;
+
+    #[inline]
+    pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+        GatherNDAttrs { _tab: table }
+    }
+    #[allow(unused_mut)]
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr>,
+        args: &'args GatherNDAttrsArgs,
+    ) -> flatbuffers::WIPOffset<GatherNDAttrs<'bldr>> {
+        let mut builder = GatherNDAttrsBuilder::new(_fbb);
+        builder.add_batch_dims(args.batch_dims);
+        builder.finish()
+    }
+
+    #[inline]
+    pub fn batch_dims(&self) -> i32 {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab
+                .get::<i32>(GatherNDAttrs::VT_BATCH_DIMS, Some(0))
+                .unwrap()
+        }
+    }
+}
+
+impl flatbuffers::Verifiable for GatherNDAttrs<'_> {
+    #[inline]
+    fn run_verifier(
+        v: &mut flatbuffers::Verifier,
+        pos: usize,
+    ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+        use self::flatbuffers::Verifiable;
+        v.visit_table(pos)?
+            .visit_field::<i32>("batch_dims", Self::VT_BATCH_DIMS, false)?
+            .finish();
+        Ok(())
+    }
+}
+pub struct GatherNDAttrsArgs {
+    pub batch_dims: i32,
+}
+impl<'a> Default for GatherNDAttrsArgs {
+    #[inline]
+    fn default() -> Self {
+        GatherNDAttrsArgs { batch_dims: 0 }
+    }
+}
+
+pub struct GatherNDAttrsBuilder<'a: 'b, 'b> {
+    fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a>,
+    start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b> GatherNDAttrsBuilder<'a, 'b> {
+    #[inline]
+    pub fn add_batch_dims(&mut self, batch_dims: i32) {
+        self.fbb_
+            .push_slot::<i32>(GatherNDAttrs::VT_BATCH_DIMS, batch_dims, 0);
+    }
+    #[inline]
+    pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a>) -> GatherNDAttrsBuilder<'a, 'b> {
+        let start = _fbb.start_table();
+        GatherNDAttrsBuilder {
+            fbb_: _fbb,
+            start_: start,
+        }
+    }
+    #[inline]
+    pub fn finish(self) -> flatbuffers::WIPOffset<GatherNDAttrs<'a>> {
+        let o = self.fbb_.end_table(self.start_);
+        flatbuffers::WIPOffset::new(o.value())
+    }
+}
+
+impl core::fmt::Debug for GatherNDAttrs<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut ds = f.debug_struct("GatherNDAttrs");
+        ds.field("batch_dims", &self.batch_dims());
         ds.finish()
     }
 }
@@ -7252,6 +7362,21 @@ impl<'a> OperatorNode<'a> {
             None
         }
     }
+
+    #[inline]
+    #[allow(non_snake_case)]
+    pub fn attrs_as_gather_ndattrs(&self) -> Option<GatherNDAttrs<'a>> {
+        if self.attrs_type() == OperatorAttrs::GatherNDAttrs {
+            self.attrs().map(|t| {
+                // Safety:
+                // Created from a valid Table for this object
+                // Which contains a valid union in this slot
+                unsafe { GatherNDAttrs::init_from_table(t) }
+            })
+        } else {
+            None
+        }
+    }
 }
 
 impl flatbuffers::Verifiable for OperatorNode<'_> {
@@ -7300,6 +7425,7 @@ impl flatbuffers::Verifiable for OperatorNode<'_> {
           OperatorAttrs::RandomUniformLikeAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<RandomUniformLikeAttrs>>("OperatorAttrs::RandomUniformLikeAttrs", pos),
           OperatorAttrs::RandomNormalAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<RandomNormalAttrs>>("OperatorAttrs::RandomNormalAttrs", pos),
           OperatorAttrs::RandomNormalLikeAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<RandomNormalLikeAttrs>>("OperatorAttrs::RandomNormalLikeAttrs", pos),
+          OperatorAttrs::GatherNDAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<GatherNDAttrs>>("OperatorAttrs::GatherNDAttrs", pos),
           _ => Ok(()),
         }
      })?
@@ -7725,6 +7851,16 @@ impl core::fmt::Debug for OperatorNode<'_> {
             }
             OperatorAttrs::RandomNormalLikeAttrs => {
                 if let Some(x) = self.attrs_as_random_normal_like_attrs() {
+                    ds.field("attrs", &x)
+                } else {
+                    ds.field(
+                        "attrs",
+                        &"InvalidFlatbuffer: Union discriminant does not match value.",
+                    )
+                }
+            }
+            OperatorAttrs::GatherNDAttrs => {
+                if let Some(x) = self.attrs_as_gather_ndattrs() {
                     ds.field("attrs", &x)
                 } else {
                     ds.field(


### PR DESCRIPTION
Add an unoptimized `GatherND` implementation, along with some new `TensorBase` methods to support the implementation.

This is one of three changes needed to run Piper TTS models, the others being support for 1D ConvTranspose with padding, and bug fixes for `ScatterND`.

**TODO:**

- [x] Review code for obvious easy performance improvements