### PR TITLE
Generalize transpose fusion

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -38,7 +38,7 @@ pub struct OperatorNode {
     name: Option<String>,
     inputs: Vec<Option<NodeId>>,
     outputs: Vec<Option<NodeId>>,
-    operator: Box<dyn Operator + Send + Sync>,
+    operator: Arc<dyn Operator + Send + Sync>,
 }
 
 impl OperatorNode {
@@ -56,6 +56,14 @@ impl OperatorNode {
 
     pub fn operator(&self) -> &dyn Operator {
         self.operator.as_ref()
+    }
+
+    /// Return a new `Arc` reference to this node's operator.
+    ///
+    /// Since operators are stateless and immutable once added to a graph, they
+    /// can be "cloned" just be creating a new reference.
+    pub fn clone_operator(&self) -> Arc<dyn Operator + Send + Sync> {
+        self.operator.clone()
     }
 
     pub fn replace_input(&mut self, old_id: NodeId, new_id: NodeId) {
@@ -413,7 +421,7 @@ impl Graph {
             name: name.map(|s| s.to_owned()),
             inputs: Vec::from(inputs),
             outputs: Vec::from(outputs),
-            operator: op,
+            operator: Arc::from(op),
         }));
         self.nodes.len() - 1
     }

--- a/src/ops/fused.rs
+++ b/src/ops/fused.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use rten_tensor::prelude::*;
 
 use crate::ops::{Input, InputList, OpError, Operator, OutputList};
@@ -42,14 +44,14 @@ impl PermuteSpec {
 /// before evaluating the wrapped operator.
 #[derive(Debug)]
 pub struct FusedTranspose {
-    inner: Box<dyn Operator + Send + Sync>,
+    inner: Arc<dyn Operator + Send + Sync>,
     perm: PermuteSpec,
     name: String,
 }
 
 impl FusedTranspose {
     pub fn wrap(
-        op: Box<dyn Operator + Send + Sync>,
+        op: Arc<dyn Operator + Send + Sync>,
         input_index: usize,
         permutation: Option<&[usize]>,
     ) -> FusedTranspose {
@@ -78,6 +80,7 @@ impl Operator for FusedTranspose {
 #[cfg(test)]
 mod tests {
     use std::error::Error;
+    use std::sync::Arc;
 
     use rten_tensor::prelude::*;
     use rten_tensor::Tensor;
@@ -127,7 +130,7 @@ mod tests {
             // binary op.
             let sub_op = Sub {};
             let fused_transpose =
-                FusedTranspose::wrap(Box::new(sub_op), transpose_input, Some(&[1, 0]));
+                FusedTranspose::wrap(Arc::new(sub_op), transpose_input, Some(&[1, 0]));
 
             let pool = new_pool();
             let mut outputs =


### PR DESCRIPTION
Revise transpose fusion to be able to support additional operators. In this initial commit, only `MatMul(Transpose(X), Y)` is fused as before, but this will make it easier to support other operators in future.

In order to construct a `FusedTranspose` from an arbitrary operator, it was necessary to support cloning any operator. Since operators are stateless, the easiest way to do this is to make them reference counted in the graph, then they can be "cloned" just by creating a new `Arc`.