### PR TITLE
Add chatbot example using Qwen2

### DIFF
--- a/rten-examples/Cargo.toml
+++ b/rten-examples/Cargo.toml
@@ -73,6 +73,10 @@ path = "src/gpt2.rs"
 name = "jina_similarity"
 path = "src/jina_similarity.rs"
 
+[[bin]]
+name = "qwen2_chat"
+path = "src/qwen2_chat.rs"
+
 # Audio
 [[bin]]
 name = "piper"

--- a/rten-examples/README.md
+++ b/rten-examples/README.md
@@ -66,6 +66,7 @@ on the [SQuAD](https://paperswithcode.com/dataset/squad) dataset
 - **gpt2** - Text generation using the [GPT-2](https://openai.com/index/better-language-models/)
 language model.
 - **jina_similarity** - Sentence similarity using vector embeddings of sentences
+- **qwen2_chat** - Chatbot using [Qwen2](https://github.com/QwenLM/Qwen2)
 
 ### Audio
 

--- a/rten-examples/src/distilvit.rs
+++ b/rten-examples/src/distilvit.rs
@@ -107,7 +107,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let generator = Generator::from_model(&decoder_model)?
         .with_prompt(&prompt)
         .with_constant_input(encoder_hidden_states_id, encoded_image.view().into())
-        .stop_on_token(eos_token)
+        .stop_on_tokens([eos_token])
         .take(max_tokens)
         .decode(&tokenizer);
 

--- a/rten-examples/src/gpt2.rs
+++ b/rten-examples/src/gpt2.rs
@@ -113,9 +113,10 @@ fn main() -> Result<(), Box<dyn Error>> {
     print!("{}", prompt);
 
     let mut metrics = Metrics::new();
+    let temperature = 1.0;
     let generator = Generator::from_model(&model)?
         .with_prompt(&token_ids)
-        .with_sampler(TopKSampler::new(args.top_k))
+        .with_sampler(TopKSampler::new(args.top_k, temperature))
         .take(args.output_length)
         .profile(&mut metrics)
         .decode(&tokenizer);

--- a/rten-examples/src/qwen2_chat.rs
+++ b/rten-examples/src/qwen2_chat.rs
@@ -1,0 +1,179 @@
+use std::collections::VecDeque;
+use std::error::Error;
+use std::fs;
+use std::io;
+use std::io::prelude::*;
+
+use rten::Model;
+use rten_generate::sampler::TopKSampler;
+use rten_generate::{Generator, GeneratorUtils};
+use rten_text::tokenizers::{Tokenizer, TokenizerError};
+
+struct Args {
+    model: String,
+    tokenizer_config: String,
+}
+
+fn parse_args() -> Result<Args, lexopt::Error> {
+    use lexopt::prelude::*;
+
+    let mut values = VecDeque::new();
+    let mut parser = lexopt::Parser::from_env();
+
+    while let Some(arg) = parser.next()? {
+        match arg {
+            Value(val) => values.push_back(val.string()?),
+            Long("help") => {
+                println!(
+                    "Chat with a large language model.
+
+Usage: {bin_name} [options] <model> <tokenizer>
+
+Args:
+
+  <model>       - Input model
+  <tokenizer>   - `tokenizer.json` file
+",
+                    bin_name = parser.bin_name().unwrap_or("chat")
+                );
+                std::process::exit(0);
+            }
+            _ => return Err(arg.unexpected()),
+        }
+    }
+
+    let model = values.pop_front().ok_or("missing `model` arg")?;
+    let tokenizer_config = values.pop_front().ok_or("missing `tokenizer` arg")?;
+
+    let args = Args {
+        model,
+        tokenizer_config,
+    };
+
+    Ok(args)
+}
+
+enum MessageChunk<'a> {
+    Text(&'a str),
+    Token(u32),
+}
+
+/// Encode a message consisting of a mix of text and special token IDs into a
+/// sequence of token IDs.
+///
+/// Special tokens need to be passed as IDs because `Tokenizer::encode` will not
+/// generate them (eg. it would treat a string such as "<|endoftext|>" as
+/// ordinary text).
+fn encode_message(
+    tokenizer: &Tokenizer,
+    chunks: &[MessageChunk],
+) -> Result<Vec<u32>, TokenizerError> {
+    let mut token_ids = Vec::new();
+    for chunk in chunks {
+        match chunk {
+            MessageChunk::Token(tok_id) => token_ids.push(*tok_id),
+            MessageChunk::Text(text) => {
+                let encoded = tokenizer.encode((*text).into(), Default::default())?;
+                token_ids.extend(encoded.token_ids().iter().map(|id| *id as u32));
+            }
+        }
+    }
+    Ok(token_ids)
+}
+
+/// Chatbot using Qwen 2 [2].
+///
+/// To obtain the model from Hugging Face, use Optimum [1], then convert it.
+/// The model is available in various sizes. The larger models are smarter
+/// but slower. To convert the smallest 0.5B model, use:
+///
+/// ```sh
+/// optimum-cli export onnx --model Qwen/Qwen2-0.5B-Instruct qwen2-0.5b
+/// rten-convert qwen2-0.5b/model.onnx
+/// ```
+///
+/// Run the converted model with a prompt:
+///
+/// ```sh
+/// cargo run --release --bin qwen2 qwen2-0.5b/model.rten qwen2-0.5b/tokenizer.json
+/// ```
+///
+/// For better output, but generated more slowly, use the "1.5b" model.
+///
+/// [1] https://huggingface.co/docs/optimum/index
+/// [2] https://github.com/QwenLM/Qwen2
+fn main() -> Result<(), Box<dyn Error>> {
+    let args = parse_args()?;
+
+    // `load_mmap` reduces model load/free time and process memory usage, at the
+    // cost of making the first execution slower.
+    let model = unsafe { Model::load_mmap(args.model) }?;
+
+    let tokenizer_config = fs::read_to_string(&args.tokenizer_config)?;
+    let tokenizer = Tokenizer::from_json(&tokenizer_config)?;
+
+    let im_start_token = tokenizer.encoder().get_token_id("<|im_start|>")? as u32;
+    let im_end_token = tokenizer.encoder().get_token_id("<|im_end|>")? as u32;
+    let end_of_text_token = tokenizer.encoder().get_token_id("<|endoftext|>")? as u32;
+
+    // From `chat_template` in tokenizer_config.json.
+    let prompt_tokens = encode_message(
+        &tokenizer,
+        &[
+            MessageChunk::Token(im_start_token),
+            MessageChunk::Text("system\nYou are a helpful assistant."),
+            MessageChunk::Token(im_end_token),
+        ],
+    )?;
+
+    // From `generation_config.json`
+    let top_k = 20;
+    let temperature = 0.7;
+
+    let mut generator = Generator::from_model(&model)?
+        .with_prompt(&prompt_tokens)
+        .with_sampler(TopKSampler::new(top_k, temperature));
+
+    loop {
+        print!("> ");
+        let _ = std::io::stdout().flush();
+
+        let mut user_input = String::new();
+        let n_read = io::stdin().read_line(&mut user_input)?;
+        if n_read == 0 {
+            // EOF
+            break;
+        }
+
+        // From `chat_template` in tokenizer_config.json.
+        let token_ids = encode_message(
+            &tokenizer,
+            &[
+                MessageChunk::Token(im_start_token),
+                MessageChunk::Text("user\n"),
+                MessageChunk::Text(&user_input),
+                MessageChunk::Token(im_end_token),
+                MessageChunk::Text("\n"),
+                MessageChunk::Token(im_start_token),
+                MessageChunk::Text("assistant\n"),
+            ],
+        )?;
+
+        generator.append_prompt(&token_ids);
+
+        let decoder = generator
+            .by_ref()
+            // See `eos_token_id` in `generation_config.json`
+            .stop_on_tokens([im_end_token, end_of_text_token])
+            .decode(&tokenizer);
+        for token in decoder {
+            let token = token?;
+            print!("{}", token);
+            let _ = std::io::stdout().flush();
+        }
+
+        println!();
+    }
+
+    Ok(())
+}

--- a/rten-generate/src/generator.rs
+++ b/rten-generate/src/generator.rs
@@ -369,7 +369,7 @@ impl<'a> Generator<'a> {
         if let Some(attention_mask_input) = attention_mask_input {
             generator = generator
                 .with_varying_input(attention_mask_input, &|batch_size, positions| {
-                    NdTensor::full([batch_size, positions.len()], 1i32).into()
+                    NdTensor::full([batch_size, positions.end], 1i32).into()
                 });
         }
 
@@ -884,7 +884,7 @@ mod tests {
                 assert_eq!(step_inputs.size(1), 1);
                 assert_eq!(step_inputs[[0, 0]] as u32, expected_token_ids[step - 1]);
 
-                assert_eq!(step_attn_mask.size(1), 1);
+                assert_eq!(step_attn_mask.size(1), prompt.len() + step);
                 assert_eq!(step_attn_mask[[0, 0]], 1);
 
                 assert_eq!(step_pos_ids.size(1), 1);

--- a/rten-text/src/tokenizers.rs
+++ b/rten-text/src/tokenizers.rs
@@ -294,6 +294,12 @@ impl Tokenizer {
                 lowercase: bert_norm.lowercase,
                 strip_accents: bert_norm.strip_accents.unwrap_or(bert_norm.lowercase),
             }),
+
+            // Dummy implementation of NFC normalization.
+            json::Normalizer::Nfc => Normalizer::new(NormalizerOptions {
+                lowercase: false,
+                strip_accents: false,
+            }),
         });
 
         match json.model {

--- a/rten-text/src/tokenizers/json.rs
+++ b/rten-text/src/tokenizers/json.rs
@@ -22,6 +22,8 @@ pub(crate) struct BertNormalizer {
 pub(crate) enum Normalizer {
     #[serde(rename = "BertNormalizer")]
     Bert(BertNormalizer),
+    #[serde(rename = "NFC")]
+    Nfc,
 }
 
 #[derive(Deserialize)]

--- a/src/model.rs
+++ b/src/model.rs
@@ -227,12 +227,17 @@ impl Model {
     ///
     /// This method requires the `mmap` crate feature to be enabled.
     ///
-    /// For large models (hundreds of MB), this can be faster and use less
-    /// memory than reading the entire model into memory. The first _run_ of a
-    /// memory-mapped model will be slower than if the file is read into memory
-    /// first and then executed. Depending on the size of the model, the overall
-    /// time taken for load + first run may be less or about the same.
-    /// Subsequent model executions should take about the same time.
+    /// Loading a model via memory-mapping makes the initial load of the model
+    /// faster for large models (hundreds of MB) and also allows sharing the
+    /// memory with other processes. If a process uses `load_file`, its private
+    /// memory usage will be the size of the model plus its working space. If a
+    /// process uses `load_mmap`, its private memory usage will only be that
+    /// needed for working space.
+    ///
+    /// The first _run_ of a memory-mapped model will be slower than if the file
+    /// is read into memory first and then executed. Depending on the size of
+    /// the model, the overall time taken for load + first run may be less or
+    /// about the same.  Subsequent model executions should the same time.
     ///
     /// # Safety
     ///


### PR DESCRIPTION
Add a chatbot demo. This uses the Qwen2 model since it provides 0.5b and 1.5b sizes that are best-in-class, and the tokenization is conveniently a derivative of the GPT-2 tokenization which rten-text supports. Larger models would produce better results, but since RTen only supports fp32 precision at present, such models become slow due to the memory bandwidth requirements. 1.5b is about the largest size that produces "usable" speed on my Intel i5.

In the process it was necessary to add some capabilities to rten-generate and rten-text to better support chat-like applications:

- Support adding user input to the model input after the initial generation, via `Generator::append_prompt`
- Fix generation of the `attention_mask` input. It is supposed to have the length of the input sequence not just the new input  IDs. Previously it was incorrect after the initial step, but the code worked because on subsequent steps it had size 1 and that gets broadcast to whatever size is required.
- Support multiple stop tokens. Qwen2 uses `<|imend|>` and `<|endoftext|>`
- Support temperature in top-K sampling
- Add fake support for NFC normalization in text encoding

**TODO**
- [x] Tests for `append_prompt`
- [x] ~~Replace dummy NFC normalization with proper implementation~~ (Deferred for later)