### PR TITLE
Allocate output from pool in `Gather`, `NonZero` ops

### DIFF
--- a/src/ops/gather.rs
+++ b/src/ops/gather.rs
@@ -39,7 +39,7 @@ pub fn gather<T: Copy + Default>(
     if let (0, Some(index)) = (indices.ndim(), indices.item()) {
         let mut slice_range = full_range(input.ndim());
         slice_range[axis] = SliceItem::Index(*index as isize);
-        let output = input.slice_dyn(slice_range.as_slice()).to_tensor();
+        let output = input.slice_dyn(slice_range.as_slice()).to_tensor_in(pool);
         return Ok(output);
     }
 


### PR DESCRIPTION
- Fix oversight where `Gather` op did not allocate from the pool in its fast path
- Make `NonZero` op allocate from the pool for its output. This operator is still not fully using the pool as it first builds up a `Vec` of all the non-zero entries, which it then transposes and copies into a contiguous tensor. Only the final copy is using the pool.