### PR TITLE
Update README and docs for the rten-vecmath crate

### DIFF
--- a/rten-vecmath/README.md
+++ b/rten-vecmath/README.md
@@ -1,4 +1,11 @@
 # rten-vecmath
 
-SIMD vectorized versions of math functions such as exp, erf, tanh, softmax etc.
-that are performance-critical in machine-learning models.
+This crate provides portable SIMD types that abstract over SIMD intrinsics on
+different architectures. Unlike
+[`std::simd`](https://doc.rust-lang.org/std/simd/index.html) this works on
+stable Rust. There is also functionality to detect the available instructions
+at runtime and dispatch to the optimal implementation.
+
+This crate also contains SIMD-vectorized versions of math functions such as exp,
+erf, tanh, softmax etc. that are performance-critical in machine-learning
+models.

--- a/rten-vecmath/src/lib.rs
+++ b/rten-vecmath/src/lib.rs
@@ -1,5 +1,27 @@
-//! SIMD-vectorized implementations of various math functions that are commonly
-//! used in neural networks.
+//! rten-vecmath provides portable SIMD types for implementing vectorized
+//! functions that work across different architectures.
+//!
+//! # Portable SIMD types
+//!
+//! The [`simd_vec`] module contains types and traits to support
+//! writing portable SIMD code, that works on stable Rust.
+//!
+//! ## Supported architectures
+//!
+//! SIMD wrappers are provided for the following architectures:
+//!
+//! - Arm Neon
+//! - AVX 2 / FMA
+//! - AVX-512 (requires `avx512` feature and nightly Rust)
+//! - WebAssembly SIMD
+//!
+//! There is also a scalar fallback that works on all platforms, but provides no
+//! performance benefit over non-SIMD code.
+//!
+//! # Vectorized math functions
+//!
+//! This crate contains SIMD-vectorized implementations of various math
+//! functions that are commonly used in neural networks.
 //!
 //! For each function in this library there are multiple variants, which
 //! typically include:


### PR DESCRIPTION
The main change since the initial release is that the SIMD types are now exported and used by other crates.