### PR TITLE
Reduce Concat op overhead

### DIFF
--- a/rten-tensor/src/copy.rs
+++ b/rten-tensor/src/copy.rs
@@ -245,34 +245,41 @@ pub fn copy_into_slice<'a, T: Clone>(
 pub fn copy_into<T: Clone>(mut src: TensorView<T>, mut dest: TensorViewMut<T>) {
     assert!(src.shape() == dest.shape());
 
-    while src.ndim() < 4 {
-        src.insert_axis(0);
-        dest.insert_axis(0);
-    }
-
     // Efficiency could be improved here by sorting dims so that those with
     // the smallest stride are innermost. Also it could use the blocked copy
     // that `copy_into_slice` uses to avoid cache conflicts when inputs are
     // transposed.
 
-    src.inner_iter::<4>()
-        .zip(dest.inner_iter_mut::<4>())
-        .for_each(|(src, mut dest)| {
-            for i0 in 0..src.size(0) {
-                for i1 in 0..src.size(1) {
-                    for i2 in 0..src.size(2) {
-                        for i3 in 0..src.size(3) {
-                            // Safety: `dest` and `src` have the same shape,
-                            // and i0..i3 are in `[0, src.size(i))`.
-                            unsafe {
-                                *dest.get_unchecked_mut([i0, i1, i2, i3]) =
-                                    src.get_unchecked([i0, i1, i2, i3]).clone();
-                            }
+    let copy_into_4d = |src: NdTensorView<T, 4>, mut dest: NdTensorViewMut<T, 4>| {
+        for i0 in 0..src.size(0) {
+            for i1 in 0..src.size(1) {
+                for i2 in 0..src.size(2) {
+                    for i3 in 0..src.size(3) {
+                        // Safety: `dest` and `src` have the same shape,
+                        // and i0..i3 are in `[0, src.size(i))`.
+                        unsafe {
+                            *dest.get_unchecked_mut([i0, i1, i2, i3]) =
+                                src.get_unchecked([i0, i1, i2, i3]).clone();
                         }
                     }
                 }
             }
-        });
+        }
+    };
+
+    if src.ndim() <= 4 {
+        while src.ndim() < 4 {
+            src.insert_axis(0);
+            dest.insert_axis(0);
+        }
+        let src: NdTensorView<T, 4> = src.nd_view();
+        let dest: NdTensorViewMut<T, 4> = dest.nd_view_mut();
+        copy_into_4d(src, dest);
+    } else {
+        src.inner_iter::<4>()
+            .zip(dest.inner_iter_mut::<4>())
+            .for_each(|(src, dest)| copy_into_4d(src, dest));
+    }
 }
 
 /// Clone elements of `src` into `dest`.

--- a/rten-tensor/src/tensor.rs
+++ b/rten-tensor/src/tensor.rs
@@ -802,7 +802,7 @@ impl<T, L: Clone + MutLayout> TensorBase<Vec<T>, L> {
     pub fn append<S2: Storage<Elem = T>>(
         &mut self,
         axis: usize,
-        other: TensorBase<S2, L>,
+        other: &TensorBase<S2, L>,
     ) -> Result<(), ExpandError>
     where
         T: Copy,
@@ -831,7 +831,7 @@ impl<T, L: Clone + MutLayout> TensorBase<Vec<T>, L> {
         }
 
         self.slice_axis_mut(axis, old_size..new_size)
-            .copy_from(&other);
+            .copy_from(other);
 
         Ok(())
     }
@@ -2234,22 +2234,22 @@ mod tests {
         assert_eq!(tensor.shape(), [3, 0]);
 
         assert_eq!(
-            tensor.append(1, NdTensor::from([[1, 2, 3]])),
+            tensor.append(1, &NdTensor::from([[1, 2, 3]])),
             Err(ExpandError::ShapeMismatch)
         );
 
         tensor
-            .append(1, NdTensor::from([[1, 2], [3, 4], [5, 6]]))
+            .append(1, &NdTensor::from([[1, 2], [3, 4], [5, 6]]))
             .unwrap();
         assert_eq!(tensor.shape(), [3, 2]);
 
-        tensor.append(1, NdTensor::from([[7], [8], [9]])).unwrap();
+        tensor.append(1, &NdTensor::from([[7], [8], [9]])).unwrap();
         assert_eq!(tensor.shape(), [3, 3]);
 
         assert_eq!(tensor, NdTensor::from([[1, 2, 7], [3, 4, 8], [5, 6, 9],]));
 
         assert_eq!(
-            tensor.append(1, NdTensor::from([[10], [11], [12]])),
+            tensor.append(1, &NdTensor::from([[10], [11], [12]])),
             Err(ExpandError::InsufficientCapacity)
         );
     }


### PR DESCRIPTION
This PR contains a few small optimizations to reduce the overhead of `Concat`, ie. the work other than actually copying the data.