### PR TITLE
Introduce version 2 `.rten` model format, with support for larger (> 2GB) models

### DIFF
--- a/docs/rten-file-format.md
+++ b/docs/rten-file-format.md
@@ -1,0 +1,65 @@
+# RTen model format
+
+RTen model files (`.rten`) contain the computation graph for a machine learning
+model, model metadata and weights.
+
+RTen files are produced by exporting models from a machine learning framework
+such as PyTorch or Keras into [ONNX](https://onnx.ai) format, and converting the
+ONNX model to `.rten` using the
+[rten-convert](https://pypi.org/project/rten-convert/) tool.
+
+## Format structure
+
+### Overall structure
+
+The overall structure of a `.rten` file is:
+
+```
+[header] … [model_data] … [tensor_data]
+```
+
+### Header
+
+The header identifies the file type, the major version of the format and
+contains the offsets of the other sections. The structure of the header is:
+
+```
+[magic:u8x4] [version:u32] [model_data_offset:u64] [model_data_len:u64] [tensor_data_offset:u64]
+```
+
+All numbers are encoded in little-endian order.
+
+- `magic` - The ASCII bytes `RTEN`
+- `version` - Currently 2
+- `model_data_offset` - Offset of the data describing the model
+- `model_data_len` - Length of the data describing the model
+- `tensor_data_offset` - Offset of the start of tensor data. Tensor references in
+  the model buffer are relative to this.
+
+### Model data
+
+The model data is a [FlatBuffers](https://flatbuffers.dev) buffer which
+describes the computation graph for the model. It also contains metadata about
+the model.
+
+The computation graph consists of three kinds of nodes: constants (weights,
+biases etc.), values (inputs or outputs from computation steps) and operators
+(computation steps such as matrix multiplication). The operators correspond
+closely to operators in the [ONNX
+specification](https://onnx.ai/onnx/operators/). Constant nodes describe the
+data type and shape of tensors. The data for a tensor can either be stored
+inline in the model or externally in the tensor data section.
+
+The FlatBuffers schema can be found in `src/schema.fbs`.
+
+### Tensor data
+
+The tensor data section is a block of bytes referenced by the model data.
+
+## Earlier versions
+
+The initial version of the `.rten` model format consisted of just the model
+data without the header or tensor data sections.
+
+This was changed due to FlatBuffers having a 2GB file
+size limit, and also to enable more control over the alignment of tensor data.

--- a/rten-convert/rten_convert/tensor_data.py
+++ b/rten-convert/rten_convert/tensor_data.py
@@ -1,0 +1,75 @@
+from typing import BinaryIO
+
+import numpy as np
+
+from rten_convert.util import round_up, write_padding
+
+
+class TensorDataBuilder:
+    offset: int
+    """End offset of written data from start of tensor data."""
+
+    tensors: list[np.ndarray]
+    """List of tensors to write."""
+
+    align: int
+    """Alignment of each tensor's data, relative to the start of the tensor data."""
+
+    def __init__(self):
+        self.offset = 0
+        self.tensors = []
+        self.tensor_offsets = []
+        self.tensor_lengths = []
+        self.align = 64
+
+    def add_tensor(self, array: np.ndarray, dtype=None) -> int:
+        """
+        Add a tensor to be written to the tensor data segment.
+
+        Returns the offset that the data will be stored at, relative to the
+        start of the tensor data segment.
+        """
+        self.tensors.append(array)
+
+        match array.dtype:
+            case np.float32 | np.int32:
+                element_size = 4
+            case _:
+                raise ValueError("Unsupported NumPy array type {}".format(array.dtype))
+
+        prev_offset = self.offset
+        padding = round_up(prev_offset, self.align) - prev_offset
+        tensor_len = array.size * element_size
+
+        self.offset += padding
+        self.tensor_offsets.append(self.offset)
+        self.tensor_lengths.append(tensor_len)
+        self.offset += tensor_len
+
+        return self.tensor_offsets[-1]
+
+    def write(self, fp: BinaryIO):
+        """
+        Write out tensor data to a file.
+        """
+
+        offset = 0
+
+        for i, tensor in enumerate(self.tensors):
+            expected_offset = self.tensor_offsets[i]
+            padding = round_up(offset, self.align) - offset
+
+            assert (
+                expected_offset == offset + padding
+            ), f"actual offset {offset} of tensor {i} does not match expected offset {expected_offset}"
+
+            write_padding(fp, padding)
+            offset += padding
+
+            tensor_data = tensor.tobytes()
+            assert (
+                len(tensor_data) == self.tensor_lengths[i]
+            ), f"actual length {len(tensor_data)} of tensor {i} does not match expected length {self.tensor_lengths[i]}"
+
+            fp.write(tensor_data)
+            offset += len(tensor_data)

--- a/rten-convert/rten_convert/util.py
+++ b/rten-convert/rten_convert/util.py
@@ -1,0 +1,24 @@
+import math
+from typing import BinaryIO
+
+
+def round_up(value: int, base: int) -> int:
+    """Round up `value` to the next multiple of `base`."""
+    return base * math.ceil(value / base)
+
+
+def write_padding(fp: BinaryIO, n: int, max_padding=1024):
+    """
+    Write `n` bytes of zero padding at the end of a file.
+
+    :param max_padding:
+        Maximum value for `n`. This is a sanity check to catch unexpectedly
+        large padding sizes.
+    """
+
+    if n < 0 or n >= max_padding:
+        raise ValueError(f"Padding size {n} is out of range")
+
+    if n == 0:
+        return
+    fp.write(b"\x00" * n)

--- a/src/header.rs
+++ b/src/header.rs
@@ -1,0 +1,250 @@
+use std::error::Error;
+use std::fmt::{Display, Formatter};
+
+use crate::number::LeBytes;
+
+/// Read little-endian encoded primitive values from a byte buffer.
+struct ValueReader<'a> {
+    pos: usize,
+    buf: &'a [u8],
+}
+
+impl<'a> ValueReader<'a> {
+    fn new(buf: &'a [u8]) -> Self {
+        Self { pos: 0, buf }
+    }
+
+    /// Return the next N bytes from the buffer, or None if there aren't enough.
+    fn read_n<const N: usize>(&mut self) -> Option<[u8; N]> {
+        let chunk = self.buf.get(self.pos..self.pos + N)?;
+        self.pos += N;
+        Some(chunk.try_into().unwrap())
+    }
+
+    /// Read a little-endian encoded value.
+    ///
+    /// Returns None if there are not enough bytes left in the buffer.
+    fn read<T: LeBytes>(&mut self) -> Option<T> {
+        let chunk = self
+            .buf
+            .get(self.pos..self.pos + std::mem::size_of::<T>())?;
+        self.pos += chunk.len();
+
+        let chunk_array = chunk.try_into().unwrap();
+        Some(T::from_le_bytes(chunk_array))
+    }
+}
+
+/// Errors produced when reading the header for an RTen model file.
+#[derive(Clone, Debug, PartialEq)]
+pub enum HeaderError {
+    /// The header is incomplete
+    TooShort,
+
+    /// The file format version specified in the header is unsupported.
+    UnsupportedVersion,
+
+    /// The header doesn't start with the magic bytes "RTEN".
+    InvalidMagic,
+
+    /// A segment offset in the header is invalid.
+    InvalidOffset,
+
+    /// A segment length in the header is invalid.
+    InvalidLength,
+}
+
+/// Header for an RTen model file.
+///
+/// This specifies the file version and offset of the model data and tensor
+/// data within the file.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Header {
+    /// Major version of the file format. Currently 2.
+    pub version: u32,
+
+    /// Offset of the FlatBuffers data describing the model.
+    pub model_offset: u64,
+
+    /// Length of the FlatBuffers data describing the model.
+    pub model_len: u64,
+
+    /// Offset of tensor data stored outside the model.
+    pub tensor_data_offset: u64,
+}
+
+impl Header {
+    /// Size of the serialized header in bytes.
+    pub const LEN: usize = 32;
+
+    /// Read the file header from a byte buffer.
+    ///
+    /// `buf` is expected to be a slice that contains the entire file, as its
+    /// length is used to validate offsets in the header.
+    pub fn from_buf(buf: &[u8]) -> Result<Header, HeaderError> {
+        let too_short = Err(HeaderError::TooShort);
+
+        // This could be passed in separately if we wanted to avoid needing to
+        // read or mmap the entire file just to read the header.
+        let file_size = buf.len() as u64;
+
+        let mut reader = ValueReader::new(buf);
+
+        let Some(magic) = reader.read_n::<4>() else {
+            return too_short;
+        };
+        if &magic != b"RTEN" {
+            return Err(HeaderError::InvalidMagic);
+        }
+
+        let Some(version) = reader.read() else {
+            return too_short;
+        };
+        if version != 2 {
+            return Err(HeaderError::UnsupportedVersion);
+        }
+
+        let Some(model_offset) = reader.read::<u64>() else {
+            return too_short;
+        };
+        if model_offset < Self::LEN as u64 || model_offset > file_size {
+            return Err(HeaderError::InvalidOffset);
+        }
+        let Some(model_len) = reader.read() else {
+            return too_short;
+        };
+        if model_offset.saturating_add(model_len) > file_size {
+            return Err(HeaderError::InvalidLength);
+        }
+
+        let Some(tensor_data_offset) = reader.read() else {
+            return too_short;
+        };
+        if tensor_data_offset < Self::LEN as u64 || tensor_data_offset > file_size {
+            return Err(HeaderError::InvalidOffset);
+        }
+
+        Ok(Header {
+            version,
+            model_offset,
+            model_len,
+            tensor_data_offset,
+        })
+    }
+
+    /// Serialize this header to a byte buffer.
+    pub fn to_buf(&self) -> Vec<u8> {
+        let mut buffer = Vec::new();
+
+        buffer.extend(b"RTEN");
+        buffer.extend(self.version.to_le_bytes());
+        buffer.extend(self.model_offset.to_le_bytes());
+        buffer.extend(self.model_len.to_le_bytes());
+        buffer.extend(self.tensor_data_offset.to_le_bytes());
+
+        buffer
+    }
+}
+
+impl Display for HeaderError {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            HeaderError::TooShort => write!(fmt, "header is too short"),
+            HeaderError::UnsupportedVersion => write!(fmt, "unsupported file version"),
+            HeaderError::InvalidMagic => write!(fmt, "incorrect file magic"),
+            HeaderError::InvalidOffset => write!(fmt, "segment offset is invalid"),
+            HeaderError::InvalidLength => write!(fmt, "segment length is invalid"),
+        }
+    }
+}
+
+impl Error for HeaderError {}
+
+#[cfg(test)]
+mod tests {
+    use super::{Header, HeaderError};
+
+    #[test]
+    fn test_read_header() {
+        let expected_header = Header {
+            version: 2,
+            // nb. Values must be >= header size and <= length of buffer.
+            model_offset: 32,
+            model_len: 32,
+            tensor_data_offset: 64,
+        };
+
+        let mut header_buf = expected_header.to_buf();
+        header_buf.extend([0; 32]);
+        let header = Header::from_buf(&header_buf).unwrap();
+
+        assert_eq!(header, expected_header);
+    }
+
+    #[test]
+    fn test_invalid_header() {
+        struct Case {
+            buf: Vec<u8>,
+            expected: HeaderError,
+        }
+
+        let cases = [
+            Case {
+                buf: Vec::new(),
+                expected: HeaderError::TooShort,
+            },
+            Case {
+                buf: b"This is some random ASCII text and not a valid header".to_vec(),
+                expected: HeaderError::InvalidMagic,
+            },
+            Case {
+                buf: Header {
+                    version: 10,
+                    model_offset: 0,
+                    model_len: 0,
+                    tensor_data_offset: 0,
+                }
+                .to_buf(),
+                expected: HeaderError::UnsupportedVersion,
+            },
+            // Offsets too small.
+            Case {
+                buf: Header {
+                    version: 2,
+                    model_offset: 0,
+                    model_len: 0,
+                    tensor_data_offset: 0,
+                }
+                .to_buf(),
+                expected: HeaderError::InvalidOffset,
+            },
+            // Offsets exceed buffer size.
+            Case {
+                buf: Header {
+                    version: 2,
+                    model_offset: 500,
+                    model_len: 0,
+                    tensor_data_offset: 500,
+                }
+                .to_buf(),
+                expected: HeaderError::InvalidOffset,
+            },
+            // Offset + length exceeds buffer size
+            Case {
+                buf: Header {
+                    version: 2,
+                    model_offset: 32,
+                    model_len: 1024,
+                    tensor_data_offset: 0,
+                }
+                .to_buf(),
+                expected: HeaderError::InvalidLength,
+            },
+        ];
+
+        for Case { buf, expected } in cases {
+            let result = Header::from_buf(&buf);
+            assert_eq!(result, Err(expected));
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,6 +96,7 @@ mod downcast;
 mod env;
 mod gemm;
 mod graph;
+mod header;
 mod iter_util;
 mod model;
 mod model_metadata;

--- a/src/model.rs
+++ b/src/model.rs
@@ -17,7 +17,9 @@ use smallvec::smallvec;
 use crate::constant_storage::{ArcSlice, ArcTensorView, ConstantStorage};
 use crate::env::str_as_bool;
 use crate::graph::{ConstantNodeData, Dimension, Graph, Node, NodeId, RunError, RunOptions};
+use crate::header::{Header, HeaderError};
 use crate::model_metadata::ModelMetadata;
+use crate::number::{LeBytes, Pod};
 use crate::ops;
 use crate::ops::{
     BoxOrder, CoordTransformMode, DataType, Direction, InputOrOutput, NearestMode, Operator,
@@ -261,13 +263,28 @@ impl Model {
         options: &ModelOptions,
     ) -> Result<Model, ModelLoadError> {
         let registry = &options.registry;
-        let model = root_as_model(storage.data()).map_err(ModelLoadError::ParseFailed)?;
+
+        let file_data = storage.data();
+        let header = match Header::from_buf(file_data) {
+            Ok(header) => Some(header),
+            Err(HeaderError::InvalidMagic) => None,
+            Err(err) => {
+                return Err(ModelLoadError::InvalidHeader(Box::new(err)));
+            }
+        };
+
+        let model_data = if let Some(header) = header.as_ref() {
+            let (offset, len) = (header.model_offset as usize, header.model_len as usize);
+            &file_data[offset..offset + len]
+        } else {
+            file_data
+        };
+
+        let model = root_as_model(model_data).map_err(ModelLoadError::ParseFailed)?;
 
         if model.schema_version() != 1 {
             return Err(ModelLoadError::SchemaVersionUnsupported);
         }
-
-        let mut graph = Graph::new();
 
         let node_count = model.graph().nodes().map(|ns| ns.len()).unwrap_or(0);
 
@@ -295,91 +312,32 @@ impl Model {
             .map(|ids| ids.iter().map(|id| id as NodeId).collect())
             .unwrap_or_default();
 
+        let mut graph = Graph::new();
         if let Some(nodes) = model.graph().nodes() {
             for (node_index, node) in nodes.iter().enumerate() {
-                if let Some(operator) = node.data_as_operator_node() {
-                    let op = registry
-                        .read_op(&operator)
-                        .map_err(ModelLoadError::OperatorInvalid)?;
-
-                    let mut inputs: Vec<Option<NodeId>> = Vec::new();
-                    if let Some(op_input_ids) = operator.inputs() {
-                        for node_index in op_input_ids.iter() {
-                            if node_index < 0 {
-                                inputs.push(None);
-                                continue;
-                            }
-                            let index_usize = node_index as usize;
-                            if let Some(node_id) = node_id_from_index.get(&index_usize) {
-                                inputs.push(Some(*node_id))
-                            } else {
-                                return Err(ModelLoadError::GraphError(
-                                    "operator input is invalid".to_string(),
-                                ));
-                            }
-                        }
-                    }
-
-                    let mut outputs: Vec<Option<NodeId>> = Vec::new();
-                    if let Some(op_output_ids) = operator.outputs() {
-                        for node_index in op_output_ids.iter() {
-                            if node_index < 0 {
-                                outputs.push(None);
-                                continue;
-                            }
-                            let index_usize = node_index as usize;
-                            if let Some(node_id) = node_id_from_index.get(&index_usize) {
-                                outputs.push(Some(*node_id))
-                            } else {
-                                return Err(ModelLoadError::GraphError(
-                                    "operator output is invalid".to_string(),
-                                ));
-                            }
-                        }
-                    }
-
-                    let graph_node = graph.add_op(node.name(), op, &inputs, &outputs);
-
-                    add_node_id(node.name(), graph_node);
-                    node_id_from_index.insert(node_index, graph_node);
-                } else if let Some(value_node) = node.data_as_value_node() {
-                    let shape: Option<Vec<Dimension>> = value_node.shape().map(|shape| {
-                        shape
-                            .iter()
-                            .map(|dim| {
-                                if let Some(name) = dim.name() {
-                                    Dimension::Symbolic(name.to_string())
-                                } else {
-                                    Dimension::Fixed(dim.value() as usize)
-                                }
-                            })
-                            .collect()
-                    });
-                    let graph_node = graph.add_value(node.name(), shape);
-
-                    add_node_id(node.name(), graph_node);
-                    node_id_from_index.insert(node_index, graph_node);
+                let graph_node = if let Some(operator) = node.data_as_operator_node() {
+                    Self::add_graph_operator(
+                        &mut graph,
+                        node.name(),
+                        operator,
+                        registry,
+                        &node_id_from_index,
+                    )?
+                } else if let Some(value) = node.data_as_value_node() {
+                    Self::add_graph_value(&mut graph, node.name(), value)?
                 } else if let Some(constant) = node.data_as_constant_node() {
-                    let shape: Vec<usize> = constant.shape().iter().map(|x| x as usize).collect();
-                    let graph_node = if let Some(float_data) = constant.data_as_float_data() {
-                        let const_data =
-                            constant_node_from_flatbuffers_vec(&storage, float_data.data(), &shape);
-                        graph.add_constant(node.name(), const_data)
-                    } else if let Some(int_data) = constant.data_as_int_data() {
-                        let const_data =
-                            constant_node_from_flatbuffers_vec(&storage, int_data.data(), &shape);
-                        graph.add_constant(node.name(), const_data)
-                    } else {
-                        return Err(ModelLoadError::GraphError(
-                            "unsupported constant data type".to_string(),
-                        ));
-                    };
-
-                    add_node_id(node.name(), graph_node);
-                    node_id_from_index.insert(node_index, graph_node);
+                    Self::add_graph_constant(
+                        &mut graph,
+                        node.name(),
+                        constant,
+                        &storage,
+                        header.as_ref().map(|h| h.tensor_data_offset),
+                    )?
                 } else {
                     return Err(ModelLoadError::GraphError("unknown node type".to_string()));
-                }
+                };
+                add_node_id(node.name(), graph_node);
+                node_id_from_index.insert(node_index, graph_node);
             }
         }
 
@@ -410,6 +368,134 @@ impl Model {
             metadata,
         };
         Ok(model)
+    }
+
+    fn add_graph_operator(
+        graph: &mut Graph,
+        name: Option<&str>,
+        operator: sg::OperatorNode,
+        registry: &OpRegistry,
+        node_id_from_index: &HashMap<usize, NodeId>,
+    ) -> Result<NodeId, ModelLoadError> {
+        let op = registry
+            .read_op(&operator)
+            .map_err(ModelLoadError::OperatorInvalid)?;
+
+        let mut inputs: Vec<Option<NodeId>> = Vec::new();
+        if let Some(op_input_ids) = operator.inputs() {
+            for node_index in op_input_ids.iter() {
+                if node_index < 0 {
+                    inputs.push(None);
+                    continue;
+                }
+                let index_usize = node_index as usize;
+                if let Some(node_id) = node_id_from_index.get(&index_usize) {
+                    inputs.push(Some(*node_id))
+                } else {
+                    return Err(ModelLoadError::GraphError(
+                        "operator input is invalid".to_string(),
+                    ));
+                }
+            }
+        }
+
+        let mut outputs: Vec<Option<NodeId>> = Vec::new();
+        if let Some(op_output_ids) = operator.outputs() {
+            for node_index in op_output_ids.iter() {
+                if node_index < 0 {
+                    outputs.push(None);
+                    continue;
+                }
+                let index_usize = node_index as usize;
+                if let Some(node_id) = node_id_from_index.get(&index_usize) {
+                    outputs.push(Some(*node_id))
+                } else {
+                    return Err(ModelLoadError::GraphError(
+                        "operator output is invalid".to_string(),
+                    ));
+                }
+            }
+        }
+
+        let graph_node = graph.add_op(name, op, &inputs, &outputs);
+        Ok(graph_node)
+    }
+
+    fn add_graph_value(
+        graph: &mut Graph,
+        name: Option<&str>,
+        value: sg::ValueNode,
+    ) -> Result<NodeId, ModelLoadError> {
+        let shape: Option<Vec<Dimension>> = value.shape().map(|shape| {
+            shape
+                .iter()
+                .map(|dim| {
+                    if let Some(name) = dim.name() {
+                        Dimension::Symbolic(name.to_string())
+                    } else {
+                        Dimension::Fixed(dim.value() as usize)
+                    }
+                })
+                .collect()
+        });
+        let graph_node = graph.add_value(name, shape);
+        Ok(graph_node)
+    }
+
+    fn add_graph_constant(
+        graph: &mut Graph,
+        name: Option<&str>,
+        constant: sg::ConstantNode,
+        storage: &Arc<ConstantStorage>,
+        tensor_data_offset: Option<u64>,
+    ) -> Result<NodeId, ModelLoadError> {
+        let shape: Vec<usize> = constant.shape().iter().map(|x| x as usize).collect();
+
+        if let Some(data_offset) = constant.data_offset() {
+            // Constant data is stored outside the model buffer, in the same file.
+
+            let Some(tensor_data_offset) = tensor_data_offset else {
+                return Err(ModelLoadError::GraphError(
+                    "tensor data section missing".to_string(),
+                ));
+            };
+            let data_offset = (tensor_data_offset + data_offset) as usize;
+
+            let graph_node = match constant.dtype() {
+                Some(sg::ConstantDataType::Int32) => {
+                    let const_data =
+                        constant_data_from_storage_offset::<i32>(storage, &shape, data_offset)?;
+                    graph.add_constant(name, const_data)
+                }
+                Some(sg::ConstantDataType::Float32) => {
+                    let const_data =
+                        constant_data_from_storage_offset::<f32>(storage, &shape, data_offset)?;
+                    graph.add_constant(name, const_data)
+                }
+                _ => {
+                    return Err(ModelLoadError::GraphError(
+                        "unsupported data type for external constant".to_string(),
+                    ));
+                }
+            };
+            Ok(graph_node)
+        } else {
+            // Constant data is stored inline in model
+            let graph_node = if let Some(float_data) = constant.data_as_float_data() {
+                let const_data =
+                    constant_data_from_flatbuffers_vec(storage, float_data.data(), &shape);
+                graph.add_constant(name, const_data)
+            } else if let Some(int_data) = constant.data_as_int_data() {
+                let const_data =
+                    constant_data_from_flatbuffers_vec(storage, int_data.data(), &shape);
+                graph.add_constant(name, const_data)
+            } else {
+                return Err(ModelLoadError::GraphError(
+                    "unsupported data type for inline constant".to_string(),
+                ));
+            };
+            Ok(graph_node)
+        }
     }
 
     /// Find a node in the model's graph given its string name.
@@ -1317,6 +1403,9 @@ pub enum ModelLoadError {
 
     /// An error occurred while optimizing the graph.
     OptimizeError(Box<dyn Error + Send>),
+
+    /// The file's header is invalid.
+    InvalidHeader(Box<dyn Error + Send>),
 }
 
 impl Display for ModelLoadError {
@@ -1328,33 +1417,77 @@ impl Display for ModelLoadError {
             ModelLoadError::OperatorInvalid(e) => write!(f, "operator error: {e}"),
             ModelLoadError::GraphError(e) => write!(f, "graph error: {e}"),
             ModelLoadError::OptimizeError(e) => write!(f, "graph optimization error: {e}"),
+            ModelLoadError::InvalidHeader(e) => write!(f, "invalid header: {e}"),
         }
     }
 }
 
 impl Error for ModelLoadError {}
 
+/// Transmute a `[u8]` to `[T]` provided it is correctly aligned and we're on
+/// a little-endian system.
+fn transmute_bytes<T: Pod>(bytes: &[u8]) -> Option<&[T]> {
+    if bytes.as_ptr() as usize % std::mem::align_of::<T>() != 0
+        || bytes.len() % std::mem::size_of::<T>() != 0
+    {
+        return None;
+    }
+
+    if std::mem::size_of::<T>() != 1 && !cfg!(target_endian = "little") {
+        return None;
+    }
+
+    // Safety: We checked that the data is correctly aligned, and this is
+    // a POD type for which any byte values are allowed.
+    let n_elements = bytes.len() / std::mem::size_of::<T>();
+    let elements = unsafe { std::slice::from_raw_parts(bytes.as_ptr() as *const T, n_elements) };
+    Some(elements)
+}
+
+/// Convert a range of bytes in storage into data for a graph constant.
+///
+/// If the data is correctly aligned and the system is little-endian, this will
+/// return a view, otherwise it will copy the data into an owned tensor.
+fn constant_data_from_storage_offset<T: LeBytes + Pod>(
+    storage: &Arc<ConstantStorage>,
+    shape: &[usize],
+    offset: usize,
+) -> Result<ConstantNodeData<T>, ModelLoadError> {
+    let n_elements: usize = shape.iter().product();
+    let byte_len = n_elements * std::mem::size_of::<T>();
+
+    let Some(bytes) = storage.data().get(offset..offset + byte_len) else {
+        return Err(ModelLoadError::GraphError(
+            "invalid tensor data offset".to_string(),
+        ));
+    };
+
+    if let Some(elements) = transmute_bytes(bytes) {
+        let storage =
+            ArcSlice::new(storage.clone(), elements).expect("storage does not contain data");
+        let const_data: ConstantNodeData<T> = ArcTensorView::from_data(shape, storage).into();
+        Ok(const_data)
+    } else {
+        let data: Vec<T> = bytes
+            .chunks(std::mem::size_of::<T>())
+            .map(|chunk| T::from_le_bytes(chunk.try_into().unwrap()))
+            .collect();
+        Ok(Tensor::from_data(shape, data).into())
+    }
+}
+
 /// Convert a vector from a FlatBuffers file into data for a graph constant node.
 ///
-/// If the data in the file is suitably aligned, as should be the case, and the
-/// current system is little endian, this will return a tensor view that
-/// references data in `storage`, without copying. Otherwise it will copy the
-/// data into an owned tensor.
-fn constant_node_from_flatbuffers_vec<'a, T: Copy + flatbuffers::Follow<'a, Inner = T>>(
+/// If the data is correctly aligned and the system is little-endian, this will
+/// return a view, otherwise it will copy the data into an owned tensor.
+fn constant_data_from_flatbuffers_vec<'a, T: Pod + flatbuffers::Follow<'a, Inner = T>>(
     storage: &Arc<ConstantStorage>,
     fb_vec: flatbuffers::Vector<'a, T>,
     shape: &[usize],
 ) -> ConstantNodeData<T> {
-    let bytes = fb_vec.bytes();
-    if bytes.as_ptr() as usize % std::mem::align_of::<T>() == 0 {
-        // Safety: We checked that the data is correctly aligned, and we trust
-        // `flatbuffers::Vector<T>` that its bytes contain `fbv.len()` Ts.
-        let typed_slice = unsafe {
-            let typed_slice = std::mem::transmute::<&[u8], &[T]>(bytes);
-            &typed_slice[..fb_vec.len()]
-        };
+    if let Some(elements) = transmute_bytes(fb_vec.bytes()) {
         let storage =
-            ArcSlice::new(storage.clone(), typed_slice).expect("storage does not contain data");
+            ArcSlice::new(storage.clone(), elements).expect("storage does not contain data");
         ArcTensorView::from_data(shape, storage).into()
     } else {
         let storage: Vec<T> = fb_vec.iter().collect();
@@ -1369,15 +1502,15 @@ mod tests {
 
     use crate::graph::{Dimension, RunError};
     use crate::model::{Model, ModelOptions};
-    use crate::model_builder::{MetadataArgs, ModelBuilder, OpType};
+    use crate::model_builder::{MetadataArgs, ModelBuilder, ModelFormat, OpType};
     use crate::ops;
     use crate::ops::{
         BoxOrder, CoordTransformMode, NearestMode, OpError, Output, ResizeMode, Scalar,
     };
     use crate::{ModelLoadError, OpRegistry, ReadOpError};
 
-    fn generate_model_buffer() -> Vec<u8> {
-        let mut builder = ModelBuilder::new();
+    fn generate_model_buffer(format: ModelFormat) -> Vec<u8> {
+        let mut builder = ModelBuilder::new(format);
 
         let const_val = Tensor::from_data(&[1, 2, 2], vec![0.5, -0.5, 0.1, -0.1]);
         let const_node = builder.add_float_constant(&const_val);
@@ -1429,7 +1562,7 @@ mod tests {
 
     #[test]
     fn test_model_input_output_ids() {
-        let buffer = generate_model_buffer();
+        let buffer = generate_model_buffer(ModelFormat::V1);
 
         let model = Model::load(buffer).unwrap();
 
@@ -1454,7 +1587,7 @@ mod tests {
 
     #[test]
     fn test_unsupported_operator() {
-        let buffer = generate_model_buffer();
+        let buffer = generate_model_buffer(ModelFormat::V1);
         let registry = OpRegistry::new();
         let result = ModelOptions::with_ops(registry).load(buffer);
 
@@ -1471,7 +1604,7 @@ mod tests {
 
     #[test]
     fn test_shape_info() {
-        let buffer = generate_model_buffer();
+        let buffer = generate_model_buffer(ModelFormat::V1);
         let model = Model::load(buffer).unwrap();
         let input_id = model.input_ids()[0];
 
@@ -1484,7 +1617,7 @@ mod tests {
 
     #[test]
     fn test_metadata() {
-        let buffer = generate_model_buffer();
+        let buffer = generate_model_buffer(ModelFormat::V1);
         let model = Model::load(buffer).unwrap();
         assert_eq!(model.metadata().onnx_hash(), Some("abc"));
         assert_eq!(model.metadata().description(), None);
@@ -1492,7 +1625,7 @@ mod tests {
 
     #[test]
     fn test_input_shape() {
-        let buffer = generate_model_buffer();
+        let buffer = generate_model_buffer(ModelFormat::V1);
         let model = Model::load(buffer).unwrap();
         assert_eq!(
             model.input_shape(0),
@@ -1506,34 +1639,49 @@ mod tests {
 
     #[test]
     fn test_load_and_run_model() {
-        let buffer = generate_model_buffer();
+        struct Case {
+            format: ModelFormat,
+        }
 
-        let model = Model::load(buffer).unwrap();
-        let input_id = model.input_ids()[0];
-        let output_id = model.output_ids()[0];
+        let cases = [
+            Case {
+                format: ModelFormat::V1,
+            },
+            Case {
+                format: ModelFormat::V2,
+            },
+        ];
 
-        let input = generate_input();
+        for Case { format } in cases {
+            let buffer = generate_model_buffer(format);
 
-        // Test a normal model run.
-        let result = model
-            .run(vec![(input_id, input.view().into())], &[output_id], None)
-            .unwrap();
-        let result_tensor = check_output(result);
+            let model = Model::load(buffer).unwrap();
+            let input_id = model.input_ids()[0];
+            let output_id = model.output_ids()[0];
 
-        // Test a partial run. Since we are providing all inputs, this works the
-        // same as `Model::run`. See `Graph::partial_run` tests for other cases.
-        let partial_run_result = model
-            .partial_run(vec![(input_id, input.into())], &[output_id], None)
-            .unwrap();
-        assert_eq!(
-            partial_run_result,
-            vec![(output_id, Output::FloatTensor(result_tensor))]
-        );
+            let input = generate_input();
+
+            // Test a normal model run.
+            let result = model
+                .run(vec![(input_id, input.view().into())], &[output_id], None)
+                .unwrap();
+            let result_tensor = check_output(result);
+
+            // Test a partial run. Since we are providing all inputs, this works the
+            // same as `Model::run`. See `Graph::partial_run` tests for other cases.
+            let partial_run_result = model
+                .partial_run(vec![(input_id, input.into())], &[output_id], None)
+                .unwrap();
+            assert_eq!(
+                partial_run_result,
+                vec![(output_id, Output::FloatTensor(result_tensor))]
+            );
+        }
     }
 
     #[test]
     fn test_load_file() {
-        let buffer = generate_model_buffer();
+        let buffer = generate_model_buffer(ModelFormat::V1);
         std::fs::write("model-load-test.rten", buffer).unwrap();
 
         let model = Model::load_file("model-load-test.rten").unwrap();
@@ -1550,7 +1698,7 @@ mod tests {
     #[cfg(feature = "mmap")]
     #[test]
     fn test_load_mmap() {
-        let buffer = generate_model_buffer();
+        let buffer = generate_model_buffer(ModelFormat::V1);
         std::fs::write("model-load-test.rten", buffer).unwrap();
 
         let model = unsafe { Model::load_mmap("model-load-test.rten").unwrap() };
@@ -1566,7 +1714,7 @@ mod tests {
 
     #[test]
     fn test_run_one() {
-        let buffer = generate_model_buffer();
+        let buffer = generate_model_buffer(ModelFormat::V1);
         let model = Model::load(buffer).unwrap();
 
         let input = tensor!((1, 2, 2); [1., 2., -1., -2.]);
@@ -1582,7 +1730,7 @@ mod tests {
 
     #[test]
     fn test_omitted_optional_inputs() {
-        let mut builder = ModelBuilder::new();
+        let mut builder = ModelBuilder::new(ModelFormat::V1);
 
         let output_node = builder.add_value("output", None);
         builder.add_output(output_node);
@@ -1613,7 +1761,7 @@ mod tests {
     // executed successfully.
     #[test]
     fn test_all_op_types() {
-        let mut builder = ModelBuilder::new();
+        let mut builder = ModelBuilder::new(ModelFormat::V1);
 
         let input_node = builder.add_value("input", None);
         let input_2d = builder.add_value("input.2d", None);

--- a/src/model.rs
+++ b/src/model.rs
@@ -1682,9 +1682,9 @@ mod tests {
     #[test]
     fn test_load_file() {
         let buffer = generate_model_buffer(ModelFormat::V1);
-        std::fs::write("model-load-test.rten", buffer).unwrap();
+        std::fs::write("model-load-file-test.rten", buffer).unwrap();
 
-        let model = Model::load_file("model-load-test.rten").unwrap();
+        let model = Model::load_file("model-load-file-test.rten").unwrap();
         let input_id = model.input_ids()[0];
         let output_id = model.output_ids()[0];
 
@@ -1699,9 +1699,9 @@ mod tests {
     #[test]
     fn test_load_mmap() {
         let buffer = generate_model_buffer(ModelFormat::V1);
-        std::fs::write("model-load-test.rten", buffer).unwrap();
+        std::fs::write("model-load-mmap-test.rten", buffer).unwrap();
 
-        let model = unsafe { Model::load_mmap("model-load-test.rten").unwrap() };
+        let model = unsafe { Model::load_mmap("model-load-mmap-test.rten").unwrap() };
         let input_id = model.input_ids()[0];
         let output_id = model.output_ids()[0];
 

--- a/src/schema.fbs
+++ b/src/schema.fbs
@@ -441,6 +441,7 @@ table OperatorNode {
   outputs:[int];
 }
 
+// Data for constants stored inline in a model.
 union ConstantData {
   FloatData,
   IntData,
@@ -454,10 +455,24 @@ table IntData {
   data: [int32] (required);
 }
 
+enum ConstantDataType: ushort {
+  Int32, // Signed 32-bit int
+  Float32, // IEEE-754 32-bit float
+}
+
 // Graph node for a constant tensor value, whose data is part of the model.
 table ConstantNode {
   shape:[uint] (required);
-  data:ConstantData (required);
+
+  // Tensor data embedded within the model file.
+  data:ConstantData;
+
+  // Data type. This is null in older models.
+  dtype:ConstantDataType = null;
+
+  // Offset of tensor data from the start of the tensor data segment in the
+  // model file. Null if the tensor data is stored inline.
+  data_offset:uint64 = null;
 }
 
 // Dimension of a ValueNode's shape. This can be either a fixed value or a


### PR DESCRIPTION
This introduces a new version of the `.rten` model format. The main improvements are:

- The addition of a header containing file magic, format version and segment offsets
- Tensors can now be stored outside the FlatBuffers data, avoiding the 2GB limit of the FB format, and also providing more control over alignment of data

The overall structure of the new format is:

```
[header] [model_data] [tensor_data]
```

Where the `[model_data]` section is the FlatBuffers data that was the entire content of the file in the V1 format. More details are provided in the `docs/rten-file-format.md` document.

The `rten-convert` tool generates models in the V1 format by default, and uses the V2 format if the `--v2` flag is provided. The `rten` crate can consume both V1 and V2 format models.

With these changes I have been able to convert models up to 14GB in size (Phi-3 mini, f32).

Fixes https://github.com/robertknight/rten/issues/225.