### PR TITLE
Use SmallVec for operator outputs

### DIFF
--- a/src/ops/binary_elementwise.rs
+++ b/src/ops/binary_elementwise.rs
@@ -5,7 +5,7 @@ use rten_tensor::prelude::*;
 use rten_tensor::{Tensor, TensorView, TensorViewMut};
 
 use crate::number::{AsBool, Identities, IsInt};
-use crate::ops::{Input, InputList, IntoOpResult, OpError, Operator, Output};
+use crate::ops::{Input, InputList, IntoOpResult, OpError, Operator, Output, OutputList};
 use crate::tensor_pool::TensorPool;
 
 /// Given the shapes of two inputs to a binary operation, return the shape
@@ -413,7 +413,7 @@ impl Operator for Add {
         "Add"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         run_typed_op!(pool, inputs, add)
     }
 
@@ -464,7 +464,7 @@ macro_rules! logical_boolean_op {
                 true
             }
 
-            fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+            fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
                 let a: TensorView<i32> = inputs.require_as(0)?;
                 let b: TensorView<i32> = inputs.require_as(1)?;
                 $op_fn(pool, a, b).into_op_result()
@@ -521,7 +521,7 @@ impl Operator for Div {
         "Div"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         run_typed_op!(pool, inputs, div)
     }
 
@@ -591,7 +591,7 @@ macro_rules! boolean_cmp_op {
                 stringify!($name) == "Equal"
             }
 
-            fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+            fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
                 run_typed_op!(pool, inputs, $func)
             }
         }
