### PR TITLE
Add empty attrs table to `Gelu` operator

### DIFF
--- a/rten-convert/rten_convert/converter.py
+++ b/rten-convert/rten_convert/converter.py
@@ -725,6 +725,11 @@ def op_node_from_onnx_operator(
             attrs = sg.GatherNDAttrsT()
             attrs.batchDims = op_reader.get_attr("batch_dims", "int", 0)
 
+        case "Gelu":
+            # Gelu has an "approximate" attr in the ONNX spec, but this is
+            # not currently implemented.
+            attrs = sg.GeluAttrsT()
+
         case "Gemm":
             attrs = sg.GemmAttrsT()
             attrs.alpha = op_reader.get_attr("alpha", "float", 1.0)

--- a/rten-convert/rten_convert/schema_generated.py
+++ b/rten-convert/rten_convert/schema_generated.py
@@ -184,6 +184,7 @@ class OperatorAttrs(object):
     RandomNormalAttrs = 34
     RandomNormalLikeAttrs = 35
     GatherNDAttrs = 36
+    GeluAttrs = 37
 
 def OperatorAttrsCreator(unionType, table):
     from flatbuffers.table import Table
@@ -261,6 +262,8 @@ def OperatorAttrsCreator(unionType, table):
         return RandomNormalLikeAttrsT.InitFromBuf(table.Bytes, table.Pos)
     if unionType == OperatorAttrs().GatherNDAttrs:
         return GatherNDAttrsT.InitFromBuf(table.Bytes, table.Pos)
+    if unionType == OperatorAttrs().GeluAttrs:
+        return GeluAttrsT.InitFromBuf(table.Bytes, table.Pos)
     return None
 
 
@@ -1981,6 +1984,71 @@ class GatherNDAttrsT(object):
         GatherNDAttrsAddBatchDims(builder, self.batchDims)
         gatherNdattrs = GatherNDAttrsEnd(builder)
         return gatherNdattrs
+
+
+class GeluAttrs(object):
+    __slots__ = ['_tab']
+
+    @classmethod
+    def GetRootAs(cls, buf, offset=0):
+        n = flatbuffers.encode.Get(flatbuffers.packer.uoffset, buf, offset)
+        x = GeluAttrs()
+        x.Init(buf, n + offset)
+        return x
+
+    @classmethod
+    def GetRootAsGeluAttrs(cls, buf, offset=0):
+        """This method is deprecated. Please switch to GetRootAs."""
+        return cls.GetRootAs(buf, offset)
+    @classmethod
+    def GeluAttrsBufferHasIdentifier(cls, buf, offset, size_prefixed=False):
+        return flatbuffers.util.BufferHasIdentifier(buf, offset, b"\x52\x54\x45\x4E", size_prefixed=size_prefixed)
+
+    # GeluAttrs
+    def Init(self, buf, pos):
+        self._tab = flatbuffers.table.Table(buf, pos)
+
+def GeluAttrsStart(builder):
+    builder.StartObject(0)
+
+def GeluAttrsEnd(builder):
+    return builder.EndObject()
+
+
+
+class GeluAttrsT(object):
+
+    # GeluAttrsT
+    def __init__(self):
+        pass
+
+    @classmethod
+    def InitFromBuf(cls, buf, pos):
+        geluAttrs = GeluAttrs()
+        geluAttrs.Init(buf, pos)
+        return cls.InitFromObj(geluAttrs)
+
+    @classmethod
+    def InitFromPackedBuf(cls, buf, pos=0):
+        n = flatbuffers.encode.Get(flatbuffers.packer.uoffset, buf, pos)
+        return cls.InitFromBuf(buf, pos+n)
+
+    @classmethod
+    def InitFromObj(cls, geluAttrs):
+        x = GeluAttrsT()
+        x._UnPack(geluAttrs)
+        return x
+
+    # GeluAttrsT
+    def _UnPack(self, geluAttrs):
+        if geluAttrs is None:
+            return
+
+    # GeluAttrsT
+    def Pack(self, builder):
+        GeluAttrsStart(builder)
+        geluAttrs = GeluAttrsEnd(builder)
+        return geluAttrs
 
 
 class GemmAttrs(object):
@@ -4517,7 +4585,7 @@ class OperatorNodeT(object):
     def __init__(self):
         self.type = 0  # type: int
         self.attrsType = 0  # type: int
-        self.attrs = None  # type: Union[None, ArgMaxAttrsT, AveragePoolAttrsT, BatchNormalizationAttrsT, CastAttrsT, ConcatAttrsT, ConstantOfShapeAttrsT, ConvAttrsT, ConvTransposeAttrsT, FlattenAttrsT, GatherAttrsT, GemmAttrsT, GRUAttrsT, LeakyReluAttrsT, LSTMAttrsT, MaxPoolAttrsT, ReduceMeanAttrsT, ReshapeAttrsT, ResizeAttrsT, SplitAttrsT, SoftmaxAttrsT, TransposeAttrsT, ModAttrsT, ScatterElementsAttrsT, OneHotAttrsT, TopKAttrsT, HardSigmoidAttrsT, TriluAttrsT, ScatterNDAttrsT, NonMaxSuppressionAttrsT, LayerNormalizationAttrsT, RandomUniformAttrsT, EluAttrsT, RandomUniformLikeAttrsT, RandomNormalAttrsT, RandomNormalLikeAttrsT, GatherNDAttrsT]
+        self.attrs = None  # type: Union[None, ArgMaxAttrsT, AveragePoolAttrsT, BatchNormalizationAttrsT, CastAttrsT, ConcatAttrsT, ConstantOfShapeAttrsT, ConvAttrsT, ConvTransposeAttrsT, FlattenAttrsT, GatherAttrsT, GemmAttrsT, GRUAttrsT, LeakyReluAttrsT, LSTMAttrsT, MaxPoolAttrsT, ReduceMeanAttrsT, ReshapeAttrsT, ResizeAttrsT, SplitAttrsT, SoftmaxAttrsT, TransposeAttrsT, ModAttrsT, ScatterElementsAttrsT, OneHotAttrsT, TopKAttrsT, HardSigmoidAttrsT, TriluAttrsT, ScatterNDAttrsT, NonMaxSuppressionAttrsT, LayerNormalizationAttrsT, RandomUniformAttrsT, EluAttrsT, RandomUniformLikeAttrsT, RandomNormalAttrsT, RandomNormalLikeAttrsT, GatherNDAttrsT, GeluAttrsT]
         self.inputs = None  # type: List[int]
         self.outputs = None  # type: List[int]
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -1120,7 +1120,7 @@ mod tests {
         let gather_elements_indices_val = Tensor::<i32>::zeros(&input_shape);
         let gather_elements_indices = builder.add_constant(gather_elements_indices_val.view());
         add_operator!(GatherElements, [input_node, gather_elements_indices], { axis: 0 });
-        add_operator!(Gelu, [input_node]);
+        add_operator!(Gelu, [input_node], {});
         add_operator!(Gemm, [input_2d, input_2d], {
             alpha: 1.0,
             beta: 1.0,

--- a/src/model_builder.rs
+++ b/src/model_builder.rs
@@ -8,10 +8,10 @@ use crate::number::LeBytes;
 use crate::ops::{
     ArgMax, ArgMin, AveragePool, BatchNormalization, BoxOrder, Cast, Concat, ConstantOfShape, Conv,
     ConvTranspose, CoordTransformMode, DataType, Elu, Flatten, Gather, GatherElements, GatherND,
-    Gemm, HardSigmoid, InstanceNormalization, LayerNormalization, LeakyRelu, LogSoftmax, MaxPool,
-    Mod, NearestMode, NonMaxSuppression, OneHot, Padding, ReduceMax, ReduceMean, ReduceMin,
-    ReduceProd, ReduceSum, ReduceSumSquare, Reshape, Resize, ResizeMode, Scalar, ScatterElements,
-    ScatterReduction, Softmax, Split, TopK, Transpose, Trilu,
+    Gelu, Gemm, HardSigmoid, InstanceNormalization, LayerNormalization, LeakyRelu, LogSoftmax,
+    MaxPool, Mod, NearestMode, NonMaxSuppression, OneHot, Padding, ReduceMax, ReduceMean,
+    ReduceMin, ReduceProd, ReduceSum, ReduceSumSquare, Reshape, Resize, ResizeMode, Scalar,
+    ScatterElements, ScatterReduction, Softmax, Split, TopK, Transpose, Trilu,
 };
 use crate::schema_generated as sg;
 
@@ -49,7 +49,7 @@ pub enum OpType {
     Gather(Gather),
     GatherElements(GatherElements),
     GatherND(GatherND),
-    Gelu,
+    Gelu(Gelu),
     Gemm(Gemm),
     GlobalAveragePool,
     Greater,
@@ -522,7 +522,7 @@ impl<'a> ModelBuilder<'a> {
                     batch_dims: args.batch_dims as i32,
                 }
             ),
-            OpType::Gelu => op!(Gelu),
+            OpType::Gelu(_args) => op_with_attrs!(Gelu, GeluAttrs, sg::GeluAttrsArgs {}),
             OpType::Gemm(args) => op_with_attrs!(
                 Gemm,
                 GemmAttrs,

--- a/src/op_registry.rs
+++ b/src/op_registry.rs
@@ -477,7 +477,9 @@ impl_read_op!(
         })
     }
 );
-impl_read_op!(Gelu);
+impl_read_op!(Gelu, attrs_as_gelu_attrs, |_attrs: sg::GeluAttrs| {
+    Ok(ops::Gelu {})
+});
 impl_read_op!(Gemm, attrs_as_gemm_attrs, |attrs: sg::GemmAttrs| {
     Ok(ops::Gemm {
         alpha: attrs.alpha(),

--- a/src/schema.fbs
+++ b/src/schema.fbs
@@ -197,6 +197,7 @@ union OperatorAttrs {
   RandomNormalAttrs,
   RandomNormalLikeAttrs,
   GatherNDAttrs,
+  GeluAttrs,
 }
 
 table ArgMaxAttrs {
@@ -286,6 +287,9 @@ table GatherAttrs {
 table GatherNDAttrs {
   batch_dims:int;
 }
+
+// Reserved for supporting `approximate` attr in future.
+table GeluAttrs {}
 
 table GemmAttrs {
   alpha:float;

--- a/src/schema_generated.rs
+++ b/src/schema_generated.rs
@@ -1078,13 +1078,13 @@ pub const ENUM_MIN_OPERATOR_ATTRS: u8 = 0;
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
-pub const ENUM_MAX_OPERATOR_ATTRS: u8 = 36;
+pub const ENUM_MAX_OPERATOR_ATTRS: u8 = 37;
 #[deprecated(
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_OPERATOR_ATTRS: [OperatorAttrs; 37] = [
+pub const ENUM_VALUES_OPERATOR_ATTRS: [OperatorAttrs; 38] = [
     OperatorAttrs::NONE,
     OperatorAttrs::ArgMaxAttrs,
     OperatorAttrs::AveragePoolAttrs,
@@ -1122,6 +1122,7 @@ pub const ENUM_VALUES_OPERATOR_ATTRS: [OperatorAttrs; 37] = [
     OperatorAttrs::RandomNormalAttrs,
     OperatorAttrs::RandomNormalLikeAttrs,
     OperatorAttrs::GatherNDAttrs,
+    OperatorAttrs::GeluAttrs,
 ];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -1166,9 +1167,10 @@ impl OperatorAttrs {
     pub const RandomNormalAttrs: Self = Self(34);
     pub const RandomNormalLikeAttrs: Self = Self(35);
     pub const GatherNDAttrs: Self = Self(36);
+    pub const GeluAttrs: Self = Self(37);
 
     pub const ENUM_MIN: u8 = 0;
-    pub const ENUM_MAX: u8 = 36;
+    pub const ENUM_MAX: u8 = 37;
     pub const ENUM_VALUES: &'static [Self] = &[
         Self::NONE,
         Self::ArgMaxAttrs,
@@ -1207,6 +1209,7 @@ impl OperatorAttrs {
         Self::RandomNormalAttrs,
         Self::RandomNormalLikeAttrs,
         Self::GatherNDAttrs,
+        Self::GeluAttrs,
     ];
     /// Returns the variant's name or "" if unknown.
     pub fn variant_name(self) -> Option<&'static str> {
@@ -1248,6 +1251,7 @@ impl OperatorAttrs {
             Self::RandomNormalAttrs => Some("RandomNormalAttrs"),
             Self::RandomNormalLikeAttrs => Some("RandomNormalLikeAttrs"),
             Self::GatherNDAttrs => Some("GatherNDAttrs"),
+            Self::GeluAttrs => Some("GeluAttrs"),
             _ => None,
         }
     }
@@ -3861,6 +3865,83 @@ impl core::fmt::Debug for GatherNDAttrs<'_> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let mut ds = f.debug_struct("GatherNDAttrs");
         ds.field("batch_dims", &self.batch_dims());
+        ds.finish()
+    }
+}
+pub enum GeluAttrsOffset {}
+#[derive(Copy, Clone, PartialEq)]
+
+pub struct GeluAttrs<'a> {
+    pub _tab: flatbuffers::Table<'a>,
+}
+
+impl<'a> flatbuffers::Follow<'a> for GeluAttrs<'a> {
+    type Inner = GeluAttrs<'a>;
+    #[inline]
+    unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self {
+            _tab: flatbuffers::Table::new(buf, loc),
+        }
+    }
+}
+
+impl<'a> GeluAttrs<'a> {
+    #[inline]
+    pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+        GeluAttrs { _tab: table }
+    }
+    #[allow(unused_mut)]
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
+        _args: &'args GeluAttrsArgs,
+    ) -> flatbuffers::WIPOffset<GeluAttrs<'bldr>> {
+        let mut builder = GeluAttrsBuilder::new(_fbb);
+        builder.finish()
+    }
+}
+
+impl flatbuffers::Verifiable for GeluAttrs<'_> {
+    #[inline]
+    fn run_verifier(
+        v: &mut flatbuffers::Verifier,
+        pos: usize,
+    ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+        use self::flatbuffers::Verifiable;
+        v.visit_table(pos)?.finish();
+        Ok(())
+    }
+}
+pub struct GeluAttrsArgs {}
+impl<'a> Default for GeluAttrsArgs {
+    #[inline]
+    fn default() -> Self {
+        GeluAttrsArgs {}
+    }
+}
+
+pub struct GeluAttrsBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+    fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
+    start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> GeluAttrsBuilder<'a, 'b, A> {
+    #[inline]
+    pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> GeluAttrsBuilder<'a, 'b, A> {
+        let start = _fbb.start_table();
+        GeluAttrsBuilder {
+            fbb_: _fbb,
+            start_: start,
+        }
+    }
+    #[inline]
+    pub fn finish(self) -> flatbuffers::WIPOffset<GeluAttrs<'a>> {
+        let o = self.fbb_.end_table(self.start_);
+        flatbuffers::WIPOffset::new(o.value())
+    }
+}
+
+impl core::fmt::Debug for GeluAttrs<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut ds = f.debug_struct("GeluAttrs");
         ds.finish()
     }
 }
