### PR TITLE
Clarify where im2col panel width / `NR_REGS` values come from

### DIFF
--- a/rten-simd/src/arch/aarch64.rs
+++ b/rten-simd/src/arch/aarch64.rs
@@ -16,13 +16,13 @@ impl SimdMask for uint32x4_t {
 }
 
 impl SimdVal for int32x4_t {
+    const LEN: usize = 4;
+
     type Mask = uint32x4_t;
 }
 
 impl SimdInt for int32x4_t {
     type Float = float32x4_t;
-
-    const LEN: usize = 4;
 
     #[inline]
     unsafe fn zero() -> Self {
@@ -96,13 +96,13 @@ impl SimdInt for int32x4_t {
 }
 
 impl SimdVal for float32x4_t {
+    const LEN: usize = 4;
+
     type Mask = uint32x4_t;
 }
 
 impl SimdFloat for float32x4_t {
     type Int = int32x4_t;
-
-    const LEN: usize = 4;
 
     #[inline]
     unsafe fn splat(val: f32) -> Self {

--- a/rten-simd/src/arch/aarch64.rs
+++ b/rten-simd/src/arch/aarch64.rs
@@ -2,8 +2,8 @@ use std::arch::aarch64::{
     float32x4_t, int32x4_t, uint32x4_t, vabsq_f32, vaddq_f32, vaddq_s32, vaddvq_f32, vandq_u32,
     vbslq_f32, vbslq_s32, vceqq_s32, vcgeq_f32, vcgeq_s32, vcgtq_s32, vcleq_f32, vcleq_s32,
     vcltq_f32, vcltq_s32, vcvtq_s32_f32, vdivq_f32, vdupq_n_f32, vdupq_n_s32, vfmaq_f32, vld1q_f32,
-    vld1q_s32, vmaxq_f32, vmulq_f32, vreinterpretq_f32_s32, vreinterpretq_u32_s32, vshlq_n_s32,
-    vst1q_f32, vst1q_s32, vsubq_f32, vsubq_s32,
+    vld1q_s32, vmaxq_f32, vmulq_f32, vreinterpretq_f32_s32, vshlq_n_s32, vst1q_f32, vst1q_s32,
+    vsubq_f32, vsubq_s32,
 };
 
 use crate::{SimdFloat, SimdInt, SimdMask, SimdVal};

--- a/rten-simd/src/arch/scalar.rs
+++ b/rten-simd/src/arch/scalar.rs
@@ -8,13 +8,13 @@ impl SimdMask for bool {
 }
 
 impl SimdVal for i32 {
+    const LEN: usize = 1;
+
     type Mask = bool;
 }
 
 /// Treat an `i32` as a single-lane SIMD "vector".
 impl SimdInt for i32 {
-    const LEN: usize = 1;
-
     type Float = f32;
 
     #[inline]
@@ -93,13 +93,13 @@ impl SimdInt for i32 {
 }
 
 impl SimdVal for f32 {
+    const LEN: usize = 1;
+
     type Mask = bool;
 }
 
 /// Treat an `f32` as a single-lane SIMD "vector".
 impl SimdFloat for f32 {
-    const LEN: usize = 1;
-
     type Int = i32;
 
     #[inline]

--- a/rten-simd/src/arch/wasm.rs
+++ b/rten-simd/src/arch/wasm.rs
@@ -25,13 +25,13 @@ impl SimdMask for v128i {
 }
 
 impl SimdVal for v128i {
+    const LEN: usize = 4;
+
     type Mask = v128i;
 }
 
 impl SimdInt for v128i {
     type Float = v128f;
-
-    const LEN: usize = 4;
 
     #[inline]
     unsafe fn splat(val: i32) -> Self {
@@ -100,13 +100,13 @@ impl SimdInt for v128i {
 }
 
 impl SimdVal for v128f {
+    const LEN: usize = 4;
+
     type Mask = v128i;
 }
 
 impl SimdFloat for v128f {
     type Int = v128i;
-
-    const LEN: usize = 4;
 
     #[inline]
     unsafe fn splat(val: f32) -> Self {

--- a/rten-simd/src/arch/x86_64.rs
+++ b/rten-simd/src/arch/x86_64.rs
@@ -20,13 +20,13 @@ impl SimdMask for __m256i {
 }
 
 impl SimdVal for __m256i {
+    const LEN: usize = 8;
+
     type Mask = __m256i;
 }
 
 impl SimdInt for __m256i {
     type Float = __m256;
-
-    const LEN: usize = 8;
 
     #[inline]
     #[target_feature(enable = "avx2")]
@@ -116,13 +116,13 @@ impl SimdInt for __m256i {
 }
 
 impl SimdVal for __m256 {
+    const LEN: usize = 8;
+
     type Mask = __m256i;
 }
 
 impl SimdFloat for __m256 {
     type Int = __m256i;
-
-    const LEN: usize = 8;
 
     #[inline]
     #[target_feature(enable = "avx2")]
@@ -281,14 +281,14 @@ impl SimdMask for __mmask16 {
 
 #[cfg(feature = "avx512")]
 impl SimdVal for __m512i {
+    const LEN: usize = 16;
+
     type Mask = __mmask16;
 }
 
 #[cfg(feature = "avx512")]
 impl SimdInt for __m512i {
     type Float = __m512;
-
-    const LEN: usize = 16;
 
     #[inline]
     #[target_feature(enable = "avx512f")]
@@ -378,14 +378,14 @@ impl SimdInt for __m512i {
 
 #[cfg(feature = "avx512")]
 impl SimdVal for __m512 {
+    const LEN: usize = 16;
+
     type Mask = __mmask16;
 }
 
 #[cfg(feature = "avx512")]
 impl SimdFloat for __m512 {
     type Int = __m512i;
-
-    const LEN: usize = 16;
 
     #[inline]
     #[target_feature(enable = "avx512f")]

--- a/rten-simd/src/lib.rs
+++ b/rten-simd/src/lib.rs
@@ -35,7 +35,7 @@ pub mod isa_detection;
 pub mod span;
 mod vec;
 
-pub use vec::{SimdFloat, SimdInt, SimdMask, SimdVal};
+pub use vec::{vec_count, SimdFloat, SimdInt, SimdMask, SimdVal};
 
 #[cfg(feature = "avx512")]
 #[cfg(target_arch = "x86_64")]

--- a/rten-simd/src/vec.rs
+++ b/rten-simd/src/vec.rs
@@ -50,11 +50,19 @@ pub const MAX_LEN: usize = 16;
 /// all SIMD vectors.
 #[allow(clippy::missing_safety_doc)]
 pub trait SimdVal: Copy + Sized {
+    /// The number of elements in the SIMD vector.
+    const LEN: usize;
+
     /// The type used by operations that use or return masks.
     ///
     /// This should be the same for all vector types with a given number of
     /// lanes in a particular architecture.
     type Mask: SimdMask;
+}
+
+/// Return the number of SIMD vectors required to hold `count` elements.
+pub const fn vec_count<S: SimdVal>(count: usize) -> usize {
+    count.div_ceil(S::LEN)
 }
 
 /// Trait implemented by SIMD masks.
@@ -67,9 +75,6 @@ pub trait SimdMask: Copy {
 /// Trait for SIMD vectors containing 32-bit integers.
 #[allow(clippy::missing_safety_doc)]
 pub trait SimdInt: SimdVal {
-    /// The number of elements in the SIMD vector.
-    const LEN: usize;
-
     /// The type produced by an operation that converts each element in this
     /// vector to a float.
     type Float: SimdFloat<Int = Self, Mask = Self::Mask>;
@@ -139,9 +144,6 @@ pub trait SimdInt: SimdVal {
 /// Trait for SIMD vectors containing single-precision floats.
 #[allow(clippy::missing_safety_doc)]
 pub trait SimdFloat: SimdVal {
-    /// The number of elements in the SIMD vector.
-    const LEN: usize;
-
     /// The type of vector produced by operations that convert this vector
     /// to a vector of ints.
     type Int: SimdInt<Float = Self, Mask = Self::Mask>;

--- a/src/gemm/kernels.rs
+++ b/src/gemm/kernels.rs
@@ -1,7 +1,7 @@
 use std::mem::MaybeUninit;
 use std::ops::Range;
 
-use rten_simd::SimdFloat;
+use rten_simd::{vec_count, SimdFloat};
 use rten_tensor::{Matrix, MatrixLayout, Storage};
 
 use crate::gemm::packing::{pack_a_block, pack_b_block};
@@ -470,7 +470,7 @@ unsafe impl Kernel for BaseKernel {
     ) {
         const MR: usize = BaseKernel::MR;
         const NR: usize = BaseKernel::NR;
-        const NR_REGS: usize = NR / <f32 as SimdFloat>::LEN;
+        const NR_REGS: usize = vec_count::<f32>(NR);
         simd_gemm::<f32, MR, NR_REGS>(tile_ptr, tile_row_stride, a, b, depth, alpha, beta);
     }
 }

--- a/src/gemm/kernels/aarch64.rs
+++ b/src/gemm/kernels/aarch64.rs
@@ -2,7 +2,7 @@ use std::arch::aarch64::float32x4_t;
 use std::mem::MaybeUninit;
 use std::ops::Range;
 
-use rten_simd::SimdFloat;
+use rten_simd::vec_count;
 use rten_tensor::Matrix;
 
 use super::{simd_gemm, simd_gemv, Kernel};
@@ -69,7 +69,7 @@ unsafe impl Kernel for ArmNeonKernel {
     ) {
         const MR: usize = ArmNeonKernel::MR;
         const NR: usize = ArmNeonKernel::NR;
-        const NR_REGS: usize = NR / <float32x4_t as SimdFloat>::LEN;
+        const NR_REGS: usize = vec_count::<float32x4_t>(NR);
 
         simd_gemm::<float32x4_t, MR, NR_REGS>(tile_ptr, tile_row_stride, a, b, depth, alpha, beta);
     }

--- a/src/gemm/kernels/wasm.rs
+++ b/src/gemm/kernels/wasm.rs
@@ -2,7 +2,7 @@ use std::mem::MaybeUninit;
 use std::ops::Range;
 
 use rten_simd::arch::wasm::v128f;
-use rten_simd::SimdFloat;
+use rten_simd::vec_count;
 use rten_tensor::Matrix;
 
 use super::{simd_gemm, simd_gemv, Kernel};
@@ -73,7 +73,7 @@ unsafe impl Kernel for WasmKernel {
     ) {
         const MR: usize = WasmKernel::MR;
         const NR: usize = WasmKernel::NR;
-        const NR_REGS: usize = NR / <v128f as SimdFloat>::LEN;
+        const NR_REGS: usize = vec_count::<v128f>(NR);
 
         simd_gemm::<v128f, MR, NR_REGS>(tile_ptr, tile_row_stride, a, b, depth, alpha, beta);
     }

--- a/src/gemm/kernels/x86_64.rs
+++ b/src/gemm/kernels/x86_64.rs
@@ -5,7 +5,7 @@ use std::ops::Range;
 #[cfg(feature = "avx512")]
 use std::arch::x86_64::__m512;
 
-use rten_simd::SimdFloat;
+use rten_simd::vec_count;
 use rten_tensor::Matrix;
 
 #[cfg(feature = "avx512")]
@@ -111,7 +111,7 @@ unsafe impl Kernel for FmaKernel {
     ) {
         const MR: usize = FmaKernel::MR;
         const NR: usize = FmaKernel::NR;
-        const NR_REGS: usize = NR / <__m256 as SimdFloat>::LEN;
+        const NR_REGS: usize = vec_count::<__m256>(NR);
 
         simd_gemm::<__m256, MR, NR_REGS>(tile_ptr, tile_row_stride, a, b, depth, alpha, beta);
     }
@@ -208,7 +208,7 @@ unsafe impl Kernel for Avx512Kernel {
     ) {
         const MR: usize = Avx512Kernel::MR;
         const NR: usize = Avx512Kernel::NR;
-        const NR_REGS: usize = NR / <__m512 as SimdFloat>::LEN;
+        const NR_REGS: usize = vec_count::<__m512>(NR);
 
         simd_gemm::<__m512, MR, NR_REGS>(tile_ptr, tile_row_stride, a, b, depth, alpha, beta)
     }


### PR DESCRIPTION
The im2col implementation had some constants with a non-obvious connection to the `NR` values used by GEMM kernels. Revise the code to make the connection more obvious. Also this makes it easier to experiment with different NR/MR sizes for microkernels. Changing these now requires updating the two constants in the GEMM kernel plus the corresponding const in `rten::ops::conv::im2col`.