### PR TITLE
Perform constant propagation when loading models

### DIFF
--- a/rten-cli/src/main.rs
+++ b/rten-cli/src/main.rs
@@ -273,7 +273,7 @@ fn run_with_random_input(
     )?;
 
     // Convert inputs from `Output` (owned) to `Input` (view).
-    let mut inputs: Vec<(NodeId, InputOrOutput)> = inputs
+    let inputs: Vec<(NodeId, InputOrOutput)> = inputs
         .iter()
         .map(|(id, output)| (*id, InputOrOutput::from(output)))
         .collect();
@@ -285,25 +285,6 @@ fn run_with_random_input(
             .and_then(|ni| ni.name())
             .unwrap_or("(unnamed)");
         println!("  Input \"{name}\" generated shape {:?}", input.shape());
-    }
-
-    // Evaluate operators that don't depend on any inputs.
-    //
-    // ONNX Runtime does this when graph optimizations are enabled. RTen
-    // doesn't have any built-in graph optimizations yet, so we have to do this
-    // manually.
-    let opt_start = Instant::now();
-    let const_prop = model.partial_run(vec![], model.output_ids(), None)?;
-    for (node_id, const_val) in const_prop.iter() {
-        inputs.push((*node_id, const_val.into()));
-    }
-    let opt_elapsed = opt_start.elapsed().as_millis();
-    if !const_prop.is_empty() {
-        println!(
-            "  Constant propagation produced {} values in {:.2}ms",
-            const_prop.len(),
-            opt_elapsed
-        );
     }
 
     // Run model and summarize outputs.

