### PR TITLE
Make rten-generate model inputs more flexible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -426,6 +426,7 @@ version = "0.10.0"
 dependencies = [
  "fastrand",
  "rten",
+ "rten-generate",
  "rten-tensor",
  "rten-text",
 ]

--- a/rten-examples/Cargo.toml
+++ b/rten-examples/Cargo.toml
@@ -17,7 +17,7 @@ png = "0.17.6"
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 rten = { path = "../", features = ["mmap", "random"] }
-rten-generate = { path = "../rten-generate" }
+rten-generate = { path = "../rten-generate", features=["text-decoder"] }
 rten-imageio = { path = "../rten-imageio" }
 rten-imageproc = { path = "../rten-imageproc" }
 rten-tensor = { path = "../rten-tensor" }

--- a/rten-generate/Cargo.toml
+++ b/rten-generate/Cargo.toml
@@ -12,5 +12,15 @@ include = ["/src", "/README.md"]
 [dependencies]
 fastrand = { version = "2.0.2" }
 rten = { path = "../", version = "0.10.0" }
-rten-text = { path = "../rten-text", version = "0.10.0" }
+rten-text = { path = "../rten-text", version = "0.10.0", optional = true }
 rten-tensor = { path = "../rten-tensor", version = "0.10.0" }
+
+[dev-dependencies]
+rten-generate = { path = ".", features = ["text-decoder"] }
+
+[features]
+# Enable text decoding using tokenizers from rten-text
+text-decoder = ["rten-text"]
+
+[package.metadata.docs.rs]
+features = ["text-decoder"]

--- a/rten-generate/src/generator.rs
+++ b/rten-generate/src/generator.rs
@@ -7,10 +7,15 @@ use std::ops::Range;
 use rten::{Dimension, Input, InputOrOutput, Model, NodeId, Output};
 use rten_tensor::prelude::*;
 use rten_tensor::{NdTensor, Tensor};
+
+#[cfg(feature = "text-decoder")]
 use rten_text::tokenizers::{Tokenizer, TokenizerError};
 
 use crate::metrics::Metrics;
 use crate::sampler::{ArgMaxSampler, Sampler};
+
+#[cfg(feature = "text-decoder")]
+use crate::text_decoder::TextDecoder;
 
 /// Errors that occur when creating or running a [`Generator`].
 #[derive(Debug)]
@@ -28,6 +33,7 @@ pub enum GeneratorError {
     GenerateError(Box<dyn Error>),
 
     /// An error occurred while decoding tokens.
+    #[cfg(feature = "text-decoder")]
     DecodeError(TokenizerError),
 }
 
@@ -38,6 +44,7 @@ impl fmt::Display for GeneratorError {
             GeneratorError::OutputNotFound(name) => write!(f, "model output not found: {}", name),
             GeneratorError::ShapeMismatch(err) => write!(f, "shape mismatch: {}", err),
             GeneratorError::GenerateError(err) => write!(f, "generation error: {}", err),
+            #[cfg(feature = "text-decoder")]
             GeneratorError::DecodeError(err) => write!(f, "decode error: {}", err),
         }
     }
@@ -555,8 +562,9 @@ pub trait GeneratorUtils: Iterator<Item = GeneratorItem> + Sized {
     }
 
     /// Decode the tokens to text using a tokenizer.
