### PR TITLE
Align `auto_pad` operator attribute name with ONNX

### DIFF
--- a/rten-convert/rten_convert/schema_generated.py
+++ b/rten-convert/rten_convert/schema_generated.py
@@ -117,9 +117,9 @@ class RNNDirection(object):
     Bidirectional = 2
 
 
-class PadMode(object):
+class AutoPad(object):
     Same = 0
-    Fixed = 1
+    NotSet = 1
 
 
 class DataType(object):
@@ -467,7 +467,7 @@ class AveragePoolAttrs(object):
         return o == 0
 
     # AveragePoolAttrs
-    def PadMode(self):
+    def AutoPad(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(6))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Uint8Flags, o + self._tab.Pos)
@@ -543,8 +543,8 @@ def AveragePoolAttrsAddKernelSize(builder, kernelSize):
 def AveragePoolAttrsStartKernelSizeVector(builder, numElems):
     return builder.StartVector(4, numElems, 4)
 
-def AveragePoolAttrsAddPadMode(builder, padMode):
-    builder.PrependUint8Slot(1, padMode, 0)
+def AveragePoolAttrsAddAutoPad(builder, autoPad):
+    builder.PrependUint8Slot(1, autoPad, 0)
 
 def AveragePoolAttrsAddPads(builder, pads):
     builder.PrependUOffsetTRelativeSlot(2, flatbuffers.number_types.UOffsetTFlags.py_type(pads), 0)
@@ -575,7 +575,7 @@ class AveragePoolAttrsT(object):
     # AveragePoolAttrsT
     def __init__(self):
         self.kernelSize = None  # type: List[int]
-        self.padMode = 0  # type: int
+        self.autoPad = 0  # type: int
         self.pads = None  # type: List[int]
         self.strides = None  # type: List[int]
         self.countIncludePad = False  # type: bool
@@ -608,7 +608,7 @@ class AveragePoolAttrsT(object):
                     self.kernelSize.append(averagePoolAttrs.KernelSize(i))
             else:
                 self.kernelSize = averagePoolAttrs.KernelSizeAsNumpy()
-        self.padMode = averagePoolAttrs.PadMode()
+        self.autoPad = averagePoolAttrs.AutoPad()
         if not averagePoolAttrs.PadsIsNone():
             if np is None:
                 self.pads = []
@@ -654,7 +654,7 @@ class AveragePoolAttrsT(object):
         AveragePoolAttrsStart(builder)
         if self.kernelSize is not None:
             AveragePoolAttrsAddKernelSize(builder, kernelSize)
-        AveragePoolAttrsAddPadMode(builder, self.padMode)
+        AveragePoolAttrsAddAutoPad(builder, self.autoPad)
         if self.pads is not None:
             AveragePoolAttrsAddPads(builder, pads)
         if self.strides is not None:
@@ -1172,7 +1172,7 @@ class ConvAttrs(object):
         self._tab = flatbuffers.table.Table(buf, pos)
 
     # ConvAttrs
-    def PadMode(self):
+    def AutoPad(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Uint8Flags, o + self._tab.Pos)
@@ -1269,8 +1269,8 @@ class ConvAttrs(object):
 def ConvAttrsStart(builder):
     builder.StartObject(5)
 
-def ConvAttrsAddPadMode(builder, padMode):
-    builder.PrependUint8Slot(0, padMode, 0)
+def ConvAttrsAddAutoPad(builder, autoPad):
+    builder.PrependUint8Slot(0, autoPad, 0)
 
 def ConvAttrsAddPads(builder, pads):
     builder.PrependUOffsetTRelativeSlot(1, flatbuffers.number_types.UOffsetTFlags.py_type(pads), 0)
@@ -1306,7 +1306,7 @@ class ConvAttrsT(object):
 
     # ConvAttrsT
     def __init__(self):
-        self.padMode = 0  # type: int
+        self.autoPad = 0  # type: int
         self.pads = None  # type: List[int]
         self.groups = 0  # type: int
         self.strides = None  # type: List[int]
@@ -1333,7 +1333,7 @@ class ConvAttrsT(object):
     def _UnPack(self, convAttrs):
         if convAttrs is None:
             return
-        self.padMode = convAttrs.PadMode()
+        self.autoPad = convAttrs.AutoPad()
         if not convAttrs.PadsIsNone():
             if np is None:
                 self.pads = []
