### PR TITLE
Unify `Operators`, `FloatOperator` impls for static and dynamic-rank tensors

### DIFF
--- a/src/ops/operators.rs
+++ b/src/ops/operators.rs
@@ -1,7 +1,7 @@
 use std::fmt::Debug;
 
 use rten_tensor::prelude::*;
-use rten_tensor::{DynLayout, NdLayout, NdTensorView, Storage, Tensor, TensorBase, TensorView};
+use rten_tensor::{MutLayout, NdTensorView, Storage, Tensor, TensorBase, TensorView};
 
 use crate::number::{Identities, IsInt};
 use crate::ops::OpError;
@@ -86,63 +86,7 @@ fn use_thread_pool<R: Send, F: Send + FnOnce() -> R>(op: F) -> R {
     thread_pool().install(op)
 }
 
-impl<T: Send, S: Storage<Elem = T>> Operators for TensorBase<S, DynLayout> {
-    type Elem = T;
-
-    fn arg_max(&self, axis: isize, keep_dims: bool) -> Result<Tensor<i32>, OpError>
-    where
-        T: Copy + PartialOrd,
-    {
-        let view = self.view();
-        use_thread_pool(|| arg_max(&TensorPool::new(), view, axis, keep_dims))
-    }
-
-    fn div(&self, other: TensorView<Self::Elem>) -> Result<Tensor<Self::Elem>, OpError>
-    where
-        Self::Elem: Copy
-            + Debug
-            + Default
-            + std::ops::Mul<Output = Self::Elem>
-            + std::ops::Div<Output = Self::Elem>
-            + IsInt
-            + Identities,
-    {
-        let view = self.view();
-        use_thread_pool(|| div(&TensorPool::new(), view, other))
-    }
-
-    fn mul(&self, other: TensorView<T>) -> Result<Tensor<T>, OpError>
-    where
-        T: Copy + Debug + Default + std::ops::Mul<Output = T>,
-    {
-        let view = self.view();
-        use_thread_pool(|| mul(&TensorPool::new(), view, other))
-    }
-
-    fn pad(&self, padding: NdTensorView<i32, 1>, val: T) -> Result<Tensor<Self::Elem>, OpError>
-    where
-        Self::Elem: Copy,
-    {
-        let view = self.view();
-        use_thread_pool(move || pad(&TensorPool::new(), view, &padding, val))
-    }
-
-    fn topk(
-        &self,
-        k: usize,
-        axis: Option<isize>,
-        largest: bool,
-        sorted: bool,
-    ) -> Result<(Tensor<Self::Elem>, Tensor<i32>), OpError>
-    where
-        T: Copy + Default + PartialOrd,
-    {
-        let view = self.view();
-        use_thread_pool(|| topk(&TensorPool::new(), view, k, axis, largest, sorted))
-    }
-}
-
-impl<T: Send, S: Storage<Elem = T>, const N: usize> Operators for TensorBase<S, NdLayout<N>> {
+impl<T: Send, S: Storage<Elem = T>, L: MutLayout> Operators for TensorBase<S, L> {
     type Elem = T;
 
     fn arg_max(&self, axis: isize, keep_dims: bool) -> Result<Tensor<i32>, OpError>
@@ -198,49 +142,7 @@ impl<T: Send, S: Storage<Elem = T>, const N: usize> Operators for TensorBase<S, 
     }
 }
 
-impl<S: Storage<Elem = f32>> FloatOperators for TensorBase<S, DynLayout> {
-    fn matmul(&self, other: TensorView) -> Result<Tensor, OpError> {
-        let view = self.view();
-        use_thread_pool(|| matmul(&TensorPool::new(), view, other))
-    }
-
-    fn reduce_l2(&self, axes: Option<&[i32]>, keep_dims: bool) -> Result<Tensor, OpError> {
-        let view = self.view();
-        use_thread_pool(|| reduce_l2(&TensorPool::new(), view, axes, keep_dims))
-    }
-
-    fn reduce_max(&self, axes: Option<&[i32]>, keep_dims: bool) -> Result<Tensor, OpError> {
-        let view = self.view();
-        use_thread_pool(|| reduce_max(&TensorPool::new(), view, axes, keep_dims))
-    }
-
-    fn reduce_min(&self, axes: Option<&[i32]>, keep_dims: bool) -> Result<Tensor, OpError> {
-        let view = self.view();
-        use_thread_pool(|| reduce_min(&TensorPool::new(), view, axes, keep_dims))
-    }
-
-    fn reduce_mean(&self, axes: Option<&[i32]>, keep_dims: bool) -> Result<Tensor, OpError> {
-        let view = self.view();
-        use_thread_pool(|| reduce_mean(&TensorPool::new(), view, axes, keep_dims))
-    }
-
-    fn reduce_sum(&self, axes: Option<&[i32]>, keep_dims: bool) -> Result<Tensor, OpError> {
-        let view = self.view();
-        use_thread_pool(|| reduce_sum(&TensorPool::new(), view, axes, keep_dims))
-    }
-
-    fn resize_image(&self, size: [usize; 2]) -> Result<Tensor, OpError> {
-        let view = self.view();
-        use_thread_pool(|| resize_image(view, size))
-    }
-
-    fn softmax(&self, axis: isize) -> Result<Tensor, OpError> {
-        let view = self.view();
-        use_thread_pool(|| softmax(&TensorPool::new(), view, axis))
-    }
-}
-
-impl<S: Storage<Elem = f32>, const N: usize> FloatOperators for TensorBase<S, NdLayout<N>> {
+impl<S: Storage<Elem = f32>, L: MutLayout> FloatOperators for TensorBase<S, L> {
     fn matmul(&self, other: TensorView) -> Result<Tensor, OpError> {
         let view = self.as_dyn();
         use_thread_pool(|| matmul(&TensorPool::new(), view, other))


### PR DESCRIPTION
These impls had to be separate when `NdTensor` and `Tensor` were entirely separate types. Now that they share a common type parametrized by a layout, we can combine the corresponding trait impls in operators.rs.