@@ -7559,6 +7640,21 @@ impl<'a> OperatorNode<'a> {
             None
         }
     }
+
+    #[inline]
+    #[allow(non_snake_case)]
+    pub fn attrs_as_gelu_attrs(&self) -> Option<GeluAttrs<'a>> {
+        if self.attrs_type() == OperatorAttrs::GeluAttrs {
+            self.attrs().map(|t| {
+                // Safety:
+                // Created from a valid Table for this object
+                // Which contains a valid union in this slot
+                unsafe { GeluAttrs::init_from_table(t) }
+            })
+        } else {
+            None
+        }
+    }
 }
 
 impl flatbuffers::Verifiable for OperatorNode<'_> {
@@ -7608,6 +7704,7 @@ impl flatbuffers::Verifiable for OperatorNode<'_> {
           OperatorAttrs::RandomNormalAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<RandomNormalAttrs>>("OperatorAttrs::RandomNormalAttrs", pos),
           OperatorAttrs::RandomNormalLikeAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<RandomNormalLikeAttrs>>("OperatorAttrs::RandomNormalLikeAttrs", pos),
           OperatorAttrs::GatherNDAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<GatherNDAttrs>>("OperatorAttrs::GatherNDAttrs", pos),
+          OperatorAttrs::GeluAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<GeluAttrs>>("OperatorAttrs::GeluAttrs", pos),
           _ => Ok(()),
         }
      })?
@@ -8045,6 +8142,16 @@ impl core::fmt::Debug for OperatorNode<'_> {
             }
             OperatorAttrs::GatherNDAttrs => {
                 if let Some(x) = self.attrs_as_gather_ndattrs() {
+                    ds.field("attrs", &x)
+                } else {
+                    ds.field(
+                        "attrs",
+                        &"InvalidFlatbuffer: Union discriminant does not match value.",
+                    )
+                }
+            }
+            OperatorAttrs::GeluAttrs => {
+                if let Some(x) = self.attrs_as_gelu_attrs() {
                     ds.field("attrs", &x)
                 } else {
                     ds.field(


### PR DESCRIPTION
This is not currently used, but will make it easier to support the `approximate` attribute in future.