### PR TITLE
Don't use WebAssembly SIMD kernels if `simd128` feature is disabled

### DIFF
--- a/rten-vecmath/src/lib.rs
+++ b/rten-vecmath/src/lib.rs
@@ -380,6 +380,7 @@ fn dispatch_unary_op<Op: SimdUnaryOp>(xs: &[f32], out: &mut [MaybeUninit<f32>], 
     }
 
     #[cfg(target_arch = "wasm32")]
+    #[cfg(target_feature = "simd128")]
     {
         use crate::simd_vec::wasm::v128f;
 
@@ -487,6 +488,7 @@ fn dispatch_unary_op_in_place<Op: SimdUnaryOp>(xs: &mut [f32], op: Op) {
     }
 
     #[cfg(target_arch = "wasm32")]
+    #[cfg(target_feature = "simd128")]
     {
         use crate::simd_vec::wasm::v128f;
 
@@ -582,6 +584,7 @@ fn dispatch_simd_op<Op: SimdOp>(input: PtrLen<f32>, out: MutPtrLen<MaybeUninit<f
     }
 
     #[cfg(target_arch = "wasm32")]
+    #[cfg(target_feature = "simd128")]
     {
         use crate::simd_vec::wasm::v128f;
 

--- a/src/gemm/kernels/wasm.rs
+++ b/src/gemm/kernels/wasm.rs
@@ -22,7 +22,11 @@ impl WasmKernel {
 // the WASM binary is loaded.
 unsafe impl Kernel for WasmKernel {
     fn new() -> Option<Self> {
-        Some(WasmKernel { _private: () })
+        #[cfg(target_feature = "simd128")]
+        return Some(WasmKernel { _private: () });
+
+        #[cfg(not(target_feature = "simd128"))]
+        None
     }
 
     fn name(&self) -> &'static str {

--- a/src/ops/conv/im2col.rs
+++ b/src/ops/conv/im2col.rs
@@ -324,6 +324,7 @@ unsafe impl<'a> VirtualMatrix for VirtualIm2Col<'a> {
                 self.pack_b_impl::<float32x4_t, 2>(out, panel_width, rows, cols);
             },
             #[cfg(target_arch = "wasm32")]
+            #[cfg(target_feature = "simd128")]
             (KernelType::Wasm, 8) => unsafe {
                 // Safety: SIMD support is checked when WASM binary is loaded.
                 use rten_vecmath::simd_vec::wasm::v128f;


### PR DESCRIPTION
Attempting to use the WASM SIMD kernels if compiling without WASM SIMD enabled (`simd128` target feature) results in code that runs *very* slowly, because every single call to a WASM SIMD intrinsic becomes a non-inlined fallback function call.

Ideally I'd like to drop non-SIMD support, but support was added in Safari 16.4 which is still quite recent (March 2023), so I'm not sure if I should to that yet.