### PR TITLE
Simplify adding operators in graph tests

### DIFF
--- a/src/optimize/pattern_matcher.rs
+++ b/src/optimize/pattern_matcher.rs
@@ -343,7 +343,6 @@ pub fn const_symbol(name: &'static str) -> Pattern {
 mod tests {
     use rten_tensor::Tensor;
 
-    use super::super::tests::GraphTestUtils;
     use super::{const_symbol, symbol, unary_op, unary_op_key, Pattern};
     use crate::graph::{Graph, Node, NodeId};
     use crate::ops::{Abs, Add, Div};


### PR DESCRIPTION
Move the `add_simple_op` trait method from `GraphTestUtils` in optimize.rs into the `Graph` struct and use it to simplfy existing tests in graph.rs.