### PR TITLE
Re-implement `Where` operator fallback

### DIFF
--- a/rten-tensor/src/iterators.rs
+++ b/rten-tensor/src/iterators.rs
@@ -1,4 +1,4 @@
-use std::iter::{repeat, zip, Cycle, FusedIterator, Take};
+use std::iter::FusedIterator;
 use std::ops::Range;
 use std::slice;
 
@@ -30,10 +30,6 @@ impl<'d, 'l, T, L: Layout> ViewRef<'d, 'l, T, L> {
             // Safety: We verified the layout is contigous
             self.data.as_slice()
         })
-    }
-
-    fn shape(&self) -> L::Index<'_> {
-        self.layout.shape()
     }
 }
 
@@ -124,38 +120,6 @@ impl IndexingIterBase {
 
         IndexingIterBase {
             len: layout.len(),
-            offset: 0,
-            pos: dims,
-        }
-    }
-
-    /// Create an iterator over offsets of elements in `tensor`, as if it had
-    /// a given `shape`. This will repeat offsets as necessary.
-    fn broadcast<L: Layout>(layout: &L, shape: &[usize]) -> IndexingIterBase {
-        // nb. We require that the broadcast shape has a length >= the actual
-        // shape.
-        let added_dims = shape.len() - layout.ndim();
-        let layout_shape = layout.shape();
-        let layout_shape = layout_shape.as_ref();
-        let padded_tensor_shape = repeat(&0).take(added_dims).chain(layout_shape.iter());
-        let dims = zip(padded_tensor_shape, shape.iter())
-            .enumerate()
-            .map(|(dim, (&actual_len, &broadcast_len))| {
-                // If the dimension is being broadcast, set its stride to 0 so
-                // that when we increment in this dimension, we just repeat
-                // elements. Otherwise, use the real stride.
-                let offset_step = if actual_len == broadcast_len {
-                    layout.stride(dim - added_dims) as isize
-                } else {
-                    0
-                };
-
-                IterPos::new(broadcast_len, offset_step)
-            })
-            .collect();
-
-        IndexingIterBase {
-            len: shape.iter().product(),
             offset: 0,
             pos: dims,
         }
@@ -292,13 +256,6 @@ impl<'a, T> IndexingIter<'a, T> {
     fn new<L: Layout>(view: ViewRef<'a, '_, T, L>) -> IndexingIter<'a, T> {
         IndexingIter {
             base: IndexingIterBase::new(view.layout),
-            data: view.data,
-        }
-    }
-
-    fn broadcast<L: Layout>(view: ViewRef<'a, '_, T, L>, shape: &[usize]) -> IndexingIter<'a, T> {
-        IndexingIter {
-            base: IndexingIterBase::broadcast(view.layout, shape),
             data: view.data,
         }
     }
@@ -459,12 +416,6 @@ impl Offsets {
             base: IndexingIterBase::new(layout),
         }
     }
