### PR TITLE
Adding "serde_traits" optional cargo feature to rten-imageproc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,10 @@ default-members = [
   "rten-text"
 ]
 
+[workspace.dependencies]
+serde = { version = "1.0.202" }
+serde_json = { version = "1.0.117" }
+
 [package]
 name = "rten"
 version = "0.9.0"
@@ -48,7 +52,7 @@ num_cpus = "1.16.0"
 [dev-dependencies]
 rten = { path = ".", features = ["mmap", "random"] }
 rten-bench = { path = "./rten-bench" }
-serde_json = "1.0.91"
+serde_json = { workspace = true }
 
 [lib]
 crate-type = ["lib", "cdylib"]

--- a/rten-examples/Cargo.toml
+++ b/rten-examples/Cargo.toml
@@ -14,8 +14,8 @@ hound = "3.5.1"
 image = { version = "0.24.6", default-features = false, features = ["png", "jpeg", "jpeg_rayon", "webp"] }
 lexopt = "0.3.0"
 png = "0.17.6"
-serde = { version = "1.0.91", features = ["derive"] }
-serde_json = "1.0.91"
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
 rten = { path = "../", features = ["mmap", "random"] }
 rten-imageio = { path = "../rten-imageio" }
 rten-imageproc = { path = "../rten-imageproc" }

--- a/rten-imageproc/Cargo.toml
+++ b/rten-imageproc/Cargo.toml
@@ -11,9 +11,14 @@ include = ["/src", "/README.md"]
 
 [dependencies]
 rten-tensor = { path = "../rten-tensor", version = "0.9.0" }
+serde = { workspace = true, features = ["derive"], optional = true }
 
 [dev-dependencies]
 rten-bench = { path = "../rten-bench" }
 
 [lib]
 crate-type = ["lib"]
+
+[features]
+# Implement serde Serialize and Deserialize traits on items where it makes sense
+serde_traits = ["serde"]

--- a/rten-imageproc/src/math.rs
+++ b/rten-imageproc/src/math.rs
@@ -1,6 +1,7 @@
 use crate::Point;
 
 #[derive(Copy, Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "serde_traits", derive(serde::Serialize, serde::Deserialize))]
 pub struct Vec2 {
     pub x: f32,
     pub y: f32,

--- a/rten-imageproc/src/shapes.rs
+++ b/rten-imageproc/src/shapes.rs
@@ -65,6 +65,7 @@ fn max_or_lhs<T: PartialOrd>(a: T, b: T) -> T {
 
 /// A point defined by X and Y coordinates.
 #[derive(Copy, Clone, Default, Eq, PartialEq)]
+#[cfg_attr(feature = "serde_traits", derive(serde::Serialize, serde::Deserialize))]
 pub struct Point<T: Coord = i32> {
     pub x: T,
     pub y: T,
@@ -197,6 +198,7 @@ fn sort_pair<T: PartialOrd>(pair: (T, T)) -> (T, T) {
 
 /// A bounded line segment defined by a start and end point.
 #[derive(Copy, Clone, PartialEq)]
+#[cfg_attr(feature = "serde_traits", derive(serde::Serialize, serde::Deserialize))]
 pub struct Line<T: Coord = i32> {
     pub start: Point<T>,
     pub end: Point<T>,
@@ -446,6 +448,7 @@ impl<T: Coord> BoundingRect for Line<T> {
 /// The left and top coordinates are inclusive. The right and bottom coordinates
 /// are exclusive.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde_traits", derive(serde::Serialize, serde::Deserialize))]
 pub struct Rect<T: Coord = i32> {
     top_left: Point<T>,
     bottom_right: Point<T>,
@@ -708,6 +711,7 @@ impl<T: Coord> BoundingRect for Rect<T> {
 /// orientation, width (extent along axis perpendicular to the up axis) and
 /// height (extent along up axis).
 #[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "serde_traits", derive(serde::Serialize, serde::Deserialize))]
 pub struct RotatedRect {
     // Centroid of the rect.
     center: PointF,
@@ -910,6 +914,7 @@ where
 /// Depending on the storage type `S`, a Polygon can own its vertices
 /// (eg. `Vec<Point>`) or they can borrowed (eg. `&[Point]`).
 #[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "serde_traits", derive(serde::Serialize, serde::Deserialize))]
 pub struct Polygon<T: Coord = i32, S: AsRef<[Point<T>]> = Vec<Point<T>>> {
     points: S,
 
@@ -1073,6 +1078,7 @@ impl_bounding_rect_for_polygon!(f32);
 /// `Polygons` is primarily useful when building up collections of many polygons
 /// as it stores all points in a single Vec, which is more efficient than
 /// allocating a separate Vec for each polygon's points.
+#[cfg_attr(feature = "serde_traits", derive(serde::Serialize, serde::Deserialize))]
 pub struct Polygons {
     points: Vec<Point>,
 

--- a/rten-text/Cargo.toml
+++ b/rten-text/Cargo.toml
@@ -15,5 +15,5 @@ crate-type = ["lib"]
 [dependencies]
 unicode_categories = "0.1.1"
 unicode-normalization = "0.1.22"
-serde_json = "1.0.108"
-serde = { version = "1.0.193", features = ["derive"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }


### PR DESCRIPTION
Adding "serde_traits" cargo feature to rten-imageproc to implement Serialize and Deserialize on the public-facing shape types.

Also synchronizing serde & serde json versions across sub-crates

This relates to https://github.com/robertknight/rten/issues/179

Thank you.