### PR TITLE
Fix backwards compatibility of `ConvTranspose` deserialization

### DIFF
--- a/rten-convert/rten_convert/schema_generated.py
+++ b/rten-convert/rten_convert/schema_generated.py
@@ -1450,7 +1450,7 @@ class ConvTransposeAttrs(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(6))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Uint8Flags, o + self._tab.Pos)
-        return 0
+        return 1
 
     # ConvTransposeAttrs
     def Pads(self, j):
@@ -1489,7 +1489,7 @@ def ConvTransposeAttrsStartStridesVector(builder, numElems):
     return builder.StartVector(4, numElems, 4)
 
 def ConvTransposeAttrsAddPadMode(builder, padMode):
-    builder.PrependUint8Slot(1, padMode, 0)
+    builder.PrependUint8Slot(1, padMode, 1)
 
 def ConvTransposeAttrsAddPads(builder, pads):
     builder.PrependUOffsetTRelativeSlot(2, flatbuffers.number_types.UOffsetTFlags.py_type(pads), 0)
@@ -1511,7 +1511,7 @@ class ConvTransposeAttrsT(object):
     # ConvTransposeAttrsT
     def __init__(self):
         self.strides = None  # type: List[int]
-        self.padMode = 0  # type: int
+        self.padMode = 1  # type: int
         self.pads = None  # type: List[int]
 
     @classmethod

--- a/src/schema.fbs
+++ b/src/schema.fbs
@@ -253,7 +253,8 @@ table ConvAttrs {
 table ConvTransposeAttrs {
   strides:[uint];
 
-  pad_mode:PadMode;
+  // Defaults to `Fixed` for backwards compatibility.
+  pad_mode:PadMode = Fixed;
 
   // Padding for spatial axes as [left, right] or [top, left, bottom, right]
   pads:[uint];

--- a/src/schema_generated.rs
+++ b/src/schema_generated.rs
@@ -3129,7 +3129,7 @@ impl<'a> ConvTransposeAttrs<'a> {
         // which contains a valid value in this slot
         unsafe {
             self._tab
-                .get::<PadMode>(ConvTransposeAttrs::VT_PAD_MODE, Some(PadMode::Same))
+                .get::<PadMode>(ConvTransposeAttrs::VT_PAD_MODE, Some(PadMode::Fixed))
                 .unwrap()
         }
     }
@@ -3181,7 +3181,7 @@ impl<'a> Default for ConvTransposeAttrsArgs<'a> {
     fn default() -> Self {
         ConvTransposeAttrsArgs {
             strides: None,
-            pad_mode: PadMode::Same,
+            pad_mode: PadMode::Fixed,
             pads: None,
         }
     }
@@ -3200,7 +3200,7 @@ impl<'a: 'b, 'b> ConvTransposeAttrsBuilder<'a, 'b> {
     #[inline]
     pub fn add_pad_mode(&mut self, pad_mode: PadMode) {
         self.fbb_
-            .push_slot::<PadMode>(ConvTransposeAttrs::VT_PAD_MODE, pad_mode, PadMode::Same);
+            .push_slot::<PadMode>(ConvTransposeAttrs::VT_PAD_MODE, pad_mode, PadMode::Fixed);
     }
     #[inline]
     pub fn add_pads(&mut self, pads: flatbuffers::WIPOffset<flatbuffers::Vector<'b, u32>>) {


### PR DESCRIPTION
The default value of the `PadMode` enum is `Same`, so we need to override that to `Fixed` in `ConvTransposeAttrs` to preserve existing behavior in models converted before the `pad_mode` attr was added.

This is unfortunately a rather easy mistake to make. An alternative option would be to default `pad_mode` to `null`, which will map to `Option<PadMode>` in Rust.