### PR TITLE
Reduce KV-cache growth cost from `O(sequence_len)` to `O(1)`

### DIFF
--- a/rten-cli/src/main.rs
+++ b/rten-cli/src/main.rs
@@ -293,7 +293,7 @@ fn run_with_random_input(
     // doesn't have any built-in graph optimizations yet, so we have to do this
     // manually.
     let opt_start = Instant::now();
-    let const_prop = model.partial_run(&[], model.output_ids(), None)?;
+    let const_prop = model.partial_run(vec![], model.output_ids(), None)?;
     for (node_id, const_val) in const_prop.iter() {
         inputs.push((*node_id, const_val.into()));
     }
@@ -312,7 +312,7 @@ fn run_with_random_input(
     let mut outputs;
     loop {
         let start = Instant::now();
-        outputs = model.run(&inputs, model.output_ids(), Some(run_opts.clone()))?;
+        outputs = model.run(inputs.clone(), model.output_ids(), Some(run_opts.clone()))?;
         let elapsed = start.elapsed().as_millis();
 
         println!(

--- a/rten-cli/src/main.rs
+++ b/rten-cli/src/main.rs
@@ -2,7 +2,7 @@ use std::collections::VecDeque;
 use std::error::Error;
 use std::time::Instant;
 
-use rten::{Dimension, Input, Model, ModelMetadata, NodeId, Output, RunOptions};
+use rten::{Dimension, InputOrOutput, Model, ModelMetadata, NodeId, Output, RunOptions};
 use rten_tensor::prelude::*;
 use rten_tensor::Tensor;
 
@@ -273,9 +273,9 @@ fn run_with_random_input(
     )?;
 
     // Convert inputs from `Output` (owned) to `Input` (view).
-    let mut inputs: Vec<(NodeId, Input)> = inputs
+    let mut inputs: Vec<(NodeId, InputOrOutput)> = inputs
         .iter()
-        .map(|(id, output)| (*id, Input::from(output)))
+        .map(|(id, output)| (*id, InputOrOutput::from(output)))
         .collect();
 
     for (id, input) in inputs.iter() {

--- a/rten-examples/src/bert_qa.rs
+++ b/rten-examples/src/bert_qa.rs
@@ -116,8 +116,7 @@ fn extract_nbest_answers<'a>(
         inputs.push((type_ids_id, type_ids.view().into()));
     }
 
-    let [start_logits, end_logits] =
-        model.run_n(&inputs, [start_logits_id, end_logits_id], None)?;
+    let [start_logits, end_logits] = model.run_n(inputs, [start_logits_id, end_logits_id], None)?;
 
     // Extract (batch, sequence)
     let mut start_logits: NdTensor<f32, 2> = start_logits.try_into()?;

--- a/rten-examples/src/bert_qa.rs
+++ b/rten-examples/src/bert_qa.rs
@@ -3,7 +3,7 @@ use std::error::Error;
 use std::fs;
 
 use rten::ops::FloatOperators;
-use rten::{Input, Model, NodeId};
+use rten::{InputOrOutput, Model, NodeId};
 use rten_tensor::prelude::*;
 use rten_tensor::*;
 use rten_text::tokenizers::{EncodeOptions, Encoded, Tokenizer};
@@ -99,7 +99,7 @@ fn extract_nbest_answers<'a>(
     let start_logits_id = model.node_id("start_logits")?;
     let end_logits_id = model.node_id("end_logits")?;
 
-    let mut inputs: Vec<(NodeId, Input)> = vec![
+    let mut inputs: Vec<(NodeId, InputOrOutput)> = vec![
         (input_ids_id, input_ids.view().into()),
         (attention_mask_id, attention_mask.view().into()),
     ];

--- a/rten-examples/src/detr.rs
+++ b/rten-examples/src/detr.rs
@@ -314,7 +314,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let boxes_output_id = model.node_id("pred_boxes")?;
 
     let [logits, boxes] = model.run_n(
-        &[(pixel_input_id, image.view().into())],
+        vec![(pixel_input_id, image.into())],
         [logits_output_id, boxes_output_id],
         None,
     )?;

--- a/rten-examples/src/jina_similarity.rs
+++ b/rten-examples/src/jina_similarity.rs
@@ -134,7 +134,7 @@ fn embed_sentence_batch(
     }
 
     let output_id = model.node_id("last_hidden_state")?;
-    let [last_hidden_state] = model.run_n(&inputs, [output_id], None)?;
+    let [last_hidden_state] = model.run_n(inputs, [output_id], None)?;
     let last_hidden_state = last_hidden_state.into_float().ok_or("wrong output type")?;
 
     // Mean pool each item in the batch. We process each batch item separately

--- a/rten-examples/src/jina_similarity.rs
+++ b/rten-examples/src/jina_similarity.rs
@@ -2,7 +2,7 @@ use std::collections::VecDeque;
 use std::error::Error;
 
 use rten::ops::concat;
-use rten::{FloatOperators, Input, Model, NodeId, Operators, TensorPool};
+use rten::{FloatOperators, InputOrOutput, Model, NodeId, Operators, TensorPool};
 use rten_tensor::prelude::*;
 use rten_tensor::{NdTensor, Tensor};
 use rten_text::tokenizers::{EncodeOptions, Tokenizer};
@@ -120,7 +120,7 @@ fn embed_sentence_batch(
     let input_ids_id = model.node_id("input_ids")?;
     let attention_mask_id = model.node_id("attention_mask")?;
 
-    let mut inputs: Vec<(NodeId, Input)> = vec![
+    let mut inputs: Vec<(NodeId, InputOrOutput)> = vec![
         (input_ids_id, input_ids.view().into()),
         (attention_mask_id, attention_mask.view().into()),
     ];

--- a/rten-examples/src/piper.rs
+++ b/rten-examples/src/piper.rs
@@ -211,10 +211,10 @@ fn main() -> Result<(), Box<dyn Error>> {
     let scales_id = model.find_node("scales").unwrap();
 
     let [samples] = model.run_n(
-        &[
-            (input_id, phoneme_ids.view().into()),
-            (input_lengths_id, input_lengths.view().into()),
-            (scales_id, scales.view().into()),
+        vec![
+            (input_id, phoneme_ids.into()),
+            (input_lengths_id, input_lengths.into()),
+            (scales_id, scales.into()),
         ],
         [output_id],
         None,

--- a/rten-examples/src/yolo.rs
+++ b/rten-examples/src/yolo.rs
@@ -130,7 +130,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let input_id = model.node_id("images")?;
     let output_id = model.node_id("output0")?;
 
-    let [output] = model.run_n(&[(input_id, image.view().into())], [output_id], None)?;
+    let [output] = model.run_n(vec![(input_id, image.view().into())], [output_id], None)?;
 
     // Output format is [N, 84, B] where `B` is the number of boxes. The second
     // dimension contains `[x, y, w, h, class_0 ... class 79]` where `(x, y)`

--- a/rten-generate/src/generator.rs
+++ b/rten-generate/src/generator.rs
@@ -191,10 +191,16 @@ impl<'a> Generator<'a> {
                 .find_node(&output_name)
                 .ok_or(GeneratorError::OutputNotFound(output_name))?;
 
+            // This value should be configurable.
+            let max_seq_len = 512;
+
             kv_cache.push(KvCache {
                 input_id,
                 output_id,
-                cache: NdTensor::zeros([batch_size, n_heads, 0 /* seq len */, size]),
+                cache: NdTensor::with_capacity(
+                    [batch_size, n_heads, max_seq_len, size],
+                    2, /* seq dim */
+                ),
             });
         }
 
@@ -292,12 +298,14 @@ impl<'a> Generator<'a> {
             );
         }
 
-        // Add key-value cache from previous run.
-        model_inputs.extend(
-            self.kv_cache
-                .iter()
-                .map(|entry| (entry.input_id, entry.cache.view().into())),
-        );
+        // Add key-value cache from previous run. The model takes ownership
+        // of the KV-cache tensor during the run so it can efficiently append
+        // the entry for the current step, without copying the existing buffer.
+        for entry in self.kv_cache.iter_mut() {
+            let empty_tensor = NdTensor::zeros([0, 0, 0, 0]);
+            let cache = std::mem::replace(&mut entry.cache, empty_tensor);
+            model_inputs.push((entry.input_id, cache.into()));
+        }
 
         // Run the model and collect outputs and updated KV cache.
         let model_outputs: Vec<NodeId> = [self.logits_output]
@@ -315,6 +323,10 @@ impl<'a> Generator<'a> {
         let next_id = self.sampler.sample(logits.slice::<1, _>((0, -1)));
 
         // Update the key-value cache.
+        //
+        // The KV cache tensors returned from the model should be the same as
+        // the passed in tensors, but extended by one element along the sequence
+        // axis.
         for cache_entry in self.kv_cache.iter_mut() {
             cache_entry.cache = outputs.remove(0).try_into().map_err(wrap_error)?;
         }

--- a/rten-generate/src/generator.rs
+++ b/rten-generate/src/generator.rs
@@ -271,16 +271,16 @@ impl<'a> Generator<'a> {
 
         // Propagate constants on the first run.
         if self.constant_prop_inputs.is_none() {
-            let inputs =
-                match self
-                    .model
-                    .partial_run(&self.constant_inputs, &[self.logits_output], None)
-                {
-                    Ok(inputs) => inputs,
-                    Err(err) => {
-                        return Err(wrap_error(err));
-                    }
-                };
+            let inputs = match self.model.partial_run(
+                self.constant_inputs.clone(),
+                &[self.logits_output],
+                None,
+            ) {
+                Ok(inputs) => inputs,
+                Err(err) => {
+                    return Err(wrap_error(err));
+                }
+            };
             self.constant_prop_inputs = Some(inputs);
         }
 
@@ -307,7 +307,7 @@ impl<'a> Generator<'a> {
 
         let mut outputs = self
             .model
-            .run(model_inputs.as_slice(), &model_outputs, None)
+            .run(model_inputs, &model_outputs, None)
             .map_err(wrap_error)?;
 
         // Sample output token.

--- a/rten-tensor/src/errors.rs
+++ b/rten-tensor/src/errors.rs
@@ -95,3 +95,30 @@ impl std::fmt::Display for ReshapeError {
         }
     }
 }
+
+/// Errors that can occur while expanding a tensor.
+#[derive(Clone, Debug, PartialEq)]
+pub enum ExpandError {
+    /// The shape of the source and destination tensor do not match, excluding
+    /// the dimensions along which expansion is happening.
+    ShapeMismatch,
+
+    /// The tensor cannot be resized without copying into a new buffer.
+    InsufficientCapacity,
+}
+
+impl std::fmt::Display for ExpandError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ExpandError::ShapeMismatch => {
+                write!(
+                    f,
+                    "non-expanding dimensions of source and destination do not match"
+                )
+            }
+            ExpandError::InsufficientCapacity => {
+                write!(f, "insufficient capacity for new dimension size")
+            }
+        }
+    }
+}

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -438,7 +438,7 @@ impl Graph {
     /// processing steps and constant values defined by the graph.
     pub fn run(
         &self,
-        inputs: &[(NodeId, InputOrOutput)],
+        inputs: Vec<(NodeId, InputOrOutput)>,
         outputs: &[NodeId],
         opts: Option<RunOptions>,
     ) -> Result<Vec<Output>, RunError> {
@@ -454,7 +454,7 @@ impl Graph {
                 Some(plan) if plan.matches(&input_ids, outputs) => plan.clone(),
                 _ => {
                     let plan = self.create_plan(
-                        inputs,
+                        &inputs,
                         outputs,
                         PlanOptions {
                             allow_missing_inputs: false,
@@ -471,7 +471,7 @@ impl Graph {
 
     fn run_plan(
         &self,
-        inputs: &[(NodeId, InputOrOutput)],
+        mut inputs: Vec<(NodeId, InputOrOutput)>,
         plan: &[NodeId],
         outputs: &[NodeId],
         opts: Option<RunOptions>,
@@ -481,6 +481,24 @@ impl Graph {
         let mut run_timer = Timer::new();
         if opts.timing {
             run_timer.start();
+        }
+
+        let mut temp_values: FxHashMap<NodeId, Output> = FxHashMap::default();
+
+        // Extract all the owned tensor inputs into the temp value map.
+        //
+        // This enables these inputs to be used for in-place operations or
+        // returned directly as outputs.
+        let mut idx = 0;
+        while idx < inputs.len() {
+            if matches!(inputs[idx], (_, InputOrOutput::Output(_))) {
+                let (node_id, InputOrOutput::Output(outp)) = inputs.remove(idx) else {
+                    unreachable!();
+                };
+                temp_values.insert(node_id, outp);
+            } else {
+                idx += 1;
+            }
         }
 
         let inputs_by_id: FxHashMap<NodeId, InputOrOutput> = inputs.iter().cloned().collect();
@@ -527,7 +545,6 @@ impl Graph {
         let use_pool = env_flag("RTEN_USE_POOL", true);
 
         // Execute the plan
-        let mut temp_values: FxHashMap<NodeId, Output> = FxHashMap::default();
         let record_timing = opts.timing || opts.verbose;
         let mut op_elapsed: Vec<TimingRecord> = if record_timing {
             Vec::with_capacity(plan.len())
@@ -779,12 +796,12 @@ impl Graph {
     /// later be passed to calls to `run` when the missing values are available.
     pub fn partial_run(
         &self,
-        inputs: &[(NodeId, InputOrOutput)],
+        inputs: Vec<(NodeId, InputOrOutput)>,
         outputs: &[NodeId],
         opts: Option<RunOptions>,
     ) -> Result<Vec<(NodeId, Output)>, RunError> {
         let plan = self.create_plan(
-            inputs,
+            &inputs,
             outputs,
             PlanOptions {
                 allow_missing_inputs: true,
@@ -1108,7 +1125,7 @@ mod tests {
         );
 
         let results = g
-            .run(&[(input_id, input.into())], &[relu_out], None)
+            .run(vec![(input_id, input.into())], &[relu_out], None)
             .unwrap();
 
         let expected = Tensor::from_data(
@@ -1265,13 +1282,13 @@ mod tests {
         let input = Tensor::from_data(&[1], vec![1.]);
 
         let results = g
-            .run(&[(input_id, input.view().into())], &[op_c_out], None)
+            .run(vec![(input_id, input.view().into())], &[op_c_out], None)
             .unwrap();
         let expected = Tensor::from_data(&[2], vec![2., 3.]);
         expect_equal(results[0].as_float_ref().unwrap(), &expected)?;
 
         let results = g
-            .run(&[(input_id, input.into())], &[op_d_out], None)
+            .run(vec![(input_id, input.into())], &[op_d_out], None)
             .unwrap();
         let expected = Tensor::from_data(&[2], vec![3., 2.]);
         expect_equal(results[0].as_float_ref().unwrap(), &expected)?;
@@ -1303,7 +1320,7 @@ mod tests {
 
         let input = tensor!(0.);
         let results = g
-            .run(&[(input_id, input.into())], &[op_a_out, op_b_out], None)
+            .run(vec![(input_id, input.into())], &[op_a_out, op_b_out], None)
             .unwrap();
         assert_eq!(results[0].as_float_ref().unwrap(), &tensor!(1.));
         assert_eq!(results[1].as_float_ref().unwrap(), &tensor!(2.));
@@ -1329,7 +1346,7 @@ mod tests {
         }
 
         let results = g
-            .run(&[(input_id, input.into())], &[prev_output], None)
+            .run(vec![(input_id, input.into())], &[prev_output], None)
             .unwrap();
 
         let expected = Tensor::from_data(&[5], vec![101., 102., 103., 104., 105.]);
@@ -1346,7 +1363,7 @@ mod tests {
         let input_id = g.add_value(Some("input"), None);
 
         let results = g
-            .run(&[(input_id, input.view().into())], &[input_id], None)
+            .run(vec![(input_id, input.view().into())], &[input_id], None)
             .unwrap();
 
         expect_equal(results[0].as_float_ref().unwrap(), &input)?;
@@ -1361,7 +1378,7 @@ mod tests {
         let value = Tensor::from_data(&[5], vec![1., 2., 3., 4., 5.]);
         let const_id = g.add_constant(Some("weight"), value.clone());
 
-        let results = g.run(&[], &[const_id], None).unwrap();
+        let results = g.run(vec![], &[const_id], None).unwrap();
 
         expect_equal(results[0].as_float_ref().unwrap(), &value)?;
 
@@ -1379,7 +1396,7 @@ mod tests {
     #[test]
     fn test_no_outputs() {
         let g = Graph::new();
-        let results = g.run(&[], &[], None).unwrap();
+        let results = g.run(vec![], &[], None).unwrap();
         assert_eq!(results.len(), 0);
     }
 
@@ -1389,7 +1406,7 @@ mod tests {
         let input_id = g.add_value(Some("input"), None);
         let input = tensor!([1.]);
         let result = g.run(
-            &[
+            vec![
                 (input_id, input.view().into()),
                 (input_id, input.view().into()),
             ],
@@ -1417,7 +1434,7 @@ mod tests {
 
         let input = tensor!([1.]);
 
-        let result = g.run(&[(input_id, input.into())], &[op_a_out, op_a_out], None);
+        let result = g.run(vec![(input_id, input.into())], &[op_a_out, op_a_out], None);
 
         assert_eq!(
             result,
@@ -1435,7 +1452,7 @@ mod tests {
         // an input but still providing subsequent ones.
         g.add_op(Some("shape"), Box::new(Shape {}), &[None], &[Some(output)]);
 
-        let results = g.run(&[], &[output], None);
+        let results = g.run(vec![], &[output], None);
 
         assert_eq!(
             results.err(),
@@ -1449,7 +1466,7 @@ mod tests {
     #[test]
     fn test_err_if_invalid_output() {
         let g = Graph::new();
-        let result = g.run(&[], &[123], None);
+        let result = g.run(vec![], &[123], None);
         assert_eq!(
             result.err(),
             Some(RunError::PlanningError("Missing output 123".to_string()))
@@ -1461,7 +1478,7 @@ mod tests {
         let mut g = Graph::new();
         let output = g.add_value(None, None);
         g.add_op(Some("op"), Box::new(Relu {}), &[Some(42)], &[Some(output)]);
-        let result = g.run(&[], &[output], None);
+        let result = g.run(vec![], &[output], None);
         assert_eq!(
             result.err(),
             Some(RunError::PlanningError(
@@ -1541,14 +1558,14 @@ mod tests {
         // First operator should not be run in-place, since it has an
         // immutable input. The result should be the same as the input.
         let results = g
-            .run(&[(input_id, input.view().into())], &[op1_out], None)
+            .run(vec![(input_id, input.view().into())], &[op1_out], None)
             .unwrap();
         assert_eq!(results[0].as_float_ref().unwrap()[[0, 0]], 0.0);
 
         // Second operator should be run in-place, as it meets all the
         // requirements for this optimization.
         let results = g
-            .run(&[(input_id, input.view().into())], &[op2_out], None)
+            .run(vec![(input_id, input.view().into())], &[op2_out], None)
             .unwrap();
         assert_eq!(results[0].as_float_ref().unwrap()[[0, 0]], 1.0);
 
@@ -1556,7 +1573,11 @@ mod tests {
         // for fourth op. Fourth op can run in place as by then, it is the
         // only consumer of its input.
         let results = g
-            .run(&[(input_id, input.into())], &[op3_out, op4_out], None)
+            .run(
+                vec![(input_id, input.view().into())],
+                &[op3_out, op4_out],
+                None,
+            )
             .unwrap();
         assert_eq!(results[0].as_float_ref().unwrap()[[0, 0]], 1.0);
         assert_eq!(results[1].as_float_ref().unwrap()[[0, 0]], 2.0);
@@ -1600,7 +1621,7 @@ mod tests {
 
         let results = g
             .run(
-                &[(input_id, input.into()), (bias_id, bias.into())],
+                vec![(input_id, input.view().into()), (bias_id, bias.into())],
                 &[op2_out],
                 None,
             )
@@ -1617,7 +1638,7 @@ mod tests {
             &[3., 3., 3., 3.]
         );
 
-        // The first operator in a graph run must always copy its input.
+        // The first operator must copy its input because it is a view.
         let op1_metrics = op1_metrics.lock().unwrap();
         assert_eq!(op1_metrics.run_count, 1);
         assert_eq!(op1_metrics.run_in_place_count, 0);
@@ -1682,7 +1703,7 @@ mod tests {
         let input = Tensor::from_vec(vec![1.0, 2.0, 3.0, 4.0, 5.0]);
         let mut results = g
             .run(
-                &[(input_id, input.into())],
+                vec![(input_id, input.into())],
                 &[left_split_out, right_split_out],
                 None,
             )
@@ -1742,13 +1763,13 @@ mod tests {
         // Run graph with no inputs. This is equivalent to constant evaluation.
         // In this case no operators can be evaluated with graph constants
         // alone, so the output is empty.
-        let partial_outs = g.partial_run(&[], &[op_2_out], None)?;
+        let partial_outs = g.partial_run(vec![], &[op_2_out], None)?;
         assert_eq!(partial_outs.len(), 0);
 
         // Run graph with just the `V0` input. This will compute the result of
         // `Op0` but not other nodes which depend on `V1`.
         let input = tensor!(2.);
-        let partial_outs = g.partial_run(&[(val_0, input.view().into())], &[op_2_out], None)?;
+        let partial_outs = g.partial_run(vec![(val_0, input.view().into())], &[op_2_out], None)?;
         assert_eq!(partial_outs.len(), 1);
         assert_eq!(partial_outs[0].0, op_0_out);
         assert_eq!(partial_outs[0].1, Output::FloatTensor(tensor!(5.)));
@@ -1756,14 +1777,14 @@ mod tests {
         // Run graph with just the `V1` input. This will compute the result of
         // `Op1` but not other nodes which depend on `V0`.
         let input = tensor!(2.);
-        let partial_outs = g.partial_run(&[(val_1, input.view().into())], &[op_2_out], None)?;
+        let partial_outs = g.partial_run(vec![(val_1, input.view().into())], &[op_2_out], None)?;
         assert_eq!(partial_outs.len(), 1);
         assert_eq!(partial_outs[0].0, op_1_out);
         assert_eq!(partial_outs[0].1, Output::FloatTensor(tensor!(6.)));
 
         // Run graph with all inputs. This should behave like `Graph::run`.
         let partial_outs = g.partial_run(
-            &[(val_1, input.view().into()), (val_0, input.view().into())],
+            vec![(val_1, input.view().into()), (val_0, input.view().into())],
             &[op_2_out],
             None,
         )?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,7 +117,7 @@ pub mod ops;
 pub use graph::{Dimension, NodeId, RunError, RunOptions};
 pub use model::{Model, ModelLoadError, ModelOptions, NodeInfo, OpRegistry, ReadOp, ReadOpError};
 pub use model_metadata::ModelMetadata;
-pub use ops::{FloatOperators, Input, Operators, Output};
+pub use ops::{FloatOperators, Input, InputOrOutput, Operators, Output};
 pub use tensor_pool::{ExtractBuffer, PoolRef, TensorPool};
 pub use threading::{thread_pool, ThreadPool};
 pub use timer::Timer;

--- a/src/model.rs
+++ b/src/model.rs
@@ -49,7 +49,7 @@ use crate::timing::TimingSort;
 ///     // Prepare inputs in format expected by model.
 ///     let input_data: Tensor<f32> = Tensor::zeros(&[1, 3, 224, 224]);
 ///
-///     let mut outputs = model.run(&[(input_id, input_data.view().into())], &[output_id], None)?;
+///     let mut outputs = model.run(vec![(input_id, input_data.into())], &[output_id], None)?;
 ///     let output: Tensor<f32> = outputs.remove(0).try_into()?;
 ///
 ///     // Post-process outputs.
@@ -440,7 +440,7 @@ impl Model {
     /// The input and output nodes are specified via IDs looked up via `find_node`.
     pub fn run(
         &self,
-        inputs: &[(NodeId, InputOrOutput)],
+        inputs: Vec<(NodeId, InputOrOutput)>,
         outputs: &[NodeId],
         opts: Option<RunOptions>,
     ) -> Result<Vec<Output>, RunError> {
@@ -458,7 +458,7 @@ impl Model {
     /// executing a model with a statically known number of outputs.
     pub fn run_n<const N: usize>(
         &self,
-        inputs: &[(NodeId, InputOrOutput)],
+        inputs: Vec<(NodeId, InputOrOutput)>,
         outputs: [NodeId; N],
         opts: Option<RunOptions>,
     ) -> Result<[Output; N], RunError> {
@@ -477,7 +477,7 @@ impl Model {
     ) -> Result<Output, RunError> {
         let &input_id = self.input_ids().first().ok_or(RunError::InvalidNodeId)?;
         let &output_id = self.output_ids().first().ok_or(RunError::InvalidNodeId)?;
-        self.run_n(&[(input_id, input)], [output_id], opts)
+        self.run_n(vec![(input_id, input)], [output_id], opts)
             .map(|[result]| result)
     }
 
@@ -498,7 +498,7 @@ impl Model {
     /// the remaining inputs to `run` calls inside the loop.
     pub fn partial_run(
         &self,
-        inputs: &[(NodeId, InputOrOutput)],
+        inputs: Vec<(NodeId, InputOrOutput)>,
         outputs: &[NodeId],
         opts: Option<RunOptions>,
     ) -> Result<Vec<(NodeId, Output)>, RunError> {
@@ -1478,14 +1478,14 @@ mod tests {
 
         // Test a normal model run.
         let result = model
-            .run(&[(input_id, input.view().into())], &[output_id], None)
+            .run(vec![(input_id, input.view().into())], &[output_id], None)
             .unwrap();
         let result_tensor = check_output(result);
 
         // Test a partial run. Since we are providing all inputs, this works the
         // same as `Model::run`. See `Graph::partial_run` tests for other cases.
         let partial_run_result = model
-            .partial_run(&[(input_id, input.into())], &[output_id], None)
+            .partial_run(vec![(input_id, input.into())], &[output_id], None)
             .unwrap();
         assert_eq!(
             partial_run_result,
@@ -1504,7 +1504,7 @@ mod tests {
 
         let input = generate_input();
         let result = model
-            .run(&[(input_id, input.into())], &[output_id], None)
+            .run(vec![(input_id, input.into())], &[output_id], None)
             .unwrap();
         check_output(result);
     }
@@ -1521,7 +1521,7 @@ mod tests {
 
         let input = generate_input();
         let result = model
-            .run(&[(input_id, input.into())], &[output_id], None)
+            .run(vec![(input_id, input.into())], &[output_id], None)
             .unwrap();
         check_output(result);
     }
@@ -1553,7 +1553,7 @@ mod tests {
         let buffer = builder.finish();
         let model = Model::load(buffer).unwrap();
 
-        let result = model.run(&[], &[output_node as usize], None);
+        let result = model.run(vec![], &[output_node as usize], None);
 
         assert_eq!(
             result.err(),
@@ -1957,7 +1957,7 @@ mod tests {
             let output_id = model.find_node(&output).unwrap();
             let result = model
                 .run(
-                    &[
+                    vec![
                         (input_node as usize, input.view().into()),
                         (input_bool as usize, input_bool_data.view().into()),
                     ],
@@ -1983,7 +1983,7 @@ mod tests {
             let output_id = model.find_node(output).unwrap();
             let result = model
                 .run(
-                    &[(input_2d as usize, input.view().into())],
+                    vec![(input_2d as usize, input.view().into())],
                     &[output_id],
                     None,
                 )
@@ -1997,7 +1997,7 @@ mod tests {
         let delta = Tensor::from_scalar(1.);
         let result = model
             .run(
-                &[
+                vec![
                     (range_start_node as usize, start.into()),
                     (range_limit_node as usize, limit.into()),
                     (range_delta_node as usize, delta.into()),
@@ -2014,7 +2014,7 @@ mod tests {
         let y = tensor!([4, 5, 6]);
         let result = model
             .run(
-                &[
+                vec![
                     (where_cond as usize, cond.into()),
                     (where_x as usize, x.into()),
                     (where_y as usize, y.into()),

--- a/src/model.rs
+++ b/src/model.rs
@@ -20,8 +20,8 @@ use crate::graph::{ConstantNodeData, Dimension, Graph, Node, NodeId, RunError, R
 use crate::model_metadata::ModelMetadata;
 use crate::ops;
 use crate::ops::{
-    BoxOrder, CoordTransformMode, DataType, Direction, Input, NearestMode, Operator, Output,
-    Padding, ResizeMode, Scalar, ScatterReduction,
+    BoxOrder, CoordTransformMode, DataType, Direction, InputOrOutput, NearestMode, Operator,
+    Output, Padding, ResizeMode, Scalar, ScatterReduction,
 };
 use crate::schema_generated as sg;
 use crate::schema_generated::{root_as_model, AutoPad, OperatorNode, OperatorType};
@@ -440,7 +440,7 @@ impl Model {
     /// The input and output nodes are specified via IDs looked up via `find_node`.
     pub fn run(
         &self,
-        inputs: &[(NodeId, Input)],
+        inputs: &[(NodeId, InputOrOutput)],
         outputs: &[NodeId],
         opts: Option<RunOptions>,
     ) -> Result<Vec<Output>, RunError> {
@@ -458,7 +458,7 @@ impl Model {
     /// executing a model with a statically known number of outputs.
     pub fn run_n<const N: usize>(
         &self,
-        inputs: &[(NodeId, Input)],
+        inputs: &[(NodeId, InputOrOutput)],
         outputs: [NodeId; N],
         opts: Option<RunOptions>,
     ) -> Result<[Output; N], RunError> {
@@ -470,7 +470,11 @@ impl Model {
     ///
     /// This is a simplified version of [Model::run] for the common case of
     /// executing a model with a single input and output.
-    pub fn run_one(&self, input: Input, opts: Option<RunOptions>) -> Result<Output, RunError> {
+    pub fn run_one(
+        &self,
+        input: InputOrOutput,
+        opts: Option<RunOptions>,
+    ) -> Result<Output, RunError> {
         let &input_id = self.input_ids().first().ok_or(RunError::InvalidNodeId)?;
         let &output_id = self.output_ids().first().ok_or(RunError::InvalidNodeId)?;
         self.run_n(&[(input_id, input)], [output_id], opts)
@@ -494,7 +498,7 @@ impl Model {
     /// the remaining inputs to `run` calls inside the loop.
     pub fn partial_run(
         &self,
-        inputs: &[(NodeId, Input)],
+        inputs: &[(NodeId, InputOrOutput)],
         outputs: &[NodeId],
         opts: Option<RunOptions>,
     ) -> Result<Vec<(NodeId, Output)>, RunError> {
@@ -1474,14 +1478,14 @@ mod tests {
 
         // Test a normal model run.
         let result = model
-            .run(&[(input_id, (&input).into())], &[output_id], None)
+            .run(&[(input_id, input.view().into())], &[output_id], None)
             .unwrap();
         let result_tensor = check_output(result);
 
         // Test a partial run. Since we are providing all inputs, this works the
         // same as `Model::run`. See `Graph::partial_run` tests for other cases.
         let partial_run_result = model
-            .partial_run(&[(input_id, (&input).into())], &[output_id], None)
+            .partial_run(&[(input_id, input.into())], &[output_id], None)
             .unwrap();
         assert_eq!(
             partial_run_result,
@@ -1500,7 +1504,7 @@ mod tests {
 
         let input = generate_input();
         let result = model
-            .run(&[(input_id, (&input).into())], &[output_id], None)
+            .run(&[(input_id, input.into())], &[output_id], None)
             .unwrap();
         check_output(result);
     }
@@ -1517,7 +1521,7 @@ mod tests {
 
         let input = generate_input();
         let result = model
-            .run(&[(input_id, (&input).into())], &[output_id], None)
+            .run(&[(input_id, input.into())], &[output_id], None)
             .unwrap();
         check_output(result);
     }
@@ -1529,7 +1533,7 @@ mod tests {
 
         let input = tensor!((1, 2, 2); [1., 2., -1., -2.]);
         let result: Tensor<f32> = model
-            .run_one((&input).into(), None)
+            .run_one(input.into(), None)
             .unwrap()
             .try_into()
             .unwrap();
@@ -1954,8 +1958,8 @@ mod tests {
             let result = model
                 .run(
                     &[
-                        (input_node as usize, (&input).into()),
-                        (input_bool as usize, (&input_bool_data).into()),
+                        (input_node as usize, input.view().into()),
+                        (input_bool as usize, input_bool_data.view().into()),
                     ],
                     &[output_id],
                     None,
@@ -1978,7 +1982,11 @@ mod tests {
         for output in outputs {
             let output_id = model.find_node(output).unwrap();
             let result = model
-                .run(&[(input_2d as usize, (&input).into())], &[output_id], None)
+                .run(
+                    &[(input_2d as usize, input.view().into())],
+                    &[output_id],
+                    None,
+                )
                 .unwrap();
             assert_eq!(result.len(), 1);
         }
@@ -1990,9 +1998,9 @@ mod tests {
         let result = model
             .run(
                 &[
-                    (range_start_node as usize, (&start).into()),
-                    (range_limit_node as usize, (&limit).into()),
-                    (range_delta_node as usize, (&delta).into()),
+                    (range_start_node as usize, start.into()),
+                    (range_limit_node as usize, limit.into()),
+                    (range_delta_node as usize, delta.into()),
                 ],
                 &[range_out as usize],
                 None,
@@ -2007,9 +2015,9 @@ mod tests {
         let result = model
             .run(
                 &[
-                    (where_cond as usize, (&cond).into()),
-                    (where_x as usize, (&x).into()),
-                    (where_y as usize, (&y).into()),
+                    (where_cond as usize, cond.into()),
+                    (where_x as usize, x.into()),
+                    (where_y as usize, y.into()),
                 ],
                 &[where_out as usize],
                 None,

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -717,6 +717,14 @@ impl<'a> InputList<'a> {
         InputList { inputs: vec![] }
     }
 
+    pub fn len(&self) -> usize {
+        self.inputs.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.inputs.is_empty()
+    }
+
     pub fn from<'b>(inputs: &[Input<'b>]) -> InputList<'b> {
         InputList {
             inputs: inputs.iter().cloned().map(Some).collect(),

--- a/src/wasm_api.rs
+++ b/src/wasm_api.rs
@@ -8,7 +8,7 @@ use wasm_bindgen::prelude::*;
 
 use crate::graph::Dimension;
 use crate::model;
-use crate::ops::{matmul, Input, Output};
+use crate::ops::{matmul, InputOrOutput, Output};
 use crate::tensor_pool::TensorPool;
 
 #[wasm_bindgen]
@@ -67,12 +67,12 @@ impl Model {
         input: Vec<Tensor>,
         output_ids: &[usize],
     ) -> Result<Vec<Tensor>, String> {
-        let inputs: Vec<(usize, Input)> = zip(
+        let inputs: Vec<(usize, InputOrOutput)> = zip(
             input_ids.iter().copied(),
-            input.iter().map(|tensor| (&*tensor.data).into()),
+            input.iter().map(|tensor| tensor.data.as_input().into()),
         )
         .collect();
-        let result = self.model.run(&inputs[..], output_ids, None);
+        let result = self.model.run(inputs, output_ids, None);
         match result {
             Ok(outputs) => {
                 let mut list = Vec::new();


### PR DESCRIPTION
This PR contains a series of changes that speed up transformer decoder models significantly by reducing the cost of extending the KV-cache at each iteration from `O(sequence_len)` to `O(1)`.

For a 300-token generation using the GPT-2 demo (GPT-2 medium model), this reduces runtime from ~28s to ~21s on my system. For comparison, GGML takes ~14s, but note that it is using FP16 weights.

The changes are as follows:

1. Add `Tensor::{with_capacity, append}` APIs. This enables creating an empty tensor with capacity to be extended to a given shape without reallocating. The extension must happen along a pre-specified axis.
2. Add an in-place implementation of the `Concat` operator, which will extend its first input in-place if possible, instead of copying all inputs to a new output.
3. Change `Model::run`'s `inputs` argument from `&[(NodeId, Input)]` to `Vec<(NodeId, InputOrOutput)>`. The `Input` and `Output` types have those names for historical reasons, but they are essentially type-erased views and owned tensors respectively. `InputOrOutput` is thus a type which is either a view or an owned tensor. This allows owned tensors to be passed into a model run, which can then perform in-place operations on them and return them as outputs.
4. Change `Generator` to pre-allocate space for the full sequence length in the KV-cache tensors, and pass those tensors as owned tensors into the model. Internally, the model can then do an `O(1)` extension of the KV-cache tensor without copying, and return that buffer from the model output.

For all these changes to work, the model has to fulfill some assumptions about how the KV cache is used. See the commit notes for the changes in rten-generate.