### PR TITLE
Improve `Slice` op efficiency

### DIFF
--- a/rten-tensor/src/copy.rs
+++ b/rten-tensor/src/copy.rs
@@ -195,6 +195,8 @@ pub fn copy_into<T: Clone>(mut src: TensorView<T>, mut dest: TensorViewMut<T>) {
                 for i1 in 0..src.size(1) {
                     for i2 in 0..src.size(2) {
                         for i3 in 0..src.size(3) {
+                            // Safety: `dest` and `src` have the same shape,
+                            // and i0..i3 are in `[0, src.size(i))`.
                             unsafe {
                                 *dest.get_unchecked_mut([i0, i1, i2, i3]) =
                                     src.get_unchecked([i0, i1, i2, i3]).clone();

--- a/rten-tensor/src/copy.rs
+++ b/rten-tensor/src/copy.rs
@@ -1,6 +1,9 @@
 use std::mem::MaybeUninit;
 use std::ops::Range;
 
+use smallvec::SmallVec;
+
+use crate::slice_range::{IndexRange, SliceItem};
 use crate::{AsView, Layout};
 use crate::{
     Matrix, MatrixLayout, MatrixMut, NdTensorView, NdTensorViewMut, TensorView, TensorViewMut,
@@ -203,11 +206,92 @@ pub fn copy_into<T: Clone>(mut src: TensorView<T>, mut dest: TensorViewMut<T>) {
         });
 }
 
+/// Copy a slice of `src` specified by `ranges` into `dest` in contiguous order.
+pub fn copy_range_into_slice<T: Clone>(
+    mut src: TensorView<T>,
+    dest: &mut [MaybeUninit<T>],
+    ranges: &[SliceItem],
+) {
+    assert!(ranges.len() <= src.ndim());
+
+    // Pad shape to at least 4 dims.
+    let mut added_dims = 0;
+    while src.ndim() < 4 {
+        src.insert_axis(0);
+        added_dims += 1;
+    }
+
+    // Resolve slice ranges to stepped index ranges over source view.
+    let index_ranges: SmallVec<[IndexRange; 4]> = src
+        .shape()
+        .iter()
+        .enumerate()
+        .map(|(i, &size)| {
+            if i < added_dims {
+                SliceItem::Index(0).index_range(size)
+            } else {
+                let full_range = SliceItem::full_range();
+                let range = ranges.get(i - added_dims).unwrap_or(&full_range);
+                range.index_range(size)
+            }
+        })
+        .collect();
+
+    copy_range_into_slice_inner(src, dest, &index_ranges);
+}
+
+fn copy_range_into_slice_inner<T: Clone>(
+    src: TensorView<T>,
+    mut dest: &mut [MaybeUninit<T>],
+    ranges: &[IndexRange],
+) {
+    assert!(ranges.len() >= 4);
+
+    if ranges.len() == 4 {
+        // Iterate over innermost 4 dims. This uses static-rank views and
+        // nested loops for efficiency.
+
+        let src = src.nd_view::<4>();
+        let ranges: [IndexRange; 4] = ranges.try_into().unwrap();
+
+        // Check output length is correct.
+        let sliced_len = ranges.iter().map(|s| s.steps()).product();
+        assert_eq!(dest.len(), sliced_len, "output too short");
+
+        let mut dest_offset = 0;
+        for i0 in ranges[0] {
+            for i1 in ranges[1] {
+                for i2 in ranges[2] {
+                    for i3 in ranges[3] {
+                        // Safety: We checked dest offset is < length product
+                        // of `index_ranges` iterators.
+                        unsafe {
+                            dest.get_unchecked_mut(dest_offset)
+                                .write(src.get_unchecked([i0, i1, i2, i3]).clone());
+                        }
+                        dest_offset += 1;
+                    }
+                }
+            }
+        }
+    } else {
+        // Iterate over views of outermost dimension and recurse.
+        for i0 in ranges[0] {
+            let src_slice = src.slice_dyn(i0);
+            let (dest_slice, dest_tail) = dest.split_at_mut(src_slice.len());
+
+            copy_range_into_slice_inner(src_slice, dest_slice, &ranges[1..]);
+
+            dest = dest_tail;
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{copy_into, copy_into_slice};
+    use super::{copy_into, copy_into_slice, copy_range_into_slice};
     use crate::rng::XorShiftRng;
-    use crate::{AsView, Layout, Tensor, TensorView};
+    use crate::{AsView, Layout, NdTensor, SliceItem, Tensor, TensorView};
 
     /// Return the elements of `src` as a contiguous vector, in the same order they
     /// would be yielded by `src.iter()`.
@@ -268,5 +352,75 @@ mod tests {
             let expected = x.transposed().iter().copied().collect::<Vec<_>>();
             assert_eq!(transposed, expected);
         }
+    }
+
+    #[test]
+    fn test_copy_range_into_slice() {
+        struct Case<'a> {
+            tensor: Tensor<i32>,
+            range: &'a [SliceItem],
+            expected: Vec<i32>,
+        }
+
+        let cases = [
+            // <= 4 dims
+            Case {
+                tensor: Tensor::arange(0, 16, None).into_shape([4, 4].as_slice()),
+                range: &[
+                    // Every other row, in order
+                    SliceItem::range(0, Some(5), 2),
+                    // Every column, reversed
+                    SliceItem::range(-1, Some(-6), -1),
+                ],
+                expected: Tensor::from([[3, 2, 1, 0], [11, 10, 9, 8]]).into_data(),
+            },
+            // > 4 dims
+            Case {
+                tensor: Tensor::arange(0, 32, None).into_shape([2, 2, 2, 2, 2].as_slice()),
+                range: &[
+                    SliceItem::range(0, Some(2), -1),
+                    SliceItem::range(0, Some(2), -1),
+                    SliceItem::range(0, Some(2), -1),
+                    SliceItem::range(0, Some(2), -1),
+                    SliceItem::range(0, Some(2), -1),
+                ],
+                expected: Tensor::arange(31, -1, Some(-1)).into_data(),
+            },
+        ];
+
+        for Case {
+            tensor,
+            range,
+            expected,
+        } in cases
+        {
+            let dest_len = expected.len();
+            let mut dest = Vec::with_capacity(dest_len);
+
+            copy_range_into_slice(
+                tensor.view(),
+                &mut dest.spare_capacity_mut()[..dest_len],
+                range,
+            );
+
+            // Assume `copy_range_into_slice` initialized all elements.
+            unsafe {
+                dest.set_len(dest_len);
+            }
+
+            assert_eq!(dest, expected);
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "output too short")]
+    fn test_copy_range_into_slice_invalid() {
+        let mut dest = Vec::new();
+
+        copy_range_into_slice(
+            NdTensor::arange(0, 4, None).into_shape([2, 2]).as_dyn(),
+            &mut dest.spare_capacity_mut(),
+            &[], // Empty range, selects whole tensor
+        );
     }
 }

--- a/rten-tensor/src/layout.rs
+++ b/rten-tensor/src/layout.rs
@@ -307,7 +307,7 @@ fn slice_layout<I: AsRef<[usize]>, O: AsMut<[usize]>>(
                     // Fast path when no custom step is used.
                     resolved.end - resolved.start
                 } else {
-                    range.steps(size)
+                    range.index_range(size).steps()
                 };
                 let new_stride = stride * step;
                 (stride * resolved.start, Some((new_size, new_stride)))

--- a/rten-tensor/src/tensor.rs
+++ b/rten-tensor/src/tensor.rs
@@ -317,16 +317,6 @@ pub trait AsView: Layout {
         Tensor::from_data(&sliced_shape, sliced_data)
     }
 
-    /// Return an iterator over a slice of this tensor.
-    ///
-    /// This is similar to `self.slice(range).iter()` except that it
-    /// returns an iterator directly instead of creating an intermediate view.
-    /// Also slicing with this method is more flexible as negative steps are
-    /// supported for items in `range`.
-    fn slice_iter(&self, range: &[SliceItem]) -> Iter<Self::Elem> {
-        self.view().slice_iter(range)
-    }
-
     /// Return a view of this tensor with all dimensions of size 1 removed.
     fn squeezed(&self) -> TensorView<Self::Elem> {
         self.view().squeezed()
@@ -1219,11 +1209,6 @@ impl<'a, T, L: Clone + MutLayout> TensorBase<ViewData<'a, T>, L> {
             data: self.data.slice(offset_range),
             layout: sliced_layout,
         }
-    }
-
-    /// See [AsView::slice_iter].
-    pub fn slice_iter(&self, range: &[SliceItem]) -> Iter<'a, T> {
-        Iter::slice(self.view_ref(), range)
     }
 
     /// Remove all size-one dimensions from this tensor.
@@ -2985,17 +2970,6 @@ mod tests {
         let row_two = tensor.slice_dyn(1);
         assert_eq!(row_two[[0]], 3.);
         assert_eq!(row_two[[1]], 4.);
-    }
-
-    #[test]
-    fn test_slice_iter() {
-        let data = vec![1., 2., 3., 4.];
-        let tensor = Tensor::from_data(&[2, 2], data);
-        let row_one: Vec<_> = tensor
-            .slice_iter(&[SliceItem::Index(0), SliceItem::full_range()])
-            .copied()
-            .collect();
-        assert_eq!(row_one, &[1., 2.]);
     }
 
     #[test]

--- a/src/ops/reduce.rs
+++ b/src/ops/reduce.rs
@@ -310,7 +310,8 @@ fn reduce<T: Copy, R: Reducer<T>>(
                             SliceItem::Index(idx as isize)
                         }
                     }));
