### PR TITLE
Add fusion for SiLU activation

### DIFF
--- a/rten-vecmath/src/lib.rs
+++ b/rten-vecmath/src/lib.rs
@@ -29,6 +29,9 @@ mod ulp;
 mod testing;
 
 pub use erf::{erf, vec_erf, vec_erf_in_place};
-pub use exp::{exp, sigmoid, vec_exp, vec_exp_in_place, vec_sigmoid, vec_sigmoid_in_place};
+pub use exp::{
+    exp, sigmoid, silu, vec_exp, vec_exp_in_place, vec_sigmoid, vec_sigmoid_in_place, vec_silu,
+    vec_silu_in_place,
+};
 pub use softmax::{vec_softmax, vec_softmax_in_place};
 pub use tanh::{tanh, vec_tanh, vec_tanh_in_place};

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -28,7 +28,6 @@ use rten_tensor::{
 use crate::downcast::impl_downcastdyn;
 use crate::tensor_pool::TensorPool;
 
-// Modules containing ops that correspond to ONNX operators.
 mod binary_elementwise;
 mod concat;
 mod conv;
@@ -109,10 +108,10 @@ pub use unary_elementwise::{
     exp, exp_in_place, floor, floor_in_place, hard_sigmoid, hard_sigmoid_in_place, hard_swish,
     hard_swish_in_place, leaky_relu, leaky_relu_in_place, log, log_in_place, neg, neg_in_place,
     not, not_in_place, reciprocal, reciprocal_in_place, relu, relu_in_place, round, round_in_place,
-    sigmoid, sigmoid_in_place, sign, sign_in_place, sin, sin_in_place, softplus, softplus_in_place,
-    sqrt, sqrt_in_place, tan, tan_in_place, tanh, tanh_in_place, Abs, Acos, Asin, Atan, Ceil, Clip,
-    Cos, Elu, Erf, Exp, Floor, HardSigmoid, HardSwish, LeakyRelu, Log, Neg, Not, Reciprocal, Relu,
-    Round, Sigmoid, Sign, Sin, Softplus, Sqrt, Tan, Tanh,
+    sigmoid, sigmoid_in_place, sign, sign_in_place, silu, silu_in_place, sin, sin_in_place,
+    softplus, softplus_in_place, sqrt, sqrt_in_place, tan, tan_in_place, tanh, tanh_in_place, Abs,
+    Acos, Asin, Atan, Ceil, Clip, Cos, Elu, Erf, Exp, Floor, HardSigmoid, HardSwish, LeakyRelu,
+    Log, Neg, Not, Reciprocal, Relu, Round, Sigmoid, Sign, Silu, Sin, Softplus, Sqrt, Tan, Tanh,
 };
 pub use variadic_elementwise::{max, mean, min, sum, Max, Mean, Min, Sum};
 


### PR DESCRIPTION
Add a fusion for the Sigmoid Linear Unit (SiLU) operation, which computes `x * sigmoid(x)`. This is the main activation in YOLOv8 among other models.

This makes YOLOv8 Small about 8% faster. Tested on a quad-core Intel i5 with f32 model.