### PR TITLE
Make `TensorBase::axis_iter` yield static-rank views if receiver has static rank

### DIFF
--- a/rten-tensor/src/tensor.rs
+++ b/rten-tensor/src/tensor.rs
@@ -27,6 +27,16 @@ use crate::{Alloc, GlobalAlloc, IntoSliceItems, RandomSource, SliceItem};
 #[derive(Debug)]
 pub struct TensorBase<S: Storage, L: MutLayout> {
     data: S,
+
+    // Layout mapping N-dimensional indices to offsets in `data`.
+    //
+    // Constructors must ensure:
+    //
+    // - Every index that is valid for `layout` must map to an offset that is
+    //   less than `data.len()`. The minimum length for a layout is given by
+    //   `Layout::min_data_len`.
+    // - If `S` is a mutable storage type, no two indices of `layout` can map to
+    //   the same offset. See the `may_have_internal_overlap` function.
     layout: L,
 }
 


### PR DESCRIPTION
Make the iterator returned by `axis_iter` yield static-rank views if `self` has a static rank. The implementation uses a specialized slicing implementation which is much more efficient than `TensorBase::slice`, especially for static-rank tensors.

These changes make it possible for operator implementations to use this iterator more in inner loops.