@@ -668,7 +668,7 @@ impl Operator for Mod {
         "Mod"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let a = inputs.require(0)?;
         let mode = if self.fmod {
             DivMode::TruncDiv
@@ -714,7 +714,7 @@ impl Operator for Mul {
         "Mul"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         run_typed_op!(pool, inputs, mul)
     }
 
@@ -773,7 +773,7 @@ impl Operator for Pow {
         "Pow"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let a = inputs.require_as(0)?;
         let b = inputs.require_as(1)?;
         pow(pool, a, b).into_op_result()
@@ -826,7 +826,7 @@ impl Operator for Sub {
         "Sub"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         run_typed_op!(pool, inputs, sub)
     }
 
@@ -933,7 +933,7 @@ impl Operator for Where {
         "Where"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let condition = inputs.require_as::<i32>(0)?;
         let x = inputs.require(1)?;
         let y = inputs.require(2)?;

--- a/src/ops/concat.rs
+++ b/src/ops/concat.rs
@@ -5,7 +5,9 @@ use rten_tensor::{NdTensorView, Tensor, TensorView};
 
 use smallvec::SmallVec;
 
-use crate::ops::{resolve_axis, Input, InputList, IntoOpResult, OpError, Operator, Output};
+use crate::ops::{
+    resolve_axis, Input, InputList, IntoOpResult, OpError, Operator, Output, OutputList,
+};
 use crate::static_dims;
 use crate::tensor_pool::{AutoReturn, TensorPool};
 
@@ -107,7 +109,7 @@ impl Operator for Concat {
         "Concat"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let first = inputs.require(0)?;
         match first {
             Input::FloatTensor(_) => {
@@ -260,7 +262,7 @@ impl Operator for Tile {
         "Tile"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let input = inputs.require(0)?;
         let repeats = inputs.require_as::<i32>(1)?;
         let repeats = static_dims!(repeats, 1)?;

--- a/src/ops/conv.rs
+++ b/src/ops/conv.rs
@@ -10,7 +10,7 @@ use rten_tensor::{NdTensor, NdTensorView, NdTensorViewMut, Tensor, TensorView};
 use crate::check_dims;
 use crate::gemm::{GemmExecutor, GemmInputA, GemmInputB};
 use crate::ops::pooling::calc_output_size_and_padding;
-use crate::ops::{InputList, IntoOpResult, OpError, Operator, Output, Padding};
+use crate::ops::{InputList, IntoOpResult, OpError, Operator, OutputList, Padding};
 use crate::tensor_pool::{AutoReturn, TensorPool};
 
 mod depthwise;
@@ -292,7 +292,7 @@ impl Operator for Conv {
         "Conv"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let input = inputs.require_as(0)?;
         let weight = inputs.require_as(1)?;
         let bias = inputs.get_as(2)?;
@@ -560,7 +560,7 @@ impl Operator for ConvTranspose {
         "ConvTranspose"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let input = inputs.require_as(0)?;
         let weight = inputs.require_as(1)?;
         let bias = inputs.get_as(2)?;

--- a/src/ops/convert.rs
+++ b/src/ops/convert.rs
@@ -1,6 +1,6 @@
 use rten_tensor::prelude::*;
 
-use crate::ops::{DataType, Input, InputList, IntoOpResult, OpError, Operator, Output};
+use crate::ops::{DataType, Input, InputList, IntoOpResult, OpError, Operator, Output, OutputList};
 use crate::tensor_pool::TensorPool;
 
 #[derive(Debug)]
@@ -13,7 +13,7 @@ impl Operator for Cast {
         "Cast"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let input = inputs.require(0)?;
         let result: Output = match self.to {
             DataType::Int32 => match input {

--- a/src/ops/fused.rs
+++ b/src/ops/fused.rs
@@ -1,6 +1,6 @@
 use rten_tensor::prelude::*;
 
-use crate::ops::{Input, InputList, OpError, Operator, Output};
+use crate::ops::{Input, InputList, OpError, Operator, OutputList};
 use crate::tensor_pool::TensorPool;
 
 /// Specifies a permutation to an operator input.
@@ -69,7 +69,7 @@ impl Operator for FusedTranspose {
         &self.name
     }
 
-    fn run(&self, pool: &TensorPool, mut inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, mut inputs: InputList) -> Result<OutputList, OpError> {
         self.perm.apply(&mut inputs)?;
         self.inner.run(pool, inputs)
     }

--- a/src/ops/gather.rs
+++ b/src/ops/gather.rs
@@ -6,7 +6,7 @@ use smallvec::SmallVec;
 
 use crate::ops::reduce::{cmp_nan_greater, cmp_nan_less};
 use crate::ops::{
-    resolve_axis, resolve_index, Input, InputList, IntoOpResult, OpError, Operator, Output,
+    resolve_axis, resolve_index, Input, InputList, IntoOpResult, OpError, Operator, OutputList,
 };
 use crate::tensor_pool::{AutoReturn, TensorPool};
 
@@ -79,7 +79,7 @@ impl Operator for Gather {
         "Gather"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let input = inputs.require(0)?;
         let indices = inputs.require_as::<i32>(1)?;
         match input {
@@ -222,7 +222,7 @@ impl Operator for GatherElements {
         "GatherElements"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let input = inputs.require(0)?;
         let indices = inputs.require_as::<i32>(1)?;
         match input {
@@ -319,7 +319,7 @@ impl Operator for GatherND {
         "GatherND"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let input = inputs.require(0)?;
         let indices = inputs.require_as::<i32>(1)?;
         match input {
@@ -429,7 +429,7 @@ impl Operator for ScatterElements {
         "ScatterElements"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let data = inputs.require(0)?;
         let indices = inputs.require_as::<i32>(1)?;
         let updates = inputs.require(2)?;
@@ -527,7 +527,7 @@ impl Operator for ScatterND {
         "ScatterND"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let data = inputs.require(0)?;
         let indices = inputs.require_as::<i32>(1)?;
         let updates = inputs.require(2)?;

--- a/src/ops/generate.rs
+++ b/src/ops/generate.rs
@@ -5,7 +5,8 @@ use rten_tensor::prelude::*;
 use rten_tensor::{NdTensorView, Tensor, TensorView};
 
 use crate::ops::{
-    resolve_axis, resolve_index, Input, InputList, IntoOpResult, OpError, Operator, Output, Scalar,
+    resolve_axis, resolve_index, Input, InputList, IntoOpResult, OpError, Operator, OutputList,
+    Scalar,
 };
 use crate::static_dims;
 use crate::tensor_pool::TensorPool;
@@ -29,7 +30,7 @@ impl Operator for ConstantOfShape {
         "ConstantOfShape"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let shape = inputs.require_as::<i32>(0)?;
         let shape = static_dims!(shape, 1)?;
 
@@ -87,7 +88,7 @@ impl Operator for OneHot {
         "OneHot"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let indices = inputs.require_as::<i32>(0)?;
         let depth = inputs.require_as::<i32>(1)?;
         let depth = depth
@@ -140,7 +141,7 @@ impl Operator for Range {
         "Range"
     }
 
-    fn run(&self, _pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, _pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let start = inputs.require(0)?;
         let limit = inputs.require(1)?;
         let delta = inputs.require(2)?;

--- a/src/ops/identity.rs
+++ b/src/ops/identity.rs
@@ -1,7 +1,7 @@
 use rten_tensor::prelude::*;
 use rten_tensor::{Tensor, TensorView};
 
-use crate::ops::{Input, InputList, IntoOpResult, OpError, Operator, Output};
+use crate::ops::{Input, InputList, IntoOpResult, OpError, Operator, Output, OutputList};
 use crate::tensor_pool::TensorPool;
 
 fn identity<T: Copy>(pool: &TensorPool, src: TensorView<T>) -> Tensor<T> {
@@ -16,7 +16,7 @@ impl Operator for Identity {
         "Identity"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let input = inputs.require(0)?;
         let result: Output = match input {
             Input::IntTensor(t) => identity(pool, t).into(),

--- a/src/ops/layout.rs
+++ b/src/ops/layout.rs
@@ -9,6 +9,7 @@ use smallvec::SmallVec;
 use crate::ops::binary_elementwise::{broadcast_shapes, fast_broadcast_cycles_repeats};
 use crate::ops::{
     resolve_axes, resolve_axis, Input, InputList, IntoOpResult, OpError, Operator, Output,
+    OutputList,
 };
 use crate::static_dims;
 use crate::tensor_pool::TensorPool;
@@ -88,7 +89,7 @@ impl Operator for Expand {
         "Expand"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let input = inputs.require(0)?;
         let shape = inputs.require_as(1)?;
         let shape = static_dims!(shape, 1)?;
@@ -165,7 +166,7 @@ impl Operator for Flatten {
         "Flatten"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let input = inputs.require(0)?;
 
         match input {
@@ -303,7 +304,7 @@ impl Operator for Reshape {
         "Reshape"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let input = inputs.require(0)?;
         let shape = inputs.require_as(1)?;
         let shape = static_dims!(shape, 1)?;
@@ -348,7 +349,7 @@ impl Operator for Shape {
         "Shape"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let input = inputs.require(0)?;
 
         // Allocate output from pool for consistency with other operators,
@@ -369,7 +370,7 @@ impl Operator for Size {
         "Size"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let input = inputs.require(0)?;
         let len = input.len() as i32;
 
@@ -437,7 +438,7 @@ impl Operator for Squeeze {
         "Squeeze"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let input = inputs.require(0)?;
         let axes = inputs.get_as(1)?;
         let axes = axes.map(|axes| static_dims!(axes, 1)).transpose()?;
@@ -508,7 +509,7 @@ impl Operator for Transpose {
         "Transpose"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let input = inputs.require(0)?;
         let perm_slice = self.perm.as_deref();
         match input {
@@ -558,7 +559,7 @@ impl Operator for Unsqueeze {
         "Unsqueeze"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let input = inputs.require(0)?;
         let axes = inputs.require_as(1)?;
         let axes = static_dims!(axes, 1)?;

--- a/src/ops/matmul.rs
+++ b/src/ops/matmul.rs
@@ -7,7 +7,7 @@ use crate::check_dims;
 use crate::gemm::{GemmExecutor, GemmInputA, GemmInputB};
 use crate::ops::binary_elementwise::broadcast_shapes;
 use crate::ops::layout::expand_to;
-use crate::ops::{InputList, IntoOpResult, OpError, Operator, Output};
+use crate::ops::{InputList, IntoOpResult, OpError, Operator, OutputList};
 use crate::tensor_pool::{AutoReturn, TensorPool};
 
 #[derive(Debug)]
@@ -85,7 +85,7 @@ impl Operator for Gemm {
         "Gemm"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let a = inputs.require_as(0)?;
         let b = inputs.require_as(1)?;
         let c = inputs.get_as(2)?;
@@ -246,7 +246,7 @@ impl Operator for MatMul {
         "MatMul"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let a = inputs.require_as(0)?;
         let b = inputs.require_as(1)?;
         matmul(pool, a, b).into_op_result()

--- a/src/ops/non_max_suppression.rs
+++ b/src/ops/non_max_suppression.rs
@@ -1,7 +1,7 @@
 use rten_tensor::prelude::*;
 use rten_tensor::{NdTensor, NdTensorView};
 
-use crate::ops::{InputList, IntoOpResult, OpError, Operator, Output};
+use crate::ops::{InputList, IntoOpResult, OpError, Operator, OutputList};
 use crate::static_dims;
 use crate::tensor_pool::TensorPool;
 
@@ -192,7 +192,7 @@ impl Operator for NonMaxSuppression {
         "NonMaxSuppression"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let boxes = inputs.require_as(0)?;
         let boxes = static_dims!(boxes, 3, "ND4")?;
 

--- a/src/ops/norm.rs
+++ b/src/ops/norm.rs
@@ -6,7 +6,7 @@ use rten_vecmath::vec_softmax_in_place;
 use smallvec::SmallVec;
 
 use crate::ops::{add, mul, reduce_mean, sub};
-use crate::ops::{resolve_axis, InputList, IntoOpResult, OpError, Operator, Output};
+use crate::ops::{resolve_axis, InputList, IntoOpResult, OpError, Operator, Output, OutputList};
 use crate::slice_reductions::{slice_max, slice_sum};
 use crate::static_dims;
 use crate::tensor_pool::{AutoReturn, TensorPool};
@@ -79,7 +79,7 @@ impl Operator for BatchNormalization {
         "BatchNormalization"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let input = inputs.require_as(0)?;
 
         let scale = inputs.require_as(1)?;
@@ -205,7 +205,7 @@ impl Operator for InstanceNormalization {
         "InstanceNormalization"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let input = inputs.require_as(0)?;
 
         let scale = inputs.require_as(1)?;
@@ -312,7 +312,7 @@ impl Operator for LayerNormalization {
         "LayerNormalization"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let input = inputs.require_as(0)?;
         let scale = inputs.require_as(1)?;
         let bias = inputs.get_as(2)?;
@@ -405,7 +405,7 @@ impl Operator for LogSoftmax {
         "LogSoftmax"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let input = inputs.require_as(0)?;
         log_softmax(pool, input.view(), self.axis).into_op_result()
     }
@@ -447,7 +447,7 @@ impl Operator for Softmax {
         "Softmax"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let input = inputs.require_as(0)?;
         softmax(pool, input.view(), self.axis).into_op_result()
     }

--- a/src/ops/pad.rs
+++ b/src/ops/pad.rs
@@ -1,7 +1,7 @@
 use rten_tensor::prelude::*;
 use rten_tensor::{NdTensorView, SliceItem, Tensor, TensorView};
 
-use crate::ops::{Input, InputList, IntoOpResult, OpError, Operator, Output};
+use crate::ops::{Input, InputList, IntoOpResult, OpError, Operator, OutputList};
 use crate::static_dims;
 use crate::tensor_pool::TensorPool;
 
@@ -57,7 +57,7 @@ impl Operator for Pad {
         "Pad"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let input = inputs.require(0)?;
         let pads = inputs.require_as::<i32>(1)?;
         let pads = static_dims!(pads, 1)?;

--- a/src/ops/pooling.rs
+++ b/src/ops/pooling.rs
@@ -6,7 +6,7 @@ use rayon::prelude::*;
 use rten_tensor::prelude::*;
 use rten_tensor::{NdTensor, NdTensorView, NdTensorViewMut, Tensor, TensorView, TensorViewMut};
 
-use crate::ops::{InputList, IntoOpResult, OpError, Operator, Output, Padding};
+use crate::ops::{InputList, IntoOpResult, OpError, Operator, OutputList, Padding};
 use crate::tensor_pool::TensorPool;
 use crate::{check_dims, static_dims};
 
@@ -277,7 +277,7 @@ impl Operator for AveragePool {
         "AveragePool"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let input = inputs.require_as(0)?;
         average_pool(
             pool,
@@ -349,7 +349,7 @@ impl Operator for GlobalAveragePool {
         "GlobalAveragePool"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let input = inputs.require_as(0)?;
         global_average_pool(pool, input).into_op_result()
     }
@@ -386,7 +386,7 @@ impl Operator for MaxPool {
         "MaxPool"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let input = inputs.require_as(0)?;
         max_pool(
             pool,

--- a/src/ops/random.rs
+++ b/src/ops/random.rs
@@ -3,7 +3,7 @@ use fastrand_contrib::RngExt;
 use rten_tensor::prelude::*;
 use rten_tensor::Tensor;
 
-use crate::ops::{InputList, IntoOpResult, OpError, Operator, Output};
+use crate::ops::{InputList, IntoOpResult, OpError, Operator, OutputList};
 use crate::tensor_pool::TensorPool;
 
 #[derive(Debug)]
@@ -28,7 +28,7 @@ impl Operator for RandomUniform {
         false
     }
 
-    fn run(&self, pool: &TensorPool, _inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, _inputs: InputList) -> Result<OutputList, OpError> {
         let scale_value = |val: f32| self.low + val * (self.high - self.low);
         let shape = self.shape.as_slice();
 
@@ -59,7 +59,7 @@ impl Operator for RandomUniformLike {
         false
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let input = inputs.require(0)?;
         let op = RandomUniform {
             low: self.low,
@@ -93,7 +93,7 @@ impl Operator for RandomNormal {
         false
     }
 
-    fn run(&self, pool: &TensorPool, _inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, _inputs: InputList) -> Result<OutputList, OpError> {
         let shape = self.shape.as_slice();
 
         let mut rng = if let Some(seed) = self.seed {
@@ -125,7 +125,7 @@ impl Operator for RandomNormalLike {
         false
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let input = inputs.require(0)?;
         let op = RandomNormal {
             mean: self.mean,

--- a/src/ops/reduce.rs
+++ b/src/ops/reduce.rs
@@ -9,7 +9,7 @@ use rten_tensor::{DynIndices, NdTensor, NdTensorView, SliceItem, Tensor, TensorV
 use crate::number::Identities;
 use crate::ops::layout::squeeze_in_place;
 use crate::ops::{
-    resolve_axes, resolve_axis, Input, InputList, IntoOpResult, OpError, Operator, Output,
+    resolve_axes, resolve_axis, Input, InputList, IntoOpResult, OpError, Operator, OutputList,
 };
 use crate::slice_reductions::slice_sum;
 use crate::tensor_pool::TensorPool;
@@ -79,7 +79,7 @@ impl Operator for ArgMax {
         "ArgMax"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let input = inputs.require_as::<f32>(0)?;
         arg_max(pool, input, self.axis, self.keep_dims).into_op_result()
     }
@@ -113,7 +113,7 @@ impl Operator for ArgMin {
         "ArgMin"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let input = inputs.require_as::<f32>(0)?;
         arg_min(pool, input, self.axis, self.keep_dims).into_op_result()
     }
@@ -155,7 +155,7 @@ impl Operator for CumSum {
         "CumSum"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let input = inputs.require(0)?;
         let axis: i32 = inputs.require_as_scalar(1)?;
         match input {
@@ -197,7 +197,7 @@ impl Operator for NonZero {
         "NonZero"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let input = inputs.require(0)?;
         match input {
             Input::IntTensor(input) => nonzero(pool, input).into_op_result(),
@@ -361,7 +361,7 @@ impl Operator for ReduceMean {
         "ReduceMean"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let input = inputs.require_as(0)?;
         let axes = get_axes(&inputs, &self.axes)?;
         reduce_mean(
@@ -402,7 +402,7 @@ impl Operator for ReduceL2 {
         "ReduceL2"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let input = inputs.require_as(0)?;
         let axes = get_axes(&inputs, &self.axes)?;
         reduce_l2(
@@ -526,7 +526,7 @@ impl Operator for ReduceMin {
         "ReduceMin"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let input = inputs.require(0)?;
         let axes = get_axes(&inputs, &self.axes)?;
         dispatch_reduce_op!(pool, input, reduce_min, axes, self.keep_dims)
@@ -553,7 +553,7 @@ impl Operator for ReduceMax {
         "ReduceMax"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let input = inputs.require(0)?;
         let axes = get_axes(&inputs, &self.axes)?;
         dispatch_reduce_op!(pool, input, reduce_max, axes, self.keep_dims)
@@ -586,7 +586,7 @@ impl Operator for ReduceProd {
         "ReduceProd"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let input = inputs.require(0)?;
         let axes = get_axes(&inputs, &self.axes)?;
         dispatch_reduce_op!(pool, input, reduce_prod, axes, self.keep_dims)
@@ -619,7 +619,7 @@ impl Operator for ReduceSum {
         "ReduceSum"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let input = inputs.require(0)?;
         let axes = get_axes(&inputs, &self.axes)?;
         dispatch_reduce_op!(pool, input, reduce_sum, axes, self.keep_dims)
@@ -652,7 +652,7 @@ impl Operator for ReduceSumSquare {
         "ReduceSumSquare"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let input = inputs.require(0)?;
         let axes = get_axes(&inputs, &self.axes)?;
         dispatch_reduce_op!(pool, input, reduce_sum_square, axes, self.keep_dims)
@@ -743,7 +743,7 @@ impl Operator for TopK {
         "TopK"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let values = inputs.require(0)?;
         let k = inputs.require_as_scalar::<i32>(1).and_then(|k| {
             if k < 0 {

--- a/src/ops/resize.rs
+++ b/src/ops/resize.rs
@@ -7,7 +7,7 @@ use rten_tensor::prelude::*;
 use rten_tensor::{NdTensor, NdTensorView, NdTensorViewMut, Tensor, TensorView};
 
 use crate::iter_util::range_chunks;
-use crate::ops::{Input, InputList, IntoOpResult, OpError, Operator, Output};
+use crate::ops::{Input, InputList, IntoOpResult, OpError, Operator, OutputList};
 use crate::tensor_pool::TensorPool;
 use crate::{check_dims, static_dims};
 
@@ -358,7 +358,7 @@ impl Operator for Resize {
         "Resize"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let input = inputs.require_as(0)?;
 
         // The `roi` input is only used if the `coordinate_transformation_mode`

--- a/src/ops/rnn.rs
+++ b/src/ops/rnn.rs
@@ -7,7 +7,8 @@ use rten_tensor::{Tensor, TensorView};
 use crate::check_dims;
 use crate::gemm::{GemmExecutor, GemmInputA, GemmInputB};
 use crate::ops::{
-    add_in_place, mul_in_place, sigmoid, tanh, InputList, IntoOpResult, OpError, Operator, Output,
+    add_in_place, mul_in_place, sigmoid, tanh, InputList, IntoOpResult, OpError, Operator,
+    OutputList,
 };
 use crate::tensor_pool::{AutoReturn, TensorPool};
 
@@ -312,7 +313,7 @@ impl Operator for GRU {
         "GRU"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let input = inputs.require_as(0)?;
         let weights = inputs.require_as(1)?;
         let recurrent_weights = inputs.require_as(2)?;
@@ -540,7 +541,7 @@ impl Operator for LSTM {
         "LSTM"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let input = inputs.require_as(0)?;
         let weights = inputs.require_as(1)?;
         let recurrent_weights = inputs.require_as(2)?;

--- a/src/ops/slice.rs
+++ b/src/ops/slice.rs
@@ -5,7 +5,9 @@ use rten_tensor::{NdTensorView, SliceItem, SliceRange, Tensor, TensorView};
 
 use smallvec::SmallVec;
 
-use crate::ops::{resolve_axis, Input, InputList, IntoOpResult, OpError, Operator, Output};
+use crate::ops::{
+    resolve_axis, Input, InputList, IntoOpResult, OpError, Operator, Output, OutputList,
+};
 use crate::static_dims;
 use crate::tensor_pool::TensorPool;
 
@@ -86,7 +88,7 @@ impl Operator for Slice {
         "Slice"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let input = inputs.require(0)?;
 
         let starts = inputs.require_as::<i32>(1)?;

--- a/src/ops/split.rs
+++ b/src/ops/split.rs
@@ -1,7 +1,7 @@
 use rten_tensor::prelude::*;
 use rten_tensor::{NdTensorView, SliceItem, Tensor, TensorView};
 
-use crate::ops::{resolve_axis, InputList, OpError, Operator, Output};
+use crate::ops::{resolve_axis, InputList, OpError, Operator, OutputList};
 use crate::static_dims;
 use crate::tensor_pool::TensorPool;
 
@@ -57,7 +57,7 @@ impl Operator for Split {
         "Split"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let input = inputs.require_as::<f32>(0)?;
         let splits = inputs.require_as::<i32>(1)?;
         let splits = static_dims!(splits, 1)?;

--- a/src/ops/trilu.rs
+++ b/src/ops/trilu.rs
@@ -1,7 +1,7 @@
 use rten_tensor::prelude::*;
 use rten_tensor::{Tensor, TensorView};
 
-use crate::ops::{Input, InputList, IntoOpResult, OpError, Operator, Output};
+use crate::ops::{Input, InputList, IntoOpResult, OpError, Operator, OutputList};
 use crate::tensor_pool::TensorPool;
 
 pub fn trilu<T: Copy + Default>(
@@ -43,7 +43,7 @@ impl Operator for Trilu {
         "Trilu"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let input = inputs.require(0)?;
         let k = inputs.get_as_scalar(1)?.unwrap_or(0);
 

--- a/src/ops/unary_elementwise.rs
+++ b/src/ops/unary_elementwise.rs
@@ -13,7 +13,7 @@ use rten_vecmath::{
 };
 
 use crate::number::AsBool;
-use crate::ops::{Input, InputList, IntoOpResult, OpError, Operator, Output};
+use crate::ops::{Input, InputList, IntoOpResult, OpError, Operator, Output, OutputList};
 use crate::tensor_pool::{AutoReturn, TensorPool};
 
 /// Trait for operators which take a single float tensor and apply a function
@@ -40,7 +40,7 @@ impl<Op: Any + Debug + UnaryFloatOp> Operator for Op {
         self.name()
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let input = inputs.require_as(0)?;
         self.map(pool, input).into_op_result()
     }
@@ -76,7 +76,7 @@ macro_rules! unary_numeric_op {
                 stringify!($name)
             }
 
-            fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+            fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
                 let input = inputs.require(0)?;
                 match input {
                     Input::FloatTensor(input) => $view_impl(pool, input).into_op_result(),
@@ -201,7 +201,7 @@ macro_rules! parallel_unary_float_op {
                 true
             }
 
-            fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+            fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
                 $func_name(pool, inputs.require_as(0)?).into_op_result()
             }
 
@@ -338,7 +338,7 @@ impl Operator for Clip {
         "Clip"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let input = inputs.require(0)?;
         match input {
             Input::FloatTensor(input) => {
@@ -535,7 +535,7 @@ impl Operator for Not {
         "Not"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let input = inputs.require_as::<i32>(0)?;
         not(pool, input).into_op_result()
     }

--- a/src/ops/variadic_elementwise.rs
+++ b/src/ops/variadic_elementwise.rs
@@ -5,7 +5,7 @@ use rten_tensor::{Tensor, TensorView};
 
 use crate::ops::binary_elementwise::binary_op;
 use crate::ops::reduce::{cmp_nan_greater, cmp_nan_less};
-use crate::ops::{Input, InputList, IntoOpResult, OpError, Operator, Output};
+use crate::ops::{Input, InputList, IntoOpResult, OpError, Operator, OutputList};
 use crate::tensor_pool::{AutoReturn, TensorPool};
 
 /// Apply an elementwise reduction to a sequence of tensors.
@@ -76,7 +76,7 @@ impl Operator for Max {
         "Max"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         run_typed_op!(pool, inputs, max)
     }
 }
@@ -95,7 +95,7 @@ impl Operator for Mean {
         "Mean"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let inputs: Vec<TensorView<f32>> = typed_views(&inputs)?;
         mean(pool, &inputs).into_op_result()
     }
@@ -119,7 +119,7 @@ impl Operator for Min {
         "Min"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         run_typed_op!(pool, inputs, min)
     }
 }
@@ -139,7 +139,7 @@ impl Operator for Sum {
         "Sum"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<Vec<Output>, OpError> {
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         run_typed_op!(pool, inputs, sum)
     }
 }


### PR DESCRIPTION
Most operators only have one output, so we can avoid allocations for the output list by using `SmallVec<[Output; 1]>` for this.

With this change, it is now possible to execute some non in-place steps in a graph with no allocations from the system allocator at all, provided that the operator's output buffer can be allocated from the pool.