### PR TITLE
Make `ModelLoadError` Sync again, support `&Tensor` => `InputOrOutput` conversion

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -639,10 +639,10 @@ pub enum ModelLoadError {
     GraphError(String),
 
     /// An error occurred while optimizing the graph.
-    OptimizeError(Box<dyn Error + Send>),
+    OptimizeError(Box<dyn Error + Send + Sync>),
 
     /// The file's header is invalid.
-    InvalidHeader(Box<dyn Error + Send>),
+    InvalidHeader(Box<dyn Error + Send + Sync>),
 }
 
 impl Display for ModelLoadError {

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -22,7 +22,7 @@ use smallvec::SmallVec;
 
 use rten_tensor::prelude::*;
 use rten_tensor::{
-    DynLayout, MutLayout, NdTensor, NdTensorView, Tensor, TensorBase, TensorView, ViewData,
+    DynLayout, MutLayout, NdTensor, NdTensorView, Storage, Tensor, TensorBase, TensorView, ViewData,
 };
 
 use crate::downcast::impl_downcastdyn;
@@ -509,6 +509,16 @@ impl<'a> InputOrOutput<'a> {
 impl<'a> From<Input<'a>> for InputOrOutput<'a> {
     fn from(val: Input<'a>) -> Self {
         InputOrOutput::Input(val)
+    }
+}
+
+impl<'a, T: 'static, S: Storage<Elem = T>, L: MutLayout> From<&'a TensorBase<S, L>>
+    for InputOrOutput<'a>
+where
+    Input<'a>: From<TensorView<'a, T>>,
+{
+    fn from(val: &'a TensorBase<S, L>) -> Self {
+        InputOrOutput::Input(val.as_dyn().into())
     }
 }
 


### PR DESCRIPTION
This PR contains a couple of small improvements needed to use the latest version of RTen in the Ocrs project.

- Make `ModelLoadError` Sync again, so it can be converted into `anyhow::Error`
- Support conversion of tensor references to `InputOrOutput`, to match existing conversion from tensor references to `Input`