### PR TITLE
Add `--n_iters` flag to CLI and perform constant propagation before running model

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -248,7 +248,7 @@ impl Error for RunError {}
 
 /// Options that control logging and other behaviors when executing a
 /// [Model](crate::Model).
-#[derive(Default)]
+#[derive(Clone, Default, PartialEq)]
 pub struct RunOptions {
     /// Whether to log times spent in different operators when run completes.
     pub timing: bool,

--- a/src/timing.rs
+++ b/src/timing.rs
@@ -367,7 +367,7 @@ pub struct TimingRecord<'a> {
 }
 
 /// Specifies sort order for graph run timings.
-#[derive(Default)]
+#[derive(Clone, Default, PartialEq)]
 pub enum TimingSort {
     /// Sort timings by operator name
     ByName,


### PR DESCRIPTION
- The `n_iters` flag is useful for assessing the initial run vs "warmed up" inference times for models
- The constant propagation step is useful to highlight where models have unnecessary operators in them that could be eliminated by a graph optimization (ORT does this automatically)