### PR TITLE
Optimize im2col - avoid redundant zeroing of packing buffer, improve lookup table construction

### DIFF
--- a/src/ops/conv/im2col.rs
+++ b/src/ops/conv/im2col.rs
@@ -12,13 +12,13 @@ use crate::ops::pooling::calc_output_size_and_padding;
 use crate::ops::Padding;
 
 struct RowOffsets {
-    /// Map of channel index to `channel * channel_stride`.
+    /// Map of row index to `channel * channel_stride`.
     chan: Vec<i32>,
 
     /// Map of row index to `row * row_stride`.
     y: Vec<i32>,
 
-    /// Map of col index to `col * col_stride`.
+    /// Map of row index to `col * col_stride`.
     x: Vec<i32>,
 }
 


### PR DESCRIPTION
This adds a couple of further optimizations for im2col:

- Avoid redundant zeroing.

   If the packing buffer needed for im2col operations needs to be resized, avoid zeroing it, since the packing code will overwrite all elements.

   As part of this change, change the callers of the packing functions in `gemm.rs` to always pass an output slice of exactly the correct size, avoiding the need for each packing function to zero unused space at the end, in order to fulfill the contract that the entire slice is initialized after the packing code returns. Previously gemm.rs would always pass an output slice of the same size for every block to be packed. However the last row/column block may be smaller, with unused space at the end.
- Improve efficiency of lookup table construction in `VirtualIm2Col::new`. See commit for details. But in short, avoid divisions where possible.

On the first item, In the Piper models, convolutions get called with progressively larger input images as you get into the deeper layers. I noticed a stall of ~12 ms or so about two-thirds of the way through evaluation, while a packing buffer was resized and zeroed in several threads. Avoiding the zeroing saves maybe 3-4ms. It would be even better if the buffer was just allocated with the largest size it will need at the start though.
