### PR TITLE
Set number of threads to match physical rather than logical core count

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,6 +143,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
 name = "hound"
 version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -261,6 +267,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -326,6 +342,7 @@ dependencies = [
  "flatbuffers",
  "libm",
  "memmap2",
+ "num_cpus",
  "rayon",
  "rten",
  "rten-bench",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ fastrand = { version = "2.0.2", optional = true }
 fastrand-contrib = { version = "0.1.0", optional = true }
 rustc-hash = "1.1.0"
 memmap2 = { version = "0.9.4", optional = true }
+num_cpus = "1.16.0"
 
 [dev-dependencies]
 rten = { path = ".", features = ["mmap", "random"] }

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,13 +1,25 @@
 # Profiling and optimizing
 
-This document provides strategies for profiling and optimizing graph execution
-performance in RTen.
+This document provides information about configuration that affects execution
+performance, and tools for profiling and optimizing inference.
 
 ## Build settings
 
 Performance sensitive numeric code like RTen will run extremely slowly in debug
-builds, to the point of being unusable. For profiling, make sure you build your
-application in release mode.
+builds, to the point of being unusable. For development and production, make
+sure you **build your application, or at least the `rten` crates, in release
+mode**.
+
+## Threading
+
+RTen will use multiple threads automatically. By default it will choose the
+number of threads to match the number of physical CPUs, as reported by the
+`num_cpus` crate. Note that this will differ from
+`std::thread::available_parallelism` on systems which support [SMT /
+Hyper-threading](https://doc.rust-lang.org/std/thread/fn.available_parallelism.html).
+
+You can vary the number of threads between 1 and the number of logical cores by
+setting the `RTEN_NUM_THREADS` environment variable.
 
 ## Profiling using built-in logging
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,15 @@
 //! See the example projects in [rten-examples][rten_examples] to see how all
 //! these pieces fit together.
 //!
+//! ## Threading
+//!
+//! RTen automatically executes models using multiple threads. For this purpose
+//! it creates its own Rayon
+//! [ThreadPool](https://docs.rs/rayon/latest/rayon/struct.ThreadPool.html)
+//! which is sized to match the number of physical cores. You can access this
+//! pool using [threading::thread_pool] if you want to run your own tasks in
+//! this pool.
+//!
 //! # Supported models and hardware
 //!
 //! ## Hardware
@@ -92,6 +101,7 @@ mod model_metadata;
 mod number;
 mod slice_reductions;
 mod tensor_pool;
+mod threading;
 mod timer;
 mod timing;
 
@@ -109,6 +119,7 @@ pub use model::{Model, ModelLoadError, ModelOptions, NodeInfo, OpRegistry, ReadO
 pub use model_metadata::ModelMetadata;
 pub use ops::{FloatOperators, Input, Operators, Output};
 pub use tensor_pool::{ExtractBuffer, PoolRef, TensorPool};
+pub use threading::thread_pool;
 pub use timer::Timer;
 pub use timing::TimingSort;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,10 +73,10 @@
 //! The [rten-cli](https://crates.io/crates/rten-cli) tool can be used to query
 //! basic information about a `.rten` model.
 //!
-//! # Profiling and performance
+//! # Performance
 //!
-//! See the [profiling
-//! guide](https://github.com/robertknight/rten/blob/main/docs/profiling.md) for
+//! See the [performance
+//! guide](https://github.com/robertknight/rten/blob/main/docs/performance.md) for
 //! information on profiling and improving model execution performance.
 //!
 //! [rten_examples]: https://github.com/robertknight/rten/tree/main/rten-examples

--- a/src/threading.rs
+++ b/src/threading.rs
@@ -1,0 +1,41 @@
+use std::env;
+use std::sync::OnceLock;
+
+use rayon::{ThreadPool, ThreadPoolBuilder};
+
+/// Return the [Rayon][rayon] thread pool which is used to execute RTen models.
+///
+/// This differs from Rayon's default global thread pool in that it is tuned for
+/// CPU rather than IO-bound work by choosing a thread count based on the number
+/// of physical rather than logical cores.
+///
+/// The thread count can be overridden at the process level by setting the
+/// `RTEN_NUM_THREADS` environment variable, whose value must be a number
+/// between 1 and the logical core count.
+///
+/// To run your own tasks in this thread pool, you can use
+/// [`ThreadPool::install`].
+///
+/// [rayon]: https://github.com/rayon-rs/rayon
+pub fn thread_pool() -> &'static ThreadPool {
+    static THREAD_POOL: OnceLock<ThreadPool> = OnceLock::new();
+    THREAD_POOL.get_or_init(|| {
+        let physical_cpus = num_cpus::get_physical();
+
+        let num_threads = if let Some(threads_var) = env::var_os("RTEN_NUM_THREADS") {
+            let requested_threads: Result<usize, _> = threads_var.to_string_lossy().parse();
+            match requested_threads {
+                Ok(n_threads) => n_threads.clamp(1, num_cpus::get()),
+                Err(_) => physical_cpus,
+            }
+        } else {
+            physical_cpus
+        };
+
+        ThreadPoolBuilder::new()
+            .num_threads(num_threads)
+            .thread_name(|index| format!("rten-{}", index))
+            .build()
+            .expect("failed to initialize RTen thread pool")
+    })
+}


### PR DESCRIPTION
Since RTen model execution is limited by CPU and memory bandwidth rather than IO, using more threads than there are physical cores is usually slower and always inefficient.

The thread pool is exposed via `rten::threading::thread_pool` so downstream crates can run their own tasks in this pool. 

Fixes https://github.com/robertknight/rten/issues/105

**TODO:**

- [x] Consider exposing the thread pool so applications can opt-in to using it for their own parallelism, rather than adding lots of extra threads to the process. Alternatively there could be a way to make it configure Rayon's global pool.
- [x] Consider changing methods defined in `src/operators.rs` to use the pool. This only makes sense for "expensive" operators though
