### PR TITLE
Make `reduce_{max, min, sum}` methods more generic

### DIFF
--- a/rten-examples/src/depth_anything.rs
+++ b/rten-examples/src/depth_anything.rs
@@ -1,7 +1,7 @@
 use std::collections::VecDeque;
 use std::error::Error;
 
-use rten::{FloatOperators, Model};
+use rten::{FloatOperators, Model, Operators};
 use rten_imageio::{normalize_image, read_image, write_image};
 use rten_tensor::prelude::*;
 use rten_tensor::{NdTensor, Tensor};

--- a/src/ops/random.rs
+++ b/src/ops/random.rs
@@ -144,7 +144,7 @@ mod tests {
     use rten_tensor::prelude::*;
     use rten_tensor::Tensor;
 
-    use crate::ops::operators::FloatOperators;
+    use crate::ops::operators::{FloatOperators, Operators};
     use crate::ops::tests::{new_pool, run_op};
     use crate::ops::{InputList, Operator};
 

--- a/src/ops/reduce.rs
+++ b/src/ops/reduce.rs
@@ -593,16 +593,16 @@ impl Operator for ReduceProd {
     }
 }
 
-pub fn reduce_sum<T: Copy + std::iter::Sum>(
+pub fn reduce_sum<T: Copy + Default + std::ops::Add<T, Output = T>>(
     pool: &TensorPool,
     input: TensorView<T>,
     axes: Option<&[i32]>,
     keep_dims: bool,
 ) -> Result<Tensor<T>, OpError> {
     struct SumReducer {}
-    impl<T: std::iter::Sum> Reducer<T> for SumReducer {
+    impl<T: Default + std::ops::Add<T, Output = T>> Reducer<T> for SumReducer {
         fn reduce<I: ExactSizeIterator<Item = T>>(&self, iter: I) -> T {
-            iter.sum()
+            iter.fold(T::default(), |a, b| a + b)
         }
     }
     reduce(pool, input, axes, keep_dims, SumReducer {})


### PR DESCRIPTION
Move them from the `FloatOperators` to the `Operators` trait, with appropriate bounds.