### PR TITLE
Fix conversion of `Transpose` operator with missing `perm` attr

### DIFF
--- a/rten-convert/rten_convert/converter.py
+++ b/rten-convert/rten_convert/converter.py
@@ -921,7 +921,7 @@ def op_node_from_onnx_operator(
 
         case "Transpose":
             attrs = sg.TransposeAttrsT()
-            attrs.perm = op_reader.get_attr("perm", "ints", [])
+            attrs.perm = op_reader.get_attr("perm", "ints", None)
 
         case "Trilu":
             attrs = sg.TriluAttrsT()


### PR DESCRIPTION
A missing `perm` attr signals that the input dimensions should be reversed.  The converter translated a missing `perm` attr into an empty permuation list instead of `None`, causing the operator to fail with an "Invalid permutation" error.

Tested with the `decoder_model.onnx` model from https://huggingface.co/Mozilla/distilvit/tree/main/onnx.