### PR TITLE
Allocate buffers from the pool when conditionally copying them

### DIFF
--- a/src/gemm.rs
+++ b/src/gemm.rs
@@ -113,8 +113,11 @@ impl<'a> PackedAMatrix<'a> {
 impl<'a> ExtractBuffer for PackedAMatrix<'a> {
     type Elem = f32;
 
-    fn extract_buffer(self) -> Vec<f32> {
-        self.data.into_owned()
+    fn extract_buffer(self) -> Option<Vec<f32>> {
+        match self.data {
+            Cow::Owned(owned) => Some(owned),
+            Cow::Borrowed(_) => None,
+        }
     }
 }
 
@@ -148,8 +151,8 @@ impl PackedBMatrix {
 impl ExtractBuffer for PackedBMatrix {
     type Elem = f32;
 
-    fn extract_buffer(self) -> Vec<f32> {
-        self.data
+    fn extract_buffer(self) -> Option<Vec<f32>> {
+        Some(self.data)
     }
 }
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -634,9 +634,9 @@ impl Graph {
                 if rc == Some(0) {
                     if let (true, Some(tensor)) = (use_pool, temp_values.remove(&node_id)) {
                         match tensor {
-                            Output::FloatTensor(t) => pool.add(t.extract_buffer()),
-                            Output::IntTensor(t) => pool.add(t.extract_buffer()),
-                        }
+                            Output::FloatTensor(t) => t.extract_buffer().map(|buf| pool.add(buf)),
+                            Output::IntTensor(t) => t.extract_buffer().map(|buf| pool.add(buf)),
+                        };
                     }
                 }
             }

--- a/src/ops/concat.rs
+++ b/src/ops/concat.rs
@@ -5,7 +5,7 @@ use rten_tensor::{Iter, NdTensorView, Tensor, TensorView};
 
 use crate::ops::{resolve_axis, Input, InputList, IntoOpResult, OpError, Operator, Output};
 use crate::static_dims;
-use crate::tensor_pool::TensorPool;
+use crate::tensor_pool::{AutoReturn, TensorPool};
 
 enum ChunkSource<'a, T: Copy> {
     Slice(&'a [T]),
@@ -209,7 +209,11 @@ pub fn tile<T: Copy>(
 
     if !output.is_empty() {
         tile_inner(
-            input.to_contiguous().data().unwrap(),
+            input
+                .to_contiguous_in(pool)
+                .auto_return(pool)
+                .data()
+                .unwrap(),
             output.data_mut().unwrap(),
             input.shape(),
             &repeats,

--- a/src/ops/conv.rs
+++ b/src/ops/conv.rs
@@ -57,8 +57,8 @@ fn conv_2d_pointwise(
 
     // Get input and kernel as contiguous tensors so we can create reshaped
     // views.
-    let input = input.to_contiguous();
-    let kernel = kernel.to_contiguous();
+    let input = input.to_contiguous_in(pool).auto_return(pool);
+    let kernel = kernel.to_contiguous_in(pool).auto_return(pool);
     let kernel_mat = kernel.reshaped([out_c, in_c]);
 
     // Bias must be contiguous for use with `gemm_bias`.
@@ -193,7 +193,7 @@ fn conv_2d_depthwise(
     let mut output = NdTensor::uninit_in(pool, [batch, out_c, out_h, out_w]);
 
     // Use of input rows below assumes contiguous last dimension.
-    let input = input.to_contiguous();
+    let input = input.to_contiguous_in(pool).auto_return(pool);
 
     // Map of kernel X position to `(in_range, out_range)` of column ranges that
     // are used in the inner loop.
@@ -692,8 +692,8 @@ pub fn conv_transpose(
     let mut output = Tensor::uninit_in(pool, [batch, out_c, out_h, out_w].as_slice());
 
     // Ensure input and kernel are contiguous to support reshaping.
-    let input = input.to_contiguous();
-    let kernel = kernel.to_contiguous();
+    let input = input.to_contiguous_in(pool).auto_return(pool);
+    let kernel = kernel.to_contiguous_in(pool).auto_return(pool);
 
     let mut col2im_mat =
         NdTensor::uninit_in(pool, [out_c * k_h * k_w, in_h * in_w]).auto_return(pool);

--- a/src/ops/matmul.rs
+++ b/src/ops/matmul.rs
@@ -161,7 +161,7 @@ fn matmul_impl(
     // `A` smaller matmuls. This is especially true if `M` is small (eg. 1).
     if strategy == MatmulStrategy::Auto && a.ndim() > 2 && b.ndim() == 2 {
         // nb. We assume `a` is likely already contiguous, so this will be cheap.
-        let a_contig = a.to_contiguous();
+        let a_contig = a.to_contiguous_in(pool).auto_return(pool);
         let a_matrix = a_contig.reshaped([num_a_matrices * a_rows, a_cols].as_slice());
         let mut output = matmul(pool, a_matrix, b.clone())?;
         output.reshape(out_shape);

--- a/src/ops/rnn.rs
+++ b/src/ops/rnn.rs
@@ -547,7 +547,7 @@ pub fn lstm(
     check_dims!(initial_cell?, 3);
 
     // Contiguous input and bias needed to allow reshaping below.
-    let input = input.to_contiguous();
+    let input = input.to_contiguous_in(pool).auto_return(pool);
     let bias = bias.map(|t| t.to_contiguous());
 
     // Indices of gates in the concatenated weight and bias tensors.

--- a/src/ops/unary_elementwise.rs
+++ b/src/ops/unary_elementwise.rs
@@ -13,7 +13,7 @@ use rten_vecmath::{
 
 use crate::number::AsBool;
 use crate::ops::{Input, InputList, IntoOpResult, OpError, Operator, Output};
-use crate::tensor_pool::TensorPool;
+use crate::tensor_pool::{AutoReturn, TensorPool};
 
 /// Trait for operators which take a single float tensor and apply a function
 /// to each element.
@@ -157,7 +157,7 @@ fn par_unary_op<
     input: TensorView<T>,
     op: F,
 ) -> Tensor<T> {
-    let input = input.to_contiguous();
+    let input = input.to_contiguous_in(pool).auto_return(pool);
     let mut output = Tensor::uninit_in(pool, input.shape());
 
     let in_chunks = input.data().unwrap().par_chunks(CHUNK_SIZE);


### PR DESCRIPTION
When operators conditionally copy inputs to make them contiguous via `Tensor::to_contiguous`, allocate buffers from and return them to the pool. This avoids the overhead of allocating / freeing these large buffers using the system allocator.

- Add `TensorBase<CowData<_>, _>::into_non_contiguous_data` and `TensorBase::to_continuous_in`
- Fix some comments in `tensor.rs` which referred to an earlier iteration of the `TensorBase` APIs that now accept an allocator
- Make `ExtractBuffer::extract_buffer` return an `Option<Vec<T>>` instead of a `Vec<T>` to support uses with maybe-owned storage types
- Change uses of `input.to_contiguous()` to `input.to_continuous_in(pool).auto_return(pool)`