### PR TITLE
Explicitly specify generic args for `transmute` calls

### DIFF
--- a/rten-simd/src/arch/x86_64.rs
+++ b/rten-simd/src/arch/x86_64.rs
@@ -8,6 +8,7 @@ use std::arch::x86_64::{
     _mm_add_ps, _mm_cvtss_f32, _mm_movehl_ps, _mm_prefetch, _mm_shuffle_ps, _CMP_GE_OQ, _CMP_LE_OQ,
     _CMP_LT_OQ, _MM_HINT_ET0, _MM_HINT_T0,
 };
+use std::mem::transmute;
 
 use crate::{SimdFloat, SimdInt, SimdMask, SimdVal};
 
@@ -177,19 +178,19 @@ impl SimdFloat for __m256 {
     #[inline]
     #[target_feature(enable = "avx2")]
     unsafe fn ge(self, rhs: Self) -> Self::Mask {
-        std::mem::transmute(_mm256_cmp_ps(self, rhs, _CMP_GE_OQ))
+        transmute(_mm256_cmp_ps(self, rhs, _CMP_GE_OQ))
     }
 
     #[inline]
     #[target_feature(enable = "avx2")]
     unsafe fn le(self, rhs: Self) -> Self::Mask {
-        std::mem::transmute(_mm256_cmp_ps(self, rhs, _CMP_LE_OQ))
+        transmute(_mm256_cmp_ps(self, rhs, _CMP_LE_OQ))
     }
 
     #[inline]
     #[target_feature(enable = "avx2")]
     unsafe fn lt(self, rhs: Self) -> Self::Mask {
-        std::mem::transmute(_mm256_cmp_ps(self, rhs, _CMP_LT_OQ))
+        transmute(_mm256_cmp_ps(self, rhs, _CMP_LT_OQ))
     }
 
     #[inline]
@@ -201,7 +202,7 @@ impl SimdFloat for __m256 {
     #[inline]
     #[target_feature(enable = "avx2")]
     unsafe fn blend(self, rhs: Self, mask: Self::Mask) -> Self {
-        _mm256_blendv_ps(self, rhs, std::mem::transmute(mask))
+        _mm256_blendv_ps(self, rhs, transmute::<__m256i, __m256>(mask))
     }
 
     #[inline]

--- a/rten-simd/src/span.rs
+++ b/rten-simd/src/span.rs
@@ -1,6 +1,6 @@
 //! Slice-like types without the restrictions on aliasing.
 
-use std::mem::MaybeUninit;
+use std::mem::{transmute, MaybeUninit};
 
 /// Const pointer to a range of `T`s.
 ///
@@ -86,7 +86,7 @@ impl<T> MutPtrLen<MaybeUninit<T>> {
     /// been initialized.
     pub unsafe fn assume_init(self) -> MutPtrLen<T> {
         MutPtrLen {
-            ptr: unsafe { std::mem::transmute(self.ptr) },
+            ptr: unsafe { transmute::<*mut MaybeUninit<T>, *mut T>(self.ptr) },
             len: self.len,
         }
     }
@@ -99,7 +99,7 @@ impl<T> MutPtrLen<T> {
         T: Copy,
     {
         MutPtrLen {
-            ptr: unsafe { std::mem::transmute(self.ptr) },
+            ptr: unsafe { transmute::<*mut T, *mut MaybeUninit<T>>(self.ptr) },
             len: self.len,
         }
     }

--- a/rten-tensor/src/copy.rs
+++ b/rten-tensor/src/copy.rs
@@ -1,4 +1,4 @@
-use std::mem::MaybeUninit;
+use std::mem::{transmute, MaybeUninit};
 use std::ops::Range;
 
 use smallvec::SmallVec;
@@ -186,7 +186,7 @@ pub fn copy_into_slice<'a, T: Clone>(
             dst.write(src.clone());
         }
         // Safety: Loop above initialized all elements of `dest`.
-        return unsafe { std::mem::transmute(dest) };
+        return unsafe { transmute::<&mut [MaybeUninit<T>], &[T]>(dest) };
     }
 
     while src.ndim() < 4 {
@@ -212,7 +212,7 @@ pub fn copy_into_slice<'a, T: Clone>(
         }
         // Safety: Loop above initialized all elements of `dest`.
         let data = dest.data().unwrap();
-        unsafe { std::mem::transmute(data) }
+        unsafe { transmute::<&[MaybeUninit<T>], &[T]>(data) }
     } else {
         let mut dest_offset = 0;
         for i0 in 0..src.size(0) {
@@ -229,7 +229,7 @@ pub fn copy_into_slice<'a, T: Clone>(
             }
         }
         // Safety: Loop above initialized all elements of `dest`.
-        unsafe { std::mem::transmute(dest) }
+        unsafe { transmute::<&[MaybeUninit<T>], &[T]>(dest) }
     }
 }
 


### PR DESCRIPTION
This addresses warnings from clippy added in Rust v1.79. See https://rust-lang.github.io/rust-clippy/master/index.html#/missing_transmute_annotations.