### PR TITLE
Clean up `Graph::run_plan`

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -652,12 +652,9 @@ impl Graph {
             // that can be used as the output. This requires that the tensor
             // is not a constant (eg. weights) and is not going to be used by
             // other ops in future.
-            let in_place_input = in_place_input_id.and_then(|first_input| {
-                if temp_values.contains_key(&first_input)
-                    && temp_value_refcount.count(first_input) == 1
-                {
-                    temp_value_refcount.dec(first_input);
-                    Some(temp_values.remove(&first_input).unwrap())
+            let in_place_input = in_place_input_id.and_then(|input| {
+                if temp_value_refcount.count(input) == 1 {
+                    temp_values.remove(&input)
                 } else {
                     None
                 }

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -26,7 +26,7 @@ use rten_tensor::{
 };
 
 use crate::downcast::impl_downcastdyn;
-use crate::tensor_pool::TensorPool;
+use crate::tensor_pool::{ExtractBuffer, TensorPool};
 
 mod binary_elementwise;
 mod concat;
@@ -323,6 +323,14 @@ impl Output {
             Self::FloatTensor(ft) => Input::FloatTensor(ft.view()),
             Self::IntTensor(it) => Input::IntTensor(it.view()),
         }
+    }
+
+    /// Move this tensor's buffer into a pool.
+    pub(crate) fn add_to_pool(self, pool: &TensorPool) {
+        match self {
+            Self::FloatTensor(t) => t.extract_buffer().map(|buf| pool.add(buf)),
+            Self::IntTensor(t) => t.extract_buffer().map(|buf| pool.add(buf)),
+        };
     }
 
     pub fn into_int(self) -> Option<Tensor<i32>> {


### PR DESCRIPTION
Make a few changes to streamline `run_plan` a little

- Avoid needing to `match` over different tensor dtypes by adding methods on the various enums that abstract over them (`Input`, `Output`, `Constant`)
- Extract logging code out of `run_plan` into separate methods