@@ -1384,7 +1384,7 @@ class ConvAttrsT(object):
                     builder.PrependUint32(self.dilations[i])
                 dilations = builder.EndVector()
         ConvAttrsStart(builder)
-        ConvAttrsAddPadMode(builder, self.padMode)
+        ConvAttrsAddAutoPad(builder, self.autoPad)
         if self.pads is not None:
             ConvAttrsAddPads(builder, pads)
         ConvAttrsAddGroups(builder, self.groups)
@@ -1446,7 +1446,7 @@ class ConvTransposeAttrs(object):
         return o == 0
 
     # ConvTransposeAttrs
-    def PadMode(self):
+    def AutoPad(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(6))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Uint8Flags, o + self._tab.Pos)
@@ -1488,8 +1488,8 @@ def ConvTransposeAttrsAddStrides(builder, strides):
 def ConvTransposeAttrsStartStridesVector(builder, numElems):
     return builder.StartVector(4, numElems, 4)
 
-def ConvTransposeAttrsAddPadMode(builder, padMode):
-    builder.PrependUint8Slot(1, padMode, 1)
+def ConvTransposeAttrsAddAutoPad(builder, autoPad):
+    builder.PrependUint8Slot(1, autoPad, 1)
 
 def ConvTransposeAttrsAddPads(builder, pads):
     builder.PrependUOffsetTRelativeSlot(2, flatbuffers.number_types.UOffsetTFlags.py_type(pads), 0)
@@ -1511,7 +1511,7 @@ class ConvTransposeAttrsT(object):
     # ConvTransposeAttrsT
     def __init__(self):
         self.strides = None  # type: List[int]
-        self.padMode = 1  # type: int
+        self.autoPad = 1  # type: int
         self.pads = None  # type: List[int]
 
     @classmethod
@@ -1542,7 +1542,7 @@ class ConvTransposeAttrsT(object):
                     self.strides.append(convTransposeAttrs.Strides(i))
             else:
                 self.strides = convTransposeAttrs.StridesAsNumpy()
-        self.padMode = convTransposeAttrs.PadMode()
+        self.autoPad = convTransposeAttrs.AutoPad()
         if not convTransposeAttrs.PadsIsNone():
             if np is None:
                 self.pads = []
@@ -1572,7 +1572,7 @@ class ConvTransposeAttrsT(object):
         ConvTransposeAttrsStart(builder)
         if self.strides is not None:
             ConvTransposeAttrsAddStrides(builder, strides)
-        ConvTransposeAttrsAddPadMode(builder, self.padMode)
+        ConvTransposeAttrsAddAutoPad(builder, self.autoPad)
         if self.pads is not None:
             ConvTransposeAttrsAddPads(builder, pads)
         convTransposeAttrs = ConvTransposeAttrsEnd(builder)
@@ -2503,7 +2503,7 @@ class MaxPoolAttrs(object):
         return o == 0
 
     # MaxPoolAttrs
-    def PadMode(self):
+    def AutoPad(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(6))
         if o != 0:
             return self._tab.Get(flatbuffers.number_types.Uint8Flags, o + self._tab.Pos)
@@ -2572,8 +2572,8 @@ def MaxPoolAttrsAddKernelSize(builder, kernelSize):
 def MaxPoolAttrsStartKernelSizeVector(builder, numElems):
     return builder.StartVector(4, numElems, 4)
 
-def MaxPoolAttrsAddPadMode(builder, padMode):
-    builder.PrependUint8Slot(1, padMode, 0)
+def MaxPoolAttrsAddAutoPad(builder, autoPad):
+    builder.PrependUint8Slot(1, autoPad, 0)
 
 def MaxPoolAttrsAddPads(builder, pads):
     builder.PrependUOffsetTRelativeSlot(2, flatbuffers.number_types.UOffsetTFlags.py_type(pads), 0)
@@ -2601,7 +2601,7 @@ class MaxPoolAttrsT(object):
     # MaxPoolAttrsT
     def __init__(self):
         self.kernelSize = None  # type: List[int]
-        self.padMode = 0  # type: int
+        self.autoPad = 0  # type: int
         self.pads = None  # type: List[int]
         self.strides = None  # type: List[int]
 
