### PR TITLE
Support creating scalar tensors using `Tensor::from`

### DIFF
--- a/rten-tensor/src/tensor.rs
+++ b/rten-tensor/src/tensor.rs
@@ -2111,6 +2111,16 @@ impl_scalar!(f64);
 // impl for a nested array literal, as it prevents `T` from matching an array
 // type.
 
+impl<T: Clone + Scalar, L: MutLayout> From<T> for TensorBase<Vec<T>, L>
+where
+    [usize; 0]: AsIndex<L>,
+{
+    /// Construct a scalar tensor from a scalar value.
+    fn from(value: T) -> Self {
+        Self::from_scalar(value)
+    }
+}
+
 impl<T: Clone + Scalar, L: MutLayout, const D0: usize> From<[T; D0]> for TensorBase<Vec<T>, L>
 where
     [usize; 1]: AsIndex<L>,
@@ -2521,6 +2531,11 @@ mod tests {
 
     #[test]
     fn test_from_nested_array() {
+        // Scalar
+        let x = NdTensor::from(5);
+        assert_eq!(x.shape(), []);
+        assert_eq!(x.data(), Some([5].as_slice()));
+
         // 1D
         let x = NdTensor::from([1, 2, 3]);
         assert_eq!(x.shape(), [3]);

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1477,7 +1477,7 @@ mod tests {
     #[test]
     fn test_typed_constant() {
         let mut g = Graph::new();
-        let scalar_id = g.add_constant(None, Tensor::from_scalar(42.));
+        let scalar_id = g.add_constant(None, Tensor::from(42.));
         let vec_id = g.add_constant(None, Tensor::from([1, 2, 3]));
 
         let scalar_node = match g.get_node(scalar_id) {
@@ -1863,7 +1863,7 @@ mod tests {
 
         fn run(&self, _pool: &TensorPool, _inputs: InputList) -> Result<OutputList, OpError> {
             let count = self.count.fetch_add(1, Ordering::SeqCst);
-            Ok([Tensor::from_scalar(count).into()].into())
+            Ok([Tensor::from(count).into()].into())
         }
     }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -1241,9 +1241,9 @@ mod tests {
         let nms_boxes = builder.add_constant(Tensor::<f32>::zeros(&[1, nms_n_boxes, 4]).view());
         let nms_scores =
             builder.add_constant(Tensor::<f32>::zeros(&[1, nms_n_classes, nms_n_boxes]).view());
-        let nms_max_outputs_per_class = builder.add_constant(Tensor::from_scalar(10).view());
-        let nms_iou_threshold = builder.add_constant(Tensor::from_scalar(0.45).view());
-        let nms_score_threshold = builder.add_constant(Tensor::from_scalar(0.2).view());
+        let nms_max_outputs_per_class = builder.add_constant(Tensor::from(10).view());
+        let nms_iou_threshold = builder.add_constant(Tensor::from(0.45).view());
+        let nms_score_threshold = builder.add_constant(Tensor::from(0.2).view());
 
         add_operator!(NonMaxSuppression, [nms_boxes, nms_scores, nms_max_outputs_per_class, nms_iou_threshold, nms_score_threshold], {
             box_order: BoxOrder::CenterWidthHeight,
@@ -1253,7 +1253,7 @@ mod tests {
         add_operator!(Not, [input_bool]);
 
         let onehot_indices = builder.add_constant(Tensor::from([0, 1, 2]).view());
-        let onehot_depth = builder.add_constant(Tensor::from_scalar(5).view());
+        let onehot_depth = builder.add_constant(Tensor::from(5).view());
         let onehot_values = builder.add_constant(Tensor::from([1., 0.]).view());
         add_operator!(OneHot, [onehot_indices, onehot_depth, onehot_values], {
             axis: -1,
@@ -1383,7 +1383,7 @@ mod tests {
         let tile_repeats = builder.add_constant(Tensor::from([1, 2, 3, 4]).view());
         add_operator!(Tile, [input_node, tile_repeats]);
 
-        let topk_k = builder.add_constant(Tensor::from_scalar(3).view());
+        let topk_k = builder.add_constant(Tensor::from(3).view());
         let topk_out_values = builder.add_value("TopK_out_values", None);
         let topk_out_indices = builder.add_value("TopK_out_indices", None);
         builder.add_operator(
@@ -1478,9 +1478,9 @@ mod tests {
         }
 
         // Range op
-        let start = Tensor::from_scalar(0.);
-        let limit = Tensor::from_scalar(5.);
-        let delta = Tensor::from_scalar(1.);
+        let start = Tensor::from(0.);
+        let limit = Tensor::from(5.);
+        let delta = Tensor::from(1.);
         let result = model
             .run(
                 vec![
@@ -1495,7 +1495,7 @@ mod tests {
         assert_eq!(result.len(), 1);
 
         // Where op
-        let cond = Tensor::from_scalar(1);
+        let cond = Tensor::from(1);
         let x = tensor!([1, 2, 3]);
         let y = tensor!([4, 5, 6]);
         let result = model

--- a/src/ops/binary_elementwise.rs
+++ b/src/ops/binary_elementwise.rs
@@ -1577,14 +1577,14 @@ mod tests {
 
         // Float tensor broadcasting `x` and `y`
         let cond = tensor!([1, 1, 0, 0]);
-        let x = Tensor::from_scalar(1.);
-        let y = Tensor::from_scalar(2.);
+        let x = Tensor::from(1.);
+        let y = Tensor::from(2.);
         let result = where_op(&pool, cond.view(), x.view(), y.view()).unwrap();
         let expected = tensor!([1., 1., 2., 2.]);
         assert_eq!(&result, &expected);
 
         // Float tensor broadcasting `cond`
-        let cond = Tensor::from_scalar(1);
+        let cond = Tensor::from(1);
         let x = tensor!([1., 2.]);
         let y = tensor!([3., 4.]);
         let result = where_op(&pool, cond.view(), x.view(), y.view()).unwrap();
@@ -1593,8 +1593,8 @@ mod tests {
 
         // Int tensor broadcasting `x` and `y`
         let cond = tensor!([1, 1, 0, 0]);
-        let x = Tensor::from_scalar(3);
-        let y = Tensor::from_scalar(4);
+        let x = Tensor::from(3);
+        let y = Tensor::from(4);
         let result = where_op(&pool, cond.view(), x.view(), y.view()).unwrap();
         let expected = tensor!([3, 3, 4, 4]);
         assert_eq!(&result, &expected);

--- a/src/ops/concat.rs
+++ b/src/ops/concat.rs
@@ -378,7 +378,7 @@ mod tests {
         assert!(result.is_err());
 
         // Dimension count mismatch.
-        let result = concat_in_place(&pool, dest.clone(), &[Tensor::from_scalar(1).view()], 1);
+        let result = concat_in_place(&pool, dest.clone(), &[Tensor::from(1).view()], 1);
         assert!(result.is_err());
 
         Ok(())

--- a/src/ops/gather.rs
+++ b/src/ops/gather.rs
@@ -647,11 +647,11 @@ mod tests {
             // Scalar indices, with 1D and ND inputs
             Case {
                 input: Tensor::from([1, 2, 3]),
-                indices: Tensor::from_scalar(4),
+                indices: Tensor::from(4),
             },
             Case {
                 input: Tensor::from([[1, 2, 3]]),
-                indices: Tensor::from_scalar(2),
+                indices: Tensor::from(2),
             },
         ];
 

--- a/src/ops/pad.rs
+++ b/src/ops/pad.rs
@@ -194,7 +194,7 @@ mod tests {
 
         // Wrong constant value type.
         let invalid_pads = from_slice(&[1, 1, 1, -1]);
-        let const_int = Tensor::from_scalar(1);
+        let const_int = Tensor::from(1);
         let result = op.run(&pool, (&input, &invalid_pads, &const_int).into());
         assert_eq!(result.err(), Some(OpError::IncorrectInputType));
 

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -670,9 +670,9 @@ mod tests {
     fn test_fuse_gelu() {
         let mut graph = Graph::new();
 
-        let sqrt_2 = graph.add_constant(None, Tensor::from_scalar((2.0f32).sqrt()));
-        let one = graph.add_constant(None, Tensor::from_scalar(1.0));
-        let half = graph.add_constant(None, Tensor::from_scalar(0.5));
+        let sqrt_2 = graph.add_constant(None, Tensor::from((2.0f32).sqrt()));
+        let one = graph.add_constant(None, Tensor::from(1.0));
+        let half = graph.add_constant(None, Tensor::from(0.5));
 
         let input = graph.add_value(None, None);
         let (_, div_out) = graph.add_simple_op("div", Div {}, &[input, sqrt_2]);
@@ -703,7 +703,7 @@ mod tests {
         let (_, sub_out) = graph.add_simple_op("sub", Sub {}, &[input, mean_out]);
 
         // Normalize variance
-        let two = graph.add_constant(None, Tensor::from_scalar(2.));
+        let two = graph.add_constant(None, Tensor::from(2.));
         let (_, pow_out) = graph.add_simple_op("pow", Pow {}, &[sub_out, two]);
         let (_, var_mean_out) = graph.add_simple_op(
             "var_mean",
@@ -713,7 +713,7 @@ mod tests {
             },
             &[pow_out],
         );
-        let epsilon = graph.add_constant(None, Tensor::from_scalar(1e-6));
+        let epsilon = graph.add_constant(None, Tensor::from(1e-6));
         let (_, add_eps_out) = graph.add_simple_op("add_eps", Add {}, &[epsilon, var_mean_out]);
         let (_, sqrt_out) = graph.add_simple_op("sqrt", Sqrt {}, &[add_eps_out]);
         let (_, div_out) = graph.add_simple_op("div", Div {}, &[sub_out, sqrt_out]);

--- a/src/optimize/pattern_matcher.rs
+++ b/src/optimize/pattern_matcher.rs
@@ -353,7 +353,7 @@ mod tests {
         let input_id = graph.add_value(Some("x"), None);
 
         let (_, abs_out) = graph.add_simple_op("abs", Abs {}, &[input_id]);
-        let one = graph.add_constant(None, Tensor::from_scalar(1.0));
+        let one = graph.add_constant(None, Tensor::from(1.0));
         let (_, add_out) = graph.add_simple_op("add", Add {}, &[one, abs_out]);
         let (_, div_out) = graph.add_simple_op("div", Div {}, &[input_id, add_out]);
 


### PR DESCRIPTION
`Tensor::from` previously supported creating tensors from 1-3D nested arrays. Extend this to scalar values..