### PR TITLE
Generate rten models in V2 format by default

### DIFF
--- a/docs/rten-file-format.md
+++ b/docs/rten-file-format.md
@@ -22,9 +22,8 @@ does not rely on operators or attributes that were added in version X.
 
 There are two versions of the RTen model format. The second version added
 support for models larger than 2GB. RTen can load models in either format. The
-`rten-convert` tool currently generates the V1 format by default, and will
-generate the V2 format if the `--v2` flag is passed. The V2 format will become
-the default in future.
+`rten-convert` tool generates the V2 format by default, and will generate the V1
+format if the `--v1` flag is passed.
 
 ## V2 format
 

--- a/rten-convert/rten_convert/converter.py
+++ b/rten-convert/rten_convert/converter.py
@@ -1397,9 +1397,9 @@ def main():
         "-m", "--metadata", help="Path to JSON file containing model metadata."
     )
     parser.add_argument(
-        "--v2",
+        "--v1",
         action="store_true",
-        help="Generate version 2 .rten models, with support for files > 2GB",
+        help="Generate version 1 .rten models. These are limited to files < 2GB",
     )
     parser.add_argument("out_name", help="Output model file name", nargs="?")
     args = parser.parse_args()
@@ -1409,7 +1409,7 @@ def main():
         model_basename = splitext(args.model)[0]
         output_path = f"{model_basename}.rten"
 
-    use_v2_format = args.v2
+    use_v2_format = not args.v1
     if use_v2_format:
         tensor_data = TensorDataBuilder()
     else:
@@ -1426,7 +1426,7 @@ def main():
         print("Model buffer exceeded maximum size (2GB)", file=sys.stderr)
         if not use_v2_format:
             print(
-                "To serialize models > 2GB, the V2 format must be used via the `--v2` flag.",
+                "To serialize models > 2GB, the V2 format must be used.",
                 file=sys.stderr,
             )
         sys.exit(1)

--- a/src/model.rs
+++ b/src/model.rs
@@ -803,7 +803,7 @@ mod tests {
 
     #[test]
     fn test_model_input_output_ids() {
-        let buffer = generate_model_buffer(ModelFormat::V1);
+        let buffer = generate_model_buffer(ModelFormat::V2);
 
         let model = Model::load(buffer).unwrap();
 
@@ -828,7 +828,7 @@ mod tests {
 
     #[test]
     fn test_unsupported_operator() {
-        let buffer = generate_model_buffer(ModelFormat::V1);
+        let buffer = generate_model_buffer(ModelFormat::V2);
         let registry = OpRegistry::new();
         let result = ModelOptions::with_ops(registry).load(buffer);
 
@@ -845,7 +845,7 @@ mod tests {
 
     #[test]
     fn test_shape_info() {
-        let buffer = generate_model_buffer(ModelFormat::V1);
+        let buffer = generate_model_buffer(ModelFormat::V2);
         let model = Model::load(buffer).unwrap();
         let input_id = model.input_ids()[0];
 
@@ -858,7 +858,7 @@ mod tests {
 
     #[test]
     fn test_metadata() {
-        let buffer = generate_model_buffer(ModelFormat::V1);
+        let buffer = generate_model_buffer(ModelFormat::V2);
         let model = Model::load(buffer).unwrap();
         assert_eq!(model.metadata().onnx_hash(), Some("abc"));
         assert_eq!(model.metadata().description(), None);
@@ -866,7 +866,7 @@ mod tests {
 
     #[test]
     fn test_input_shape() {
-        let buffer = generate_model_buffer(ModelFormat::V1);
+        let buffer = generate_model_buffer(ModelFormat::V2);
         let model = Model::load(buffer).unwrap();
         assert_eq!(
             model.input_shape(0),
@@ -922,7 +922,7 @@ mod tests {
 
     #[test]
     fn test_load_file() {
-        let buffer = generate_model_buffer(ModelFormat::V1);
+        let buffer = generate_model_buffer(ModelFormat::V2);
         std::fs::write("model-load-file-test.rten", buffer).unwrap();
 
         let model = Model::load_file("model-load-file-test.rten").unwrap();
@@ -939,7 +939,7 @@ mod tests {
     #[cfg(feature = "mmap")]
     #[test]
     fn test_load_mmap() {
-        let buffer = generate_model_buffer(ModelFormat::V1);
+        let buffer = generate_model_buffer(ModelFormat::V2);
         std::fs::write("model-load-mmap-test.rten", buffer).unwrap();
 
         let model = unsafe { Model::load_mmap("model-load-mmap-test.rten").unwrap() };
@@ -955,7 +955,7 @@ mod tests {
 
     #[test]
     fn test_run_one() {
-        let buffer = generate_model_buffer(ModelFormat::V1);
+        let buffer = generate_model_buffer(ModelFormat::V2);
         let model = Model::load(buffer).unwrap();
 
         let input = tensor!((1, 2, 2); [1., 2., -1., -2.]);
@@ -971,7 +971,7 @@ mod tests {
 
     #[test]
     fn test_omitted_optional_inputs() {
-        let mut builder = ModelBuilder::new(ModelFormat::V1);
+        let mut builder = ModelBuilder::new(ModelFormat::V2);
 
         let output_node = builder.add_value("output", None);
         builder.add_output(output_node);
@@ -1002,7 +1002,7 @@ mod tests {
     // executed successfully.
     #[test]
     fn test_all_op_types() {
-        let mut builder = ModelBuilder::new(ModelFormat::V1);
+        let mut builder = ModelBuilder::new(ModelFormat::V2);
 
         let input_node = builder.add_value("input", None);
         let input_2d = builder.add_value("input.2d", None);

--- a/src/model_builder.rs
+++ b/src/model_builder.rs
@@ -879,7 +879,7 @@ impl<'a> ModelBuilder<'a> {
 
 impl<'a> Default for ModelBuilder<'a> {
     fn default() -> Self {
-        Self::new(ModelFormat::V1)
+        Self::new(ModelFormat::V2)
     }
 }
 


### PR DESCRIPTION
This allows converting large (> 2GB) models without needing to pass the `--v2` flag to `rten-convert`. There is a `--v1` flag to force creation of V1 models for use with older rten versions.

 - Make rten-convert use the V2 format by default
 - Change all tests to use the V2 model format, except for one test to check that loading and running V1 models still works