### PR TITLE
Improve slow-path performance for unary ops

### DIFF
--- a/rten-tensor/src/overlap.rs
+++ b/rten-tensor/src/overlap.rs
@@ -3,7 +3,7 @@ use std::iter::zip;
 use smallvec::SmallVec;
 
 /// Return true if a given shape and strides describe a contiguous layout in
-/// "C" order.
+/// row-major ("C") order.
 pub fn is_contiguous<S: AsRef<[usize]>>(shape: S, strides: S) -> bool {
     // Trim leading 1s from the shape. These dimensions can have a larger
     // stride than the product of inner dimensions without affecting whether


### PR DESCRIPTION
Replace iterators with a pattern that uses a fixed number of nested loops. The same approach was previously applied to binary and ternary ops.

Part of https://github.com/robertknight/rten/issues/192.

**Benchmark:**

```rs
let mut x = Tensor::arange(0., 1024., None).into_shape([32, 32]);
x.clip_dim(1, 2..30);

let start = std::time::Instant::now();
for _ in 0..1000 {
    x.apply(|x| x + 0.001);
}
let elapsed = start.elapsed().as_secs_f64() * 1000.0;
println!("duration {}", elapsed);
```

Before: 2.95ms
After: 0.5ms
Without the `clip_dim` call (making it contiguous): 0.22ms
