### PR TITLE
Re-implement variadic ops as a series of binary ops

### DIFF
--- a/src/ops/binary_elementwise.rs
+++ b/src/ops/binary_elementwise.rs
@@ -154,7 +154,7 @@ fn fast_broadcast_cycles(from_shape: &[usize], to_shape: &[usize]) -> Option<usi
 /// Compute the result of applying the binary operation `op` to corresponding
 /// elements of `a` and `b`. The shapes of `a` and `b` are broadcast to a
 /// matching shape if necessary.
-fn binary_op<T: Copy + Debug, R: Default, F: Fn(T, T) -> R>(
+pub fn binary_op<T: Copy, R, F: Fn(T, T) -> R>(
     pool: &TensorPool,
     a: TensorView<T>,
     b: TensorView<T>,


### PR DESCRIPTION
Assuming that variadic operators like `Sum`, `Mean` etc. are most often called with two or a small number of operands, re-using the optimized code for binary operators will be much more efficient than iterators.

Part of https://github.com/robertknight/rten/issues/189.