### PR TITLE
Add graph pattern matcher, rewrite SiLU fusion using it

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -54,6 +54,13 @@ impl OperatorNode {
         &self.outputs
     }
 
+    pub fn output_id(&self) -> Option<NodeId> {
+        match &self.outputs[..] {
+            [Some(id)] => Some(*id),
+            _ => None,
+        }
+    }
+
     pub fn operator(&self) -> &dyn Operator {
         self.operator.as_ref()
     }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -145,7 +145,8 @@ impl Constant {
         }
     }
 
-    fn as_input(&self) -> Input {
+    /// Return the data for this constant as a tensor view.
+    pub fn as_input(&self) -> Input {
         match self {
             Constant::Float(f) => Input::FloatTensor(f.view()),
             Constant::Int(i) => Input::IntTensor(i.view()),
@@ -386,6 +387,10 @@ pub struct Graph {
 
     /// The plan that was used for the most recent execution of the graph.
     cached_plan: Mutex<Option<Arc<CachedPlan>>>,
+
+    /// Map of value node ID => source operator ID. This enables traversing the
+    /// graph from outputs to inputs.
+    source_ids: FxHashMap<NodeId, NodeId>,
 }
 
 impl Graph {
@@ -394,6 +399,7 @@ impl Graph {
         Graph {
             nodes: Vec::new(),
             cached_plan: Mutex::new(None),
+            source_ids: FxHashMap::default(),
         }
     }
 
@@ -423,7 +429,13 @@ impl Graph {
             outputs: Vec::from(outputs),
             operator: Arc::from(op),
         }));
-        self.nodes.len() - 1
+        let op_id = self.nodes.len() - 1;
+
+        for output_id in outputs.iter().flatten() {
+            self.source_ids.insert(*output_id, op_id);
+        }
+
+        op_id
     }
 
     /// Add a constant node to the graph.
@@ -478,6 +490,16 @@ impl Graph {
     /// Retrieve a node by ID
     pub fn get_node(&self, id: NodeId) -> Option<&Node> {
         self.nodes.get(id)
+    }
+
+    /// Look up the operator node which produced a given value node.
+    pub fn get_source_node(&self, id: NodeId) -> Option<(NodeId, &OperatorNode)> {
+        self.source_ids
+            .get(&id)
+            .and_then(|&id| match self.get_node(id) {
+                Some(Node::Operator(op_node)) => Some((id, op_node)),
+                _ => None,
+            })
     }
 
     /// Retrieve a node by ID
@@ -971,16 +993,6 @@ impl Graph {
             return Err(RunError::PlanningError("input IDs are not unique".into()));
         }
 
-        // Map of output node to source operator
-        let mut operator_nodes = FxHashMap::default();
-        for (node_id, node) in self.nodes.iter().enumerate() {
-            if let Node::Operator(op_node) = node {
-                for output_id in op_node.outputs.iter().filter_map(|node| *node) {
-                    operator_nodes.insert(output_id, (node_id, op_node));
-                }
-            }
-        }
-
         // Build an execution plan via a depth first traversal of the graph
         // starting at the output nodes. A helper struct is used as recursive
         // closures are not supported in Rust.
@@ -988,10 +1000,6 @@ impl Graph {
             graph: &'a Graph,
             resolved_values: FxHashSet<NodeId>,
             plan: Vec<(NodeId, &'a OperatorNode)>,
-
-            // Map of output ID to (op node ID, op)
-            operator_nodes: FxHashMap<NodeId, (NodeId, &'a OperatorNode)>,
-
             options: PlanOptions,
         }
         impl<'a> PlanBuilder<'a> {
@@ -1006,9 +1014,7 @@ impl Graph {
                     if self.resolved_values.contains(&input) {
                         continue;
                     }
-                    if let Some((input_op_id, input_op_node)) =
-                        self.operator_nodes.get(&input).copied()
-                    {
+                    if let Some((input_op_id, input_op_node)) = self.graph.get_source_node(input) {
                         self.visit(input_op_id, input_op_node)?;
                     } else if self.options.allow_missing_inputs {
                         continue;
@@ -1038,8 +1044,7 @@ impl Graph {
                         continue;
                     }
 
-                    if let Some((op_node_id, op_node)) = self.operator_nodes.get(output_id).copied()
-                    {
+                    if let Some((op_node_id, op_node)) = self.graph.get_source_node(*output_id) {
                         self.visit(op_node_id, op_node)?;
                     } else {
                         let msg = format!("Missing output {}", output_id);
@@ -1058,10 +1063,15 @@ impl Graph {
             graph: self,
             resolved_values,
             plan: Vec::new(),
-            operator_nodes,
             options,
         };
         builder.plan(outputs)
+    }
+}
+
+impl Default for Graph {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -10,6 +10,8 @@ use crate::ops::fused::FusedTranspose;
 use crate::ops::{Mul, Operator, Sigmoid, Silu, Transpose};
 use crate::Output;
 
+mod pattern_matcher;
+
 /// Errors that occur while applying graph optimizations.
 #[derive(Debug, PartialEq)]
 pub enum OptimizeError {
@@ -435,7 +437,7 @@ mod tests {
     use crate::ops::{Add, MatMul, Mul, Operator, Sigmoid, Transpose};
 
     /// Extensions to [`Graph`] to make tests easier to write.
-    trait GraphTestUtils {
+    pub(crate) trait GraphTestUtils {
         /// Add a single-output operator to the graph and return a tuple of
         /// `(operator_node_id, output_node_id)`.
         fn add_simple_op<Op: Operator + Send + Sync + 'static>(

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -7,7 +7,7 @@ use rustc_hash::FxHashMap;
 use crate::downcast::DowncastDyn;
 use crate::graph::{Constant, ConstantNode, Graph, Node, NodeId, OperatorNode, RunError};
 use crate::ops::fused::FusedTranspose;
-use crate::ops::{Mul, Operator, Sigmoid, Silu, Transpose};
+use crate::ops::{Operator, Silu, Transpose};
 use crate::Output;
 
 mod pattern_matcher;
@@ -133,11 +133,14 @@ impl GraphMutator {
 
     /// Iterate over each operator node in the graph and potentially apply a
     /// fusion which combines this node and adjacent nodes.
-    fn apply_fusion<F: Fn(&Self, &OperatorNode) -> Option<Fusion>>(&mut self, create_fusion: F) {
+    fn apply_fusion<F: Fn(&Self, NodeId, &OperatorNode) -> Option<Fusion>>(
+        &mut self,
+        create_fusion: F,
+    ) {
         let mut fusions = Vec::new();
 
-        for (_, op_node) in self.iter_operators() {
-            if let Some(fusion) = create_fusion(self, op_node) {
+        for (op_node_id, op_node) in self.iter_operators() {
+            if let Some(fusion) = create_fusion(self, op_node_id, op_node) {
                 fusions.push(fusion);
             }
         }
@@ -271,13 +274,6 @@ impl OperatorMatch for OperatorNode {
     }
 }
 
-/// Return true if `a` and `b`, viewed as sets, contain the same elements.
-fn array_sets_equal<T: PartialEq + Ord, const N: usize>(mut a: [T; N], mut b: [T; N]) -> bool {
-    a.sort_unstable();
-    b.sort_unstable();
-    a == b
-}
-
 /// Applies optimizations to a [`Graph`] to enable faster inference.
 pub struct GraphOptimizer {}
 
@@ -352,7 +348,7 @@ impl GraphOptimizer {
     /// This avoids materializing the transposed input for operators which can
     /// efficiently handle the input being non-contiguous.
     fn fuse_transpose(&self, graph: &mut GraphMutator) -> Result<(), OptimizeError> {
-        graph.apply_fusion(|edges, op_node| {
+        graph.apply_fusion(|edges, _op_node_id, op_node| {
             let (transpose_op, [transpose_input], [transpose_output]) =
                 op_node.match_type::<Transpose, 1, 1>()?;
 
@@ -399,21 +395,21 @@ impl GraphOptimizer {
 
     /// Fuse `x * Sigmoid(x)` into `Silu(x)`.
     fn fuse_silu(&self, graph: &mut GraphMutator) -> Result<(), OptimizeError> {
-        graph.apply_fusion(|graph, op_node| {
-            let (_sigmoid_op, [sigmoid_input], [sigmoid_output]) =
-                op_node.match_type::<Sigmoid, 1, 1>()?;
-            let sigmoid_target = graph.find_operator_with_input(sigmoid_output)?;
+        use pattern_matcher::{symbol, unary_op};
+        let x = symbol("x");
+        let silu_pattern = x.clone() * unary_op("Sigmoid", x.clone());
 
-            let (_mul_op, mul_inputs, [mul_output]) = sigmoid_target.match_type::<Mul, 2, 1>()?;
+        graph.apply_fusion(|graph, op_node_id, op_node| {
+            let silu_match = silu_pattern.test(op_node_id, graph.graph())?;
+            let silu_input = silu_match.resolved_symbol("x").expect("missing symbol");
+            let op_output = op_node.output_id()?;
 
-            array_sets_equal(mul_inputs, [sigmoid_input, sigmoid_output]).then(|| {
-                Fusion::from_op(
-                    sigmoid_target.name(),
-                    Silu {},
-                    vec![Some(sigmoid_input)],
-                    mul_output,
-                )
-            })
+            Some(Fusion::from_op(
+                op_node.name(),
+                Silu {},
+                vec![Some(silu_input)],
+                op_output,
+            ))
         });
 
         Ok(())

--- a/src/optimize/pattern_matcher.rs
+++ b/src/optimize/pattern_matcher.rs
@@ -1,0 +1,382 @@
+use std::ops::{Add, Div, Mul, Neg, Sub};
+
+use crate::graph::{Constant, Graph, Node, NodeId, OperatorNode};
+use crate::ops::Input;
+
+/// Tracks an association between named symbols (variables) in a pattern and
+/// the node IDs they have been resolved to.
+struct SymbolMap {
+    // Map of `(name, node_id)` for resolved symbols. This is modified only
+    // by extending and truncating it.
+    symbols: Vec<(&'static str, NodeId)>,
+
+    // Stack of checkpoints. Each is the length of `symbols` at the time of
+    // the checkpoint.
+    checkpoints: Vec<usize>,
+}
+
+impl SymbolMap {
+    fn new() -> SymbolMap {
+        SymbolMap {
+            symbols: Vec::new(),
+            checkpoints: Vec::new(),
+        }
+    }
+
+    /// Save the current state of the map.
+    ///
+    /// This is useful if we need to backtrack during pattern matching.
+    fn checkpoint(&mut self) {
+        self.checkpoints.push(self.symbols.len());
+    }
+
+    /// Discard any new symbols recorded since the last call to `checkpoint`.
+    fn revert(&mut self) {
+        if let Some(checkpoint) = self.checkpoints.pop() {
+            self.symbols.truncate(checkpoint);
+        }
+    }
+
+    /// Add a new symbol-node association.
+    fn add(&mut self, name: &'static str, node_id: NodeId) {
+        self.symbols.push((name, node_id));
+    }
+
+    /// Find the node ID that a symbol has been resolved to.
+    fn find(&self, name: &str) -> Option<NodeId> {
+        self.symbols.iter().find_map(|(sym_name, node_id)| {
+            if *sym_name == name {
+                Some(*node_id)
+            } else {
+                None
+            }
+        })
+    }
+}
+
+/// The result of matching a [`Pattern`] against a graph node.
+pub struct Match {
+    symbols: SymbolMap,
+}
+
+impl Match {
+    /// Return the value node ID that a symbol was resolved to.
+    pub fn resolved_symbol(&self, name: &str) -> Option<NodeId> {
+        self.symbols.find(name)
+    }
+}
+
+/// Absolute tolerance for matching float constants against constant patterns.
+const CONST_TOLERANCE: f32 = 1e-4;
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct ConstantPattern {
+    value: f32,
+}
+
+impl ConstantPattern {
+    fn matches(&self, node: &Constant) -> bool {
+        match node.as_input() {
+            Input::FloatTensor(t) => t
+                .item()
+                .is_some_and(|x| (x - self.value).abs() <= CONST_TOLERANCE),
+            _ => false,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct OpPattern {
+    name: &'static str,
+    inputs: Vec<Pattern>,
+}
+
+impl OpPattern {
+    fn matches(&self, node: &OperatorNode, graph: &Graph, symbols: &mut SymbolMap) -> bool {
+        if node.operator().name() != self.name {
+            return false;
+        }
+        if self.inputs.len() != node.input_ids().len() {
+            return false;
+        }
+
+        // For commutative binary operators, we allow the pattern to match
+        // either way around.
+        if let (true, [pat_a, pat_b], [Some(input_a), Some(input_b)]) = (
+            node.operator().is_commutative(),
+            &self.inputs[..],
+            node.input_ids(),
+        ) {
+            symbols.checkpoint();
+
+            if pat_a.test_impl(*input_a, graph, symbols)
+                && pat_b.test_impl(*input_b, graph, symbols)
+            {
+                return true;
+            }
+
+            symbols.revert();
+
+            pat_b.test_impl(*input_a, graph, symbols) && pat_a.test_impl(*input_b, graph, symbols)
+        } else {
+            self.inputs
+                .iter()
+                .zip(node.input_ids())
+                .all(|(input_expr, input_id)| {
+                    input_id.map(|input_id| input_expr.test_impl(input_id, graph, symbols))
+                        == Some(true)
+                })
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct SymbolPattern {
+    name: &'static str,
+}
+
+/// Specifies a pattern for a subgraph within a [`Graph`].
+///
+/// Patterns consist of matchers for operators, constants and symbols
+/// (variables). These are matched against a node in in a [`Graph`]. The node
+/// matches if it is the output of a subgraph that matches the pattern.
+///
+/// Patterns are created using functions in this module such as [`constant`],
+/// [`symbol`], [`binary_op`] and [`unary_op`]. They are combined using either
+/// the `_op` functions or using mathematical expressions. For example
+/// [`constant(1.0) + symbol("x")`] describes a graph with an `Add` operator
+/// that takes the float constant `1.0` and a free variable `x` as inputs.
+#[derive(Clone, Debug, PartialEq)]
+pub enum Pattern {
+    /// Expression which matches an operator.
+    Operator(OpPattern),
+    /// Expression which matches a constant value.
+    Constant(ConstantPattern),
+    /// Expression which matches a variable.
+    Symbol(SymbolPattern),
+}
+
+impl Pattern {
+    /// Test this pattern is a subgraph of a graph.
+    ///
+    /// The matching starts from `node_id`, which specifies the output of
+    /// the subgraph.
+    ///
+    /// If the pattern matches, this returns a [`Match`] which allows looking
+    /// up the node IDs that any symbols in the pattern were resolved to.
+    pub fn test(&self, node_id: NodeId, graph: &Graph) -> Option<Match> {
+        let mut symbols = SymbolMap::new();
+        if self.test_impl(node_id, graph, &mut symbols) {
+            Some(Match { symbols })
+        } else {
+            None
+        }
+    }
+
+    /// Match this pattern against a subgraph with output `node_id` and record
+    /// symbol-node associations in `symbols`.
+    fn test_impl(&self, node_id: NodeId, graph: &Graph, symbols: &mut SymbolMap) -> bool {
+        let Some(node) = graph.get_node(node_id) else {
+            return false;
+        };
+
+        match (self, node) {
+            // Operator patterns can match either an operator node or an
+            // operator output.
+            (Pattern::Operator(op_pat), Node::Operator(op_node)) => {
+                op_pat.matches(op_node, graph, symbols)
+            }
+            (Pattern::Operator(op_pat), Node::Value(_)) => {
+                let Some((_op_node_id, op_node)) = graph.get_source_node(node_id) else {
+                    return false;
+                };
+                op_pat.matches(op_node, graph, symbols)
+            }
+            (Pattern::Constant(const_pat), Node::Constant(const_node)) => {
+                const_pat.matches(const_node)
+            }
+            (Pattern::Symbol(sym_pat), _) => {
+                // If we have seen this symbol before, it must resolve to the
+                // same node. Otherwise it always matches.
+                if let Some(resolved_id) = symbols.find(sym_pat.name) {
+                    resolved_id == node_id
+                } else {
+                    symbols.add(sym_pat.name, node_id);
+                    true
+                }
+            }
+            _ => false,
+        }
+    }
+}
+
+impl From<f32> for Pattern {
+    fn from(val: f32) -> Pattern {
+        constant(val)
+    }
+}
+
+macro_rules! impl_binop_for_pattern {
+    ($trait:ident, $method:ident, $op_name:expr) => {
+        impl $trait<Pattern> for Pattern {
+            type Output = Pattern;
+
+            fn $method(self, rhs: Pattern) -> Pattern {
+                binary_op($op_name, self, rhs)
+            }
+        }
+
+        impl $trait<Pattern> for f32 {
+            type Output = Pattern;
+
+            fn $method(self, rhs: Pattern) -> Pattern {
+                binary_op($op_name, constant(self), rhs)
+            }
+        }
+    };
+}
+impl_binop_for_pattern!(Add, add, "Add");
+impl_binop_for_pattern!(Mul, mul, "Mul");
+impl_binop_for_pattern!(Div, div, "Div");
+impl_binop_for_pattern!(Sub, sub, "Sub");
+
+impl Neg for Pattern {
+    type Output = Pattern;
+
+    fn neg(self) -> Pattern {
+        unary_op("Neg", self)
+    }
+}
+
+/// Create a pattern that matches an operator.
+pub fn operator<I: Into<Vec<Pattern>>>(name: &'static str, inputs: I) -> Pattern {
+    Pattern::Operator(OpPattern {
+        name,
+        inputs: inputs.into(),
+    })
+}
+
+/// Create a pattern that matches a binary operator.
+pub fn binary_op<A: Into<Pattern>, B: Into<Pattern>>(
+    name: &'static str,
+    input_a: A,
+    input_b: B,
+) -> Pattern {
+    let inputs: [Pattern; 2] = [input_a.into(), input_b.into()];
+    operator(name, inputs)
+}
+
+/// Create a pattern that matches a unary operator.
+pub fn unary_op<I: Into<Pattern>>(name: &'static str, input: I) -> Pattern {
+    let inputs: [Pattern; 1] = [input.into()];
+    operator(name, inputs)
+}
+
+/// Create a pattern that matches a constant node with a given value.
+pub fn constant(value: f32) -> Pattern {
+    Pattern::Constant(ConstantPattern { value })
+}
+
+/// Create a pattern that matches any value.
+///
+/// In order for a pattern to match a node, all symbols with the same name
+/// must resolve to the same node.
+pub fn symbol(name: &'static str) -> Pattern {
+    Pattern::Symbol(SymbolPattern { name })
+}
+
+#[cfg(test)]
+mod tests {
+    use rten_tensor::Tensor;
+
+    use super::super::tests::GraphTestUtils;
+    use super::{constant, symbol, unary_op, Pattern};
+    use crate::graph::{Graph, NodeId};
+    use crate::ops::{Abs, Add, Div};
+
+    fn softsign_graph() -> (Graph, NodeId, NodeId) {
+        let mut graph = Graph::new();
+        let input_id = graph.add_value(Some("x"), None);
+
+        let (_, abs_out) = graph.add_simple_op("abs", Abs {}, &[input_id]);
+        let one = graph.add_constant(None, Tensor::from_scalar(1.0));
+        let (_, add_out) = graph.add_simple_op("add", Add {}, &[one, abs_out]);
+        let (_, div_out) = graph.add_simple_op("div", Div {}, &[input_id, add_out]);
+
+        (graph, input_id, div_out)
+    }
+
+    #[test]
+    fn test_pattern_match() {
+        struct Case {
+            graph: (Graph, NodeId, NodeId), // (graph, input_id, output_id)
+            pattern: Pattern,
+            expect_match: bool,
+        }
+
+        let x = symbol("x");
+        let cases = [
+            Case {
+                graph: softsign_graph(),
+                pattern: x.clone() / (1.0 + unary_op("Abs", x.clone())),
+                expect_match: true,
+            },
+            // Pattern with operands of a non-commutative operator ("/") swapped.
+            Case {
+                graph: softsign_graph(),
+                pattern: (1.0 + unary_op("Abs", x.clone())) / x.clone(),
+                expect_match: false,
+            },
+            // Pattern with operands of a commutative operator ("+") swapped around.
+            Case {
+                graph: softsign_graph(),
+                pattern: x.clone() / (unary_op("Abs", x.clone()) + constant(1.0)),
+                expect_match: true,
+            },
+            // Pattern with "+" operator swapped for "-".
+            Case {
+                graph: softsign_graph(),
+                pattern: x.clone() / (1.0 - unary_op("Abs", x.clone())),
+                expect_match: false,
+            },
+            // Pattern with modified constant value.
+            Case {
+                graph: softsign_graph(),
+                pattern: x.clone() / (1.1 + unary_op("Abs", x.clone())),
+                expect_match: false,
+            },
+            // Pattern with constant value which doesn't exactly match graph,
+            // but is within the allowed tolerance.
+            Case {
+                graph: softsign_graph(),
+                pattern: x.clone() / (1.00001 + unary_op("Abs", x.clone())),
+                expect_match: true,
+            },
+            // Pattern where a symbol ("x") does not resolve to the same node
+            // in all positions.
+            Case {
+                graph: softsign_graph(),
+                pattern: x.clone() / (x.clone() + unary_op("Abs", x.clone())),
+                expect_match: false,
+            },
+        ];
+
+        for (
+            i,
+            Case {
+                graph,
+                pattern,
+                expect_match,
+            },
+        ) in cases.into_iter().enumerate()
+        {
+            let (graph, input, output) = graph;
+            let pat_match = pattern.test(output, &graph);
+
+            assert_eq!(pat_match.is_some(), expect_match, "mismatch for case {}", i);
+            if let Some(pat_match) = pat_match {
+                assert_eq!(pat_match.resolved_symbol("x"), Some(input));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Writing complex fusions was difficult using the existing APIs. Add tools to make writing and matching subgraph patterns easier. The existing SiLU fusion has been rewritten using them as a proof of concept.

With these new APIs, matching the subgraph pattern for SiLU looks like:

```rs
use pattern_matcher::{symbol, unary_op};
let x = symbol("x");
let silu_pattern = x.clone() * unary_op("Sigmoid", x.clone());
if let Some(silu_match) = silu_pattern.test(operator_node_id, graph) {
  // Handle match
}
```

**TODO:**

- [x] Make pattern matching agnostic to the order of inputs for commutative ops (Add, Mul)