### PR TITLE
Add Transpose + MatMul fusion

### DIFF
--- a/src/downcast.rs
+++ b/src/downcast.rs
@@ -1,0 +1,90 @@
+use std::any::Any;
+
+/// Allows downcasting a trait object to a concrete type.
+///
+/// This can be implemented for `dyn SomeTrait`, where `SomeTrait` is a trait
+/// that has `Any` as a supertrait, by using [`impl_downcastdyn`].
+///
+/// When the `trait_upcasting` feature is stabilized, this can be removed
+/// as callers can upcast the trait object to `dyn Any` and then downcast.
+pub(crate) trait DowncastDyn {
+    fn is<T: Any>(&self) -> bool;
+    fn downcast_ref<T: Any>(&self) -> Option<&T>;
+}
+
+/// Implement [`DowncastDyn`] for a trait. The trait must have `Any` as a
+/// supertrait.
+macro_rules! impl_downcastdyn {
+    ($trait:ident) => {
+        // Trigger compile error if `Any` is not a supertrait of `$trait`.
+        //
+        // Credit: https://stackoverflow.com/a/64826111/434243
+        fn _assert_any_supertrait<T: $trait>() {
+            fn has_any_supertrait<T: Any>() {}
+            let _ = has_any_supertrait::<T>;
+        }
+
+        // The implementation approach was taken from how `downcast_ref` is implemented
+        // for `dyn Error` in the standard library.
+        impl $crate::downcast::DowncastDyn for dyn $trait {
+            fn is<T: std::any::Any>(&self) -> bool {
+                // nb. If `$trait` does not have an `Any` supertrait, this code
+                // still compiles, but `type_id` will return a different value.
+                // Hence the `_assert_any_supertrait` check above.
+                std::any::TypeId::of::<T>() == <Self as std::any::Any>::type_id(self)
+            }
+
+            fn downcast_ref<T: std::any::Any>(&self) -> Option<&T> {
+                if self.is::<T>() {
+                    // SAFETY: `is` ensures the cast is correct.
+                    Some(unsafe { &*(self as *const dyn $trait as *const T) })
+                } else {
+                    None
+                }
+            }
+        }
+    };
+}
+
+pub(crate) use impl_downcastdyn;
+
+#[cfg(test)]
+mod tests {
+    use std::any::Any;
+
+    use super::{impl_downcastdyn, DowncastDyn};
+
+    trait Foo: Any {}
+    impl_downcastdyn!(Foo);
+
+    struct TypeA {}
+    impl Foo for TypeA {}
+
+    struct TypeB {}
+    impl Foo for TypeB {}
+
+    #[test]
+    fn test_downcast_ref() {
+        let type_a = TypeA {};
+        let type_b = TypeB {};
+
+        let type_a_dyn: &dyn Foo = &type_a;
+        let type_b_dyn: &dyn Foo = &type_b;
+
+        assert!(type_a_dyn.is::<TypeA>());
+        assert!(!type_a_dyn.is::<TypeB>());
+        assert!(std::ptr::eq(
+            type_a_dyn.downcast_ref::<TypeA>().unwrap(),
+            &type_a
+        ));
+        assert!(type_a_dyn.downcast_ref::<TypeB>().is_none());
+
+        assert!(type_b_dyn.is::<TypeB>());
+        assert!(!type_b_dyn.is::<TypeA>());
+        assert!(std::ptr::eq(
+            type_b_dyn.downcast_ref::<TypeB>().unwrap(),
+            &type_b
+        ));
+        assert!(type_b_dyn.downcast_ref::<TypeA>().is_none());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,6 +92,7 @@
 use rten_tensor::{NdTensor, Tensor};
 
 mod constant_storage;
+mod downcast;
 mod env;
 mod gemm;
 mod graph;

--- a/src/ops/fused.rs
+++ b/src/ops/fused.rs
@@ -1,0 +1,143 @@
+use rten_tensor::prelude::*;
+
+use crate::ops::{Input, InputList, OpError, Operator, Output};
+use crate::tensor_pool::TensorPool;
+
+/// Specifies a permutation to an operator input.
+#[derive(Clone, Debug, PartialEq)]
+struct PermuteSpec {
+    index: usize,
+    perm: Option<Vec<usize>>,
+}
+
+impl PermuteSpec {
+    /// Apply the permutation to the matching operator input in `inputs`.
+    fn apply(&self, inputs: &mut InputList) -> Result<(), OpError> {
+        let Some(input) = inputs.get_mut(self.index) else {
+            return Err(OpError::MissingInputs);
+        };
+
+        match input {
+            Input::IntTensor(ref mut t) => {
+                if let Some(perm) = self.perm.as_ref() {
+                    t.permute(perm);
+                } else {
+                    t.transpose();
+                }
+            }
+            Input::FloatTensor(ref mut t) => {
+                if let Some(perm) = self.perm.as_ref() {
+                    t.permute(perm);
+                } else {
+                    t.transpose();
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Operator which wraps another operator to permute one or more input views
+/// before evaluating the wrapped operator.
+#[derive(Debug)]
+pub struct FusedTranspose {
+    inner: Box<dyn Operator + Send + Sync>,
+    perm: PermuteSpec,
+    name: String,
+}
+
+impl FusedTranspose {
+    pub fn wrap(
+        op: Box<dyn Operator + Send + Sync>,
+        input_index: usize,
+        permutation: Option<&[usize]>,
+    ) -> FusedTranspose {
+        FusedTranspose {
+            perm: PermuteSpec {
+                index: input_index,
+                perm: permutation.map(|slice| slice.to_vec()),
+            },
+            name: format!("FusedTranspose({})", op.name()),
+            inner: op,
+        }
+    }
+}
+
+impl Operator for FusedTranspose {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn run(&self, pool: &TensorPool, mut inputs: InputList) -> Result<Vec<Output>, OpError> {
+        self.perm.apply(&mut inputs)?;
+        self.inner.run(pool, inputs)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::error::Error;
+
+    use rten_tensor::prelude::*;
+    use rten_tensor::Tensor;
+
+    use super::FusedTranspose;
+    use crate::ops::tests::new_pool;
+    use crate::ops::{InputList, Operator, Sub};
+
+    #[test]
+    fn test_fused_transpose() -> Result<(), Box<dyn Error>> {
+        struct Case {
+            a: Tensor<i32>,
+            b: Tensor<i32>,
+            transpose_input: usize,
+            expected: Tensor<i32>,
+        }
+
+        let cases = [
+            Case {
+                a: Tensor::from([[1, 2], [3, 4]]),
+                b: Tensor::from([[0, 1], [2, 3]]),
+                transpose_input: 1,
+
+                // 1 2 - 0 2 = 1 0
+                // 3 4   1 3   2 1
+                expected: Tensor::from([[1, 0], [2, 1]]),
+            },
+            Case {
+                a: Tensor::from([[1, 2], [3, 4]]),
+                b: Tensor::from([[0, 1], [2, 3]]),
+                transpose_input: 0,
+
+                // 1 3 - 0 1 = 1 2
+                // 2 4   2 3   0 1
+                expected: Tensor::from([[1, 2], [0, 1]]),
+            },
+        ];
+
+        for Case {
+            a,
+            b,
+            transpose_input,
+            expected,
+        } in cases
+        {
+            // nb. `Sub` operator chosen because it is a simple non-commutative
+            // binary op.
+            let sub_op = Sub {};
+            let fused_transpose =
+                FusedTranspose::wrap(Box::new(sub_op), transpose_input, Some(&[1, 0]));
+
+            let pool = new_pool();
+            let mut outputs =
+                fused_transpose.run(&pool, InputList::from(&[a.view().into(), b.view().into()]))?;
+
+            let output: Tensor<i32> = outputs.remove(0).try_into().unwrap();
+
+            assert_eq!(output, expected);
+        }
+
+        Ok(())
+    }
+}

--- a/src/ops/matmul.rs
+++ b/src/ops/matmul.rs
@@ -238,7 +238,7 @@ fn matmul_impl(
     Ok(output)
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct MatMul {}
 
 impl Operator for MatMul {

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -27,6 +27,7 @@ use rten_tensor::{
 use crate::downcast::impl_downcastdyn;
 use crate::tensor_pool::TensorPool;
 
+// Modules containing ops that correspond to ONNX operators.
 mod binary_elementwise;
 mod concat;
 mod conv;
@@ -52,6 +53,9 @@ mod split;
 mod trilu;
 mod unary_elementwise;
 mod variadic_elementwise;
+
+// Fused operators.
+pub(crate) mod fused;
 
 pub use binary_elementwise::{
     add, add_in_place, and, div, div_in_place, equal, greater, greater_or_equal, less,
@@ -883,6 +887,10 @@ impl<'a> InputList<'a> {
     /// Get an optional input.
     pub fn get(&self, index: usize) -> Option<Input<'a>> {
         self.inputs.get(index).cloned().flatten()
+    }
+
+    pub fn get_mut(&mut self, index: usize) -> Option<&mut Input<'a>> {
+        self.inputs.get_mut(index)?.as_mut()
     }
 
     /// Get an optional input as a tensor.

--- a/src/ops/unary_elementwise.rs
+++ b/src/ops/unary_elementwise.rs
@@ -1,5 +1,6 @@
 use rayon::prelude::*;
 
+use std::any::Any;
 use std::fmt::Debug;
 use std::mem::MaybeUninit;
 
@@ -34,7 +35,7 @@ pub trait UnaryFloatOp {
     }
 }
 
-impl<Op: UnaryFloatOp + Debug> Operator for Op {
+impl<Op: Any + Debug + UnaryFloatOp> Operator for Op {
     fn name(&self) -> &str {
         self.name()
     }

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -1,9 +1,13 @@
 use std::error::Error;
 use std::fmt::{Display, Formatter};
 
+use rten_tensor::Tensor;
 use rustc_hash::FxHashMap;
 
-use crate::graph::{Graph, Node, NodeId, RunError};
+use crate::downcast::DowncastDyn;
+use crate::graph::{Constant, ConstantNode, Graph, Node, NodeId, OperatorNode, RunError};
+use crate::ops::fused::FusedTranspose;
+use crate::ops::{MatMul, Operator, Transpose};
 use crate::Output;
 
 /// Errors that occur while applying graph optimizations.
@@ -38,6 +42,215 @@ pub struct OptimizedGraph {
     pub output_ids: Vec<NodeId>,
 }
 
+/// Holds a [`Graph`] and associated data structures while it is being mutated
+/// by an optimizer, and provides operations to update the graph.
+struct GraphMutator {
+    /// Map of (value_node_id, operator_node_ids) for each value node that
+    /// is an input to one or more operators.
+    edges: FxHashMap<NodeId, Vec<NodeId>>,
+    graph: Graph,
+    output_ids: Vec<usize>,
+}
+
+impl GraphMutator {
+    fn from_graph(graph: Graph, output_ids: &[usize]) -> GraphMutator {
+        // Map of value_node => operator_node.
+        let edges: FxHashMap<NodeId, Vec<NodeId>> = graph.iter().fold(
+            FxHashMap::default(),
+            |mut edges, (node_id, node)| match node {
+                Node::Operator(op_node) => {
+                    for &edge_start in op_node.input_ids().iter().flatten() {
+                        if let Some(edge_ends) = edges.get_mut(&edge_start) {
+                            edge_ends.push(node_id);
+                        } else {
+                            edges.insert(edge_start, vec![node_id]);
+                        }
+                    }
+                    edges
+                }
+                _ => edges,
+            },
+        );
+        GraphMutator {
+            edges,
+            graph,
+            output_ids: output_ids.to_vec(),
+        }
+    }
+
+    /// Add a new constant value to the graph.
+    fn add_constant<T>(&mut self, name: Option<&str>, value: Tensor<T>) -> NodeId
+    where
+        Constant: From<ConstantNode<T>>,
+    {
+        self.graph.add_constant(name, value)
+    }
+
+    /// Add a new operator to the graph with a single output node.
+    ///
+    /// Returns the ID of the output node.
+    fn add_operator(
+        &mut self,
+        name: Option<&str>,
+        op: Box<dyn Operator + Send + Sync>,
+        inputs: &[Option<NodeId>],
+    ) -> NodeId {
+        let op_output_id = self.graph.add_value(None, None);
+        let op_id = self.graph.add_op(name, op, inputs, &[Some(op_output_id)]);
+
+        for input_id in inputs.iter().filter_map(|id| *id) {
+            if let Some(op_ids) = self.edges.get_mut(&input_id) {
+                op_ids.push(op_id);
+            } else {
+                self.edges.insert(input_id, vec![op_id]);
+            }
+        }
+
+        op_output_id
+    }
+
+    /// Return a reference to the graph.
+    ///
+    /// Note there is no mutable variant of this method. All graph updates must
+    /// be done via methods of this struct.
+    fn graph(&self) -> &Graph {
+        &self.graph
+    }
+
+    fn into_graph_and_output_ids(self) -> (Graph, Vec<NodeId>) {
+        (self.graph, self.output_ids)
+    }
+
+    /// Iterate over operator nodes and their IDs.
+    fn iter_operators(&self) -> impl Iterator<Item = (NodeId, &OperatorNode)> {
+        self.graph.iter().filter_map(|(node_id, node)| match node {
+            Node::Operator(op) => Some((node_id, op)),
+            _ => None,
+        })
+    }
+
+    /// Iterate over each operator node in the graph and potentially apply a
+    /// fusion which combines this node and adjacent nodes.
+    fn apply_fusion<F: Fn(&Self, &OperatorNode) -> Option<Fusion>>(&mut self, create_fusion: F) {
+        let mut fusions = Vec::new();
+
+        for (_, op_node) in self.iter_operators() {
+            if let Some(fusion) = create_fusion(self, op_node) {
+                fusions.push(fusion);
+            }
+        }
+
+        for fusion in fusions {
+            fusion.apply(self);
+        }
+    }
+
+    fn output_ids(&self) -> &[NodeId] {
+        &self.output_ids
+    }
+
+    /// Return the operator node in `graph` that has an incoming edge from a
+    /// value node.
+    ///
+    /// Returns `None` if there are zero or many such operators.
+    fn find_operator_with_input(&self, value_node_id: NodeId) -> Option<&OperatorNode> {
+        let targets = self.edges.get(&value_node_id).map(|v| v.as_slice())?;
+        let target = match targets {
+            &[op_id] => Some(op_id),
+            _ => None,
+        };
+        target.map(|id| match self.graph.get_node(id) {
+            Some(Node::Operator(op_node)) => op_node,
+            _ => panic!("expected operator"),
+        })
+    }
+
+    /// Replace `old_value_id` with `new_value_id` in operator inputs and graph
+    /// outputs.
+    fn replace_value(&mut self, old_value_id: NodeId, new_value_id: NodeId) {
+        // Replace `old_value_id` in graph outputs.
+        for output_id in self.output_ids.iter_mut().filter(|id| **id == old_value_id) {
+            *output_id = new_value_id;
+        }
+
+        // Replace `old_value_id` in operator inputs.
+        let Some(old_value_op_ids) = self.edges.remove(&old_value_id) else {
+            return;
+        };
+
+        for &op_id in &old_value_op_ids {
+            let Some(Node::Operator(op_node)) = self.graph.get_node_mut(op_id) else {
+                panic!("operator node not found");
+            };
+            op_node.replace_input(old_value_id, new_value_id);
+        }
+
+        if let Some(new_value_op_ids) = self.edges.get_mut(&new_value_id) {
+            new_value_op_ids.extend(old_value_op_ids);
+        } else {
+            self.edges.insert(new_value_id, old_value_op_ids);
+        }
+    }
+}
+
+/// Defines a fused operator which replaces a subgraph.
+struct Fusion {
+    name: Option<String>,
+    fused_op: Box<dyn Operator + Send + Sync>,
+    input_ids: Vec<Option<NodeId>>,
+    old_output_id: NodeId,
+}
+
+impl Fusion {
+    /// Apply the fusion to the graph.
+    ///
+    /// This adds the fused operator to the graph and replaces references to
+    /// the original output nodes with the fused operator's outputs.
+    fn apply(self, graph: &mut GraphMutator) {
+        let Fusion {
+            name,
+            fused_op,
+            input_ids,
+            old_output_id,
+        } = self;
+
+        let fused_op_output_id = graph.add_operator(name.as_deref(), fused_op, &input_ids);
+        graph.replace_value(old_output_id, fused_op_output_id);
+    }
+}
+
+/// Utilities for matching patterns in a graph.
+trait OperatorMatch {
+    /// Test if an operator node matches a given operator and has N inputs and
+    /// M outputs.
+    fn match_type<Op: Operator, const N: usize, const M: usize>(
+        &self,
+    ) -> Option<(&Op, [usize; N], [usize; M])>;
+}
+
+impl OperatorMatch for OperatorNode {
+    fn match_type<Op: Operator, const N: usize, const M: usize>(
+        &self,
+    ) -> Option<(&Op, [usize; N], [usize; M])> {
+        let op = self.operator().downcast_ref::<Op>()?;
+
+        let input_ids = self.input_ids();
+        if input_ids.len() != N || input_ids.iter().any(|n| n.is_none()) {
+            return None;
+        }
+
+        let output_ids = self.output_ids();
+        if output_ids.len() != M || output_ids.iter().any(|n| n.is_none()) {
+            return None;
+        }
+
+        let input_ids: [usize; N] = std::array::from_fn(|i| input_ids[i].unwrap());
+        let output_ids: [usize; M] = std::array::from_fn(|i| output_ids[i].unwrap());
+
+        Some((op, input_ids, output_ids))
+    }
+}
+
 /// Applies optimizations to a [`Graph`] to enable faster inference.
 pub struct GraphOptimizer {}
 
@@ -57,12 +270,17 @@ impl GraphOptimizer {
     /// graph that correspond to `input_ids` and `output_ids`.
     pub fn optimize(
         &self,
-        mut graph: Graph,
+        graph: Graph,
         input_ids: &[NodeId],
         output_ids: &[NodeId],
     ) -> Result<OptimizedGraph, OptimizeError> {
-        let mut output_ids = output_ids.to_vec();
-        self.propagate_constants(&mut graph, &mut output_ids)?;
+        let mut graph_mut = GraphMutator::from_graph(graph, output_ids);
+
+        self.propagate_constants(&mut graph_mut)?;
+
+        self.fuse_transpose_matmul(&mut graph_mut)?;
+
+        let (graph, output_ids) = graph_mut.into_graph_and_output_ids();
 
         Ok(OptimizedGraph {
             graph,
@@ -73,63 +291,69 @@ impl GraphOptimizer {
 
     /// Apply constant propagation to replace parts of the graph which depend
     /// only on constant values with a pre-computed constant.
-    fn propagate_constants(
-        &self,
-        graph: &mut Graph,
-        output_ids: &mut [NodeId],
-    ) -> Result<(), OptimizeError> {
-        // Map of (value_node_id, operator_node_ids) for each value node that is
-        // an input to one or more operators.
-        let edges: FxHashMap<NodeId, Vec<NodeId>> = graph.iter().fold(
-            FxHashMap::default(),
-            |mut edges, (node_id, node)| match node {
-                Node::Operator(op_node) => {
-                    for edge_start in op_node.input_ids().flatten() {
-                        if let Some(edge_ends) = edges.get_mut(&edge_start) {
-                            edge_ends.push(node_id);
-                        } else {
-                            edges.insert(edge_start, vec![node_id]);
-                        }
-                    }
-                    edges
-                }
-                _ => edges,
-            },
-        );
-
+    fn propagate_constants(&self, graph: &mut GraphMutator) -> Result<(), OptimizeError> {
         // Do a partial run with no inputs. This evaluates all nodes that
         // transitively depend only on constants.
         let leaves = graph
-            .partial_run(vec![], output_ids, None)
+            .graph()
+            .partial_run(vec![], graph.output_ids(), None)
             .map_err(OptimizeError::RunError)?;
 
         // Take the resulting (value_node_id, value) list, create new constant
         // nodes in the graph with the value and replace references to
         // `value_node_id` in operator inputs and model outputs with the new
         // constant.
-        for (node_id, output) in leaves {
+        for (value_node_id, output) in leaves {
             let const_name = graph
-                .get_node(node_id)
+                .graph()
+                .get_node(value_node_id)
                 .and_then(|n| n.name())
                 .map(|name| name.to_string());
             let const_id = match output {
                 Output::FloatTensor(tensor) => graph.add_constant(const_name.as_deref(), tensor),
                 Output::IntTensor(tensor) => graph.add_constant(const_name.as_deref(), tensor),
             };
+            graph.replace_value(value_node_id, const_id);
+        }
 
-            if let Some(operator_ids) = edges.get(&node_id) {
-                for &op_id in operator_ids {
-                    let Some(Node::Operator(op_node)) = graph.get_node_mut(op_id) else {
-                        panic!("operator node not found");
-                    };
-                    op_node.replace_input(node_id, const_id);
-                }
+        Ok(())
+    }
+
+    /// Fuse `[Transpose(X), Y] -> MatMul` subgraphs, where the inputs can be in
+    /// either order.
+    fn fuse_transpose_matmul(&self, graph: &mut GraphMutator) -> Result<(), OptimizeError> {
+        graph.apply_fusion(|edges, op_node| {
+            let (transpose_op, [transpose_input], [transpose_output]) =
+                op_node.match_type::<Transpose, 1, 1>()?;
+
+            let transpose_target = edges.find_operator_with_input(transpose_output)?;
+
+            let (matmul_op, matmul_inputs, [matmul_output]) =
+                transpose_target.match_type::<MatMul, 2, 1>()?;
+            let [matmul_input_a, matmul_input_b] = matmul_inputs;
+
+            let fused_input = if matmul_input_a == transpose_output {
+                [transpose_input, matmul_input_b]
+            } else {
+                [matmul_input_a, transpose_input]
             };
 
-            for output_id in output_ids.iter_mut().filter(|id| **id == node_id) {
-                *output_id = const_id;
-            }
-        }
+            let fused_transpose_matmul = FusedTranspose::wrap(
+                Box::new(matmul_op.clone()),
+                if matmul_input_a == transpose_output {
+                    0
+                } else {
+                    1
+                },
+                transpose_op.perm.as_deref(),
+            );
+            Some(Fusion {
+                name: transpose_target.name().map(|s| s.to_string()),
+                fused_op: Box::new(fused_transpose_matmul),
+                input_ids: fused_input.map(Some).to_vec(),
+                old_output_id: matmul_output,
+            })
+        });
 
         Ok(())
     }
@@ -149,7 +373,7 @@ mod tests {
 
     use super::{GraphOptimizer, OptimizeError, OptimizedGraph};
     use crate::graph::{Constant, Graph, Node, NodeId, OperatorNode};
-    use crate::ops::{Add, Operator};
+    use crate::ops::{Add, MatMul, Operator, Transpose};
 
     /// Extensions to [`Graph`] to make tests easier to write.
     trait GraphTestUtils {
@@ -236,13 +460,49 @@ mod tests {
 
         // Check input to second operator was replaced with constant.
         let op = optimized_graph.get_operator(add_op_2).unwrap();
-        let input_ids: Vec<_> = op.input_ids().map(|id| id.unwrap()).collect();
+        let input_ids: Vec<_> = op.input_ids().iter().map(|id| id.unwrap()).collect();
         assert_eq!(input_ids.len(), 2);
         assert_ne!(input_ids[0], add_out);
         assert_eq!(input_ids[0], optimized_graph_output_ids[0]);
         assert_eq!(input_ids[1], input);
 
         Ok(())
+    }
+
+    #[test]
+    fn test_fuse_transpose_matmul() {
+        let mut graph = Graph::new();
+
+        let input_1 = graph.add_value(None, None);
+        let input_2 = graph.add_value(None, None);
+
+        let transpose_op = Transpose { perm: None };
+
+        let (_, transpose_out) = graph.add_simple_op("transpose", transpose_op, &[input_1]);
+        let (_, matmul_out) = graph.add_simple_op("matmul", MatMul {}, &[transpose_out, input_2]);
+
+        let optimizer = GraphOptimizer::new();
+        let OptimizedGraph {
+            graph: optimized_graph,
+            output_ids: new_output_ids,
+            ..
+        } = optimizer
+            .optimize(graph, &[input_1, input_2], &[matmul_out])
+            .unwrap();
+
+        let Some((_, new_op)) = optimized_graph.iter().find(|(_, node)| match node {
+            Node::Operator(op) => op.output_ids() == &[Some(new_output_ids[0])],
+            _ => false,
+        }) else {
+            panic!("node not found");
+        };
+
+        let Node::Operator(op) = new_op else {
+            panic!("should be an operator");
+        };
+
+        assert_eq!(op.operator().name(), "FusedTranspose(MatMul)");
+        assert_eq!(op.name(), Some("matmul"));
     }
 
     #[test]


### PR DESCRIPTION
This fuses subgraphs of the form:

```
(Transpose(X), Y) -> MatMul
```

Where the MatMul operands can be in either order, but only either `X` or `Y` can be transposed.

The fused operation transposes the `X` view before invoking the `MatMul` op with
the transposed view. This avoids materializing the transposed matrix.

This fusion works because the `MatMul` operation can efficiently handle
transposed input views. Other operations could also support an extended version
of this fusion in future.

In the context of transformer models this fusion avoids materializing the transposed `K` matrix in the Scaled Dot Product Attention (SDPA) operation. In that context more sophisticated fusions are possible here, such as replacing the whole SDPA with a fusion that implements flash attention. That will come later though.