### PR TITLE
Add fallback for platforms where Rayon cannot construct a thread pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,17 +150,13 @@ To build RTen for WebAssembly you will need:
 ```sh
 git clone https://github.com/robertknight/rten.git
 cd rten
-make wasm-all
+make wasm
 ```
 
-The `make wasm-all` command will build two versions of the library, one for
-browsers that support SIMD (Chrome 91, Firefox 89, Safari 16.4) and one for
-those which do not (primarily older Safari releases). See the [WebAssembly
-Roadmap](https://webassembly.org/roadmap/) for a full list of which features
-different engines support. **The SIMD build is significantly faster**.
+The build created by `make wasm` requires support for WebAssembly SIMD,
+available since Chrome 91, Firefox 89 and Safari 16.4. It is possible to
+build the library without WebAssembly SIMD support using `make wasm-nosimd`,
+or both using `make wasm-all`. The non-SIMD builds are significantly slower.
 
-During development, you can speed up the testing cycle by running `make wasm`
-to build only the SIMD version, or `make wasm-nosimd` for the non-SIMD version.
-
-At runtime, you can find out which build is supported by calling the `binaryName()`
-function exported by this package.
+At runtime, you can find out which build is supported by calling the
+`binaryName()` function exported by this package.

--- a/js-examples/image-classification/README.md
+++ b/js-examples/image-classification/README.md
@@ -7,13 +7,14 @@ kind of object.
 
 ## Setup
 
-1. Build the main RTen project. See the README.md file at the root of the
-   repository.
+1. Build the main RTen project for WebAssembly. See the README.md file at the
+   root of the repository.
 2. In this directory, run `npm install`
-3. Download and convert the ONNX MobileNet model:
+3. Download the ONNX MobileNet model from the ONNX Model Zoo and convert it
+   to `.rten` format:
 
    ```sh
-   curl -L https://github.com/onnx/models/raw/main/vision/classification/mobilenet/model/mobilenetv2-10.onnx -o mobilenet.onnx
+   curl -L https://github.com/onnx/models/raw/main/Computer_Vision/mobilenetv2_110d_Opset18_timm/mobilenetv2_110d_Opset18.onnx -o mobilenet.onnx
 
    rten-convert mobilenet.onnx mobilenet.rten
    ```

--- a/js-examples/image-classification/package-lock.json
+++ b/js-examples/image-classification/package-lock.json
@@ -17,7 +17,7 @@
       "version": "1.0.0",
       "license": "BSD-2-Clause",
       "devDependencies": {
-        "sharp": "^0.31.1"
+        "sharp": "^0.33.1"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -801,7 +801,7 @@
     "rten": {
       "version": "file:../..",
       "requires": {
-        "sharp": "^0.31.1"
+        "sharp": "^0.33.1"
       }
     },
     "semver": {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -391,7 +391,7 @@ impl Graph {
             },
         )?;
 
-        threading::thread_pool().install(|| self.run_plan(inputs, &plan, outputs, opts))
+        threading::thread_pool().run(|| self.run_plan(inputs, &plan, outputs, opts))
     }
 
     fn run_plan(
@@ -708,7 +708,7 @@ impl Graph {
         let input_ids: Vec<_> = inputs.iter().map(|(id, _)| id).copied().collect();
         let (pruned_plan, pruned_plan_output_ids) = self.prune_plan(&plan, &input_ids, outputs);
         let outputs = threading::thread_pool()
-            .install(|| self.run_plan(inputs, &pruned_plan, &pruned_plan_output_ids, opts))?;
+            .run(|| self.run_plan(inputs, &pruned_plan, &pruned_plan_output_ids, opts))?;
         let output_ids_and_values: Vec<_> =
             pruned_plan_output_ids.into_iter().zip(outputs).collect();
         Ok(output_ids_and_values)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,7 +119,7 @@ pub use model::{Model, ModelLoadError, ModelOptions, NodeInfo, OpRegistry, ReadO
 pub use model_metadata::ModelMetadata;
 pub use ops::{FloatOperators, Input, Operators, Output};
 pub use tensor_pool::{ExtractBuffer, PoolRef, TensorPool};
-pub use threading::thread_pool;
+pub use threading::{thread_pool, ThreadPool};
 pub use timer::Timer;
 pub use timing::TimingSort;
 

--- a/src/ops/operators.rs
+++ b/src/ops/operators.rs
@@ -83,7 +83,7 @@ pub trait FloatOperators {
 /// it does not change which thread pool is used by parallel iterators. See
 /// https://github.com/rayon-rs/rayon/issues/1165.
 fn use_thread_pool<R: Send, F: Send + FnOnce() -> R>(op: F) -> R {
-    thread_pool().install(op)
+    thread_pool().run(op)
 }
 
 impl<T: Send, S: Storage<Elem = T>, L: MutLayout> Operators for TensorBase<S, L> {


### PR DESCRIPTION
Make `threading::thread_pool` return a wrapper around the underlying `rayon::ThreadPool` which has a fallback for platforms where Rayon cannot build a thread pool, eg. WebAssembly.
