### PR TITLE
Add a Python script to summarize ONNX Runtime profile output

### DIFF
--- a/tools/ort-profile-summarize.py
+++ b/tools/ort-profile-summarize.py
@@ -1,0 +1,114 @@
+from argparse import ArgumentParser
+import json
+from typing import TypedDict, cast
+
+
+class TypeShape(TypedDict):
+    """
+    Type and shape for a tensor.
+
+    There will be one key specifying the type, and it's value is the shape.
+    """
+
+    float: list[int]
+    int64: list[int]
+
+
+class FenceNodeArgs(TypedDict):
+    """Node args for a `*_fence_{before, after}` profile node."""
+
+    op_name: str
+
+
+class KernelTimeNodeArgs(TypedDict):
+    """Node args for a `*_kernel_time` profile node."""
+
+    op_name: str
+    """
+    ONNX operator name, eg. "MatMul".
+    """
+
+    input_type_shape: list[TypeShape]
+
+    # Other fields:
+    # - provider (execution provider)
+    # - thread_scheduling_stats
+    # - output_size (bytes?)
+    # - parameter_size (bytes?)
+
+
+class OtherNodeArgs(TypedDict):
+    """
+    Node args for other types of profile node.
+
+    This is for profile nodes that don't have any arguments or aren't used by
+    this script.
+    """
+
+    pass
+
+
+class ProfNode(TypedDict):
+    """Entry in an ORT JSON profile."""
+
+    name: str
+    """
+    Profile node name.
+
+    For nodes that relate to execution of an operator, this is a concatenation
+    of the ONNX node name and sub-task, eg. "/module.0/layer.0/MatMul_kernel_time".
+    """
+
+    args: FenceNodeArgs | KernelTimeNodeArgs | OtherNodeArgs
+    """Detailed information for this node."""
+
+    dur: int
+    """Duration in microseconds"""
+
+
+def summarize_profile(profile: list[ProfNode]):
+    # Extract nodes containing details for execution of an operator.
+    op_execution_nodes = [
+        node for node in profile if node["name"].endswith("_kernel_time")
+    ]
+    nodes_by_op = {}
+    for node in op_execution_nodes:
+        args = cast(KernelTimeNodeArgs, node["args"])
+        op_name = args["op_name"]
+        if op_name not in nodes_by_op:
+            nodes_by_op[op_name] = []
+        nodes_by_op[op_name].append(node)
+
+    # Calculate duration metrics for each operator type.
+    op_time_stats = []
+    for op_name, nodes in nodes_by_op.items():
+        total_dur_us = sum(n["dur"] for n in nodes)
+        mean_dur_us = float(total_dur_us) / float(len(nodes))
+
+        op_time_stats.append(
+            {
+                "op_name": op_name,
+                "mean": mean_dur_us,
+                "total": total_dur_us,
+            }
+        )
+
+    op_time_stats.sort(key=lambda entry: entry["total"], reverse=True)
+    sum_total = sum(n["total"] for n in op_time_stats)
+
+    # Print a summary by operator type.
+    for stats in op_time_stats:
+        op_name = stats["op_name"]
+        total_ms = stats["total"] / 1000.0
+        mean_ms = stats["mean"] / 1000.0
+        percent = float(stats["total"]) * 100.0 / float(sum_total)
+        print(f"{op_name: <16}\t{total_ms: <10.3f}{mean_ms:<8.3f}{percent:.2f}%")
+
+
+parser = ArgumentParser(description="Analyze profiler output from ONNX Runtime")
+parser.add_argument("profile", help="Path to JSON profile")
+args = parser.parse_args()
+
+with open(args.profile) as profile_fp:
+    profile_data = json.load(profile_fp)
+    summarize_profile(profile_data)


### PR DESCRIPTION
This produces a summary by operator which is useful for comparison with RTen's output when the `RTEN_TIMING` environment variable is set.

Example usage / output (using [this model](https://huggingface.co/Mozilla/distilvit/blob/main/onnx/encoder_model.onnx)):

```
$ python tools/ort-profile-summarize.py onnxruntime_profile__2024-05-28_23-56-00.json

MatMul          	122.952   1.281   75.49%
Add             	8.071     0.051   4.96%
Erf             	6.341     0.528   3.89%
Mul             	4.561     0.091   2.80%
Div             	3.455     0.071   2.12%
Softmax         	2.771     0.231   1.70%
Conv            	2.654     2.654   1.63%
Transpose       	2.301     0.047   1.41%
ReduceMean      	1.503     0.030   0.92%
Shape           	1.319     0.013   0.81%
Concat          	1.226     0.024   0.75%
Pow             	0.923     0.037   0.57%
Gather          	0.909     0.009   0.56%
Reshape         	0.896     0.018   0.55%
Unsqueeze       	0.709     0.007   0.44%
Sub             	0.603     0.024   0.37%
Slice           	0.568     0.568   0.35%
Where           	0.558     0.558   0.34%
Expand          	0.340     0.340   0.21%
Sqrt            	0.186     0.007   0.11%
Equal           	0.021     0.021   0.01%
ConstantOfShape 	0.008     0.008   0.00%
```

Output from `RTEN_TIMING` for comparison:

```
Graph run of 952 ops finished in 190.214ms
Pool allocs 484 hits 469
MatMul           142.48ms (74.91%)
Pow              8.51ms   (4.47%)
Add              8.21ms   (4.31%)
Div              6.26ms   (3.29%)
Transpose        5.59ms   (2.94%)
Erf              3.97ms   (2.09%)
Mul              3.53ms   (1.86%)
Softmax          2.87ms   (1.51%)
Conv             2.50ms   (1.31%)
ReduceMean       2.01ms   (1.06%)
Sub              1.36ms   (0.72%)
[Other]          1.08ms   (0.57%)
Concat           0.85ms   (0.45%)
Unsqueeze        0.21ms   (0.11%)
Shape            0.20ms   (0.11%)
Gather           0.19ms   (0.10%)
[Mem alloc/free] 0.15ms   (0.08%)
Reshape          0.12ms   (0.06%)
Slice            0.06ms   (0.03%)
Sqrt             0.02ms   (0.01%)
Where            0.02ms   (0.01%)
ConstantOfShape  0.01ms   (0.01%)
Equal            0.01ms   (0.01%)
Expand           0.01ms   (0.00%)
```