### PR TITLE
Optimize `TensorBase::copy_from` for non-contiguous `self`

### DIFF
--- a/rten-tensor/src/lib.rs
+++ b/rten-tensor/src/lib.rs
@@ -40,6 +40,7 @@
 //! }
 //! ```
 
+mod copy;
 mod errors;
 mod index_iterator;
 mod iterators;
@@ -49,7 +50,6 @@ mod overlap;
 mod slice_range;
 mod storage;
 mod tensor;
-mod transpose;
 
 /// Trait for sources of random data for tensors, for use with [Tensor::rand].
 pub trait RandomSource<T> {


### PR DESCRIPTION
Replace the slow iterator-based fallback in `TensorBase::copy_from` with a much faster version which uses nested loops over the innermost 4 dimensions.

This reduces time in the `Pad` operator from ~4.5ms to ~0.8ms in Piper TTS models. That operator used the fallback because it creates a non-contiguous view of the non-padded region into which it copies the source.