--- a/rten-generate/src/generator.rs
+++ b/rten-generate/src/generator.rs
@@ -207,7 +207,12 @@ impl<'a> Generator<'a> {
         Ok(Generator {
             model,
             constant_inputs: Vec::new(),
-            constant_prop_inputs: None,
+
+            // Constant propagation is performed as a graph optimization when
+            // the model is loaded, so we only need to re-do it if additional
+            // constant inputs are added.
+            constant_prop_inputs: Some(Vec::new()),
+
             input_ids: vec![],
             input_ids_input,
             attention_mask_input,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,6 +99,7 @@ mod iter_util;
 mod model;
 mod model_metadata;
 mod number;
+mod optimize;
 mod slice_reductions;
 mod tensor_pool;
 mod threading;

--- a/src/model.rs
+++ b/src/model.rs
@@ -79,6 +79,13 @@ use crate::timing::TimingSort;
 /// of generating a plan which starts with the input nodes, and executes the
 /// necessary operators to generate the requested outputs.
 ///
+/// ## Graph optimizations
+///
+/// By default RTen applies various optimizations to the model when it is loaded
+/// to improve inference performance. These optimizations guarantee to preserve
+/// the model's inputs and outputs, but other nodes may be replaced or
+/// eliminated. To configure or disable optimizations, use [`ModelOptions`].
+///
 /// ## Partial evaluation
 ///
 /// Some models, such as transformer decoders, are evaluated repeatedly in a

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -1,0 +1,70 @@
+use std::error::Error;
+use std::fmt::{Display, Formatter};
+
+use crate::graph::{Graph, NodeId};
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum OptimizeError {
+    UnknownError,
+}
+
+impl Display for OptimizeError {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        match self {
+            Self::UnknownError => write!(f, "optimizing graph failed"),
+        }
+    }
+}
+
+impl Error for OptimizeError {}
+
+/// Optimized graph produced by [`GraphOptimizer`].
+pub struct OptimizedGraph {
+    /// The optimized graph.
+    pub graph: Graph,
+
+    /// IDs of input nodes. These correspond to the input IDs passed to
+    /// [`GraphOptimizer::optimize`].
+    pub input_ids: Vec<NodeId>,
+
+    /// IDs of output nodes. These correspond to the output IDs passed to
+    /// [`GraphOptimizer::optimize`].
+    pub output_ids: Vec<NodeId>,
+}
+
+/// Applies optimizations to a [`Graph`] to enable faster inference.
+pub struct GraphOptimizer {}
+
+impl GraphOptimizer {
+    /// Create a new optimizer with the default set of optimizations enabled.
+    pub fn new() -> Self {
+        GraphOptimizer {}
+    }
+
+    /// Apply optimizations to a graph and return the new graph.
+    ///
+    /// The input and output nodes specified by `input_ids` and `output_ids`
+    /// will be preserved, but their IDs may change.
+    ///
+    /// Other nodes in the graph
+    pub fn optimize(
+        &self,
+        graph: Graph,
+        input_ids: &[NodeId],
+        output_ids: &[NodeId],
+    ) -> Result<OptimizedGraph, OptimizeError> {
+        let x = OptimizeError::UnknownError;
+
+        Ok(OptimizedGraph {
+            graph,
+            input_ids: input_ids.to_vec(),
+            output_ids: output_ids.to_vec(),
+        })
+    }
+}
+
+impl Default for GraphOptimizer {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -1,17 +1,23 @@
 use std::error::Error;
 use std::fmt::{Display, Formatter};
 
-use crate::graph::{Graph, NodeId};
+use rustc_hash::FxHashMap;
 
-#[derive(Clone, Debug, PartialEq)]
+use crate::graph::{Graph, Node, NodeId, RunError};
+use crate::Output;
+
+/// Errors that occur while applying graph optimizations.
+#[derive(Debug, PartialEq)]
 pub enum OptimizeError {
-    UnknownError,
+    /// An error occurred while evaluating parts of the graph (eg. as part
+    /// of constant propagation).
+    RunError(RunError),
 }
 
 impl Display for OptimizeError {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
-            Self::UnknownError => write!(f, "optimizing graph failed"),
+            Self::RunError(err) => write!(f, "partial evaluation failed: {}", err),
         }
     }
 }
@@ -41,30 +47,210 @@ impl GraphOptimizer {
         GraphOptimizer {}
     }
 
-    /// Apply optimizations to a graph and return the new graph.
+    /// Apply optimizations to a graph.
     ///
     /// The input and output nodes specified by `input_ids` and `output_ids`
-    /// will be preserved, but their IDs may change.
+    /// will be preserved, but their IDs may change. Other nodes in the graph
+    /// may be modified, removed or replaced by optimization.
     ///
-    /// Other nodes in the graph
+    /// This method returns the new graph along with the node IDs in the new
+    /// graph that correspond to `input_ids` and `output_ids`.
     pub fn optimize(
         &self,
-        graph: Graph,
+        mut graph: Graph,
         input_ids: &[NodeId],
         output_ids: &[NodeId],
     ) -> Result<OptimizedGraph, OptimizeError> {
-        let x = OptimizeError::UnknownError;
+        let mut output_ids = output_ids.to_vec();
+        self.propagate_constants(&mut graph, &mut output_ids)?;
 
         Ok(OptimizedGraph {
             graph,
             input_ids: input_ids.to_vec(),
-            output_ids: output_ids.to_vec(),
+            output_ids,
         })
+    }
+
+    /// Apply constant propagation to replace parts of the graph which depend
+    /// only on constant values with a pre-computed constant.
+    fn propagate_constants(
+        &self,
+        graph: &mut Graph,
+        output_ids: &mut [NodeId],
+    ) -> Result<(), OptimizeError> {
+        // Map of (value_node_id, operator_node_ids) for each value node that is
+        // an input to one or more operators.
+        let edges: FxHashMap<NodeId, Vec<NodeId>> = graph.iter().fold(
+            FxHashMap::default(),
+            |mut edges, (node_id, node)| match node {
+                Node::Operator(op_node) => {
+                    for edge_start in op_node.input_ids().flatten() {
+                        if let Some(edge_ends) = edges.get_mut(&edge_start) {
+                            edge_ends.push(node_id);
+                        } else {
+                            edges.insert(edge_start, vec![node_id]);
+                        }
+                    }
+                    edges
+                }
+                _ => edges,
+            },
+        );
+
+        // Do a partial run with no inputs. This evaluates all nodes that
+        // transitively depend only on constants.
+        let leaves = graph
+            .partial_run(vec![], output_ids, None)
+            .map_err(OptimizeError::RunError)?;
+
+        // Take the resulting (value_node_id, value) list, create new constant
+        // nodes in the graph with the value and replace references to
+        // `value_node_id` in operator inputs and model outputs with the new
+        // constant.
+        for (node_id, output) in leaves {
+            let const_name = graph
+                .get_node(node_id)
+                .and_then(|n| n.name())
+                .map(|name| name.to_string());
+            let const_id = match output {
+                Output::FloatTensor(tensor) => graph.add_constant(const_name.as_deref(), tensor),
+                Output::IntTensor(tensor) => graph.add_constant(const_name.as_deref(), tensor),
+            };
+
+            if let Some(operator_ids) = edges.get(&node_id) {
+                for &op_id in operator_ids {
+                    let Some(Node::Operator(op_node)) = graph.get_node_mut(op_id) else {
+                        panic!("operator node not found");
+                    };
+                    op_node.replace_input(node_id, const_id);
+                }
+            };
+
+            for output_id in output_ids.iter_mut().filter(|id| **id == node_id) {
+                *output_id = const_id;
+            }
+        }
+
+        Ok(())
     }
 }
 
 impl Default for GraphOptimizer {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::error::Error;
+
+    use rten_tensor::Tensor;
+
+    use super::{GraphOptimizer, OptimizeError, OptimizedGraph};
+    use crate::graph::{Constant, Graph, Node, NodeId, OperatorNode};
+    use crate::ops::{Add, Operator};
+
+    /// Extensions to [`Graph`] to make tests easier to write.
+    trait GraphTestUtils {
+        /// Add a single-output operator to the graph and return a tuple of
+        /// `(operator_node_id, output_node_id)`.
+        fn add_simple_op<Op: Operator + Send + Sync + 'static>(
+            &mut self,
+            name: &str,
+            op: Op,
+            input_ids: &[NodeId],
+        ) -> (NodeId, NodeId);
+
+        fn get_operator(&self, node_id: NodeId) -> Option<&OperatorNode>;
+        fn get_constant(&self, node_id: NodeId) -> Option<&Constant>;
+    }
+
+    impl GraphTestUtils for Graph {
+        fn add_simple_op<Op: Operator + Send + Sync + 'static>(
+            &mut self,
+            name: &str,
+            op: Op,
+            input_ids: &[NodeId],
+        ) -> (NodeId, NodeId) {
+            let op_out_name = format!("{}_out", name);
+            let op_out_id = self.add_value(Some(&op_out_name), None);
+            let input_ids: Vec<_> = input_ids.iter().copied().map(Some).collect();
+            let op_node_id =
+                self.add_op(Some(name), Box::new(op), &input_ids, &[op_out_id].map(Some));
+            (op_node_id, op_out_id)
+        }
+
+        fn get_operator(&self, node_id: NodeId) -> Option<&OperatorNode> {
+            match self.get_node(node_id) {
+                Some(Node::Operator(op)) => Some(op),
+                _ => None,
+            }
+        }
+
+        fn get_constant(&self, node_id: NodeId) -> Option<&Constant> {
+            match self.get_node(node_id) {
+                Some(Node::Constant(constant)) => Some(constant),
+                _ => None,
+            }
+        }
+    }
+
+    #[test]
+    fn test_constant_propagation() -> Result<(), Box<dyn Error>> {
+        let mut graph = Graph::new();
+
+        // Add an operator with constant inputs.
+        let const_a = graph.add_constant(Some("const_a"), Tensor::from([1, 2, 3]));
+        let const_b = graph.add_constant(Some("const_b"), Tensor::from([4, 5, 6]));
+        let (_, add_out) = graph.add_simple_op("add_1", Add {}, &[const_a, const_b]);
+
+        // Add an operator with a dynamic input and the output of the previous operator.
+        let input = graph.add_value(Some("input"), None);
+        let (add_op_2, add_2_out) = graph.add_simple_op("add_2", Add {}, &[add_out, input]);
+
+        // Optimize the graph. This should replace the first operator's output
+        // with a constant value.
+        let optimizer = GraphOptimizer::new();
+        let OptimizedGraph {
+            graph: optimized_graph,
+            input_ids: optimized_graph_input_ids,
+            output_ids: optimized_graph_output_ids,
+        } = optimizer.optimize(graph, &[input], &[add_out, add_2_out])?;
+
+        // Check that we got the expected inputs and outputs. The optimizer
+        // does not promise to preserve IDs for unmodified parts of the graph,
+        // but the current implementation does.
+        assert_eq!(optimized_graph_input_ids, &[input]);
+        assert_ne!(optimized_graph_output_ids[0], add_out);
+        assert_eq!(optimized_graph_output_ids[1], add_2_out);
+
+        // Check first output was replaced with constant.
+        let replaced_node = optimized_graph
+            .get_constant(optimized_graph_output_ids[0])
+            .unwrap();
+        let Constant::Int(const_int) = replaced_node else {
+            return Err("constant not an int".into());
+        };
+        assert_eq!(const_int.view(), Tensor::from([5, 7, 9]));
+
+        // Check input to second operator was replaced with constant.
+        let op = optimized_graph.get_operator(add_op_2).unwrap();
+        let input_ids: Vec<_> = op.input_ids().map(|id| id.unwrap()).collect();
+        assert_eq!(input_ids.len(), 2);
+        assert_ne!(input_ids[0], add_out);
+        assert_eq!(input_ids[0], optimized_graph_output_ids[0]);
+        assert_eq!(input_ids[1], input);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_optimize_error() {
+        let graph = Graph::new();
+        let optimizer = GraphOptimizer::new();
+        let invalid_id = 123;
+        let result = optimizer.optimize(graph, &[invalid_id], &[invalid_id]);
+        assert!(matches!(result, Err(OptimizeError::RunError(_))));
     }
 }


### PR DESCRIPTION
Add initial infrastructure to perform graph optimizations as part of loading a model, and implement constant propagation (pre-evaluating the parts of the graph that don't depend on dynamic input values) as the first graph-level optimization. This is an optimization that was already implemented downstream in `rten-cli` and `rten-generate` after the model was loaded. Those downstream implementations are also removed in this change. 

Optimization is performed by default when a model is loaded, but can be disabled using `ModelOptions`. This mirrors ONNX Runtime's approach of enabling optimizations unless the consumer opts out.

**TODO:**
- [x] Tests
- [x] Consider making the graph immutable once optimized. This avoids hazards where eg. cached execution plans could become invalidated by model changes (Edit: Will revisit this later)