### PR TITLE
Revise model loading API for ease of use and efficiency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,6 +185,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baff4b617f7df3d896f97fe922b64817f6cd9a756bb81d40f8883f2f66dcb401"
 
 [[package]]
+name = "libc"
+version = "0.2.154"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
+
+[[package]]
 name = "libm"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,6 +201,15 @@ name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+
+[[package]]
+name = "memmap2"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memoffset"
@@ -310,6 +325,7 @@ dependencies = [
  "fastrand-contrib",
  "flatbuffers",
  "libm",
+ "memmap2",
  "rayon",
  "rten",
  "rten-bench",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,9 +42,10 @@ rten-vecmath = { path = "./rten-vecmath", version = "0.8.0" }
 fastrand = { version = "2.0.2", optional = true }
 fastrand-contrib = { version = "0.1.0", optional = true }
 rustc-hash = "1.1.0"
+memmap2 = { version = "0.9.4", optional = true }
 
 [dev-dependencies]
-rten = { path = ".", features = ["random"] }
+rten = { path = ".", features = ["mmap", "random"] }
 rten-bench = { path = "./rten-bench" }
 serde_json = "1.0.91"
 
@@ -54,6 +55,8 @@ crate-type = ["lib", "cdylib"]
 [features]
 # Use AVX-512 instructions if available. Requires nightly Rust for AVX-512 intrinsics.
 avx512 = ["rten-vecmath/avx512"]
+# Enable loading models using memory mapping
+mmap = ["memmap2"]
 # Generate WebAssembly API using wasm-bindgen.
 wasm_api = []
 # Enable operators that generate random numbers.

--- a/rten-cli/src/main.rs
+++ b/rten-cli/src/main.rs
@@ -1,6 +1,5 @@
 use std::collections::{HashMap, VecDeque};
 use std::error::Error;
-use std::fs;
 use std::time::Instant;
 
 use rten::{Dimension, Input, Model, ModelMetadata, NodeId, Output, RunOptions};
@@ -301,8 +300,7 @@ fn print_input_output_list(model: &Model, node_ids: &[NodeId]) {
 /// running. See `docs/profiling.md`.
 fn main() -> Result<(), Box<dyn Error>> {
     let args = parse_args()?;
-    let model_bytes = fs::read(args.model)?;
-    let model = Model::load(&model_bytes)?;
+    let model = Model::load_file(args.model)?;
 
     println!(
         "Model summary: {} inputs, {} outputs, {} params",

--- a/rten-examples/Cargo.toml
+++ b/rten-examples/Cargo.toml
@@ -16,7 +16,7 @@ lexopt = "0.3.0"
 png = "0.17.6"
 serde = { version = "1.0.91", features = ["derive"] }
 serde_json = "1.0.91"
-rten = { path = "../", features = ["random"] }
+rten = { path = "../", features = ["mmap", "random"] }
 rten-imageio = { path = "../rten-imageio" }
 rten-imageproc = { path = "../rten-imageproc" }
 rten-tensor = { path = "../rten-tensor" }

--- a/rten-examples/src/bert_qa.rs
+++ b/rten-examples/src/bert_qa.rs
@@ -224,8 +224,7 @@ fn extract_nbest_answers<'a>(
 /// [^2]: <https://huggingface.co/docs/optimum/index>
 fn main() -> Result<(), Box<dyn Error>> {
     let args = parse_args()?;
-    let model_bytes = fs::read(args.model)?;
-    let model = Model::load(&model_bytes)?;
+    let model = Model::load_file(args.model)?;
 
     let context = fs::read_to_string(args.context_doc)?;
 

--- a/rten-examples/src/deeplab.rs
+++ b/rten-examples/src/deeplab.rs
@@ -1,6 +1,5 @@
 use std::collections::{HashSet, VecDeque};
 use std::error::Error;
-use std::fs;
 
 use rten::{Dimension, FloatOperators, Model, Operators};
 use rten_imageio::{normalize_image, read_image, write_image};
@@ -107,8 +106,7 @@ const PASCAL_VOC_LABELS: [(&str, Rgb); 21] = [
 /// [^1] <https://arxiv.org/abs/1706.05587>
 fn main() -> Result<(), Box<dyn Error>> {
     let args = parse_args()?;
-    let model_bytes = fs::read(args.model)?;
-    let model = Model::load(&model_bytes)?;
+    let model = Model::load_file(args.model)?;
 
     let mut image: Tensor = read_image(&args.image)?.into();
     normalize_image(image.nd_view_mut());

--- a/rten-examples/src/depth_anything.rs
+++ b/rten-examples/src/depth_anything.rs
@@ -1,6 +1,5 @@
 use std::collections::VecDeque;
 use std::error::Error;
-use std::fs;
 
 use rten::{FloatOperators, Model};
 use rten_imageio::{normalize_image, read_image, write_image};
@@ -75,8 +74,7 @@ Args:
 /// [depth_anything]: <https://github.com/LiheYoung/Depth-Anything>
 fn main() -> Result<(), Box<dyn Error>> {
     let args = parse_args()?;
-    let model_bytes = fs::read(args.model)?;
-    let model = Model::load(&model_bytes)?;
+    let model = Model::load_file(args.model)?;
 
     let mut image: Tensor = read_image(&args.image)?.into();
     let [_, orig_height, orig_width] = image.shape().try_into()?;

--- a/rten-examples/src/detr.rs
+++ b/rten-examples/src/detr.rs
@@ -1,6 +1,5 @@
 use std::collections::VecDeque;
 use std::error::Error;
-use std::fs;
 
 use rten::{FloatOperators, Model, Operators};
 use rten_imageio::{normalize_image, read_image, write_image};
@@ -279,8 +278,7 @@ const LABELS: &[&str] = &[
 fn main() -> Result<(), Box<dyn Error>> {
     let args = parse_args()?;
 
-    let model_data = fs::read(args.model)?;
-    let model = Model::load(&model_data)?;
+    let model = Model::load_file(args.model)?;
 
     let mut image = read_image(&args.image)?;
 

--- a/rten-examples/src/imagenet.rs
+++ b/rten-examples/src/imagenet.rs
@@ -1,6 +1,5 @@
 use std::collections::{HashMap, VecDeque};
 use std::error::Error;
-use std::fs;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
@@ -211,8 +210,7 @@ Where config is one of:
 /// the models.
 fn main() -> Result<(), Box<dyn Error>> {
     let args = parse_args()?;
-    let model_bytes = fs::read(args.model)?;
-    let model = Model::load(&model_bytes)?;
+    let model = Model::load_file(args.model)?;
 
     let normalize_pixel = match args.config.norm {
         PixelNorm::NoNorm => |_, value| value,

--- a/rten-examples/src/jina_similarity.rs
+++ b/rten-examples/src/jina_similarity.rs
@@ -1,6 +1,5 @@
 use std::collections::VecDeque;
 use std::error::Error;
-use std::fs;
 
 use rten::ops::concat;
 use rten::{FloatOperators, Input, Model, NodeId, Operators, TensorPool};
@@ -200,8 +199,7 @@ fn embed_sentence_batch(
 /// ```
 fn main() -> Result<(), Box<dyn Error>> {
     let args = parse_args()?;
-    let model_bytes = fs::read(args.model)?;
-    let model = Model::load(&model_bytes)?;
+    let model = Model::load_file(args.model)?;
 
     let tokenizer_json = std::fs::read_to_string(&args.tokenizer)?;
     let tokenizer = Tokenizer::from_json(&tokenizer_json)?;

--- a/rten-examples/src/piper.rs
+++ b/rten-examples/src/piper.rs
@@ -179,9 +179,7 @@ fn phonemes_to_ids(phonemes: &str, config: &ModelConfig) -> NdTensor<i32, 1> {
 fn main() -> Result<(), Box<dyn Error>> {
     let args = parse_args()?;
 
-    let model_data = std::fs::read(args.model)?;
-    let model = Model::load(&model_data)?;
-    std::mem::drop(model_data);
+    let model = Model::load_file(args.model)?;
 
     let config_json = std::fs::read_to_string(args.model_config)?;
     let config: ModelConfig = serde_json::from_str(&config_json)?;

--- a/rten-examples/src/wav2vec2.rs
+++ b/rten-examples/src/wav2vec2.rs
@@ -1,6 +1,5 @@
 use std::collections::VecDeque;
 use std::error::Error;
-use std::fs;
 
 use rten::ctc::CtcDecoder;
 use rten::Model;
@@ -111,9 +110,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     // with index 0 is omitted, as that is used for a CTC blank.
     let vocab = "???|ETAONIHSRDLUMWCFGYPBVK'XJQZ";
 
-    let model_data = fs::read(args.model)?;
-    let model = Model::load(&model_data)?;
-
+    let model = Model::load_file(args.model)?;
     let samples = read_wav_file(&args.wav_file)?;
 
     let mut sample_batch = Tensor::from_vec(samples);

--- a/rten-examples/src/yolo.rs
+++ b/rten-examples/src/yolo.rs
@@ -99,8 +99,7 @@ fn resource_path(path: &str) -> PathBuf {
 fn main() -> Result<(), Box<dyn Error>> {
     let args = parse_args()?;
 
-    let model_data = fs::read(args.model)?;
-    let model = Model::load(&model_data)?;
+    let model = Model::load_file(args.model)?;
 
     let image = read_image(&args.image)?;
     let labels: Vec<_> = fs::read_to_string(resource_path("coco.names"))?

--- a/src/constant_storage.rs
+++ b/src/constant_storage.rs
@@ -1,0 +1,188 @@
+//! Storage for constants (ie. weights) in a graph.
+
+use std::marker::PhantomData;
+use std::ops::Range;
+use std::sync::Arc;
+
+use rten_tensor::{DynLayout, Storage, TensorBase};
+
+#[cfg(feature = "mmap")]
+use memmap2::Mmap;
+
+/// Return the range of pointer addresses of a slice.
+fn slice_address_range<T>(slice: &[T]) -> Range<usize> {
+    let addr = slice.as_ptr() as usize;
+    addr..(addr + std::mem::size_of_val(slice))
+}
+
+/// A buffer containing aligned data for heterogenous tensor types. This will
+/// usually be a model data/weights file (eg. in FlatBuffers format) read in
+/// or memory-mapped from disk.
+///
+/// This can be used as the storage for tensor views by creating [ArcSlice]
+/// instances which reference a region of this buffer, and then using that
+/// slice as the storage for an [ArcTensorView].
+#[derive(Debug)]
+pub enum ConstantStorage {
+    /// Storage that references a memory-mapped file.
+    #[cfg(feature = "mmap")]
+    Mmap(Mmap),
+
+    /// An in-memory buffer, such as a FlatBuffers file that has been read
+    /// into memory using functions from `std::fs`.
+    Buffer(Vec<u8>),
+}
+
+impl ConstantStorage {
+    /// Return the data in this storage as a slice of bytes.
+    pub fn data(&self) -> &[u8] {
+        match &self {
+            ConstantStorage::Buffer(data) => data,
+            #[cfg(feature = "mmap")]
+            ConstantStorage::Mmap(mmap) => mmap,
+        }
+    }
+
+    /// Return the byte offsets of a sub-slice of this storage as a range, or
+    /// `None` if any part of `data` lies outside storage.
+    ///
+    /// Note this always returns `None` if `T` is a zero-sized type.
+    fn byte_range_of<T>(&self, data: &[T]) -> Option<Range<usize>> {
+        // See https://internals.rust-lang.org/t/proposal-get-range-of-sub-slice/16556
+        if std::mem::size_of::<T>() == 0 {
+            return None;
+        }
+
+        let self_range = slice_address_range(self.data());
+        let data_range = slice_address_range(data);
+
+        if !self_range.contains(&data_range.start) || self_range.end < data_range.end {
+            return None;
+        }
+
+        let start = data_range.start - self_range.start;
+        let end = data_range.end - self_range.start;
+        Some(start..end)
+    }
+}
+
+/// Tensor storage which references data owned by an `Arc<ConstantStorage>`.
+#[derive(Debug)]
+pub struct ArcSlice<T> {
+    storage: Arc<ConstantStorage>,
+    byte_offset: usize,
+    len: usize,
+    phantom: PhantomData<T>,
+}
+
+impl<T> ArcSlice<T> {
+    /// Return an ArcSlice which references the subslice of `storage` specified
+    /// by `data`.
+    ///
+    /// Returns `None` if the data slice is not contained within `storage` or
+    /// is incorrectly aligned.
+    pub fn new(storage: Arc<ConstantStorage>, data: &[T]) -> Option<ArcSlice<T>> {
+        let byte_range = storage.byte_range_of(data)?;
+        Some(ArcSlice::<T> {
+            storage,
+            byte_offset: byte_range.start,
+            len: data.len(),
+            phantom: PhantomData,
+        })
+    }
+}
+
+unsafe impl<T> Storage for ArcSlice<T> {
+    type Elem = T;
+
+    fn len(&self) -> usize {
+        self.len
+    }
+
+    fn as_ptr(&self) -> *const Self::Elem {
+        // Safety: We checked the data range was in-bounds when the ArcSlice
+        // was constructed.
+        unsafe {
+            let ptr = self.storage.data().as_ptr().add(self.byte_offset);
+            std::mem::transmute(ptr)
+        }
+    }
+}
+
+/// Tensor view whose data is a slice of a buffer owned by a [ConstantStorage].
+pub type ArcTensorView<T> = TensorBase<ArcSlice<T>, DynLayout>;
+
+#[cfg(test)]
+mod tests {
+    use std::ops::Range;
+    use std::sync::Arc;
+
+    use rten_tensor::prelude::*;
+
+    use super::{ArcSlice, ArcTensorView, ConstantStorage};
+
+    /// Trait for types which allow any bit pattern, and thus can be cast
+    /// freely to/from bytes without worrying about constructing invalid
+    /// data.
+    ///
+    /// See https://docs.rs/bytemuck/latest/bytemuck/trait.Pod.html.
+    trait Pod: Copy {}
+
+    impl Pod for i32 {}
+
+    /// Convert a `Vec<i32>` to native-endian bytes.
+    fn vec_to_ne_bytes(vec: Vec<i32>) -> Vec<u8> {
+        vec.into_iter()
+            .flat_map(|x| x.to_ne_bytes().into_iter())
+            .collect()
+    }
+
+    /// Cast a range of bytes in a slice to `T`s.
+    fn cast_slice<T: Pod>(slice: &[u8], range: Range<usize>) -> Option<&[T]> {
+        let size = std::mem::size_of::<T>();
+        let data = slice.get(range)?;
+        let typed_slice = unsafe {
+            let ptr: *const T = std::mem::transmute(data.as_ptr());
+            let len = match size {
+                0 => 0,
+                _ => data.len() / size,
+            };
+            std::slice::from_raw_parts(ptr, len)
+        };
+        Some(typed_slice)
+    }
+
+    #[test]
+    fn test_constant_storage() {
+        let data: Vec<i32> = (0..16).collect();
+        let bytes = vec_to_ne_bytes(data);
+        let storage = Arc::new(ConstantStorage::Buffer(bytes));
+
+        // Create two slices referencing memory from the storage.
+        let slice_one = cast_slice::<i32>(storage.data(), 0..32).unwrap();
+        assert_eq!(slice_one, [0, 1, 2, 3, 4, 5, 6, 7]);
+
+        let slice_two = cast_slice::<i32>(storage.data(), 32..64).unwrap();
+        assert_eq!(slice_two, [8, 9, 10, 11, 12, 13, 14, 15]);
+
+        let arc_slice_one = ArcSlice::new(storage.clone(), slice_one).unwrap();
+        let arc_slice_two = ArcSlice::new(storage.clone(), slice_two).unwrap();
+
+        let view_one = ArcTensorView::from_data(&[2, 4], arc_slice_one);
+        let view_two = ArcTensorView::from_data(&[4, 2], arc_slice_two);
+
+        assert_eq!(view_one.shape(), &[2, 4]);
+        assert_eq!(view_one.data().unwrap(), slice_one);
+
+        assert_eq!(view_two.shape(), &[4, 2]);
+        assert_eq!(view_two.data().unwrap(), slice_two);
+
+        // Create a slice referencing data outside the storage.
+        let slice_outside = &[1, 2, 3];
+        assert!(ArcSlice::new(storage.clone(), slice_outside).is_none());
+
+        // Try with a zero-sized type.
+        let zst_slice = &[(), ()];
+        assert!(ArcSlice::new(storage.clone(), zst_slice).is_none());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,7 @@
 #[allow(unused)] // Docs only
 use rten_tensor::{NdTensor, Tensor};
 
+mod constant_storage;
 mod env;
 mod gemm;
 mod graph;
@@ -66,7 +67,7 @@ pub mod ctc;
 pub mod ops;
 
 pub use graph::{Dimension, NodeId, RunOptions};
-pub use model::{Model, ModelLoadError, NodeInfo, OpRegistry, ReadOp, ReadOpError};
+pub use model::{Model, ModelLoadError, ModelOptions, NodeInfo, OpRegistry, ReadOp, ReadOpError};
 pub use model_metadata::ModelMetadata;
 pub use ops::{FloatOperators, Input, Operators, Output};
 pub use tensor_pool::TensorPool;

--- a/src/wasm_api.rs
+++ b/src/wasm_api.rs
@@ -20,7 +20,7 @@ pub struct Model {
 impl Model {
     /// Construct a new model from a serialized graph.
     #[wasm_bindgen(constructor)]
-    pub fn new(model_data: &[u8]) -> Result<Model, String> {
+    pub fn new(model_data: Vec<u8>) -> Result<Model, String> {
         let model = model::Model::load(model_data).map_err(|e| e.to_string())?;
         Ok(Model { model })
     }


### PR DESCRIPTION
Previously loading a model involved two steps, each of which copied the entire
model:

 1. Reading the file from disk into a `Vec<u8>`, eg. using
    `std::fs::read`
 2. `Model::load` then received a `&[u8]` slice of this and would copy
    the weights into individual owned tensors.

Usually callers would then not immediately free the buffer loaded in step (1),
so the program would use twice as much memory as needed for the weights.

This commit revises the model loading API to be more convenient to use for
common use cases and more efficient:

 - The `Model::load` API now takes a `Vec<u8>` rather than `&[u8]`.

   `Model` then puts this `Vec<u8>` into a reference-counted container and graph
   nodes reference slices of this. This avoids an expensive copy of all the
   model weights.

 - Add a `Model::load_file` API to simplify the most common use case into
   a single call: `Model::load_file("model.rten")`

 - Add a `Model::load_mmap` API which allows loading a model with zero copying
   of weights by creating a memory-mapped view of the file, which graph nodes
   reference directly. This requires additional dependencies, and so is behind
   an `mmap` feature.

To avoid adding variants of each of these methods that allow customizing the
available operators, a `ModelOptions` struct has been added which is modeled
on `std::fs::OpenOptions` and allows configuring the available operators and
other things that have to be specified before the model is loaded.

**TODO:**

- [x] Add test for loading with mmap
- [x] Add note that using mmap will be slightly slower on the first run