-                    let reduced = reducer.reduce(input.slice_iter(&inner_range).copied());
+                    let slice = input.slice_dyn(inner_range.as_slice());
+                    let reduced = reducer.reduce(slice.iter().copied());
                     reduced_data.push(reduced);
                 }
             }

--- a/src/ops/rnn.rs
+++ b/src/ops/rnn.rs
@@ -902,36 +902,19 @@ mod tests {
             // The last hidden state should match the end of the hidden sequence
             // for the forwards direction, and the start of the hidden sequence
             // for the reverse direction.
-            let hss = hidden_seq.shape();
-            let hidden_seq_fwd = hidden_seq
-                .slice_iter(&[
-                    (..hss[0]).into(), // seq
-                    (0..1).into(),     // direction
-                    (..hss[2]).into(), // batch
-                    (..hss[3]).into(), // hidden
-                ])
-                .collect::<Vec<_>>();
-            let last_hidden_fwd = last_hidden
-                .slice_iter(&[(0..1).into(), (..batch).into(), (..hidden_size).into()])
-                .collect::<Vec<_>>();
+            let hidden_seq_fwd = hidden_seq.slice::<2, _>((
+                -1, // seq
+                0,  // direction
+            ));
+            let last_hidden_fwd = last_hidden.slice::<2, _>(0);
+            assert_eq!(hidden_seq_fwd, last_hidden_fwd);
 
-            assert_eq!(
-                hidden_seq_fwd[hidden_seq_fwd.len() - batch * hidden_size..],
-                last_hidden_fwd
-            );
-
-            let hidden_seq_rev = hidden_seq
-                .slice_iter(&[
-                    (..hss[0]).into(), // seq
-                    (1..2).into(),     // direction
-                    (..hss[2]).into(), // batch
-                    (..hss[3]).into(), // hidden
-                ])
-                .collect::<Vec<_>>();
-            let last_hidden_rev = last_hidden
-                .slice_iter(&[(1..2).into(), (..batch).into(), (..hidden_size).into()])
-                .collect::<Vec<_>>();
-            assert_eq!(hidden_seq_rev[0..batch * hidden_size], last_hidden_rev);
+            let hidden_seq_rev = hidden_seq.slice::<2, _>((
+                0, // seq
+                1, // direction
+            ));
+            let last_hidden_rev = last_hidden.slice::<2, _>(1);
+            assert_eq!(hidden_seq_rev, last_hidden_rev);
         }
     }
 

