### PR TITLE
Make `TensorBase::{inner_iter, inner_iter_mut}` more efficient

### DIFF
--- a/src/constant_storage.rs
+++ b/src/constant_storage.rs
@@ -95,6 +95,8 @@ impl<T> ArcSlice<T> {
 unsafe impl<T> Storage for ArcSlice<T> {
     type Elem = T;
 
+    const MUTABLE: bool = false;
+
     fn len(&self) -> usize {
         self.len
     }


### PR DESCRIPTION
The slicing in each call to `next` was slow. Since these iterators yield views with the same layout each time, we can precompute the layout when the iterator is constructed. Each call to `next` then just has to compute the storage offset for the next view.

This optimization is not yet implemented for `inner_iter_dyn`, but in principle it could be.

**TODO:**

- [x] Enforce absence of internal overlap in `TensorBase::from_storage_and_layout`, when the storage is mutable, or change the API