### PR TITLE
Prevent `Model::partial_run` from propagating values through random ops

### DIFF
--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -806,6 +806,19 @@ pub trait Operator: Debug {
         false
     }
 
+    /// Return true if this operator's outputs depend only on its inputs.
+    ///
+    /// The default implementation returns true, since most operators are
+    /// deterministic. Operators such as random number generators however are
+    /// not.
+    ///
+    /// The definition of _deterministic_ used here excludes minor differences
+    /// due to eg. the order in which results from parallel sub-problems are
+    /// accumulated. It also does not guarantee exact consistency across devices.
+    fn is_deterministic(&self) -> bool {
+        true
+    }
+
     /// Execute this operator in-place on an existing tensor.
     ///
     /// This may only be called if `can_run_in_place` returns true.

--- a/src/ops/random.rs
+++ b/src/ops/random.rs
@@ -24,6 +24,10 @@ impl Operator for RandomUniform {
         "RandomUniform"
     }
 
+    fn is_deterministic(&self) -> bool {
+        false
+    }
+
     fn run(&self, pool: &TensorPool, _inputs: InputList) -> Result<Vec<Output>, OpError> {
         let scale_value = |val: f32| self.low + val * (self.high - self.low);
         let shape = self.shape.as_slice();
@@ -49,6 +53,10 @@ pub struct RandomUniformLike {
 impl Operator for RandomUniformLike {
     fn name(&self) -> &str {
         "RandomUniformLike"
+    }
+
+    fn is_deterministic(&self) -> bool {
+        false
     }
 
     fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
@@ -81,6 +89,10 @@ impl Operator for RandomNormal {
         "RandomNormal"
     }
 
+    fn is_deterministic(&self) -> bool {
+        false
+    }
+
     fn run(&self, pool: &TensorPool, _inputs: InputList) -> Result<Vec<Output>, OpError> {
         let shape = self.shape.as_slice();
 
@@ -107,6 +119,10 @@ pub struct RandomNormalLike {
 impl Operator for RandomNormalLike {
     fn name(&self) -> &str {
         "RandomNormalLike"
+    }
+
+    fn is_deterministic(&self) -> bool {
+        false
     }
 
     fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {


### PR DESCRIPTION
Allow operators to declare whether they are deterministic or not, make the `Random*` ops return `false`, and prevent `Graph::partial_run` from propagating values through non-deterministic operators.

With this change it should become safe to apply constant propagation as an optimization when models are loaded.

Fixes https://github.com/robertknight/rten/issues/90.