-
-    pub fn broadcast<L: Layout>(layout: &L, shape: &[usize]) -> Offsets {
-        Offsets {
-            base: IndexingIterBase::broadcast(layout, shape),
-        }
-    }
 }
 
 impl Iterator for Offsets {
@@ -492,99 +443,6 @@ impl Iterator for Offsets {
 impl ExactSizeIterator for Offsets {}
 
 impl FusedIterator for Offsets {}
-
-/// Iterator over elements of a tensor which broadcasts to a different shape.
-///
-/// This iterator will repeat elements of the underlying tensor until the total
-/// number yielded matches the product of the shape being broadcast to.
-pub struct BroadcastIter<'a, T> {
-    iter: BroadcastIterKind<'a, T>,
-}
-
-/// Alternate implementations for broadcasting. See notes in
-/// `BroadcastElements::can_broadcast_by_cycling`.
-enum BroadcastIterKind<'a, T> {
-    Direct(Take<Cycle<slice::Iter<'a, T>>>),
-    Indexing(IndexingIter<'a, T>),
-}
-
-/// Return true if a tensor with shape `from_shape` can be broadcast to shape
-/// `to_shape` by cycling through all of its elements repeatedly.
-///
-/// This requires that, after left-padding `from_shape` with 1s to match the
-/// length of `to_shape`, all non-1 dimensions in `from_shape` are contiguous
-/// at the end. For example, `[1, 5, 10]` can be broadcast to `[3, 4, 5, 10]`
-/// by cycling, but `[5, 1, 10]` cannot be broadcast to `[5, 4, 10]` this way,
-/// as the inner (`[1, 10]`) dimensions will need to be repeated 4 times before
-/// moving to the next index in the outermost dimension.
-///
-/// If the tensor can be broadcast via cycling, and is also contiguous, it can
-/// be broadcast efficiently using `tensor.data().iter().cycle()`.
-fn can_broadcast_by_cycling(from_shape: &[usize], to_shape: &[usize]) -> bool {
-    assert!(to_shape.len() >= from_shape.len());
-
-    let excess_dims = to_shape.len() - from_shape.len();
-    let mut dims_to_check = to_shape.len() - excess_dims;
-
-    while dims_to_check > 0 {
-        if from_shape[dims_to_check - 1] != to_shape[excess_dims + dims_to_check - 1] {
-            break;
-        }
-        dims_to_check -= 1;
-    }
-
-    while dims_to_check > 0 {
-        if from_shape[dims_to_check - 1] != 1 {
-            return false;
-        }
-        dims_to_check -= 1;
-    }
-
-    true
-}
-
-impl<'a, T> BroadcastIter<'a, T> {
-    pub(crate) fn new<L: Layout>(
-        view: ViewRef<'a, '_, T, L>,
-        to_shape: &[usize],
-    ) -> BroadcastIter<'a, T> {
-        let tmp_view = view.clone();
-        let iter = match (
-            view.contiguous_data(),
-            can_broadcast_by_cycling(view.shape().as_ref(), to_shape),
-        ) {
-            (Some(data), true) => {
-                let iter_len = to_shape.iter().product();
-                BroadcastIterKind::Direct(data.iter().cycle().take(iter_len))
-            }
-            _ => BroadcastIterKind::Indexing(IndexingIter::broadcast(tmp_view, to_shape)),
-        };
-        BroadcastIter { iter }
-    }
-}
-
-impl<'a, T> Iterator for BroadcastIter<'a, T> {
-    type Item = &'a T;
-
-    #[inline]
-    fn next(&mut self) -> Option<Self::Item> {
-        match self.iter {
-            BroadcastIterKind::Direct(ref mut iter) => iter.next(),
-            BroadcastIterKind::Indexing(ref mut iter) => iter.next(),
-        }
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        match &self.iter {
-            BroadcastIterKind::Direct(iter) => iter.size_hint(),
-            BroadcastIterKind::Indexing(iter) => iter.size_hint(),
-        }
-    }
-}
-
-impl<'a, T> ExactSizeIterator for BroadcastIter<'a, T> {}
-
-impl<'a, T> FusedIterator for BroadcastIter<'a, T> {}
 
 /// Iterator over the ranges of a tensor's data that correspond to 1D lanes
 /// along a particular dimension.

--- a/rten-tensor/src/lib.rs
+++ b/rten-tensor/src/lib.rs
@@ -92,8 +92,8 @@ impl Alloc for GlobalAlloc {
 
 pub use index_iterator::{DynIndices, Indices, NdIndices};
 pub use iterators::{
-    AxisChunks, AxisChunksMut, AxisIter, AxisIterMut, BroadcastIter, InnerIter, InnerIterMut, Iter,
-    IterMut, Lanes, LanesMut, Offsets,
+    AxisChunks, AxisChunksMut, AxisIter, AxisIterMut, InnerIter, InnerIterMut, Iter, IterMut,
+    Lanes, LanesMut, Offsets,
 };
 pub use layout::{
     is_valid_permutation, DynLayout, IntoLayout, Layout, MatrixLayout, MutLayout, NdLayout,

--- a/rten-tensor/src/tensor.rs
+++ b/rten-tensor/src/tensor.rs
@@ -5,8 +5,8 @@ use std::ops::{Index, IndexMut, Range};
 use crate::copy::{copy_into, copy_into_slice, copy_into_uninit, copy_range_into_slice};
 use crate::errors::{DimensionError, FromDataError, SliceError};
 use crate::iterators::{
-    AxisChunks, AxisChunksMut, AxisIter, AxisIterMut, BroadcastIter, InnerIter, InnerIterDyn,
-    InnerIterDynMut, InnerIterMut, Iter, IterMut, Lanes, LanesMut, MutViewRef, ViewRef,
+    AxisChunks, AxisChunksMut, AxisIter, AxisIterMut, InnerIter, InnerIterDyn, InnerIterDynMut,
+    InnerIterMut, Iter, IterMut, Lanes, LanesMut, MutViewRef, ViewRef,
 };
 use crate::layout::{
     AsIndex, BroadcastLayout, DynLayout, IntoLayout, Layout, MatrixLayout, MutLayout, NdLayout,
@@ -111,14 +111,6 @@ pub trait AsView: Layout {
         Self::Layout: BroadcastLayout<S::Layout>,
     {
         self.view().broadcast(shape)
-    }
-
-    /// Return an iterator over elements of this tensor, broadcast to `shape`.
-    ///
-    /// This is equivalent to `self.broadcast(shape).iter()` but has some
-    /// additional optimizations.
-    fn broadcast_iter(&self, shape: &[usize]) -> BroadcastIter<Self::Elem> {
-        self.view().broadcast_iter(shape)
     }
 
     /// Return the layout of this tensor as a slice, if it is contiguous.
@@ -1139,14 +1131,6 @@ impl<'a, T, L: Clone + MutLayout> TensorBase<ViewData<'a, T>, L> {
             layout: self.layout.broadcast(shape),
             data: self.data,
         }
-    }
-
-    /// Return an iterator over elements as if this tensor was broadcast to
-    /// another shape.
-    ///
-    /// See [AsView::broadcast_iter].
-    pub fn broadcast_iter(&self, shape: &[usize]) -> BroadcastIter<'a, T> {
-        BroadcastIter::new(self.view_ref(), shape)
     }
 
     /// Return the data in this tensor as a slice if it is contiguous, ie.
@@ -2256,13 +2240,6 @@ mod tests {
         let view = tensor.broadcast(dest_shape.as_slice());
         assert_eq!(view.shape(), dest_shape);
         assert_eq!(view.to_vec(), expected_data);
-    }
-
-    #[test]
-    fn test_broadcast_iter() {
-        let tensor = NdTensor::from_data([1], vec![3]);
-        let elems: Vec<_> = tensor.broadcast_iter(&[2, 2]).copied().collect();
-        assert_eq!(elems, &[3, 3, 3, 3]);
     }
 
     #[test]


### PR DESCRIPTION
Re-implement the slow path in the `Where` operator to use a code pattern similar to that added for binary ops in https://github.com/robertknight/rten/pull/190.

This replaces the last usage of the `TensorBase::broadcast_iter` method, so that code has been removed from rten-tensor. Any code outside the rten crates needing to broadcast tensors should be migrated to `TensorBase::broadcast`.

Fixes https://github.com/robertknight/rten/issues/189