### PR TITLE
Improve handling of decoding errors and special tokens in `TextGenerator::next`

### DIFF
--- a/rten-generate/src/generator.rs
+++ b/rten-generate/src/generator.rs
@@ -449,3 +449,105 @@ impl<'a, G: Iterator> Iterator for Profiler<'a, G> {
         Some(item)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::{GeneratorError, GeneratorUtils};
+    use rten_text::tokenizers::patterns::GPT2;
+    use rten_text::tokenizers::{Bpe, Tokenizer, WordPiece};
+
+    /// Create a simple WordPiece tokenizer. This is essentially just a lookup
+    /// from token ID to string.
+    fn create_tokenizer() -> Tokenizer {
+        let vocab: HashMap<String, usize> = [("one", 1), ("two", 2), ("three", 3)]
+            .into_iter()
+            .map(|(s, id)| (s.to_string(), id))
+            .collect();
+        let encoder = WordPiece::from_vocab(vocab, Default::default());
+        Tokenizer::new(encoder, Default::default())
+    }
+
+    /// Create a BPE tokenizer with an empty vocab. This can encode and decode
+    /// arbitrary Unicode characters, by using one token per UTF-8 byte.
+    fn create_bpe_tokenizer() -> Tokenizer {
+        let encoder = Bpe::new(&[], GPT2, None, Default::default()).unwrap();
+        Tokenizer::new(encoder, Default::default())
+    }
+
+    #[test]
+    fn test_text_generator() {
+        let tokenizer = create_tokenizer();
+        let generator = [1, 2, 3].into_iter().map(Ok);
+        let tokens: Vec<_> = generator
+            .decode(&tokenizer)
+            .map(|tok| tok.map_err(|e| e.to_string()))
+            .collect();
+        assert_eq!(tokens, ["one", "two", "three"].map(|s| Ok(s.to_string())));
+    }
+
+    #[test]
+    fn test_text_generator_partial_utf8() {
+        let tokenizer = create_bpe_tokenizer();
+
+        // Encode a character which will require multiple token IDs. This means
+        // the text decoder will need to loop until accumulated tokens decode
+        // to a valid UTF-8 sequence.
+        let token_ids = tokenizer.encoder().encode("😊").unwrap();
+        assert!(token_ids.len() > 1);
+        let generator = token_ids.into_iter().map(|tok_id| Ok(tok_id as u32));
+
+        let tokens: Vec<_> = generator
+            .decode(&tokenizer)
+            .map(|tok| tok.map_err(|e| e.to_string()))
+            .collect();
+
+        assert_eq!(tokens, ["😊"].map(|s| Ok(s.to_string())));
+    }
+
+    #[test]
+    fn test_text_generator_generate_error() {
+        let tokenizer = create_tokenizer();
+        let generator = [
+            Ok(1),
+            Err(GeneratorError::GenerateError("oh no".to_string().into())),
+            Ok(3),
+        ]
+        .into_iter();
+
+        let tokens: Vec<_> = generator
+            .decode(&tokenizer)
+            .map(|tok| tok.map_err(|e| e.to_string()))
+            .collect();
+
+        assert_eq!(
+            tokens,
+            [
+                Ok("one".to_string()),
+                Err("generation error: oh no".to_string()),
+                Ok("three".to_string())
+            ]
+        );
+    }
+
+    #[test]
+    fn test_text_generator_decode_error() {
+        let tokenizer = create_tokenizer();
+        let generator = [1, 5, 3].into_iter().map(Ok);
+
+        let tokens: Vec<_> = generator
+            .decode(&tokenizer)
+            .map(|tok| tok.map_err(|e| e.to_string()))
+            .collect();
+
+        assert_eq!(
+            tokens,
+            [
+                Ok("one".to_string()),
+                Err("decode error: unknown token id 5".to_string()),
+                Ok("three".to_string())
+            ]
+        );
+    }
+}

--- a/rten-text/src/tokenizers/bpe.rs
+++ b/rten-text/src/tokenizers/bpe.rs
@@ -403,7 +403,7 @@ impl Encoder for Bpe {
         }
     }
 
-    fn encode_sequence(
+    fn encode_with_offsets(
         &self,
         text: &str,
         on_token: &mut dyn FnMut(usize, usize),

--- a/rten-text/src/tokenizers/bpe.rs
+++ b/rten-text/src/tokenizers/bpe.rs
@@ -288,11 +288,7 @@ impl Bpe {
             for (token, id) in vocab.into_iter() {
                 if let Some(rank) = builder.get_token_rank(&token) {
                     rank_to_token_id.insert(rank, id);
-                } else if !added_tokens
-                    .values()
-                    .find(|s| *s == token.as_str())
-                    .is_some()
-                {
+                } else if !added_tokens.values().any(|s| *s == token.as_str()) {
                     return Err(BpeError::InvalidVocabEntry(token));
                 }
             }

--- a/rten-text/src/tokenizers/json.rs
+++ b/rten-text/src/tokenizers/json.rs
@@ -8,6 +8,7 @@ use serde::Deserialize;
 #[derive(Deserialize)]
 pub(crate) struct AddedToken {
     pub content: String,
+    pub id: u32,
 }
 
 #[derive(Deserialize)]

--- a/rten-text/src/tokenizers/wordpiece.rs
+++ b/rten-text/src/tokenizers/wordpiece.rs
@@ -60,7 +60,7 @@ impl WordPiece {
 }
 
 impl Encoder for WordPiece {
-    fn encode_sequence(
+    fn encode_with_offsets(
         &self,
         text: &str,
         on_token: &mut dyn FnMut(usize, usize),

--- a/rten-text/tests/reftest.rs
+++ b/rten-text/tests/reftest.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::error::Error;
 use std::fs::read_to_string;
 use std::io;
@@ -158,7 +158,7 @@ fn test_bpe_gpt2() -> Result<(), Box<dyn Error>> {
     // Create tokenizer manually.
     let merges = read_test_file("models/gpt2/merges.txt")?;
     let merges: Vec<_> = merges.lines().collect();
-    let encoder = Bpe::new(&merges, GPT2_SPLIT_PATTERN, None, HashSet::new())?;
+    let encoder = Bpe::new(&merges, GPT2_SPLIT_PATTERN, None, Default::default())?;
     let tokenizer = Tokenizer::new(encoder, Default::default());
 
     // Create tokenizer from a `tokenizers.json` file.


### PR DESCRIPTION
This PR solves a few connected issues with token ID decoding during generation:

- Previously any decoding errors in `TextGenerator::next` would cause the iterator to loop, accumulating additional tokens under the assumption that decoding had failed because it had produced an incomplete UTF-8 sequence. Decoding can fail for other reasons however, in which case the text decoder just gets stuck looping until the source generator yields no more tokens. This PR fixes `TextGenerator::next` to yield an error if decoding fails for reasons other than an incomplete UTF-8 sequence.
- rten-text didn't provide an API specifically for decoding a sequence of token IDs. Instead it had an API for returning the canonical string representations of each token ID. For the BPE tokenizer, this encoded string representation is different from the decoded text, since each token represents a sequence of bytes, not a sequence of characters. Add an `Encoder::decode` API which does decode a sequence of token IDs into Unicode text and change the existing `get_token_str` impl for BPE to return the encoded string representation.
- In the GPT-2 demo, decoding errors would occur was when the model predicted an `<|endoftext|>` special token, as the decoding didn't handle added token IDs. Now the decoding handles special characters by just producing their string representation.