--- a/src/ops/slice.rs
+++ b/src/ops/slice.rs
@@ -57,25 +57,7 @@ pub fn slice<T: Copy>(
 ) -> Result<Tensor<T>, OpError> {
     let ranges = slice_ranges(input.shape(), starts, ends, axes, steps)?;
     let items: Vec<_> = ranges.iter().map(|r| SliceItem::Range(*r)).collect();
-
-    // Fast path for slice ranges supported by `Tensor::slice`. This includes
-    // all ranges except those with a negative step. This benefits from
-    // optimizations that `Tensor::to_tensor` has for slices that are already
-    // contiguous or have a small number of dims.
-    if let Ok(slice_view) = input.try_slice_dyn(items.as_slice()) {
-        return Ok(slice_view.to_tensor());
-    }
-
-    let sliced_shape: Vec<_> = ranges
-        .iter()
-        .copied()
-        .enumerate()
-        .map(|(dim, range)| range.steps(input.size(dim)))
-        .collect();
-    let mut sliced_data = pool.alloc(sliced_shape.iter().product());
-    sliced_data.extend(input.slice_iter(&items).copied());
-
-    Ok(Tensor::from_data(&sliced_shape, sliced_data))
+    Ok(input.slice_copy_in(pool, items.as_slice()))
 }
 
 /// Clip the dimensions of the input tensor specified by `axes` to the ranges


### PR DESCRIPTION
Improve the efficiency of the `Slice` operator by:

- Allocating the output buffer from the pool. I missed this previously for the fast path, used when the slice ranges don't contain negative strides
- Rewriting the fallback implementation used when the range contains negative steps. This is now implemented by a new `TensorBase::slice_copy` API, which uses nested loops with a fixed number of inner dims (4) instead of external iteration with a dynamic number of dims.

In the process I found and fixed some bugs in the handling of negative steps in `SliceRange::resolve`, as well as a missing layout + data length compatibility check in `TensorBase::into_shape`.

Combined these reduce time in `Slice` ops in Piper TTS models from ~3.1ms to ~0.9ms.

**TODO:**

- [x] Add more tests for `IndexRange`, `SliceRange::index_range`
- [x] Support inputs with more than 4 dims