@@ -2633,7 +2633,7 @@ class MaxPoolAttrsT(object):
                     self.kernelSize.append(maxPoolAttrs.KernelSize(i))
             else:
                 self.kernelSize = maxPoolAttrs.KernelSizeAsNumpy()
-        self.padMode = maxPoolAttrs.PadMode()
+        self.autoPad = maxPoolAttrs.AutoPad()
         if not maxPoolAttrs.PadsIsNone():
             if np is None:
                 self.pads = []
@@ -2678,7 +2678,7 @@ class MaxPoolAttrsT(object):
         MaxPoolAttrsStart(builder)
         if self.kernelSize is not None:
             MaxPoolAttrsAddKernelSize(builder, kernelSize)
-        MaxPoolAttrsAddPadMode(builder, self.padMode)
+        MaxPoolAttrsAddAutoPad(builder, self.autoPad)
         if self.pads is not None:
             MaxPoolAttrsAddPads(builder, pads)
         if self.strides is not None:

--- a/src/model_builder.rs
+++ b/src/model_builder.rs
@@ -148,18 +148,18 @@ pub struct MetadataArgs {
 }
 
 struct PadArgs {
-    pad_mode: sg::PadMode,
+    auto_pad: sg::AutoPad,
     pads: Option<Vec<usize>>,
 }
 
 fn pad_args_from_padding(padding: Padding) -> PadArgs {
     match padding {
         Padding::Same => PadArgs {
-            pad_mode: sg::PadMode::Same,
+            auto_pad: sg::AutoPad::Same,
             pads: None,
         },
         Padding::Fixed(pads) => PadArgs {
-            pad_mode: sg::PadMode::Fixed,
+            auto_pad: sg::AutoPad::NotSet,
             pads: Some(pads.iter().copied().collect()),
         },
     }
@@ -362,7 +362,7 @@ impl<'a> ModelBuilder<'a> {
                 let strides = self.create_vec(Some(args.strides.into()), |s| s as u32);
                 sg::AveragePoolAttrsArgs {
                     kernel_size,
-                    pad_mode: pad_args.pad_mode,
+                    auto_pad: pad_args.auto_pad,
                     pads,
                     strides,
                     count_include_pad: args.count_include_pad,
@@ -429,7 +429,7 @@ impl<'a> ModelBuilder<'a> {
                 sg::ConvAttrsArgs {
                     dilations,
                     groups: args.groups as u32,
-                    pad_mode: pad_args.pad_mode,
+                    auto_pad: pad_args.auto_pad,
                     pads,
                     strides,
                 }
@@ -440,7 +440,7 @@ impl<'a> ModelBuilder<'a> {
                 let strides = self.create_vec(Some(args.strides), |s| s as u32);
                 sg::ConvTransposeAttrsArgs {
                     strides,
-                    pad_mode: pad_args.pad_mode,
+                    auto_pad: pad_args.auto_pad,
                     pads,
                 }
             }),
@@ -544,7 +544,7 @@ impl<'a> ModelBuilder<'a> {
                 let strides = self.create_vec(Some(args.strides.into()), |s| s as u32);
                 sg::MaxPoolAttrsArgs {
                     kernel_size,
-                    pad_mode: pad_args.pad_mode,
+                    auto_pad: pad_args.auto_pad,
                     pads,
                     strides,
                 }

--- a/src/schema.fbs
+++ b/src/schema.fbs
@@ -120,9 +120,11 @@ enum RNNDirection: ubyte {
   Bidirectional
 }
 
-enum PadMode: ubyte {
+enum AutoPad: ubyte {
+  // nb. ONNX defines `SAME_UPPER` and `SAME_LOWER`. This corresponds to
+  // `SAME_UPPER` and TensorFlow / Keras's "same".
   Same,
-  Fixed
+  NotSet
 }
 
 enum DataType: ubyte {
@@ -200,7 +202,7 @@ table ArgMaxAttrs {
 
 table AveragePoolAttrs {
   kernel_size:[uint] (required);
-  pad_mode:PadMode;
+  auto_pad:AutoPad;
 
   // Padding for spatial axes as [top, left, bottom, right]
   pads:[uint];
@@ -240,7 +242,7 @@ table ConstantOfShapeAttrs {
 }
 
 table ConvAttrs {
-  pad_mode:PadMode;
+  auto_pad:AutoPad;
 
   // Padding for spatial axes as [left, right] or [top, left, bottom, right]
   pads:[uint];
@@ -253,8 +255,8 @@ table ConvAttrs {
 table ConvTransposeAttrs {
   strides:[uint];
 
-  // Defaults to `Fixed` for backwards compatibility.
-  pad_mode:PadMode = Fixed;
+  // Defaults to `NotSet` for backwards compatibility.
+  auto_pad:AutoPad = NotSet;
 
   // Padding for spatial axes as [left, right] or [top, left, bottom, right]
   pads:[uint];
@@ -310,7 +312,7 @@ table LSTMAttrs {
 
 table MaxPoolAttrs {
   kernel_size:[uint] (required);
-  pad_mode:PadMode;
+  auto_pad:AutoPad;
 
   // Padding for spatial axes as [top, left, bottom, right]
   pads:[uint];

--- a/src/schema.fbs
+++ b/src/schema.fbs
@@ -1,6 +1,9 @@
 // Flatbuffers schema for serialized RTen models.
 //
 // See https://google.github.io/flatbuffers/flatbuffers_guide_writing_schema.html.
+//
+// Operator names and attributes align with the corresponding ONNX operators.
+// See https://onnx.ai/onnx/operators/index.html.
 
 file_identifier "RTEN";
 file_extension "rten";

--- a/src/schema_generated.rs
+++ b/src/schema_generated.rs
@@ -603,40 +603,40 @@ impl flatbuffers::SimpleToVerifyInSlice for RNNDirection {}
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
-pub const ENUM_MIN_PAD_MODE: u8 = 0;
+pub const ENUM_MIN_AUTO_PAD: u8 = 0;
 #[deprecated(
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
-pub const ENUM_MAX_PAD_MODE: u8 = 1;
+pub const ENUM_MAX_AUTO_PAD: u8 = 1;
 #[deprecated(
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_PAD_MODE: [PadMode; 2] = [PadMode::Same, PadMode::Fixed];
+pub const ENUM_VALUES_AUTO_PAD: [AutoPad; 2] = [AutoPad::Same, AutoPad::NotSet];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-pub struct PadMode(pub u8);
+pub struct AutoPad(pub u8);
 #[allow(non_upper_case_globals)]
-impl PadMode {
+impl AutoPad {
     pub const Same: Self = Self(0);
-    pub const Fixed: Self = Self(1);
+    pub const NotSet: Self = Self(1);
 
     pub const ENUM_MIN: u8 = 0;
     pub const ENUM_MAX: u8 = 1;
-    pub const ENUM_VALUES: &'static [Self] = &[Self::Same, Self::Fixed];
+    pub const ENUM_VALUES: &'static [Self] = &[Self::Same, Self::NotSet];
     /// Returns the variant's name or "" if unknown.
     pub fn variant_name(self) -> Option<&'static str> {
         match self {
             Self::Same => Some("Same"),
-            Self::Fixed => Some("Fixed"),
+            Self::NotSet => Some("NotSet"),
             _ => None,
         }
     }
 }
-impl core::fmt::Debug for PadMode {
+impl core::fmt::Debug for AutoPad {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         if let Some(name) = self.variant_name() {
             f.write_str(name)
@@ -645,7 +645,7 @@ impl core::fmt::Debug for PadMode {
         }
     }
 }
-impl<'a> flatbuffers::Follow<'a> for PadMode {
+impl<'a> flatbuffers::Follow<'a> for AutoPad {
     type Inner = Self;
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
@@ -654,15 +654,15 @@ impl<'a> flatbuffers::Follow<'a> for PadMode {
     }
 }
 
-impl flatbuffers::Push for PadMode {
-    type Output = PadMode;
+impl flatbuffers::Push for AutoPad {
+    type Output = AutoPad;
     #[inline]
     unsafe fn push(&self, dst: &mut [u8], _written_len: usize) {
         flatbuffers::emplace_scalar::<u8>(dst, self.0);
     }
 }
 
-impl flatbuffers::EndianScalar for PadMode {
+impl flatbuffers::EndianScalar for AutoPad {
     type Scalar = u8;
     #[inline]
     fn to_little_endian(self) -> u8 {
@@ -676,7 +676,7 @@ impl flatbuffers::EndianScalar for PadMode {
     }
 }
 
-impl<'a> flatbuffers::Verifiable for PadMode {
+impl<'a> flatbuffers::Verifiable for AutoPad {
     #[inline]
     fn run_verifier(
         v: &mut flatbuffers::Verifier,
@@ -687,7 +687,7 @@ impl<'a> flatbuffers::Verifiable for PadMode {
     }
 }
 
-impl flatbuffers::SimpleToVerifyInSlice for PadMode {}
+impl flatbuffers::SimpleToVerifyInSlice for AutoPad {}
 #[deprecated(
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
@@ -1933,7 +1933,7 @@ impl<'a> flatbuffers::Follow<'a> for AveragePoolAttrs<'a> {
 
 impl<'a> AveragePoolAttrs<'a> {
     pub const VT_KERNEL_SIZE: flatbuffers::VOffsetT = 4;
-    pub const VT_PAD_MODE: flatbuffers::VOffsetT = 6;
+    pub const VT_AUTO_PAD: flatbuffers::VOffsetT = 6;
     pub const VT_PADS: flatbuffers::VOffsetT = 8;
     pub const VT_STRIDES: flatbuffers::VOffsetT = 10;
     pub const VT_COUNT_INCLUDE_PAD: flatbuffers::VOffsetT = 12;
@@ -1958,7 +1958,7 @@ impl<'a> AveragePoolAttrs<'a> {
             builder.add_kernel_size(x);
         }
         builder.add_count_include_pad(args.count_include_pad);
-        builder.add_pad_mode(args.pad_mode);
+        builder.add_auto_pad(args.auto_pad);
         builder.finish()
     }
 
@@ -1977,13 +1977,13 @@ impl<'a> AveragePoolAttrs<'a> {
         }
     }
     #[inline]
-    pub fn pad_mode(&self) -> PadMode {
+    pub fn auto_pad(&self) -> AutoPad {
         // Safety:
         // Created from valid Table for this object
         // which contains a valid value in this slot
         unsafe {
             self._tab
-                .get::<PadMode>(AveragePoolAttrs::VT_PAD_MODE, Some(PadMode::Same))
+                .get::<AutoPad>(AveragePoolAttrs::VT_AUTO_PAD, Some(AutoPad::Same))
                 .unwrap()
         }
     }
@@ -2039,7 +2039,7 @@ impl flatbuffers::Verifiable for AveragePoolAttrs<'_> {
                 Self::VT_KERNEL_SIZE,
                 true,
             )?
-            .visit_field::<PadMode>("pad_mode", Self::VT_PAD_MODE, false)?
+            .visit_field::<AutoPad>("auto_pad", Self::VT_AUTO_PAD, false)?
             .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, u32>>>(
                 "pads",
                 Self::VT_PADS,
@@ -2057,7 +2057,7 @@ impl flatbuffers::Verifiable for AveragePoolAttrs<'_> {
 }
 pub struct AveragePoolAttrsArgs<'a> {
     pub kernel_size: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u32>>>,
-    pub pad_mode: PadMode,
+    pub auto_pad: AutoPad,
     pub pads: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u32>>>,
     pub strides: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u32>>>,
     pub count_include_pad: bool,
@@ -2067,7 +2067,7 @@ impl<'a> Default for AveragePoolAttrsArgs<'a> {
     fn default() -> Self {
         AveragePoolAttrsArgs {
             kernel_size: None, // required field
-            pad_mode: PadMode::Same,
+            auto_pad: AutoPad::Same,
             pads: None,
             strides: None,
             count_include_pad: false,
@@ -2091,9 +2091,9 @@ impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> AveragePoolAttrsBuilder<'a, 'b,
         );
     }
     #[inline]
-    pub fn add_pad_mode(&mut self, pad_mode: PadMode) {
+    pub fn add_auto_pad(&mut self, auto_pad: AutoPad) {
         self.fbb_
-            .push_slot::<PadMode>(AveragePoolAttrs::VT_PAD_MODE, pad_mode, PadMode::Same);
+            .push_slot::<AutoPad>(AveragePoolAttrs::VT_AUTO_PAD, auto_pad, AutoPad::Same);
     }
     #[inline]
     pub fn add_pads(&mut self, pads: flatbuffers::WIPOffset<flatbuffers::Vector<'b, u32>>) {
@@ -2136,7 +2136,7 @@ impl core::fmt::Debug for AveragePoolAttrs<'_> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let mut ds = f.debug_struct("AveragePoolAttrs");
         ds.field("kernel_size", &self.kernel_size());
-        ds.field("pad_mode", &self.pad_mode());
+        ds.field("auto_pad", &self.auto_pad());
         ds.field("pads", &self.pads());
         ds.field("strides", &self.strides());
         ds.field("count_include_pad", &self.count_include_pad());
@@ -2877,7 +2877,7 @@ impl<'a> flatbuffers::Follow<'a> for ConvAttrs<'a> {
 }
 
 impl<'a> ConvAttrs<'a> {
-    pub const VT_PAD_MODE: flatbuffers::VOffsetT = 4;
+    pub const VT_AUTO_PAD: flatbuffers::VOffsetT = 4;
     pub const VT_PADS: flatbuffers::VOffsetT = 6;
     pub const VT_GROUPS: flatbuffers::VOffsetT = 8;
     pub const VT_STRIDES: flatbuffers::VOffsetT = 10;
@@ -2903,18 +2903,18 @@ impl<'a> ConvAttrs<'a> {
         if let Some(x) = args.pads {
             builder.add_pads(x);
         }
-        builder.add_pad_mode(args.pad_mode);
+        builder.add_auto_pad(args.auto_pad);
         builder.finish()
     }
 
     #[inline]
-    pub fn pad_mode(&self) -> PadMode {
+    pub fn auto_pad(&self) -> AutoPad {
         // Safety:
         // Created from valid Table for this object
         // which contains a valid value in this slot
         unsafe {
             self._tab
-                .get::<PadMode>(ConvAttrs::VT_PAD_MODE, Some(PadMode::Same))
+                .get::<AutoPad>(ConvAttrs::VT_AUTO_PAD, Some(AutoPad::Same))
                 .unwrap()
         }
     }
@@ -2974,7 +2974,7 @@ impl flatbuffers::Verifiable for ConvAttrs<'_> {
     ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
         use self::flatbuffers::Verifiable;
         v.visit_table(pos)?
-            .visit_field::<PadMode>("pad_mode", Self::VT_PAD_MODE, false)?
+            .visit_field::<AutoPad>("auto_pad", Self::VT_AUTO_PAD, false)?
             .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, u32>>>(
                 "pads",
                 Self::VT_PADS,
@@ -2996,7 +2996,7 @@ impl flatbuffers::Verifiable for ConvAttrs<'_> {
     }
 }
 pub struct ConvAttrsArgs<'a> {
-    pub pad_mode: PadMode,
+    pub auto_pad: AutoPad,
     pub pads: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u32>>>,
     pub groups: u32,
     pub strides: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u32>>>,
@@ -3006,7 +3006,7 @@ impl<'a> Default for ConvAttrsArgs<'a> {
     #[inline]
     fn default() -> Self {
         ConvAttrsArgs {
-            pad_mode: PadMode::Same,
+            auto_pad: AutoPad::Same,
             pads: None,
             groups: 0,
             strides: None,
@@ -3021,9 +3021,9 @@ pub struct ConvAttrsBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
 }
 impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> ConvAttrsBuilder<'a, 'b, A> {
     #[inline]
-    pub fn add_pad_mode(&mut self, pad_mode: PadMode) {
+    pub fn add_auto_pad(&mut self, auto_pad: AutoPad) {
         self.fbb_
-            .push_slot::<PadMode>(ConvAttrs::VT_PAD_MODE, pad_mode, PadMode::Same);
+            .push_slot::<AutoPad>(ConvAttrs::VT_AUTO_PAD, auto_pad, AutoPad::Same);
     }
     #[inline]
     pub fn add_pads(&mut self, pads: flatbuffers::WIPOffset<flatbuffers::Vector<'b, u32>>) {
@@ -3065,7 +3065,7 @@ impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> ConvAttrsBuilder<'a, 'b, A> {
 impl core::fmt::Debug for ConvAttrs<'_> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let mut ds = f.debug_struct("ConvAttrs");
-        ds.field("pad_mode", &self.pad_mode());
+        ds.field("auto_pad", &self.auto_pad());
         ds.field("pads", &self.pads());
         ds.field("groups", &self.groups());
         ds.field("strides", &self.strides());
@@ -3092,7 +3092,7 @@ impl<'a> flatbuffers::Follow<'a> for ConvTransposeAttrs<'a> {
 
 impl<'a> ConvTransposeAttrs<'a> {
     pub const VT_STRIDES: flatbuffers::VOffsetT = 4;
-    pub const VT_PAD_MODE: flatbuffers::VOffsetT = 6;
+    pub const VT_AUTO_PAD: flatbuffers::VOffsetT = 6;
     pub const VT_PADS: flatbuffers::VOffsetT = 8;
 
     #[inline]
@@ -3111,7 +3111,7 @@ impl<'a> ConvTransposeAttrs<'a> {
         if let Some(x) = args.strides {
             builder.add_strides(x);
         }
-        builder.add_pad_mode(args.pad_mode);
+        builder.add_auto_pad(args.auto_pad);
         builder.finish()
     }
 
@@ -3129,13 +3129,13 @@ impl<'a> ConvTransposeAttrs<'a> {
         }
     }
     #[inline]
-    pub fn pad_mode(&self) -> PadMode {
+    pub fn auto_pad(&self) -> AutoPad {
         // Safety:
         // Created from valid Table for this object
         // which contains a valid value in this slot
         unsafe {
             self._tab
-                .get::<PadMode>(ConvTransposeAttrs::VT_PAD_MODE, Some(PadMode::Fixed))
+                .get::<AutoPad>(ConvTransposeAttrs::VT_AUTO_PAD, Some(AutoPad::NotSet))
                 .unwrap()
         }
     }
@@ -3167,7 +3167,7 @@ impl flatbuffers::Verifiable for ConvTransposeAttrs<'_> {
                 Self::VT_STRIDES,
                 false,
             )?
-            .visit_field::<PadMode>("pad_mode", Self::VT_PAD_MODE, false)?
+            .visit_field::<AutoPad>("auto_pad", Self::VT_AUTO_PAD, false)?
             .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, u32>>>(
                 "pads",
                 Self::VT_PADS,
@@ -3179,7 +3179,7 @@ impl flatbuffers::Verifiable for ConvTransposeAttrs<'_> {
 }
 pub struct ConvTransposeAttrsArgs<'a> {
     pub strides: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u32>>>,
-    pub pad_mode: PadMode,
+    pub auto_pad: AutoPad,
     pub pads: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u32>>>,
 }
 impl<'a> Default for ConvTransposeAttrsArgs<'a> {
@@ -3187,7 +3187,7 @@ impl<'a> Default for ConvTransposeAttrsArgs<'a> {
     fn default() -> Self {
         ConvTransposeAttrsArgs {
             strides: None,
-            pad_mode: PadMode::Fixed,
+            auto_pad: AutoPad::NotSet,
             pads: None,
         }
     }
@@ -3204,9 +3204,9 @@ impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> ConvTransposeAttrsBuilder<'a, '
             .push_slot_always::<flatbuffers::WIPOffset<_>>(ConvTransposeAttrs::VT_STRIDES, strides);
     }
     #[inline]
-    pub fn add_pad_mode(&mut self, pad_mode: PadMode) {
+    pub fn add_auto_pad(&mut self, auto_pad: AutoPad) {
         self.fbb_
-            .push_slot::<PadMode>(ConvTransposeAttrs::VT_PAD_MODE, pad_mode, PadMode::Fixed);
+            .push_slot::<AutoPad>(ConvTransposeAttrs::VT_AUTO_PAD, auto_pad, AutoPad::NotSet);
     }
     #[inline]
     pub fn add_pads(&mut self, pads: flatbuffers::WIPOffset<flatbuffers::Vector<'b, u32>>) {
@@ -3234,7 +3234,7 @@ impl core::fmt::Debug for ConvTransposeAttrs<'_> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let mut ds = f.debug_struct("ConvTransposeAttrs");
         ds.field("strides", &self.strides());
-        ds.field("pad_mode", &self.pad_mode());
+        ds.field("auto_pad", &self.auto_pad());
         ds.field("pads", &self.pads());
         ds.finish()
     }
@@ -4465,7 +4465,7 @@ impl<'a> flatbuffers::Follow<'a> for MaxPoolAttrs<'a> {
 
 impl<'a> MaxPoolAttrs<'a> {
     pub const VT_KERNEL_SIZE: flatbuffers::VOffsetT = 4;
-    pub const VT_PAD_MODE: flatbuffers::VOffsetT = 6;
+    pub const VT_AUTO_PAD: flatbuffers::VOffsetT = 6;
     pub const VT_PADS: flatbuffers::VOffsetT = 8;
     pub const VT_STRIDES: flatbuffers::VOffsetT = 10;
 
@@ -4488,7 +4488,7 @@ impl<'a> MaxPoolAttrs<'a> {
         if let Some(x) = args.kernel_size {
             builder.add_kernel_size(x);
         }
-        builder.add_pad_mode(args.pad_mode);
+        builder.add_auto_pad(args.auto_pad);
         builder.finish()
     }
 
@@ -4507,13 +4507,13 @@ impl<'a> MaxPoolAttrs<'a> {
         }
     }
     #[inline]
-    pub fn pad_mode(&self) -> PadMode {
+    pub fn auto_pad(&self) -> AutoPad {
         // Safety:
         // Created from valid Table for this object
         // which contains a valid value in this slot
         unsafe {
             self._tab
-                .get::<PadMode>(MaxPoolAttrs::VT_PAD_MODE, Some(PadMode::Same))
+                .get::<AutoPad>(MaxPoolAttrs::VT_AUTO_PAD, Some(AutoPad::Same))
                 .unwrap()
         }
     }
@@ -4558,7 +4558,7 @@ impl flatbuffers::Verifiable for MaxPoolAttrs<'_> {
                 Self::VT_KERNEL_SIZE,
                 true,
             )?
-            .visit_field::<PadMode>("pad_mode", Self::VT_PAD_MODE, false)?
+            .visit_field::<AutoPad>("auto_pad", Self::VT_AUTO_PAD, false)?
             .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, u32>>>(
                 "pads",
                 Self::VT_PADS,
@@ -4575,7 +4575,7 @@ impl flatbuffers::Verifiable for MaxPoolAttrs<'_> {
 }
 pub struct MaxPoolAttrsArgs<'a> {
     pub kernel_size: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u32>>>,
-    pub pad_mode: PadMode,
+    pub auto_pad: AutoPad,
     pub pads: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u32>>>,
     pub strides: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u32>>>,
 }
@@ -4584,7 +4584,7 @@ impl<'a> Default for MaxPoolAttrsArgs<'a> {
     fn default() -> Self {
         MaxPoolAttrsArgs {
             kernel_size: None, // required field
-            pad_mode: PadMode::Same,
+            auto_pad: AutoPad::Same,
             pads: None,
             strides: None,
         }
@@ -4607,9 +4607,9 @@ impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> MaxPoolAttrsBuilder<'a, 'b, A> 
         );
     }
     #[inline]
-    pub fn add_pad_mode(&mut self, pad_mode: PadMode) {
+    pub fn add_auto_pad(&mut self, auto_pad: AutoPad) {
         self.fbb_
-            .push_slot::<PadMode>(MaxPoolAttrs::VT_PAD_MODE, pad_mode, PadMode::Same);
+            .push_slot::<AutoPad>(MaxPoolAttrs::VT_AUTO_PAD, auto_pad, AutoPad::Same);
     }
     #[inline]
     pub fn add_pads(&mut self, pads: flatbuffers::WIPOffset<flatbuffers::Vector<'b, u32>>) {
@@ -4644,7 +4644,7 @@ impl core::fmt::Debug for MaxPoolAttrs<'_> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let mut ds = f.debug_struct("MaxPoolAttrs");
         ds.field("kernel_size", &self.kernel_size());
-        ds.field("pad_mode", &self.pad_mode());
+        ds.field("auto_pad", &self.auto_pad());
         ds.field("pads", &self.pads());
         ds.field("strides", &self.strides());
         ds.finish()


### PR DESCRIPTION
Rename the `pad_mode` attribute to `auto_pad` to match the corresponding
attribute in the ONNX specs. Also this avoids confusion with the `mode` property
for the `Pad` operator. This is backwards compatible since only the field and
enum names are changed, not the values.
