### PR TITLE
Support padding and 3D (NCW) inputs for `ConvTranspose` op

### DIFF
--- a/rten-convert/rten_convert/converter.py
+++ b/rten-convert/rten_convert/converter.py
@@ -689,7 +689,6 @@ def op_node_from_onnx_operator(
             attrs = sg.ConvTransposeAttrsT()
             attrs.strides = read_strides(op_reader)
 
-            op_reader.check_attr("auto_pad", "string", "NOTSET")
             op_reader.check_attr("dilations", "ints", ([1], [1, 1]))
             op_reader.check_attr("group", "int", 1)
 
@@ -697,7 +696,13 @@ def op_node_from_onnx_operator(
             op_reader.ignore_attr("kernel_shape")
 
             op_reader.check_attr("output_padding", "ints", [0, 0, 0, 0])
-            op_reader.check_attr("pads", "ints", [0, 0, 0, 0])
+
+            pad_mode, pads = read_pads(op_reader)
+            if pad_mode == "same":
+                attrs.padMode = sg.PadMode.Same
+            else:
+                attrs.padMode = sg.PadMode.Fixed
+                attrs.pads = pads
 
         case "CumSum":
             op_reader.check_attr("exclusive", "int", 0)

--- a/src/model_builder.rs
+++ b/src/model_builder.rs
@@ -435,8 +435,14 @@ impl<'a> ModelBuilder<'a> {
                 }
             }),
             OpType::ConvTranspose(args) => op_with_attrs!(ConvTranspose, ConvTransposeAttrs, {
-                let strides = self.create_vec(Some(args.strides.into()), |s| s as u32);
-                sg::ConvTransposeAttrsArgs { strides }
+                let pad_args = pad_args_from_padding(args.padding);
+                let pads = self.create_vec(pad_args.pads, |pad| pad as u32);
+                let strides = self.create_vec(Some(args.strides), |s| s as u32);
+                sg::ConvTransposeAttrsArgs {
+                    strides,
+                    pad_mode: pad_args.pad_mode,
+                    pads,
+                }
             }),
             OpType::Cos => op!(Cos),
             OpType::Div => op!(Div),

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -126,6 +126,24 @@ pub enum Padding {
     Fixed(SmallVec<[usize; 4]>),
 }
 
