### PR TITLE
Avoid calling `std::time::Instant::now` on wasm32-unknown-unknown

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,8 @@ test:
 wasm:
 	RUSTFLAGS="-C target-feature=+simd128" cargo build --features=wasm_api --release --target wasm32-unknown-unknown
 	wasm-bindgen target/wasm32-unknown-unknown/release/rten.wasm --out-dir dist/ --target web --weak-refs
+	# This makes the binary smaller but also removes all symbols. Comment this
+	# out to get a release WASM build with symbols.
 	tools/optimize-wasm.sh dist/rten_bg.wasm
 
 .PHONY: wasm-nosimd

--- a/js-examples/image-classification/image-classifier.js
+++ b/js-examples/image-classification/image-classifier.js
@@ -75,7 +75,7 @@ export class ImageClassifier {
     try {
       this.model = new Model(modelData);
     } catch (err) {
-      throw new Error(`Failed to load model: ${err}`);
+      throw new Error('Failed to load model', { cause: err });
     }
   }
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -2,7 +2,7 @@ use std::error::Error;
 use std::fmt;
 use std::iter::zip;
 use std::sync::{Arc, Mutex};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use rten_tensor::prelude::*;
 use rten_tensor::{DynLayout, Tensor, TensorView};
@@ -19,7 +19,7 @@ use crate::env::env_flag;
 use crate::ops::{Input, InputList, InputOrOutput, OpError, Operator, Output, OutputList};
 use crate::tensor_pool::TensorPool;
 use crate::threading;
-use crate::timing::{InputShape, RunTiming, TimingRecord, TimingSort};
+use crate::timing::{InputShape, Instant, RunTiming, TimingRecord, TimingSort};
 
 /// Represents the size of a dimension of a runtime-provided value, such as
 /// an operator input, output or intermediate value.
@@ -801,7 +801,7 @@ impl Graph {
             // op's result, so logs will contain details of the failed operation
             // in the event of an error.
             if opts.verbose {
-                let op_duration = op_start.elapsed();
+                let op_duration = Instant::now() - op_start;
                 self.print_op_timing(step, op_node, &op_result, op_duration, &input_shapes);
             }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -246,6 +246,11 @@ impl Model {
     /// `Model`. Callers will need to decide whether this is an acceptable risk
     /// for their context.
     ///
+    /// # Platform support
+    ///
+    /// This function is not available on WebAssembly. Use [`load`](Self::load)
+    /// or [`load_file`](Self::load_file) instead.
+    ///
     /// ```no_run
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// use rten::Model;
@@ -255,6 +260,7 @@ impl Model {
     /// # }
     /// ```
     #[cfg(feature = "mmap")]
+    #[cfg(not(target_arch = "wasm32"))]
     pub unsafe fn load_mmap<P: AsRef<Path>>(path: P) -> Result<Model, ModelLoadError> {
         ModelOptions::with_all_ops().load_mmap(path)
     }
@@ -942,6 +948,7 @@ mod tests {
     }
 
     #[cfg(feature = "mmap")]
+    #[cfg(not(target_arch = "wasm32"))]
     #[test]
     fn test_load_mmap() {
         let buffer = generate_model_buffer(ModelFormat::V2);


### PR DESCRIPTION
- `std::time::Instant::now` panics on wasm32-unknown-unknown. Replace calls with a wrapper which is currently a no-op, but can be modified to use `performance.now()` in future.
- Fix test execution under wasm32 by skipping the `Model::load_mmap` test
- Add a note about how to modify the wasm build to get a useful stacktrace if a crash happens

See https://github.com/robertknight/ocrs/issues/93.
