### PR TITLE
Export `RunError`

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -161,7 +161,11 @@ pub enum RunError {
     PlanningError(String),
 
     /// Execution of an operator failed
-    OperatorError { name: String, error: OpError },
+    OperatorError {
+        /// Name of the operator node.
+        name: String,
+        error: OpError,
+    },
 
     /// The output of a graph operator did not match expectations (eg. the
     /// count, types or shapes of outputs did not match what was expected.)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,7 +114,7 @@ pub mod ctc;
 
 pub mod ops;
 
-pub use graph::{Dimension, NodeId, RunOptions};
+pub use graph::{Dimension, NodeId, RunError, RunOptions};
 pub use model::{Model, ModelLoadError, ModelOptions, NodeInfo, OpRegistry, ReadOp, ReadOpError};
 pub use model_metadata::ModelMetadata;
 pub use ops::{FloatOperators, Input, Operators, Output};


### PR DESCRIPTION
Export the error type returned by `Model::run`, so that consumers can match on it.