### PR TITLE
Reduce allocations during graph execution

### DIFF
--- a/rten-tensor/src/layout.rs
+++ b/rten-tensor/src/layout.rs
@@ -514,7 +514,7 @@ impl<'a, const N: usize> TryFrom<&'a DynLayout> for NdLayout<N> {
 ///
 /// Zero-strides are used for broadcasting, which is widely used and easy to
 /// check for.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct DynLayout {
     /// Array of dimension sizes followed by the corresponding dimension strides.
     ///
@@ -522,6 +522,17 @@ pub struct DynLayout {
     /// are combined into one array to avoid redundantly storing separate
     /// lengths for each.
     shape_and_strides: SmallVec<[usize; 8]>,
+}
+
+impl Clone for DynLayout {
+    fn clone(&self) -> DynLayout {
+        DynLayout {
+            // We implement `Clone` manually here so we can clone
+            // `shape_and_strides` using `SmallVec::from_slice` instead of
+            // `SmallVec::from`. This is faster for `Copy` types.
+            shape_and_strides: SmallVec::from_slice(self.shape_and_strides.as_slice()),
+        }
+    }
 }
 
 impl Layout for DynLayout {

--- a/src/ops/gather.rs
+++ b/src/ops/gather.rs
@@ -31,8 +31,9 @@ pub fn gather<T: Copy + Default>(
         }
     }
 
-    let full_range =
-        |ndim: usize| -> Vec<SliceItem> { (0..ndim).map(|_| SliceItem::full_range()).collect() };
+    let full_range = |ndim: usize| -> SmallVec<[SliceItem; 4]> {
+        (0..ndim).map(|_| SliceItem::full_range()).collect()
+    };
 
     // Fast path for scalar `indices`. This amounts to indexing `input` along
     // `axis`.

--- a/src/ops/layout.rs
+++ b/src/ops/layout.rs
@@ -208,7 +208,7 @@ fn resolve_shape(
     input_shape: &[usize],
     shape: &NdTensorView<i32, 1>,
     allow_zero: bool,
-) -> Result<Vec<usize>, OpError> {
+) -> Result<SmallVec<[usize; 4]>, OpError> {
     // If exactly one of the new shape's dimensions is -1, infer the size
     // from the input length and the sizes of the other dimensions.
     let mut unspecified_dim = None;

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -13,6 +13,7 @@
 //! and one which takes a view as input and returns a new tensor as output.
 
 use std::any::Any;
+use std::borrow::Cow;
 use std::error::Error;
 use std::fmt;
 use std::fmt::{Debug, Display};
@@ -857,13 +858,15 @@ impl_downcastdyn!(Operator);
 /// An InputList can be constructed from a tensor reference or tuple of tensor
 /// references using `into`.
 pub struct InputList<'a> {
-    inputs: Vec<Option<Input<'a>>>,
+    inputs: Cow<'a, [Option<Input<'a>>]>,
 }
 
 impl<'a> InputList<'a> {
     /// Construct an empty input list.
     pub fn new() -> InputList<'static> {
-        InputList { inputs: vec![] }
+        InputList {
+            inputs: Cow::Owned(vec![]),
+        }
     }
 
     pub fn len(&self) -> usize {
@@ -874,14 +877,16 @@ impl<'a> InputList<'a> {
         self.inputs.is_empty()
     }
 
-    pub fn from<'b>(inputs: &[Input<'b>]) -> InputList<'b> {
+    pub fn from(inputs: &[Input<'a>]) -> InputList<'a> {
         InputList {
             inputs: inputs.iter().cloned().map(Some).collect(),
         }
     }
 
-    pub fn from_optional(inputs: Vec<Option<Input>>) -> InputList {
-        InputList { inputs }
+    pub fn from_optional(inputs: &'a [Option<Input<'a>>]) -> InputList<'a> {
+        InputList {
+            inputs: Cow::Borrowed(inputs),
+        }
     }
 
     /// Get an optional input.
@@ -890,7 +895,7 @@ impl<'a> InputList<'a> {
     }
 
     pub fn get_mut(&mut self, index: usize) -> Option<&mut Input<'a>> {
-        self.inputs.get_mut(index)?.as_mut()
+        self.inputs.to_mut().get_mut(index)?.as_mut()
     }
 
     /// Get an optional input as a tensor.

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -1007,8 +1007,8 @@ fn resolve_axis(ndim: usize, axis: isize) -> Result<usize, OpError> {
 pub fn resolve_axes<'a, I: ExactSizeIterator<Item = &'a i32>>(
     ndim: usize,
     axes: I,
-) -> Result<Vec<usize>, OpError> {
-    let mut resolved_axes = Vec::with_capacity(axes.len());
+) -> Result<SmallVec<[usize; 4]>, OpError> {
+    let mut resolved_axes = SmallVec::with_capacity(axes.len());
     for axis in axes {
         let resolved = resolve_axis(ndim, *axis as isize)?;
         resolved_axes.push(resolved);

--- a/src/ops/resize.rs
+++ b/src/ops/resize.rs
@@ -779,7 +779,7 @@ mod tests {
                 case.scales.as_ref().map(|t| t.into()),
                 case.sizes.as_ref().map(|t| t.into()),
             ];
-            let result = op.run(&pool, InputList::from_optional(inputs));
+            let result = op.run(&pool, InputList::from_optional(&inputs));
             match (case.expected, result) {
                 (CaseOutput::Shape(shape), Ok(out)) => {
                     let tensor = out[0].as_float_ref().unwrap();

--- a/src/ops/slice.rs
+++ b/src/ops/slice.rs
@@ -142,8 +142,14 @@ impl Operator for Slice {
         // Fall back to copying if non-default steps are given.
         if let Some(steps) = steps {
             if steps.iter().any(|step| *step != 1) {
-                let mut inputs: Vec<_> = vec![(&input).into()];
-                inputs.extend(other.iter());
+                let mut inputs: Vec<_> = vec![input.as_input()];
+
+                // `inputs.extend(other.iter())` not used here as it triggers
+                // a borrow-checking error.
+                for x in other.iter() {
+                    inputs.push(x);
+                }
+
                 return self
                     .run(pool, InputList::from(&inputs))
                     .map(|mut outputs| outputs.remove(0));

--- a/src/ops/slice.rs
+++ b/src/ops/slice.rs
@@ -3,6 +3,8 @@ use std::iter::zip;
 use rten_tensor::prelude::*;
 use rten_tensor::{NdTensorView, SliceItem, SliceRange, Tensor, TensorView};
 
+use smallvec::SmallVec;
+
 use crate::ops::{resolve_axis, Input, InputList, IntoOpResult, OpError, Operator, Output};
 use crate::static_dims;
 use crate::tensor_pool::TensorPool;
@@ -17,7 +19,7 @@ fn slice_ranges(
     ends: &NdTensorView<i32, 1>,
     axes: Option<&NdTensorView<i32, 1>>,
     steps: Option<&NdTensorView<i32, 1>>,
-) -> Result<Vec<SliceRange>, OpError> {
+) -> Result<SmallVec<[SliceRange; 4]>, OpError> {
     // FIXME: Verify that `starts`, `ends`, `axes` and `steps` have compatible
     // lengths.
 
@@ -29,7 +31,7 @@ fn slice_ranges(
         }
     }
 
-    let mut ranges: Vec<SliceRange> = input_shape
+    let mut ranges: SmallVec<_> = input_shape
         .iter()
         .map(|dim_size| SliceRange::new(0, Some(*dim_size as isize), 1))
         .collect();


### PR DESCRIPTION
This is a collection of micro-optimizations to reduce from overhead when executing a graph. Mostly this involves using `SmallVec` instead of `Vec` in cases where we expect the number of items will almost always be small.

Also I found that the overhead of creating tensor views could be reduced by implementing `Clone` manually for `DynLayout`, in order to use a `SmallVec` fast path for `Copy`-able items.

In the test scenario described in https://github.com/robertknight/rten/pull/239 this decreases time spent doing non-compute work on the "main" thread (the one where `Graph::run_plan` runs) by ~3%.