+impl Padding {
+    /// Return fixed zero padding for an N-dimensional shape.
+    pub fn zero<const N: usize>() -> Padding {
+        Padding::Fixed(SmallVec::from_elem(0, N * 2))
+    }
+
+    /// Expand padding for a 1D operation to 2D.
+    pub fn expand_1d_to_2d(&self) -> Result<Padding, OpError> {
+        match self {
+            Padding::Same => Ok(Padding::Same),
+            Padding::Fixed(pads) => match pads.as_slice() {
+                &[pad_start, pad_end] => Ok([0, pad_start, 0, pad_end].into()),
+                _ => Err(OpError::InvalidValue("expected 2 pad values")),
+            },
+        }
+    }
+}
+
 /// Construct a [Padding::Fixed] from a slice of paddings for each size.
 impl<S: AsRef<[usize]>> From<S> for Padding {
     fn from(val: S) -> Padding {

--- a/src/schema.fbs
+++ b/src/schema.fbs
@@ -242,7 +242,7 @@ table ConstantOfShapeAttrs {
 table ConvAttrs {
   pad_mode:PadMode;
 
-  // Padding for spatial axes as [top, left, bottom, right]
+  // Padding for spatial axes as [left, right] or [top, left, bottom, right]
   pads:[uint];
 
   groups:uint;
@@ -252,6 +252,11 @@ table ConvAttrs {
 
 table ConvTransposeAttrs {
   strides:[uint];
+
+  pad_mode:PadMode;
+
+  // Padding for spatial axes as [left, right] or [top, left, bottom, right]
+  pads:[uint];
 }
 
 table EluAttrs {

--- a/src/schema_generated.rs
+++ b/src/schema_generated.rs
@@ -3086,6 +3086,8 @@ impl<'a> flatbuffers::Follow<'a> for ConvTransposeAttrs<'a> {
 
 impl<'a> ConvTransposeAttrs<'a> {
     pub const VT_STRIDES: flatbuffers::VOffsetT = 4;
+    pub const VT_PAD_MODE: flatbuffers::VOffsetT = 6;
+    pub const VT_PADS: flatbuffers::VOffsetT = 8;
 
     #[inline]
     pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
@@ -3097,9 +3099,13 @@ impl<'a> ConvTransposeAttrs<'a> {
         args: &'args ConvTransposeAttrsArgs<'args>,
     ) -> flatbuffers::WIPOffset<ConvTransposeAttrs<'bldr>> {
         let mut builder = ConvTransposeAttrsBuilder::new(_fbb);
+        if let Some(x) = args.pads {
+            builder.add_pads(x);
+        }
         if let Some(x) = args.strides {
             builder.add_strides(x);
         }
+        builder.add_pad_mode(args.pad_mode);
         builder.finish()
     }
 
@@ -3112,6 +3118,30 @@ impl<'a> ConvTransposeAttrs<'a> {
             self._tab
                 .get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u32>>>(
                     ConvTransposeAttrs::VT_STRIDES,
+                    None,
+                )
+        }
+    }
+    #[inline]
+    pub fn pad_mode(&self) -> PadMode {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab
+                .get::<PadMode>(ConvTransposeAttrs::VT_PAD_MODE, Some(PadMode::Same))
+                .unwrap()
+        }
+    }
+    #[inline]
+    pub fn pads(&self) -> Option<flatbuffers::Vector<'a, u32>> {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab
+                .get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u32>>>(
+                    ConvTransposeAttrs::VT_PADS,
                     None,
                 )
         }
@@ -3131,17 +3161,29 @@ impl flatbuffers::Verifiable for ConvTransposeAttrs<'_> {
                 Self::VT_STRIDES,
                 false,
             )?
+            .visit_field::<PadMode>("pad_mode", Self::VT_PAD_MODE, false)?
+            .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, u32>>>(
+                "pads",
+                Self::VT_PADS,
+                false,
+            )?
             .finish();
         Ok(())
     }
 }
 pub struct ConvTransposeAttrsArgs<'a> {
     pub strides: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u32>>>,
+    pub pad_mode: PadMode,
+    pub pads: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u32>>>,
 }
 impl<'a> Default for ConvTransposeAttrsArgs<'a> {
     #[inline]
     fn default() -> Self {
-        ConvTransposeAttrsArgs { strides: None }
+        ConvTransposeAttrsArgs {
+            strides: None,
+            pad_mode: PadMode::Same,
+            pads: None,
+        }
     }
 }
 
@@ -3154,6 +3196,16 @@ impl<'a: 'b, 'b> ConvTransposeAttrsBuilder<'a, 'b> {
     pub fn add_strides(&mut self, strides: flatbuffers::WIPOffset<flatbuffers::Vector<'b, u32>>) {
         self.fbb_
             .push_slot_always::<flatbuffers::WIPOffset<_>>(ConvTransposeAttrs::VT_STRIDES, strides);
+    }
+    #[inline]
+    pub fn add_pad_mode(&mut self, pad_mode: PadMode) {
+        self.fbb_
+            .push_slot::<PadMode>(ConvTransposeAttrs::VT_PAD_MODE, pad_mode, PadMode::Same);
+    }
+    #[inline]
+    pub fn add_pads(&mut self, pads: flatbuffers::WIPOffset<flatbuffers::Vector<'b, u32>>) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(ConvTransposeAttrs::VT_PADS, pads);
     }
     #[inline]
     pub fn new(
@@ -3176,6 +3228,8 @@ impl core::fmt::Debug for ConvTransposeAttrs<'_> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let mut ds = f.debug_struct("ConvTransposeAttrs");
         ds.field("strides", &self.strides());
+        ds.field("pad_mode", &self.pad_mode());
+        ds.field("pads", &self.pads());
         ds.finish()
     }
 }


### PR DESCRIPTION
 - 1D ConvTranspose is handled the same way as for Conv, by inserting a dummy 1-sized height dimension, performing a 2D ConvTranspose and removing it afterwards.
 - Padding for ConvTranspose has the effect of removing rows and columns from the output. This is handled by the col2im transform.

This is one of three changes needed to support Piper TTS models. See https://github.com/robertknight/rten/pull/155.