### PR TITLE
Add missing checks for length match in reshaping methods

### DIFF
--- a/rten-tensor/src/errors.rs
+++ b/rten-tensor/src/errors.rs
@@ -72,3 +72,24 @@ impl Display for SliceError {
 }
 
 impl Error for SliceError {}
+
+/// Errors that can occur while reshaping a layout or tensor.
+#[derive(Clone, Debug, PartialEq)]
+pub enum ReshapeError {
+    /// Attempted to reshape a tensor without copying data, but the layout
+    /// is not contiguous.
+    NotContiguous,
+
+    /// The reshaped layout would have a different length than the current
+    /// layout.
+    LengthMismatch,
+}
+
+impl std::fmt::Display for ReshapeError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ReshapeError::NotContiguous => write!(f, "view is not contiguous"),
+            ReshapeError::LengthMismatch => write!(f, "new shape has a different length"),
+        }
+    }
+}


### PR DESCRIPTION
Failing to check the requirements for length match or contiguity when reshaping
is a sure fire way to cause OOB reads.

 - Change `TensorBase` to call `MutLayout::reshaped` to ensure the new
   shape is checked for compatibility with the existing layout length
   and contiguous-ness.

 - Change reshaping methods in `layout.rs` to return results, as these
   are more convenient to work with in tests.

 - Remove unused mutating `Layout::reshape` methods

