### PR TITLE
Extract `Generator` and `GeneratorUtils` into `rten-generate` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,12 +411,22 @@ dependencies = [
  "lexopt",
  "png",
  "rten",
+ "rten-generate",
  "rten-imageio",
  "rten-imageproc",
  "rten-tensor",
  "rten-text",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "rten-generate"
+version = "0.10.0"
+dependencies = [
+ "rten",
+ "rten-tensor",
+ "rten-text",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
   ".",
   "rten-cli",
+  "rten-generate",
   "rten-imageio",
   "rten-imageproc",
   "rten-simd",

--- a/rten-examples/Cargo.toml
+++ b/rten-examples/Cargo.toml
@@ -17,6 +17,7 @@ png = "0.17.6"
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 rten = { path = "../", features = ["mmap", "random"] }
+rten-generate = { path = "../rten-generate" }
 rten-imageio = { path = "../rten-imageio" }
 rten-imageproc = { path = "../rten-imageproc" }
 rten-tensor = { path = "../rten-tensor" }

--- a/rten-examples/src/distilvit.rs
+++ b/rten-examples/src/distilvit.rs
@@ -4,7 +4,7 @@ use std::fs;
 use std::io::prelude::*;
 
 use rten::{FloatOperators, Model};
-use rten_examples::generator::{Generator, GeneratorUtils};
+use rten_generate::{Generator, GeneratorUtils};
 use rten_imageio::read_image;
 use rten_tensor::prelude::*;
 use rten_tensor::NdTensor;

--- a/rten-examples/src/gpt2.rs
+++ b/rten-examples/src/gpt2.rs
@@ -4,7 +4,7 @@ use std::fs;
 use std::io::prelude::*;
 
 use rten::Model;
-use rten_examples::generator::{Generator, GeneratorUtils};
+use rten_generate::{Generator, GeneratorUtils};
 use rten_text::tokenizers::Tokenizer;
 
 struct Args {

--- a/rten-examples/src/lib.rs
+++ b/rten-examples/src/lib.rs
@@ -1,1 +1,0 @@
-pub mod generator;

--- a/rten-generate/Cargo.toml
+++ b/rten-generate/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "rten-generate"
+version = "0.10.0"
+edition = "2021"
+authors = ["Robert Knight"]
+description = "Utilities to simplify running auto-regressive models with RTen"
+license = "MIT OR Apache-2.0"
+homepage = "https://github.com/robertknight/rten"
+repository = "https://github.com/robertknight/rten"
+include = ["/src", "/README.md"]
+
+[dependencies]
+rten = { path = "../", version = "0.10.0" }
+rten-text = { path = "../rten-text", version = "0.10.0" }
+rten-tensor = { path = "../rten-tensor", version = "0.10.0" }

--- a/rten-generate/src/lib.rs
+++ b/rten-generate/src/lib.rs
@@ -1,0 +1,12 @@
+//! Utilities to simplify running auto-regressive [RTen][rten] models such
+//! as transformer decoders.
+//!
+//! For working examples, see the examples in the [rten-examples][rten-examples]
+//! crate which import `rten_generate`.
+//!
+//! [rten]: https://github.com/robertknight/rten
+//! [rten-examples]: https://github.com/robertknight/rten/tree/main/rten-examples
+
+pub mod generator;
+
+pub use generator::{Generator, GeneratorError, GeneratorUtils};


### PR DESCRIPTION
Add a new create which contains utilities for running the decoding loop for transformer decoder-only and encoder-decoder models. It could also be adapted to support other kinds of auto-regressive models in future.

The initial implementation assumes the model input and output names match the conventions of the Hugging Face's [Optimum ONNX exporter](https://huggingface.co/docs/optimum/en/exporters/onnx/overview). This can be made more flexible in time.