### PR TITLE
Implement Gelu operator

### DIFF
--- a/rten-convert/rten_convert/schema_generated.py
+++ b/rten-convert/rten_convert/schema_generated.py
@@ -109,6 +109,7 @@ class OperatorType(object):
     RandomNormalLike = 99
     Softplus = 100
     GatherND = 101
+    Gelu = 102
 
 
 class RNNDirection(object):

--- a/rten-vecmath/src/lib.rs
+++ b/rten-vecmath/src/lib.rs
@@ -28,7 +28,7 @@ mod ulp;
 #[cfg(test)]
 mod testing;
 
-pub use erf::{erf, vec_erf, vec_erf_in_place};
+pub use erf::{erf, gelu, vec_erf, vec_erf_in_place, vec_gelu, vec_gelu_in_place};
 pub use exp::{
     exp, sigmoid, silu, vec_exp, vec_exp_in_place, vec_sigmoid, vec_sigmoid_in_place, vec_silu,
     vec_silu_in_place,

--- a/rten-vecmath/src/testing.rs
+++ b/rten-vecmath/src/testing.rs
@@ -169,10 +169,12 @@ pub fn check_f32s_are_equal_atol<I: Iterator<Item = (f32, f32, f32)>>(results: I
         let diff = (actual - expected).abs();
         assert!(
             diff <= max_diff,
-            "diff {} exceeds expected {} at x = {}",
+            "diff {} exceeds expected {} at x = {}. actual = {}, expected = {}",
             diff,
             max_diff,
-            x
+            x,
+            actual,
+            expected
         );
     }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -783,6 +783,7 @@ impl_read_op!(
         })
     }
 );
