### PR TITLE
Fix documentation warnings and broken link on `docs.rs`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,3 +84,10 @@ assertions_on_constants = "allow"
 # potentially less efficient.
 needless_range_loop = "allow"
 too_many_arguments = "allow"
+
+[package.metadata.docs.rs]
+# These features should match the features enabled by `make docs`.
+features = [
+  "mmap",
+  "random",
+]

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ checkformatting:
 
 .PHONY: docs
 docs:
-	RUSTDOCFLAGS='-D warnings' cargo doc -p rten --features mmap
+	RUSTDOCFLAGS='-D warnings' cargo doc -p rten --features mmap,random
 
 .PHONY: lint
 lint:

--- a/rten-text/src/tokenizers/bpe.rs
+++ b/rten-text/src/tokenizers/bpe.rs
@@ -12,7 +12,7 @@ use crate::tokenizers::{Encoder, TokenizerError};
 #[derive(Debug)]
 pub enum BpeError {
     /// There was an invalid entry in the merge list. This means that either
-    /// the entry doesn't have the expected "<token> [SPACE] <token>" format
+    /// the entry doesn't have the expected `<token> [SPACE] <token>` format
     /// or the `<token>` is not either a single character or the concatenation
     /// of another pair in the merge list.
     InvalidMergeEntry(String),


### PR DESCRIPTION
 - Enable all features that don't require nightly Rust when building for docs.rs. This should fix the broken link for `Model::load_mmap`
 - Enable the `random` feature for `Random*` operators when building docs
 - Fix strings being treated as Markdown syntax in BPE tokenizer docs