### PR TITLE
Un-export `Offsets` type, address warnings from Rust v1.78

### DIFF
--- a/rten-tensor/src/iterators.rs
+++ b/rten-tensor/src/iterators.rs
@@ -406,7 +406,7 @@ impl<'a, T> FusedIterator for IndexingIterMut<'a, T> {}
 /// be modified during iteration. It is the caller's responsibilty not to modify
 /// the tensor in ways that invalidate the offset sequence returned by this
 /// iterator.
-pub struct Offsets {
+struct Offsets {
     base: IndexingIterBase,
 }
 

--- a/rten-tensor/src/lib.rs
+++ b/rten-tensor/src/lib.rs
@@ -93,7 +93,7 @@ impl Alloc for GlobalAlloc {
 pub use index_iterator::{DynIndices, Indices, NdIndices};
 pub use iterators::{
     AxisChunks, AxisChunksMut, AxisIter, AxisIterMut, InnerIter, InnerIterMut, Iter, IterMut,
-    Lanes, LanesMut, Offsets,
+    Lanes, LanesMut,
 };
 pub use layout::{
     is_valid_permutation, DynLayout, IntoLayout, Layout, MatrixLayout, MutLayout, NdLayout,

--- a/rten-tensor/src/lib.rs
+++ b/rten-tensor/src/lib.rs
@@ -84,6 +84,12 @@ impl GlobalAlloc {
     }
 }
 
+impl Default for GlobalAlloc {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Alloc for GlobalAlloc {
     fn alloc<T>(&self, capacity: usize) -> Vec<T> {
         Vec::with_capacity(capacity)

--- a/rten-vecmath/src/lib.rs
+++ b/rten-vecmath/src/lib.rs
@@ -21,6 +21,8 @@ mod erf;
 mod exp;
 mod softmax;
 mod tanh;
+
+#[cfg(test)]
 mod ulp;
 
 #[cfg(test)]

--- a/src/number.rs
+++ b/src/number.rs
@@ -62,12 +62,14 @@ impl Identities for i32 {
 
 pub trait MinMax {
     /// Return the maximum value for this type.
+    #[allow(unused)] // Not used yet, but included for completeness
     fn max_val() -> Self;
 
     /// Return the minimum value for this type.
     fn min_val() -> Self;
 
     /// Return the minimum of `self` and `other`.
+    #[allow(unused)] // Not used yet, but included for completeness
     fn min(self, other: Self) -> Self;
 
     /// Return the maximum of `self` and `other`.

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -769,9 +769,9 @@ impl<'a> InputList<'a> {
     }
 
     /// Get a required input as a scalar value.
-    pub fn require_as_scalar<T: Copy + 'a>(&self, index: usize) -> Result<T, OpError>
+    pub fn require_as_scalar<T>(&self, index: usize) -> Result<T, OpError>
     where
-        T: TryFrom<Input<'a>, Error = OpError>,
+        T: 'a + Copy + TryFrom<Input<'a>, Error = OpError>,
     {
         self.require(index).and_then(|input| input.try_into())
     }


### PR DESCRIPTION
- Remove `Offsets` type from the rten-tensor public API, as it isn't used by any other crates in this repo
- Address a few warnings and clippy suggestions after updating to Rust v1.78