+impl_read_op!(Gelu);
 impl_read_op!(Gemm, attrs_as_gemm_attrs, |attrs: sg::GemmAttrs| {
     Ok(ops::Gemm {
         alpha: attrs.alpha(),
@@ -1176,6 +1177,7 @@ impl OpRegistry {
         register_op!(Gather);
         register_op!(GatherElements);
         register_op!(GatherND);
+        register_op!(Gelu);
         register_op!(Gemm);
         register_op!(GlobalAveragePool);
         register_op!(Greater);
@@ -1733,7 +1735,7 @@ mod tests {
         let gather_elements_indices_val = Tensor::zeros(&input_shape);
         let gather_elements_indices = builder.add_int_constant(&gather_elements_indices_val);
         add_operator!(GatherElements, [input_node, gather_elements_indices], { axis: 0 });
-
+        add_operator!(Gelu, [input_node]);
         add_operator!(Gemm, [input_2d, input_2d], {
             alpha: 1.0,
             beta: 1.0,

--- a/src/model_builder.rs
+++ b/src/model_builder.rs
@@ -47,6 +47,7 @@ pub enum OpType {
     Gather(Gather),
     GatherElements(GatherElements),
     GatherND(GatherND),
+    Gelu,
     Gemm(Gemm),
     GlobalAveragePool,
     Greater,
@@ -482,6 +483,7 @@ impl<'a> ModelBuilder<'a> {
                     batch_dims: args.batch_dims as i32,
                 }
             ),
+            OpType::Gelu => op!(Gelu),
             OpType::Gemm(args) => op_with_attrs!(
                 Gemm,
                 GemmAttrs,

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -105,13 +105,14 @@ pub use trilu::{trilu, Trilu};
 pub use unary_elementwise::{
     abs, abs_in_place, acos, acos_in_place, asin, asin_in_place, atan, atan_in_place, ceil,
     ceil_in_place, clip, clip_in_place, cos, cos_in_place, elu, elu_in_place, erf, erf_in_place,
-    exp, exp_in_place, floor, floor_in_place, hard_sigmoid, hard_sigmoid_in_place, hard_swish,
-    hard_swish_in_place, leaky_relu, leaky_relu_in_place, log, log_in_place, neg, neg_in_place,
-    not, not_in_place, reciprocal, reciprocal_in_place, relu, relu_in_place, round, round_in_place,
-    sigmoid, sigmoid_in_place, sign, sign_in_place, silu, silu_in_place, sin, sin_in_place,
-    softplus, softplus_in_place, sqrt, sqrt_in_place, tan, tan_in_place, tanh, tanh_in_place, Abs,
-    Acos, Asin, Atan, Ceil, Clip, Cos, Elu, Erf, Exp, Floor, HardSigmoid, HardSwish, LeakyRelu,
-    Log, Neg, Not, Reciprocal, Relu, Round, Sigmoid, Sign, Silu, Sin, Softplus, Sqrt, Tan, Tanh,
+    exp, exp_in_place, floor, floor_in_place, gelu, gelu_in_place, hard_sigmoid,
+    hard_sigmoid_in_place, hard_swish, hard_swish_in_place, leaky_relu, leaky_relu_in_place, log,
+    log_in_place, neg, neg_in_place, not, not_in_place, reciprocal, reciprocal_in_place, relu,
+    relu_in_place, round, round_in_place, sigmoid, sigmoid_in_place, sign, sign_in_place, silu,
+    silu_in_place, sin, sin_in_place, softplus, softplus_in_place, sqrt, sqrt_in_place, tan,
+    tan_in_place, tanh, tanh_in_place, Abs, Acos, Asin, Atan, Ceil, Clip, Cos, Elu, Erf, Exp,
+    Floor, Gelu, HardSigmoid, HardSwish, LeakyRelu, Log, Neg, Not, Reciprocal, Relu, Round,
+    Sigmoid, Sign, Silu, Sin, Softplus, Sqrt, Tan, Tanh,
 };
 pub use variadic_elementwise::{max, mean, min, sum, Max, Mean, Min, Sum};
 

--- a/src/schema.fbs
+++ b/src/schema.fbs
@@ -115,6 +115,7 @@ enum OperatorType: ubyte {
   RandomNormalLike,
   Softplus,
   GatherND,
+  Gelu,
 }
 
 enum RNNDirection: ubyte {

--- a/src/schema_generated.rs
+++ b/src/schema_generated.rs
@@ -18,13 +18,13 @@ pub const ENUM_MIN_OPERATOR_TYPE: u8 = 0;
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
-pub const ENUM_MAX_OPERATOR_TYPE: u8 = 101;
+pub const ENUM_MAX_OPERATOR_TYPE: u8 = 102;
 #[deprecated(
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 102] = [
+pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 103] = [
     OperatorType::Add,
     OperatorType::ArgMin,
     OperatorType::ArgMax,
@@ -127,6 +127,7 @@ pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 102] = [
     OperatorType::RandomNormalLike,
     OperatorType::Softplus,
     OperatorType::GatherND,
+    OperatorType::Gelu,
 ];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -236,9 +237,10 @@ impl OperatorType {
     pub const RandomNormalLike: Self = Self(99);
     pub const Softplus: Self = Self(100);
     pub const GatherND: Self = Self(101);
+    pub const Gelu: Self = Self(102);
 
     pub const ENUM_MIN: u8 = 0;
-    pub const ENUM_MAX: u8 = 101;
+    pub const ENUM_MAX: u8 = 102;
     pub const ENUM_VALUES: &'static [Self] = &[
         Self::Add,
         Self::ArgMin,
@@ -342,6 +344,7 @@ impl OperatorType {
         Self::RandomNormalLike,
         Self::Softplus,
         Self::GatherND,
+        Self::Gelu,
     ];
     /// Returns the variant's name or "" if unknown.
     pub fn variant_name(self) -> Option<&'static str> {
@@ -448,6 +451,7 @@ impl OperatorType {
             Self::RandomNormalLike => Some("RandomNormalLike"),
             Self::Softplus => Some("Softplus"),
             Self::GatherND => Some("GatherND"),
+            Self::Gelu => Some("Gelu"),
             _ => None,
         }
     }


### PR DESCRIPTION
Initially only the non-approximate version is implemented.

AFAIK the tanh-based approximation supported in the ONNX spec is a relic from when certain ML runtimes lacked an efficient implementation of the `Erf` operator, and is not frequently used in newer models.