-    fn decode(self, tokenizer: &Tokenizer) -> TextGenerator<Self> {
-        TextGenerator::wrap(self, tokenizer)
+    #[cfg(feature = "text-decoder")]
+    fn decode(self, tokenizer: &Tokenizer) -> TextDecoder<Self> {
+        TextDecoder::wrap(self, tokenizer)
     }
 
     /// Record timing metrics.
@@ -569,67 +577,6 @@ pub trait GeneratorUtils: Iterator<Item = GeneratorItem> + Sized {
 }
 
 impl<I: Iterator<Item = GeneratorItem>> GeneratorUtils for I {}
-
-/// Wraps a [`Generator`] to decode the output token IDs from the model into
-/// text using a [`Tokenizer`].
-pub struct TextGenerator<'a, G: Iterator<Item = GeneratorItem>> {
-    generator: G,
-    tokenizer: &'a Tokenizer,
-}
-
-impl<'a, G> TextGenerator<'a, G>
-where
-    G: Iterator<Item = GeneratorItem>,
-{
-    /// Wrap a token generator and decode its outputs using `tokenizer`.
-    pub fn wrap(generator: G, tokenizer: &'a Tokenizer) -> TextGenerator<'a, G> {
-        TextGenerator {
-            generator,
-            tokenizer,
-        }
-    }
-}
-
-impl<'a, G: Iterator<Item = GeneratorItem>> Iterator for TextGenerator<'a, G> {
-    /// The generated token string, or the error that occurred during generation.
-    type Item = Result<String, GeneratorError>;
-
-    /// Run the model repeatedly until it generates a sequence of tokens which
-    /// can be decoded into a valid UTF-8 sequence.
-    ///
-    /// Returns `Some(Ok(text))` if successful, `Some(Err(error))` if an error
-    /// occurs during generation or `None` if the end of output has been
-    /// reached.
-    fn next(&mut self) -> Option<Self::Item> {
-        // Buffer that holds model output tokens until it forms a valid UTF-8
-        // sequence.
-        let mut token_buf = Vec::new();
-
-        for token in self.generator.by_ref() {
-            let token = match token {
-                Ok(tok) => tok,
-                Err(err) => return Some(Err(err)),
-            };
-
-            token_buf.push(token as usize);
-
-            let text = self.tokenizer.encoder().decode(&token_buf);
-            match text {
-                Ok(text) => return Some(Ok(text)),
-                Err(TokenizerError::InvalidUtf8) => {
-                    // If the current token sequence doesn't correspond to a
-                    // complete UTF-8 sequence, add more tokens until it does.
-                    continue;
-                }
-                Err(err) => {
-                    return Some(Err(GeneratorError::DecodeError(err)));
-                }
-            }
-        }
-
-        None
-    }
-}
 
 /// Wraps a [`Generator`] to record timing metrics into a [`Metrics`] struct.
 struct Profiler<'a, G: Iterator> {
@@ -651,107 +598,5 @@ impl<'a, G: Iterator> Iterator for Profiler<'a, G> {
         let item = self.generator.next()?;
         self.metrics.add_step_duration(start.elapsed());
         Some(item)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::collections::HashMap;
-
-    use super::{GeneratorError, GeneratorUtils};
-    use rten_text::tokenizers::patterns::GPT2;
-    use rten_text::tokenizers::{Bpe, Tokenizer, WordPiece};
-
-    /// Create a simple WordPiece tokenizer. This is essentially just a lookup
-    /// from token ID to string.
-    fn create_tokenizer() -> Tokenizer {
-        let vocab: HashMap<String, usize> = [("one", 1), ("two", 2), ("three", 3)]
-            .into_iter()
-            .map(|(s, id)| (s.to_string(), id))
-            .collect();
-        let encoder = WordPiece::from_vocab(vocab, Default::default());
-        Tokenizer::new(encoder, Default::default())
-    }
-
-    /// Create a BPE tokenizer with an empty vocab. This can encode and decode
-    /// arbitrary Unicode characters, by using one token per UTF-8 byte.
-    fn create_bpe_tokenizer() -> Tokenizer {
-        let encoder = Bpe::new(&[], GPT2, None, Default::default()).unwrap();
-        Tokenizer::new(encoder, Default::default())
-    }
-
-    #[test]
-    fn test_text_generator() {
-        let tokenizer = create_tokenizer();
-        let generator = [1, 2, 3].into_iter().map(Ok);
-        let tokens: Vec<_> = generator
-            .decode(&tokenizer)
-            .map(|tok| tok.map_err(|e| e.to_string()))
-            .collect();
-        assert_eq!(tokens, ["one", "two", "three"].map(|s| Ok(s.to_string())));
-    }
-
-    #[test]
-    fn test_text_generator_partial_utf8() {
-        let tokenizer = create_bpe_tokenizer();
-
-        // Encode a character which will require multiple token IDs. This means
-        // the text decoder will need to loop until accumulated tokens decode
-        // to a valid UTF-8 sequence.
-        let token_ids = tokenizer.encoder().encode("😊").unwrap();
-        assert!(token_ids.len() > 1);
-        let generator = token_ids.into_iter().map(|tok_id| Ok(tok_id as u32));
-
-        let tokens: Vec<_> = generator
-            .decode(&tokenizer)
-            .map(|tok| tok.map_err(|e| e.to_string()))
-            .collect();
-
-        assert_eq!(tokens, ["😊"].map(|s| Ok(s.to_string())));
-    }
-
-    #[test]
-    fn test_text_generator_generate_error() {
-        let tokenizer = create_tokenizer();
-        let generator = [
-            Ok(1),
-            Err(GeneratorError::GenerateError("oh no".to_string().into())),
-            Ok(3),
-        ]
-        .into_iter();
-
-        let tokens: Vec<_> = generator
-            .decode(&tokenizer)
-            .map(|tok| tok.map_err(|e| e.to_string()))
-            .collect();
-
-        assert_eq!(
-            tokens,
-            [
-                Ok("one".to_string()),
-                Err("generation error: oh no".to_string()),
-                Ok("three".to_string())
-            ]
-        );
-    }
-
-    #[test]
-    fn test_text_generator_decode_error() {
-        let tokenizer = create_tokenizer();
-        let generator = [1, 5, 3].into_iter().map(Ok);
-
-        let tokens: Vec<_> = generator
-            .decode(&tokenizer)
-            .map(|tok| tok.map_err(|e| e.to_string()))
-            .collect();
-
-        assert_eq!(
-            tokens,
-            [
-                Ok("one".to_string()),
-                Err("decode error: unknown token id 5".to_string()),
-                Ok("three".to_string())
-            ]
-        );
     }
 }

--- a/rten-generate/src/lib.rs
+++ b/rten-generate/src/lib.rs
@@ -11,6 +11,9 @@ pub mod generator;
 pub mod metrics;
 pub mod sampler;
 
+#[cfg(feature = "text-decoder")]
+pub mod text_decoder;
+
 pub use generator::{
     Generator, GeneratorConfig, GeneratorError, GeneratorUtils, ModelInputsConfig,
 };

--- a/rten-generate/src/lib.rs
+++ b/rten-generate/src/lib.rs
@@ -11,4 +11,6 @@ pub mod generator;
 pub mod metrics;
 pub mod sampler;
 
-pub use generator::{Generator, GeneratorError, GeneratorUtils};
+pub use generator::{
+    Generator, GeneratorConfig, GeneratorError, GeneratorUtils, ModelInputsConfig,
+};

--- a/rten-generate/src/text_decoder.rs
+++ b/rten-generate/src/text_decoder.rs
@@ -1,0 +1,172 @@
+//! Iterator adapters to decode token IDs into text using `rten-text`.
+
+use rten_text::tokenizers::{Tokenizer, TokenizerError};
+
+use crate::generator::{GeneratorError, GeneratorItem};
+
+/// Wraps a [`Generator`](crate::Generator) to decode the output token IDs from
+/// the model into text using a [`Tokenizer`].
+///
+/// This is normally created by calling [`decode`](crate::GeneratorUtils::decode)
+/// on a `Generator`.
+pub struct TextDecoder<'a, G: Iterator<Item = GeneratorItem>> {
+    generator: G,
+    tokenizer: &'a Tokenizer,
+}
+
+impl<'a, G> TextDecoder<'a, G>
+where
+    G: Iterator<Item = GeneratorItem>,
+{
+    /// Wrap a token generator and decode its outputs using `tokenizer`.
+    pub fn wrap(generator: G, tokenizer: &'a Tokenizer) -> TextDecoder<'a, G> {
+        TextDecoder {
+            generator,
+            tokenizer,
+        }
+    }
+}
+
+impl<'a, G: Iterator<Item = GeneratorItem>> Iterator for TextDecoder<'a, G> {
+    /// The decoded string, or the error that occurred during generation.
+    type Item = Result<String, GeneratorError>;
+
+    /// Run the model repeatedly until it generates a sequence of tokens which
+    /// can be decoded into a valid UTF-8 sequence.
+    ///
+    /// Returns `Some(Ok(text))` if successful, `Some(Err(error))` if an error
+    /// occurs during generation or `None` if the end of output has been
+    /// reached.
+    fn next(&mut self) -> Option<Self::Item> {
+        // Buffer that holds model output tokens until it forms a valid UTF-8
+        // sequence.
+        let mut token_buf = Vec::new();
+
+        for token in self.generator.by_ref() {
+            let token = match token {
+                Ok(tok) => tok,
+                Err(err) => return Some(Err(err)),
+            };
+
+            token_buf.push(token as usize);
+
+            let text = self.tokenizer.encoder().decode(&token_buf);
+            match text {
+                Ok(text) => return Some(Ok(text)),
+                Err(TokenizerError::InvalidUtf8) => {
+                    // If the current token sequence doesn't correspond to a
+                    // complete UTF-8 sequence, add more tokens until it does.
+                    continue;
+                }
+                Err(err) => {
+                    return Some(Err(GeneratorError::DecodeError(err)));
+                }
+            }
+        }
+
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use rten_text::tokenizers::patterns::GPT2;
+    use rten_text::tokenizers::{Bpe, Tokenizer, WordPiece};
+
+    use crate::{GeneratorError, GeneratorUtils};
+
+    /// Create a simple WordPiece tokenizer. This is essentially just a lookup
+    /// from token ID to string.
+    fn create_tokenizer() -> Tokenizer {
+        let vocab: HashMap<String, usize> = [("one", 1), ("two", 2), ("three", 3)]
+            .into_iter()
+            .map(|(s, id)| (s.to_string(), id))
+            .collect();
+        let encoder = WordPiece::from_vocab(vocab, Default::default());
+        Tokenizer::new(encoder, Default::default())
+    }
+
+    /// Create a BPE tokenizer with an empty vocab. This can encode and decode
+    /// arbitrary Unicode characters, by using one token per UTF-8 byte.
+    fn create_bpe_tokenizer() -> Tokenizer {
+        let encoder = Bpe::new(&[], GPT2, None, Default::default()).unwrap();
+        Tokenizer::new(encoder, Default::default())
+    }
+
+    #[test]
+    fn test_decode() {
+        let tokenizer = create_tokenizer();
+        let generator = [1, 2, 3].into_iter().map(Ok);
+        let tokens: Vec<_> = generator
+            .decode(&tokenizer)
+            .map(|tok| tok.map_err(|e| e.to_string()))
+            .collect();
+        assert_eq!(tokens, ["one", "two", "three"].map(|s| Ok(s.to_string())));
+    }
+
+    #[test]
+    fn test_decode_partial_utf8() {
+        let tokenizer = create_bpe_tokenizer();
+
+        // Encode a character which will require multiple token IDs. This means
+        // the text decoder will need to loop until accumulated tokens decode
+        // to a valid UTF-8 sequence.
+        let token_ids = tokenizer.encoder().encode("😊").unwrap();
+        assert!(token_ids.len() > 1);
+        let generator = token_ids.into_iter().map(|tok_id| Ok(tok_id as u32));
+
+        let tokens: Vec<_> = generator
+            .decode(&tokenizer)
+            .map(|tok| tok.map_err(|e| e.to_string()))
+            .collect();
+
+        assert_eq!(tokens, ["😊"].map(|s| Ok(s.to_string())));
+    }
+
+    #[test]
+    fn test_generate_error() {
+        let tokenizer = create_tokenizer();
+        let generator = [
+            Ok(1),
+            Err(GeneratorError::GenerateError("oh no".to_string().into())),
+            Ok(3),
+        ]
+        .into_iter();
+
+        let tokens: Vec<_> = generator
+            .decode(&tokenizer)
+            .map(|tok| tok.map_err(|e| e.to_string()))
+            .collect();
+
+        assert_eq!(
+            tokens,
+            [
+                Ok("one".to_string()),
+                Err("generation error: oh no".to_string()),
+                Ok("three".to_string())
+            ]
+        );
+    }
+
+    #[test]
+    fn test_decode_error() {
+        let tokenizer = create_tokenizer();
+        let generator = [1, 5, 3].into_iter().map(Ok);
+
+        let tokens: Vec<_> = generator
+            .decode(&tokenizer)
+            .map(|tok| tok.map_err(|e| e.to_string()))
+            .collect();
+
+        assert_eq!(
+            tokens,
+            [
+                Ok("one".to_string()),
+                Err("decode error: unknown token id 5".to_string()),
+                Ok("three".to_string())
+            ]
+        );
+    }
+}


### PR DESCRIPTION
This is a collection of changes needed to make rten-generate usable with a wider range of models.

- Enable customizing the names of the model inputs and outputs that the generator works with
- Support custom inputs whose values vary depending on the sequence position. This is useful to pass position embeddings if they are not computed internally by the model
- Support key-value caches that have shape `(batch, seq, chans)` instead of `(batch, heads, seq, chans)`. In the 3D case the heads are included in the `chans` dimension
- Make `rten-text` an optional dependency in rten-generate. Downstream projects may be using other tokenizer libraries or decoding into a non-text output mode. This change allows such projects to avoid rten-text and its larger dependencies (regex engine etc.)