### PR TITLE
Deprecate `tensor!` and `ndtensor!` macros in favor of `{Tensor, NdTensor}::from`

### DIFF
--- a/rten-examples/src/piper.rs
+++ b/rten-examples/src/piper.rs
@@ -149,7 +149,7 @@ fn phonemes_to_ids(phonemes: &str, config: &ModelConfig) -> NdTensor<i32, 1> {
         }
     }));
     ids.extend(end_ids);
-    NdTensor::from_vec(ids)
+    ids.into()
 }
 
 /// Text to speech demo using models from Piper [1].

--- a/rten-examples/src/wav2vec2.rs
+++ b/rten-examples/src/wav2vec2.rs
@@ -113,7 +113,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let model = Model::load_file(args.model)?;
     let samples = read_wav_file(&args.wav_file)?;
 
-    let mut sample_batch = Tensor::from_vec(samples);
+    let mut sample_batch = Tensor::from(samples);
     sample_batch.insert_axis(0);
 
     let result: NdTensor<f32, 3> = model

--- a/rten-tensor/src/lib.rs
+++ b/rten-tensor/src/lib.rs
@@ -32,12 +32,10 @@
 //! use rten_tensor::prelude::*;
 //! use rten_tensor::NdTensor;
 //!
-//! let tensor = NdTensor::from_data([2, 2], vec![1, 2, 3, 4]);
+//! let tensor = NdTensor::from([[1, 2], [3, 4]]);
 //!
-//! // Logs 1, 3, 2, 4.
-//! for x in tensor.transposed().iter() {
-//!   println!("{}", x);
-//! }
+//! let transposed_elems: Vec<_> = tensor.transposed().iter().copied().collect();
+//! assert_eq!(transposed_elems, [1, 3, 2, 4]);
 //! ```
 
 mod copy;

--- a/rten-tensor/src/macros.rs
+++ b/rten-tensor/src/macros.rs
@@ -21,6 +21,7 @@
 /// Tensor::from([1, 2, 3, 4]).into_shape([1, 2, 2].as_slice());
 /// ```
 #[macro_export]
+#[deprecated(note = "Use `Tensor::from` or `Tensor::from_data` instead")]
 macro_rules! tensor {
     [[$($elem:expr),*]] => {
         {
@@ -80,6 +81,7 @@ macro_rules! tensor {
 /// NdTensor::from([1, 2, 3, 4]).into_shape([1, 2, 2]);
 /// ```
 #[macro_export]
+#[deprecated(note = "Use `NdTensor::from` or `NdTensor::from_data` instead")]
 macro_rules! ndtensor {
     [[$($elem:expr),*]] => {
         {
@@ -121,6 +123,7 @@ macro_rules! ndtensor {
 }
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod tests {
     use crate::{ndtensor, tensor, NdTensor, Tensor};
 

--- a/rten-tensor/src/macros.rs
+++ b/rten-tensor/src/macros.rs
@@ -18,6 +18,7 @@
 /// // Create a 3D tensor with shape [1, 2, 2] and elements [1, 2, 3, 4].
 /// tensor!((1, 2, 2); [1, 2, 3, 4]);
 /// Tensor::from([[[1, 2], [3, 4]]]);
+/// Tensor::from([1, 2, 3, 4]).into_shape([1, 2, 2].as_slice());
 /// ```
 #[macro_export]
 macro_rules! tensor {
@@ -76,6 +77,7 @@ macro_rules! tensor {
 /// // Create a 3D tensor with shape [1, 2, 2] and elements [1, 2, 3, 4].
 /// ndtensor!((1, 2, 2); [1, 2, 3, 4]);
 /// NdTensor::from([[[1, 2], [3, 4]]]);
+/// NdTensor::from([1, 2, 3, 4]).into_shape([1, 2, 2]);
 /// ```
 #[macro_export]
 macro_rules! ndtensor {

--- a/rten-tensor/src/macros.rs
+++ b/rten-tensor/src/macros.rs
@@ -1,16 +1,23 @@
-/// Construct a `Tensor`.
+/// Construct a [`Tensor`](crate::Tensor) from literal elements.
+///
+/// This macro has been kept for compatibility with existing code, but using
+/// `Tensor::from` is preferred. `Tensor::from` accepts scalar values and nested
+/// arrays.
 ///
 /// ```
-/// use rten_tensor::tensor;
+/// use rten_tensor::{Tensor, tensor};
 ///
 /// // Create a scalar (0D tensor)
 /// tensor!(2.);
+/// Tensor::from(2.);
 ///
 /// // Create a vector (1D tensor)
 /// tensor!([1, 2, 3]);
+/// Tensor::from([1, 2, 3]);
 ///
 /// // Create a 3D tensor with shape [1, 2, 2] and elements [1, 2, 3, 4].
 /// tensor!((1, 2, 2); [1, 2, 3, 4]);
+/// Tensor::from([[[1, 2], [3, 4]]]);
 /// ```
 #[macro_export]
 macro_rules! tensor {
@@ -49,19 +56,26 @@ macro_rules! tensor {
     };
 }
 
-/// Construct an `NdTensor`.
+/// Construct an [`NdTensor`](crate::NdTensor) from literal elements.
+///
+/// This macro has been kept for compatibility with existing code, but using
+/// `NdTensor::from` is preferred. `NdTensor::from` accepts scalar values and
+/// nested arrays.
 ///
 /// ```
-/// use rten_tensor::ndtensor;
+/// use rten_tensor::{NdTensor, ndtensor};
 ///
 /// // Create a scalar (0D tensor)
 /// ndtensor!(2.);
+/// NdTensor::from(2.);
 ///
 /// // Create a vector (1D tensor)
 /// ndtensor!([1, 2, 3]);
+/// NdTensor::from([1, 2, 3]);
 ///
 /// // Create a 3D tensor with shape [1, 2, 2] and elements [1, 2, 3, 4].
 /// ndtensor!((1, 2, 2); [1, 2, 3, 4]);
+/// NdTensor::from([[[1, 2], [3, 4]]]);
 /// ```
 #[macro_export]
 macro_rules! ndtensor {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1775,7 +1775,7 @@ mod tests {
             &[left_split_out, right_split_out].map(Some),
         );
 
-        let input = Tensor::from_vec(vec![1.0, 2.0, 3.0, 4.0, 5.0]);
+        let input = Tensor::from([1.0, 2.0, 3.0, 4.0, 5.0]);
         let mut results = g
             .run(
                 vec![(input_id, input.into())],

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1145,7 +1145,7 @@ mod tests {
 
     use rten_tensor::prelude::*;
     use rten_tensor::test_util::{expect_equal, expect_equal_with_tolerance};
-    use rten_tensor::{tensor, Tensor, TensorView};
+    use rten_tensor::{Tensor, TensorView};
 
     use smallvec::smallvec;
 
@@ -1407,12 +1407,12 @@ mod tests {
         let (_, op_a_out) = g.add_simple_op("op_a", AddOne {}, &[input_id]);
         let (_, op_b_out) = g.add_simple_op("op_b", AddOne {}, &[op_a_out]);
 
-        let input = tensor!(0.);
+        let input = Tensor::from(0.);
         let results = g
             .run(vec![(input_id, input.into())], &[op_a_out, op_b_out], None)
             .unwrap();
-        assert_eq!(results[0].as_float_ref().unwrap(), &tensor!(1.));
-        assert_eq!(results[1].as_float_ref().unwrap(), &tensor!(2.));
+        assert_eq!(results[0].as_float_ref().unwrap(), &Tensor::from(1.));
+        assert_eq!(results[1].as_float_ref().unwrap(), &Tensor::from(2.));
     }
 
     #[test]
@@ -1518,7 +1518,7 @@ mod tests {
     fn test_duplicate_inputs() {
         let mut g = Graph::new();
         let input_id = g.add_value(Some("input"), None);
-        let input = tensor!([1.]);
+        let input = Tensor::from([1.]);
         let result = g.run(
             vec![
                 (input_id, input.view().into()),
@@ -1540,7 +1540,7 @@ mod tests {
         let input_id = g.add_value(Some("input"), None);
         let (_, op_a_out) = g.add_simple_op("op_a", AddOne {}, &[input_id]);
 
-        let input = tensor!([1.]);
+        let input = Tensor::from([1.]);
 
         let result = g.run(vec![(input_id, input.into())], &[op_a_out, op_a_out], None);
 
@@ -1692,7 +1692,7 @@ mod tests {
             &[bias_id, op1_out],
         );
         let input = Tensor::<f32>::zeros(&[2, 2]);
-        let bias = tensor!(1.5);
+        let bias = Tensor::from(1.5);
 
         let results = g
             .run(
@@ -1803,9 +1803,9 @@ mod tests {
         // Where `Cn` are constants, `Vn` are input values and `OpN` are
         // operators.
         let mut g = Graph::new();
-        let const_0 = g.add_constant(Some("c0"), tensor!(3.));
+        let const_0 = g.add_constant(Some("c0"), Tensor::from(3.));
         let val_0 = g.add_value(Some("i0"), None);
-        let const_1 = g.add_constant(Some("c1"), tensor!(4.));
+        let const_1 = g.add_constant(Some("c1"), Tensor::from(4.));
         let val_1 = g.add_value(Some("i1"), None);
 
         let (_, op_0_out) = g.add_simple_op("Add_0", Add {}, &[const_0, val_0]);
@@ -1820,19 +1820,19 @@ mod tests {
 
         // Run graph with just the `V0` input. This will compute the result of
         // `Op0` but not other nodes which depend on `V1`.
-        let input = tensor!(2.);
+        let input = Tensor::from(2.);
         let partial_outs = g.partial_run(vec![(val_0, input.view().into())], &[op_2_out], None)?;
         assert_eq!(partial_outs.len(), 1);
         assert_eq!(partial_outs[0].0, op_0_out);
-        assert_eq!(partial_outs[0].1, Output::FloatTensor(tensor!(5.)));
+        assert_eq!(partial_outs[0].1, Output::FloatTensor(Tensor::from(5.)));
 
         // Run graph with just the `V1` input. This will compute the result of
         // `Op1` but not other nodes which depend on `V0`.
-        let input = tensor!(2.);
+        let input = Tensor::from(2.);
         let partial_outs = g.partial_run(vec![(val_1, input.view().into())], &[op_2_out], None)?;
         assert_eq!(partial_outs.len(), 1);
         assert_eq!(partial_outs[0].0, op_1_out);
-        assert_eq!(partial_outs[0].1, Output::FloatTensor(tensor!(6.)));
+        assert_eq!(partial_outs[0].1, Output::FloatTensor(Tensor::from(6.)));
 
         // Run graph with all inputs. This should behave like `Graph::run`.
         let partial_outs = g.partial_run(
@@ -1842,7 +1842,7 @@ mod tests {
         )?;
         assert_eq!(partial_outs.len(), 1);
         assert_eq!(partial_outs[0].0, op_2_out);
-        assert_eq!(partial_outs[0].1, Output::FloatTensor(tensor!(11.)));
+        assert_eq!(partial_outs[0].1, Output::FloatTensor(Tensor::from(11.)));
 
         Ok(())
     }
@@ -1870,7 +1870,7 @@ mod tests {
     #[test]
     fn test_partial_run_non_deterministic_ops() -> Result<(), Box<dyn Error>> {
         let mut g = Graph::new();
-        let const_val = g.add_constant(Some("c0"), tensor!(3));
+        let const_val = g.add_constant(Some("c0"), Tensor::from(3));
 
         // Add deterministic op with constant inputs.
         let (_, add_op_0_out) = g.add_simple_op("Add_0", Add {}, &[const_val, const_val]);

--- a/src/model.rs
+++ b/src/model.rs
@@ -750,7 +750,7 @@ fn constant_data_from_flatbuffers_vec<'a, T: Pod + flatbuffers::Follow<'a, Inner
 #[cfg(test)]
 mod tests {
     use rten_tensor::prelude::*;
-    use rten_tensor::{tensor, Tensor};
+    use rten_tensor::Tensor;
 
     use crate::graph::{Dimension, RunError};
     use crate::model::{Model, ModelOptions};
@@ -1011,7 +1011,7 @@ mod tests {
         let buffer = generate_model_buffer(ModelFormat::V2);
         let model = Model::load(buffer).unwrap();
 
-        let input = tensor!((1, 2, 2); [1., 2., -1., -2.]);
+        let input = Tensor::from([[[1., 2.], [-1., -2.]]]);
         let result: Tensor<f32> = model
             .run_one(input.into(), None)
             .unwrap()
@@ -1120,7 +1120,7 @@ mod tests {
 
         // Dummy value for BatchNormalization inputs which are vectors with
         // per-channel values.
-        let batch_norm_param_val = tensor!([1.0]);
+        let batch_norm_param_val = Tensor::from([1.0]);
         let batch_norm_param = builder.add_constant(batch_norm_param_val.view());
         add_operator!(
             BatchNormalization,
@@ -1137,8 +1137,8 @@ mod tests {
         add_operator!(Cast, [input_node], { to: ops::DataType::Float });
         add_operator!(Ceil, [input_node]);
 
-        let clip_min = builder.add_constant(tensor!(1.).view());
-        let clip_max = builder.add_constant(tensor!(6.).view());
+        let clip_min = builder.add_constant(Tensor::from(1.).view());
+        let clip_max = builder.add_constant(Tensor::from(6.).view());
         add_operator!(Clip, [input_node, clip_min, clip_max]);
         add_operator!(Concat, [input_node, input_node], { axis: 0 });
 
@@ -1163,7 +1163,7 @@ mod tests {
         add_operator!(Erf, [input_node]);
         add_operator!(Exp, [input_node]);
 
-        let expand_shape_val = tensor!([2, 2, 3, 3]);
+        let expand_shape_val = Tensor::from([2, 2, 3, 3]);
         let expand_shape = builder.add_constant(expand_shape_val.view());
         add_operator!(Expand, [input_node, expand_shape]);
 
@@ -1197,17 +1197,17 @@ mod tests {
 
         add_operator!(Identity, [input_node]);
 
-        let instance_norm_scale_val = tensor!([1.0]);
+        let instance_norm_scale_val = Tensor::from([1.0]);
         let instance_norm_scale = builder.add_constant(instance_norm_scale_val.view());
-        let instance_norm_bias_val = tensor!([1.0]);
+        let instance_norm_bias_val = Tensor::from([1.0]);
         let instance_norm_bias = builder.add_constant(instance_norm_bias_val.view());
         add_operator!(InstanceNormalization, [
             input_node, instance_norm_scale, instance_norm_bias
         ], { epsilon: Some(1e-5) });
 
-        let layer_norm_scale_val = tensor!([1.0]);
+        let layer_norm_scale_val = Tensor::from([1.0]);
         let layer_norm_scale = builder.add_constant(layer_norm_scale_val.view());
-        let layer_norm_bias_val = tensor!([1.0]);
+        let layer_norm_bias_val = Tensor::from([1.0]);
         let layer_norm_bias = builder.add_constant(layer_norm_bias_val.view());
         add_operator!(LayerNormalization, [
             input_node, layer_norm_scale, layer_norm_bias
@@ -1328,8 +1328,8 @@ mod tests {
             allow_zero: false,
         });
 
-        let resize_roi_val = tensor!([0., 0., 0., 0., 1., 1., 1., 1.]);
-        let resize_scales_val = tensor!([1., 1., 2., 2.]);
+        let resize_roi_val = Tensor::from([0., 0., 0., 0., 1., 1., 1., 1.]);
+        let resize_scales_val = Tensor::from([1., 1., 2., 2.]);
         let resize_roi = builder.add_constant(resize_roi_val.view());
         let resize_scales = builder.add_constant(resize_scales_val.view());
         add_operator!(Resize, [input_node, resize_roi, resize_scales], {
@@ -1422,7 +1422,7 @@ mod tests {
         //
         // A few require different shapes are tested separately.
         let input = Tensor::from_data(&input_shape, vec![1., 2., 3., 4., 5., 6., 7., 8., 9.]);
-        let input_bool_data: Tensor<i32> = tensor!([0, 1, 1]);
+        let input_bool_data: Tensor<i32> = Tensor::from([0, 1, 1]);
         for output in op_outputs {
             if [
                 "Gemm_out",
@@ -1496,8 +1496,8 @@ mod tests {
 
         // Where op
         let cond = Tensor::from(1);
-        let x = tensor!([1, 2, 3]);
-        let y = tensor!([4, 5, 6]);
+        let x = Tensor::from([1, 2, 3]);
+        let y = Tensor::from([4, 5, 6]);
         let result = model
             .run(
                 vec![

--- a/src/ops/binary_elementwise.rs
+++ b/src/ops/binary_elementwise.rs
@@ -956,7 +956,7 @@ mod tests {
 
     use rten_tensor::prelude::*;
     use rten_tensor::test_util::expect_equal;
-    use rten_tensor::{tensor, Tensor};
+    use rten_tensor::Tensor;
 
     use super::{fast_broadcast_cycles, fast_broadcast_cycles_repeats};
     use crate::ops::tests::new_pool;
@@ -1158,7 +1158,7 @@ mod tests {
         // In-place addition where the second input must be broadcast to the
         // shape of the first.
         let mut a = Tensor::from_data(&[2, 2], vec![1., 2., 3., 4.]);
-        let b = tensor!([1., 2.]);
+        let b = Tensor::from([1., 2.]);
         let expected = Tensor::from_data(&[2, 2], vec![2., 4., 4., 6.]);
 
         add_in_place(a.view_mut(), b.view());
@@ -1169,7 +1169,7 @@ mod tests {
         let mut a = Tensor::from_data(&[2, 3], vec![1., 2., 0., 3., 4., 0.]);
         a.clip_dim(1, 0..2);
         assert!(!a.is_contiguous());
-        let b = tensor!([1., 2.]);
+        let b = Tensor::from([1., 2.]);
         let expected = Tensor::from_data(&[2, 2], vec![2., 4., 4., 6.]);
 
         add_in_place(a.view_mut(), b.view());
@@ -1196,9 +1196,9 @@ mod tests {
     #[test]
     fn test_and() {
         let pool = new_pool();
-        let a = tensor!([0, 1, 0, 1]);
-        let b = tensor!([0, 0, 1, 1]);
-        let expected = tensor!([0, 0, 0, 1]);
+        let a = Tensor::from([0, 1, 0, 1]);
+        let b = Tensor::from([0, 0, 1, 1]);
+        let expected = Tensor::from([0, 0, 0, 1]);
         let result = and(&pool, a.view(), b.view()).unwrap();
         assert_eq!(&result, &expected);
     }
@@ -1222,16 +1222,16 @@ mod tests {
         expect_equal(&result, &expected)?;
 
         // Non-scalar a and b ints
-        let a = tensor!([1, 2, 3, 4]);
-        let b = tensor!([2, 2, 2, 2]);
-        let expected = tensor!([0, 1, 1, 2]);
+        let a = Tensor::from([1, 2, 3, 4]);
+        let b = Tensor::from([2, 2, 2, 2]);
+        let expected = Tensor::from([0, 1, 1, 2]);
         let result = div(&pool, a.view(), b.view()).unwrap();
         assert_eq!(&result, &expected);
 
         // Scalar b int
-        let a = tensor!([1, 2, 3, 4]);
+        let a = Tensor::from([1, 2, 3, 4]);
         let b = Tensor::from_scalar(2);
-        let expected = tensor!([0, 1, 1, 2]);
+        let expected = Tensor::from([0, 1, 1, 2]);
         let result = div(&pool, a.view(), b.view()).unwrap();
         assert_eq!(&result, &expected);
 
@@ -1255,16 +1255,16 @@ mod tests {
         expect_equal(&a, &expected)?;
 
         // Non-scalar a and b ints
-        let mut a = tensor!([1, 2, 3, 4]);
-        let b = tensor!([2, 2, 2, 2]);
-        let expected = tensor!([0, 1, 1, 2]);
+        let mut a = Tensor::from([1, 2, 3, 4]);
+        let b = Tensor::from([2, 2, 2, 2]);
+        let expected = Tensor::from([0, 1, 1, 2]);
         div_in_place(a.view_mut(), b.view());
         assert_eq!(&a, &expected);
 
         // Scalar b int
-        let mut a = tensor!([1, 2, 3, 4]);
+        let mut a = Tensor::from([1, 2, 3, 4]);
         let b = Tensor::from_scalar(2);
-        let expected = tensor!([0, 1, 1, 2]);
+        let expected = Tensor::from([0, 1, 1, 2]);
         div_in_place(a.view_mut(), b.view());
         assert_eq!(&a, &expected);
 
@@ -1276,16 +1276,16 @@ mod tests {
         let pool = new_pool();
 
         // Int tensor
-        let a = tensor!([1, 2]);
-        let b = tensor!([1, 3]);
-        let expected = tensor!([1, 0]);
+        let a = Tensor::from([1, 2]);
+        let b = Tensor::from([1, 3]);
+        let expected = Tensor::from([1, 0]);
         let result = equal(&pool, a.view(), b.view()).unwrap();
         assert_eq!(&result, &expected);
 
         // Float tensor
-        let a = tensor!([1., 2.]);
-        let b = tensor!([1., 3.]);
-        let expected = tensor!([1, 0]);
+        let a = Tensor::from([1., 2.]);
+        let b = Tensor::from([1., 3.]);
+        let expected = Tensor::from([1, 0]);
         let result = equal(&pool, a.view(), b.view()).unwrap();
         assert_eq!(&result, &expected);
     }
@@ -1295,16 +1295,16 @@ mod tests {
         let pool = new_pool();
 
         // Int tensor
-        let a = tensor!([1, 2, 5]);
-        let b = tensor!([1, 3, 4]);
-        let expected = tensor!([0, 0, 1]);
+        let a = Tensor::from([1, 2, 5]);
+        let b = Tensor::from([1, 3, 4]);
+        let expected = Tensor::from([0, 0, 1]);
         let result = greater(&pool, a.view(), b.view()).unwrap();
         assert_eq!(&result, &expected);
 
         // Float tensor
-        let a = tensor!([1., 2., 5.]);
-        let b = tensor!([1., 3., 4.]);
-        let expected = tensor!([0, 0, 1]);
+        let a = Tensor::from([1., 2., 5.]);
+        let b = Tensor::from([1., 3., 4.]);
+        let expected = Tensor::from([0, 0, 1]);
         let result = greater(&pool, a.view(), b.view()).unwrap();
         assert_eq!(&result, &expected);
     }
@@ -1314,16 +1314,16 @@ mod tests {
         let pool = new_pool();
 
         // Int tensor
-        let a = tensor!([1, 2, 5]);
-        let b = tensor!([1, 3, 4]);
-        let expected = tensor!([1, 0, 1]);
+        let a = Tensor::from([1, 2, 5]);
+        let b = Tensor::from([1, 3, 4]);
+        let expected = Tensor::from([1, 0, 1]);
         let result = greater_or_equal(&pool, a.view(), b.view()).unwrap();
         assert_eq!(&result, &expected);
 
         // Float tensor
-        let a = tensor!([1., 2., 5.]);
-        let b = tensor!([1., 3., 4.]);
-        let expected = tensor!([1, 0, 1]);
+        let a = Tensor::from([1., 2., 5.]);
+        let b = Tensor::from([1., 3., 4.]);
+        let expected = Tensor::from([1, 0, 1]);
         let result = greater_or_equal(&pool, a.view(), b.view()).unwrap();
         assert_eq!(&result, &expected);
     }
@@ -1333,16 +1333,16 @@ mod tests {
         let pool = new_pool();
 
         // Int tensor
-        let a = tensor!([1, 2]);
-        let b = tensor!([1, 3]);
-        let expected = tensor!([0, 1]);
+        let a = Tensor::from([1, 2]);
+        let b = Tensor::from([1, 3]);
+        let expected = Tensor::from([0, 1]);
         let result = less(&pool, a.view(), b.view()).unwrap();
         assert_eq!(&result, &expected);
 
         // Float tensor
-        let a = tensor!([1., 2.]);
-        let b = tensor!([1., 3.]);
-        let expected = tensor!([0, 1]);
+        let a = Tensor::from([1., 2.]);
+        let b = Tensor::from([1., 3.]);
+        let expected = Tensor::from([0, 1]);
         let result = less(&pool, a.view(), b.view()).unwrap();
         assert_eq!(&result, &expected);
     }
@@ -1352,16 +1352,16 @@ mod tests {
         let pool = new_pool();
 
         // Int tensor
-        let a = tensor!([1, 2, 5]);
-        let b = tensor!([1, 3, 4]);
-        let expected = tensor!([1, 1, 0]);
+        let a = Tensor::from([1, 2, 5]);
+        let b = Tensor::from([1, 3, 4]);
+        let expected = Tensor::from([1, 1, 0]);
         let result = less_or_equal(&pool, a.view(), b.view()).unwrap();
         assert_eq!(&result, &expected);
 
         // Float tensor
-        let a = tensor!([1., 2., 5.]);
-        let b = tensor!([1., 3., 4.]);
-        let expected = tensor!([1, 1, 0]);
+        let a = Tensor::from([1., 2., 5.]);
+        let b = Tensor::from([1., 3., 4.]);
+        let expected = Tensor::from([1, 1, 0]);
         let result = less_or_equal(&pool, a.view(), b.view()).unwrap();
         assert_eq!(&result, &expected);
     }
@@ -1371,26 +1371,26 @@ mod tests {
         let pool = new_pool();
 
         // Int tensor, floor division (like Python's `%`, `numpy.mod`).
-        let a = tensor!([10, -10, 10, -10]);
-        let b = tensor!([3, 3, -3, -3]);
-        let expected = tensor!([1, 2, -2, -1]);
+        let a = Tensor::from([10, -10, 10, -10]);
+        let b = Tensor::from([3, 3, -3, -3]);
+        let expected = Tensor::from([1, 2, -2, -1]);
         let result = mod_op(&pool, a.view(), b.view(), DivMode::FloorDiv).unwrap();
         assert_eq!(&result, &expected);
 
         // Int tensor, truncated division (like Rust's `%`, `numpy.fmod`).
-        let expected = tensor!([1, -1, 1, -1]);
+        let expected = Tensor::from([1, -1, 1, -1]);
         let result = mod_op(&pool, a.view(), b.view(), DivMode::TruncDiv).unwrap();
         assert_eq!(&result, &expected);
 
         // Float tensor, floor division.
-        let af = tensor!([3.5, -3.5, 3.5, -3.5]);
-        let bf = tensor!([2.5, 2.5, -2.5, -2.5]);
-        let expected = tensor!([1., 1.5, -1.5, -1.]);
+        let af = Tensor::from([3.5, -3.5, 3.5, -3.5]);
+        let bf = Tensor::from([2.5, 2.5, -2.5, -2.5]);
+        let expected = Tensor::from([1., 1.5, -1.5, -1.]);
         let result = mod_op(&pool, af.view(), bf.view(), DivMode::FloorDiv).unwrap();
         assert_eq!(&result, &expected);
 
         // Float tensor, truncated division.
-        let expected = tensor!([1., -1., 1., -1.]);
+        let expected = Tensor::from([1., -1., 1., -1.]);
         let result = mod_op(&pool, af.view(), bf.view(), DivMode::TruncDiv).unwrap();
         assert_eq!(&result, &expected);
     }
@@ -1438,9 +1438,9 @@ mod tests {
     #[test]
     fn test_or() {
         let pool = new_pool();
-        let a = tensor!([0, 1, 0, 1]);
-        let b = tensor!([0, 0, 1, 1]);
-        let expected = tensor!([0, 1, 1, 1]);
+        let a = Tensor::from([0, 1, 0, 1]);
+        let b = Tensor::from([0, 0, 1, 1]);
+        let expected = Tensor::from([0, 1, 1, 1]);
         let result = or(&pool, a.view(), b.view()).unwrap();
         assert_eq!(&result, &expected);
     }
@@ -1456,27 +1456,27 @@ mod tests {
         let cases = [
             // Square input
             Case {
-                a: tensor!([2., 3., 4.]),
-                b: tensor!(2.),
-                expected: tensor!([4., 9., 16.]),
+                a: [2., 3., 4.].into(),
+                b: (2.).into(),
+                expected: [4., 9., 16.].into(),
             },
             // Cube input
             Case {
-                a: tensor!([2., 3., 4.]),
-                b: tensor!(3.),
-                expected: tensor!([8., 27., 64.]),
+                a: [2., 3., 4.].into(),
+                b: (3.).into(),
+                expected: [8., 27., 64.].into(),
             },
             // Raise all inputs to scalar
             Case {
-                a: tensor!([2., 3., 4.]),
-                b: tensor!(0.256),
-                expected: tensor!([(2f32).powf(0.256), (3f32).powf(0.256), (4f32).powf(0.256)]),
+                a: [2., 3., 4.].into(),
+                b: (0.256).into(),
+                expected: [(2f32).powf(0.256), (3f32).powf(0.256), (4f32).powf(0.256)].into(),
             },
             // Raise each input to different powers
             Case {
-                a: tensor!([2., 3., 4.]),
-                b: tensor!([1., 2., 3.]),
-                expected: tensor!([2., 9., 64.]),
+                a: [2., 3., 4.].into(),
+                b: [1., 2., 3.].into(),
+                expected: [2., 9., 64.].into(),
             },
         ];
 
@@ -1576,27 +1576,27 @@ mod tests {
         assert_eq!(&result, &expected);
 
         // Float tensor broadcasting `x` and `y`
-        let cond = tensor!([1, 1, 0, 0]);
+        let cond = Tensor::from([1, 1, 0, 0]);
         let x = Tensor::from(1.);
         let y = Tensor::from(2.);
         let result = where_op(&pool, cond.view(), x.view(), y.view()).unwrap();
-        let expected = tensor!([1., 1., 2., 2.]);
+        let expected = Tensor::from([1., 1., 2., 2.]);
         assert_eq!(&result, &expected);
 
         // Float tensor broadcasting `cond`
         let cond = Tensor::from(1);
-        let x = tensor!([1., 2.]);
-        let y = tensor!([3., 4.]);
+        let x = Tensor::from([1., 2.]);
+        let y = Tensor::from([3., 4.]);
         let result = where_op(&pool, cond.view(), x.view(), y.view()).unwrap();
-        let expected = tensor!([1., 2.]);
+        let expected = Tensor::from([1., 2.]);
         assert_eq!(&result, &expected);
 
         // Int tensor broadcasting `x` and `y`
-        let cond = tensor!([1, 1, 0, 0]);
+        let cond = Tensor::from([1, 1, 0, 0]);
         let x = Tensor::from(3);
         let y = Tensor::from(4);
         let result = where_op(&pool, cond.view(), x.view(), y.view()).unwrap();
-        let expected = tensor!([3, 3, 4, 4]);
+        let expected = Tensor::from([3, 3, 4, 4]);
         assert_eq!(&result, &expected);
 
         // Int tensor broadcasting `x` and `y`, and broadcasting involves
@@ -1614,9 +1614,9 @@ mod tests {
     fn test_where_invalid_inputs() {
         let pool = new_pool();
 
-        let cond = tensor!([1, 1]);
-        let x = tensor!([1, 2, 3]);
-        let y = tensor!([2, 2]);
+        let cond = Tensor::from([1, 1]);
+        let x = Tensor::from([1, 2, 3]);
+        let y = Tensor::from([2, 2]);
 
         // Failure to broadcast `x` to match `cond`
         let result = where_op(&pool, cond.view(), x.view(), y.view());
@@ -1636,9 +1636,9 @@ mod tests {
     #[test]
     fn test_xor() {
         let pool = new_pool();
-        let a = tensor!([0, 1, 0, 1]);
-        let b = tensor!([0, 0, 1, 1]);
-        let expected = tensor!([0, 1, 1, 0]);
+        let a = Tensor::from([0, 1, 0, 1]);
+        let b = Tensor::from([0, 0, 1, 1]);
+        let expected = Tensor::from([0, 1, 1, 0]);
         let result = xor(&pool, a.view(), b.view()).unwrap();
         assert_eq!(&result, &expected);
     }

--- a/src/ops/binary_elementwise.rs
+++ b/src/ops/binary_elementwise.rs
@@ -1095,7 +1095,7 @@ mod tests {
         expect_equal(&result, &expected)?;
 
         // Case where one of the inputs is a scalar.
-        let a = Tensor::from_scalar(3.0);
+        let a = Tensor::from(3.0);
         let b = Tensor::from_data(&[2, 2], vec![1.0, 2.0, 3.0, 4.0]);
         let result = add(&pool, a.view(), b.view()).unwrap();
         let expected = Tensor::from_data(&[2, 2], vec![4.0, 5.0, 6.0, 7.0]);
@@ -1148,7 +1148,7 @@ mod tests {
 
         // Run `Add` operator in-place with inputs that don't support in-place
         // addition. The operator should fall back to creating a new output tensor.
-        let scalar = Tensor::from_scalar(1.0);
+        let scalar = Tensor::from(1.0);
         let expected = Tensor::from_data(&[2, 2], vec![11., 21., 31., 41.]);
         let result = op
             .run_in_place(&pool, Output::FloatTensor(scalar), (&b).into())
@@ -1216,7 +1216,7 @@ mod tests {
 
         // Scalar b
         let a = Tensor::from_data(&[2, 2], vec![10., 20., 30., 40.]);
-        let b = Tensor::from_scalar(10.);
+        let b = Tensor::from(10.);
         let expected = Tensor::from_data(&[2, 2], vec![1., 2., 3., 4.]);
         let result = div(&pool, a.view(), b.view()).unwrap();
         expect_equal(&result, &expected)?;
@@ -1230,7 +1230,7 @@ mod tests {
 
         // Scalar b int
         let a = Tensor::from([1, 2, 3, 4]);
-        let b = Tensor::from_scalar(2);
+        let b = Tensor::from(2);
         let expected = Tensor::from([0, 1, 1, 2]);
         let result = div(&pool, a.view(), b.view()).unwrap();
         assert_eq!(&result, &expected);
@@ -1249,7 +1249,7 @@ mod tests {
 
         // Scalar b
         let mut a = Tensor::from_data(&[2, 2], vec![10., 20., 30., 40.]);
-        let b = Tensor::from_scalar(10.);
+        let b = Tensor::from(10.);
         let expected = Tensor::from_data(&[2, 2], vec![1., 2., 3., 4.]);
         div_in_place(a.view_mut(), b.view());
         expect_equal(&a, &expected)?;
@@ -1263,7 +1263,7 @@ mod tests {
 
         // Scalar b int
         let mut a = Tensor::from([1, 2, 3, 4]);
-        let b = Tensor::from_scalar(2);
+        let b = Tensor::from(2);
         let expected = Tensor::from([0, 1, 1, 2]);
         div_in_place(a.view_mut(), b.view());
         assert_eq!(&a, &expected);

--- a/src/ops/concat.rs
+++ b/src/ops/concat.rs
@@ -300,7 +300,7 @@ mod tests {
 
     use rten_tensor::prelude::*;
     use rten_tensor::test_util::expect_equal;
-    use rten_tensor::{tensor, Tensor};
+    use rten_tensor::Tensor;
 
     use crate::ops::tests::new_pool;
     use crate::ops::OpError;
@@ -422,60 +422,51 @@ mod tests {
 
         // Empty
         let input = Tensor::<f32>::zeros(&[3, 4, 5]);
-        let repeats = tensor!([4, 0, 1]);
+        let repeats = Tensor::from([4, 0, 1]);
         let result = tile(&pool, input.view(), repeats.nd_view()).unwrap();
         assert_eq!(result.shape(), &[12, 0, 5]);
         assert!(result.is_empty());
 
         // Scalar
-        let input = tensor!(5.);
-        let repeats = tensor!([]);
+        let input = Tensor::from(5.);
+        let empty: [i32; 0] = [];
+        let repeats = Tensor::from(empty);
         let result = tile(&pool, input.view(), repeats.nd_view()).unwrap();
-        assert_eq!(result, tensor!(5.));
+        assert_eq!(result, Tensor::from(5.));
 
         // 1D tile
-        let input = tensor!([1, 2, 3, 4]);
-        let repeats = tensor!([3]);
+        let input = Tensor::from([1, 2, 3, 4]);
+        let repeats = Tensor::from([3]);
         let result = tile(&pool, input.view(), repeats.nd_view()).unwrap();
-        assert_eq!(result, tensor!([1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4]));
+        assert_eq!(result, Tensor::from([1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4]));
 
         // 2D tile
-        let input = tensor!((1, 1); [3.]);
-        let repeats = tensor!([3, 2]);
+        let input = Tensor::from([[3.]]);
+        let repeats = Tensor::from([3, 2]);
         let result = tile(&pool, input.view(), repeats.nd_view()).unwrap();
-        assert_eq!(
-            result,
-            tensor!(
-                (3, 2);
-                [
-                    3., 3., //
-                    3., 3., //
-                    3., 3. //
-                ]
-            )
-        );
+        assert_eq!(result, Tensor::from([[3., 3.], [3., 3.], [3., 3.]]));
 
         // Noop tile
-        let input = tensor!([1, 2, 3, 4]);
-        let repeats = tensor!([1]);
+        let input = Tensor::from([1, 2, 3, 4]);
+        let repeats = Tensor::from([1]);
         let result = tile(&pool, input.view(), repeats.nd_view()).unwrap();
         assert_eq!(input, result);
 
         // Repeat inner dim of a 2D tensor
         let input = Tensor::from([[1, 2], [3, 4]]);
-        let repeats = tensor!([1, 2]);
+        let repeats = Tensor::from([1, 2]);
         let result = tile(&pool, input.view(), repeats.nd_view()).unwrap();
         assert_eq!(result, Tensor::from([[1, 2, 1, 2], [3, 4, 3, 4]]));
 
         // Repeat outer dim of a 2D tensor
         let input = Tensor::from([[1, 2], [3, 4]]);
-        let repeats = tensor!([2, 1]);
+        let repeats = Tensor::from([2, 1]);
         let result = tile(&pool, input.view(), repeats.nd_view()).unwrap();
         assert_eq!(result, Tensor::from([[1, 2], [3, 4], [1, 2], [3, 4]]));
 
         // Repeat inner and outer dims of a 2D tensor
         let input = Tensor::from([[1, 2], [3, 4]]);
-        let repeats = tensor!([2, 2]);
+        let repeats = Tensor::from([2, 2]);
         let result = tile(&pool, input.view(), repeats.nd_view()).unwrap();
         assert_eq!(
             result,
@@ -488,14 +479,14 @@ mod tests {
         let pool = new_pool();
 
         // Repeats length does not match input ndim.
-        let input = tensor!([1, 2, 3]);
-        let repeats = tensor!([1, 2]);
+        let input = Tensor::from([1, 2, 3]);
+        let repeats = Tensor::from([1, 2]);
         let result = tile(&pool, input.view(), repeats.nd_view());
         assert_eq!(result, Err(OpError::InvalidValue("invalid repeats")));
 
         // Negative repeats
-        let input = tensor!([1, 2, 3]);
-        let repeats = tensor!([-1]);
+        let input = Tensor::from([1, 2, 3]);
+        let repeats = Tensor::from([-1]);
         let result = tile(&pool, input.view(), repeats.nd_view());
         assert_eq!(result, Err(OpError::InvalidValue("invalid repeats")));
     }

--- a/src/ops/convert.rs
+++ b/src/ops/convert.rs
@@ -52,8 +52,8 @@ impl Operator for Cast {
 mod tests {
     use std::error::Error;
 
-    use rten_tensor::tensor;
     use rten_tensor::test_util::expect_equal;
+    use rten_tensor::Tensor;
 
     use crate::ops::tests::new_pool;
     use crate::ops::{Cast, DataType, Operator};
@@ -61,8 +61,8 @@ mod tests {
     #[test]
     fn test_cast() -> Result<(), Box<dyn Error>> {
         let pool = new_pool();
-        let int_input = tensor!([1, 2, 3]);
-        let float_input = tensor!([1.0, 2.0, 3.0]);
+        let int_input = Tensor::from([1, 2, 3]);
+        let float_input = Tensor::from([1.0, 2.0, 3.0]);
 
         // No-op cast from int32 => int32
         let cast_to_int = Cast {
@@ -112,7 +112,7 @@ mod tests {
     #[test]
     fn test_cast_out_of_range() -> Result<(), Box<dyn Error>> {
         let pool = new_pool();
-        let int_input = tensor!([i32::MIN, i32::MAX]);
+        let int_input = Tensor::from([i32::MIN, i32::MAX]);
 
         // Out-of-range cast from int => float. This will simply lose some
         // significant digits.
@@ -125,10 +125,10 @@ mod tests {
             .remove(0)
             .into_float()
             .unwrap();
-        expect_equal(&result, &tensor!([-2147483600.0, 2147483600.0]))?;
+        expect_equal(&result, &Tensor::from([-2147483600.0, 2147483600.0]))?;
 
         // Out-of-range cast from float => int.
-        let float_input = tensor!([f32::MIN, f32::MAX]);
+        let float_input = Tensor::from([f32::MIN, f32::MAX]);
         let cast_to_int = Cast {
             to: DataType::Int32,
         };
@@ -138,7 +138,7 @@ mod tests {
             .remove(0)
             .into_int()
             .unwrap();
-        assert_eq!(&result, &tensor!([i32::MIN, i32::MAX]));
+        assert_eq!(&result, &Tensor::from([i32::MIN, i32::MAX]));
 
         Ok(())
     }

--- a/src/ops/fused.rs
+++ b/src/ops/fused.rs
@@ -100,22 +100,22 @@ mod tests {
 
         let cases = [
             Case {
-                a: Tensor::from([[1, 2], [3, 4]]),
-                b: Tensor::from([[0, 1], [2, 3]]),
+                a: [[1, 2], [3, 4]].into(),
+                b: [[0, 1], [2, 3]].into(),
                 transpose_input: 1,
 
                 // 1 2 - 0 2 = 1 0
                 // 3 4   1 3   2 1
-                expected: Tensor::from([[1, 0], [2, 1]]),
+                expected: [[1, 0], [2, 1]].into(),
             },
             Case {
-                a: Tensor::from([[1, 2], [3, 4]]),
-                b: Tensor::from([[0, 1], [2, 3]]),
+                a: [[1, 2], [3, 4]].into(),
+                b: [[0, 1], [2, 3]].into(),
                 transpose_input: 0,
 
                 // 1 3 - 0 1 = 1 2
                 // 2 4   2 3   0 1
-                expected: Tensor::from([[1, 2], [0, 1]]),
+                expected: [[1, 2], [0, 1]].into(),
             },
         ];
 

--- a/src/ops/generate.rs
+++ b/src/ops/generate.rs
@@ -166,7 +166,7 @@ impl Operator for Range {
 #[cfg(test)]
 mod tests {
     use rten_tensor::prelude::*;
-    use rten_tensor::{tensor, Tensor};
+    use rten_tensor::Tensor;
 
     use crate::ops::tests::new_pool;
     use crate::ops::{onehot, range, ConstantOfShape, OpError, Operator, Scalar};
@@ -205,60 +205,54 @@ mod tests {
             // Common case of converting class labels to a float one-hot tensor
             // with values of 0/1.
             Case {
-                classes: tensor!([0, 1, 2, 3, 4]),
+                classes: [0, 1, 2, 3, 4].into(),
                 axis: -1,
                 depth: 5,
                 on_value: 1.,
                 off_value: 0.,
-                expected: Ok(tensor!((5, 5); [
-                    1., 0., 0., 0., 0., // 1
-                    0., 1., 0., 0., 0., // 2
-                    0., 0., 1., 0., 0., // 3
-                    0., 0., 0., 1., 0., // 4
-                    0., 0., 0., 0., 1. // 5
-                ])),
+                expected: Ok([
+                    [1., 0., 0., 0., 0.],
+                    [0., 1., 0., 0., 0.],
+                    [0., 0., 1., 0., 0.],
+                    [0., 0., 0., 1., 0.],
+                    [0., 0., 0., 0., 1.],
+                ]
+                .into()),
             },
             // Non-standard on/off values.
             Case {
-                classes: tensor!([0, 1]),
+                classes: [0, 1].into(),
                 axis: -1,
                 depth: 2,
                 on_value: 2.,
                 off_value: -3.,
-                expected: Ok(tensor!((2, 2); [
-                    2., -3., // 1
-                    -3., 2. // 2
-                ])),
+                expected: Ok([[2., -3.], [-3., 2.]].into()),
             },
             // Add classes as first axis.
             Case {
-                classes: tensor!([0, 1]),
+                classes: [0, 1].into(),
                 axis: 0,
                 depth: 2,
                 on_value: 1.,
                 off_value: 0.,
-                expected: Ok(tensor!((2, 2); [
-                    1., 0., // 1
-                    0., 1. // 2
-                ])
-                .transposed()
-                .to_tensor()),
+                expected: Ok(Tensor::from([[1., 0.], [0., 1.]]).transposed().to_tensor()),
             },
             // Invalid class index for depth.
             Case {
-                classes: tensor!([0, 2]),
+                classes: [0, 2].into(),
                 axis: -1,
                 depth: 2,
                 on_value: 1.,
                 off_value: 0.,
-                expected: Ok(tensor!((2, 2); [
-                    1., 0., // 1
-                    0., 0. // 2. All "off" because class is out of range.
-                ])),
+                expected: Ok([
+                    [1., 0.],
+                    [0., 0.], // All "off" because class is out of range.
+                ]
+                .into()),
             },
             // Invalid axis
             Case {
-                classes: tensor!([0, 1]),
+                classes: [0, 1].into(),
                 axis: 2,
                 depth: 2,
                 on_value: 1.,

--- a/src/ops/generate.rs
+++ b/src/ops/generate.rs
@@ -130,7 +130,7 @@ pub fn range<T: Copy + Default + ops::Add<Output = T> + PartialOrd>(
         output.push(val);
         val = val + delta;
     }
-    Ok(Tensor::from_vec(output))
+    Ok(output.into())
 }
 
 #[derive(Debug)]
@@ -177,7 +177,7 @@ mod tests {
         let op = ConstantOfShape {
             value: Scalar::Int(42),
         };
-        let shape = Tensor::from_vec(vec![1, 5, 10]);
+        let shape = Tensor::from([1, 5, 10]);
 
         let result = op
             .run(&pool, (&shape).into())

--- a/src/ops/identity.rs
+++ b/src/ops/identity.rs
@@ -54,7 +54,7 @@ mod tests {
         let pool = new_pool();
         let id_op = Identity {};
 
-        let int_input = Tensor::from_vec(vec![1, 2, 3]);
+        let int_input = Tensor::from([1, 2, 3]);
         let result = id_op
             .run(&pool, (&int_input).into())
             .unwrap()
@@ -63,7 +63,7 @@ mod tests {
             .unwrap();
         assert_eq!(result, int_input);
 
-        let float_input = Tensor::from_vec(vec![1.0, 2.0, 3.0]);
+        let float_input = Tensor::from([1.0, 2.0, 3.0]);
         let result = id_op
             .run(&pool, (&float_input).into())
             .unwrap()

--- a/src/ops/norm.rs
+++ b/src/ops/norm.rs
@@ -488,7 +488,7 @@ mod tests {
     use rten_tensor::prelude::*;
     use rten_tensor::rng::XorShiftRng;
     use rten_tensor::test_util::expect_equal;
-    use rten_tensor::{tensor, Tensor};
+    use rten_tensor::Tensor;
 
     use super::SOFTMAX_GRAIN_SIZE;
     use crate::ops::tests::{expect_eq_1e4, new_pool};
@@ -604,19 +604,25 @@ mod tests {
     #[test]
     fn test_instance_normalization() -> Result<(), Box<dyn Error>> {
         // Sample values generated using `torch.rand`.
-        let input = tensor!((1, 5, 2); [
-            0.9562, 0.0572, 0.4366, 0.5655, 0.2017,
-            0.0230, 0.7941, 0.1554, 0.3226, 0.120
-        ]);
-        let scale = tensor!([0.0751, 0.6952, 0.5800, 0.6791, 0.9884]);
-        let bias = tensor!([0.9993, 0.7632, 0.7679, 0.2427, 0.0728]);
+        let input = Tensor::from([[
+            [0.9562, 0.0572],
+            [0.4366, 0.5655],
+            [0.2017, 0.0230],
+            [0.7941, 0.1554],
+            [0.3226, 0.120],
+        ]]);
+        let scale = Tensor::from([0.0751, 0.6952, 0.5800, 0.6791, 0.9884]);
+        let bias = Tensor::from([0.9993, 0.7632, 0.7679, 0.2427, 0.0728]);
 
         // Expected result computed with `torch.nn.functional.instance_norm`.
         // The `scale` parameter in ONNX is called `weight` in PyTorch.
-        let expected = tensor!((1, 5, 2); [
-            1.0744,  0.9242,  0.0688,  1.4576,  1.3476,
-            0.1883,  0.9217, -0.4364, 1.0608, -0.9152
-        ]);
+        let expected = Tensor::from([[
+            [1.0744, 0.9242],
+            [0.0688, 1.4576],
+            [1.3476, 0.1883],
+            [0.9217, -0.4364],
+            [1.0608, -0.9152],
+        ]]);
 
         let pool = new_pool();
         let result =
@@ -633,12 +639,15 @@ mod tests {
         let pool = new_pool();
 
         // Sample values generated using `torch.rand`.
-        let input = tensor!((1, 5, 2); [
-            0.9562, 0.0572, 0.4366, 0.5655, 0.2017,
-            0.0230, 0.7941, 0.1554, 0.3226, 0.120
-        ]);
-        let scale = tensor!([0.0751, 0.6952]);
-        let bias = tensor!([0.9993, 0.7632]);
+        let input = Tensor::from([[
+            [0.9562, 0.0572],
+            [0.4366, 0.5655],
+            [0.2017, 0.0230],
+            [0.7941, 0.1554],
+            [0.3226, 0.120],
+        ]]);
+        let scale = Tensor::from([0.0751, 0.6952]);
+        let bias = Tensor::from([0.9993, 0.7632]);
 
         let result = layer_normalization(
             &pool,
@@ -667,8 +676,8 @@ mod tests {
         let pool = new_pool();
 
         // 1D input
-        let mut input = tensor!([0.1634, 0.8647, 0.6401, 0.8265, 0.0560, 0.2345]);
-        let expected = tensor!([-2.1447, -1.4434, -1.6680, -1.4816, -2.2521, -2.0736]);
+        let mut input = Tensor::from([0.1634, 0.8647, 0.6401, 0.8265, 0.0560, 0.2345]);
+        let expected = Tensor::from([-2.1447, -1.4434, -1.6680, -1.4816, -2.2521, -2.0736]);
         let result = log_softmax(&pool, input.view(), 0).unwrap();
         expect_eq_1e4(&result, &expected)?;
 
@@ -703,8 +712,8 @@ mod tests {
         let pool = new_pool();
 
         // Softmax on a 1D input
-        let mut input = tensor!([0.1634, 0.8647, 0.6401, 0.8265, 0.0560, 0.2304]);
-        let expected = tensor!([0.1172, 0.2362, 0.1887, 0.2274, 0.1052, 0.1253]);
+        let mut input = Tensor::from([0.1634, 0.8647, 0.6401, 0.8265, 0.0560, 0.2304]);
+        let expected = Tensor::from([0.1172, 0.2362, 0.1887, 0.2274, 0.1052, 0.1253]);
         let result = softmax(&pool, input.view(), 0).unwrap();
         expect_eq_1e4(&result, &expected)?;
 

--- a/src/ops/reduce.rs
+++ b/src/ops/reduce.rs
@@ -774,7 +774,7 @@ mod tests {
 
     use rten_tensor::prelude::*;
     use rten_tensor::test_util::{eq_with_nans, expect_equal};
-    use rten_tensor::{tensor, NdTensor, Tensor};
+    use rten_tensor::{NdTensor, Tensor};
 
     use crate::ops::tests::{new_pool, run_op};
     use crate::ops::{
@@ -788,7 +788,7 @@ mod tests {
         let pool = new_pool();
 
         // Reduce a simple vector.
-        let probs = tensor!([0.1, 0.5, 0.2, 0.9, 0.01, 0.6]);
+        let probs = Tensor::from([0.1, 0.5, 0.2, 0.9, 0.01, 0.6]);
         let class = arg_max(&pool, probs.view(), 0, false /* keep_dims */).unwrap();
         assert_eq!(class.item(), Some(&3));
 
@@ -840,7 +840,7 @@ mod tests {
     #[test]
     fn test_arg_min() {
         let pool = new_pool();
-        let probs = tensor!([0.1, 0.5, 0.2, 0.9, 0.01, 0.6]);
+        let probs = Tensor::from([0.1, 0.5, 0.2, 0.9, 0.01, 0.6]);
         let class = arg_min(&pool, probs.view(), 0, false /* keep_dims */).unwrap();
         assert_eq!(class.item(), Some(&4));
     }
@@ -852,7 +852,7 @@ mod tests {
     #[test]
     fn test_arg_min_max_nan() {
         let pool = new_pool();
-        let probs = tensor!([0.1, 0.5, f32::NAN, 0.9, 0.01, 0.6]);
+        let probs = Tensor::from([0.1, 0.5, f32::NAN, 0.9, 0.01, 0.6]);
         let min_idx = arg_min(&pool, probs.view(), 0, false /* keep_dims */).unwrap();
         let max_idx = arg_max(&pool, probs.view(), 0, false /* keep_dims */).unwrap();
         assert_eq!(min_idx.item(), Some(&2));
@@ -882,7 +882,7 @@ mod tests {
             &[1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4]
         );
 
-        let elements: Tensor<f32> = tensor!([]);
+        let elements: Tensor<f32> = Tensor::from([0.; 0]);
         let sums = cum_sum(&pool, elements.view(), 0).unwrap();
         assert_eq!(sums.shape(), &[0]);
         assert_eq!(sums.to_vec(), &[] as &[f32]);
@@ -891,7 +891,7 @@ mod tests {
     #[test]
     fn test_nonzero() {
         let pool = new_pool();
-        let input = tensor!((2, 2); [0., 1., 1., 1.]);
+        let input = Tensor::from([[0., 1.], [1., 1.]]);
         let result = nonzero(&pool, input.view());
         assert_eq!(result.shape(), &[2, 3]);
 
@@ -912,11 +912,11 @@ mod tests {
     #[test]
     fn test_nonzero_scalar() {
         let pool = new_pool();
-        let input = tensor!(3.);
+        let input = Tensor::from(3.);
         let result = nonzero(&pool, input.view());
         assert_eq!(result.shape(), &[0, 1]);
 
-        let input = tensor!(0.);
+        let input = Tensor::from(0.);
         let result = nonzero(&pool, input.view());
         assert_eq!(result.shape(), &[0, 0]);
     }
@@ -952,11 +952,11 @@ mod tests {
 
         for Case { op } in cases {
             let input = NdTensor::from([[0., 1., 2.], [3., 4., 5.]]);
-            let axes = tensor!([0]);
+            let axes = Tensor::from([0]);
             let result: NdTensor<f32, 2> = run_op(&*op, (input.view(), axes.view()))?;
             assert_eq!(result.shape(), [1, 3]);
 
-            let axes = tensor!([1]);
+            let axes = Tensor::from([1]);
             let result: NdTensor<f32, 2> = run_op(&*op, (input.view(), axes.view()))?;
             assert_eq!(result.shape(), [2, 1]);
         }
@@ -997,7 +997,7 @@ mod tests {
 
         // Test with `keep_dims` off
         let result = reduce_mean(&pool, input.view(), Some(&[-1]), false /* keep_dims */).unwrap();
-        let expected = tensor!([2., 5., 8.]);
+        let expected = Tensor::from([2., 5., 8.]);
         expect_equal(&result, &expected)?;
 
         // Test with `keep_dims` on
@@ -1007,17 +1007,17 @@ mod tests {
 
         // Reduce first dim
         let result = reduce_mean(&pool, input.view(), Some(&[0]), false /* keep_dims */).unwrap();
-        let expected = tensor!([4., 5., 6.]);
+        let expected = Tensor::from([4., 5., 6.]);
         expect_equal(&result, &expected)?;
 
         // Reduce all axes
         let result = reduce_mean(&pool, input.view(), None, false /* keep_dims */).unwrap();
-        let expected = Tensor::from_scalar(5.);
+        let expected = Tensor::from(5.);
         expect_equal(&result, &expected)?;
 
         // Reduce all axes (specified via empty array)
         let result = reduce_mean(&pool, input.view(), Some(&[]), false /* keep_dims */).unwrap();
-        let expected = Tensor::from_scalar(5.);
+        let expected = Tensor::from(5.);
         expect_equal(&result, &expected)?;
 
         // Test case from ONNX spec
@@ -1032,7 +1032,7 @@ mod tests {
         // Reduce a scalar value
         let result = reduce_mean(
             &pool,
-            Tensor::from_scalar(5.0).view(),
+            Tensor::from(5.0).view(),
             Some(&[]),
             false, /* keep_dims */
         )
@@ -1042,7 +1042,7 @@ mod tests {
         // Reduce a vector
         let result = reduce_mean(
             &pool,
-            tensor!([0., 10.]).view(),
+            Tensor::from([0., 10.]).view(),
             Some(&[0]),
             false, /* keep_dims */
         )
@@ -1066,7 +1066,7 @@ mod tests {
         // Empty tensor
         let result = reduce_mean(
             &pool,
-            tensor!([]).view(),
+            Tensor::from([0.; 0]).view(),
             Some(&[0]),
             false, /* keep_dims */
         );
@@ -1083,7 +1083,7 @@ mod tests {
     #[test]
     fn test_reduce_min_max() {
         let pool = new_pool();
-        let input: Tensor<f32> = tensor!([1.5, 2.5, 3.5, 4.5, 5.5]);
+        let input: Tensor<f32> = [1.5, 2.5, 3.5, 4.5, 5.5].into();
         let min = result_item(reduce_min(
             &pool,
             input.view(),
@@ -1108,7 +1108,7 @@ mod tests {
     #[test]
     fn test_reduce_min_max_propagates_nan() {
         let pool = new_pool();
-        let input: Tensor<f32> = tensor!([1.5, 2.5, 3.5, f32::NAN, 5.5]);
+        let input: Tensor<f32> = [1.5, 2.5, 3.5, f32::NAN, 5.5].into();
         let min = result_item(reduce_min(
             &pool,
             input.view(),
@@ -1130,7 +1130,7 @@ mod tests {
         let pool = new_pool();
 
         // Int tensor
-        let input: Tensor<i32> = tensor!([1, 2, 3, 4, 5]);
+        let input: Tensor<i32> = [1, 2, 3, 4, 5].into();
         let result = result_item(reduce_prod(
             &pool,
             input.view(),
@@ -1140,7 +1140,7 @@ mod tests {
         assert_eq!(result, input.iter().product::<i32>());
 
         // Float tensor
-        let input: Tensor<f32> = tensor!([1.5, 2.5, 3.5, 4.5, 5.5]);
+        let input: Tensor<f32> = [1.5, 2.5, 3.5, 4.5, 5.5].into();
         let result = result_item(reduce_prod(
             &pool,
             input.view(),
@@ -1155,7 +1155,7 @@ mod tests {
         let pool = new_pool();
 
         // Int tensor
-        let input: Tensor<i32> = tensor!([1, 2, 3, 4, 5]);
+        let input: Tensor<i32> = [1, 2, 3, 4, 5].into();
         let result = result_item(reduce_sum(
             &pool,
             input.view(),
@@ -1165,7 +1165,7 @@ mod tests {
         assert_eq!(result, input.iter().sum::<i32>());
 
         // Float tensor
-        let input: Tensor<f32> = tensor!([1.5, 2.5, 3.5, 4.5, 5.5]);
+        let input: Tensor<f32> = [1.5, 2.5, 3.5, 4.5, 5.5].into();
         let result = result_item(reduce_sum(
             &pool,
             input.view(),
@@ -1180,7 +1180,7 @@ mod tests {
         let pool = new_pool();
 
         // Int tensor
-        let input: Tensor<i32> = tensor!([1, 2, 3, 4, 5]);
+        let input: Tensor<i32> = [1, 2, 3, 4, 5].into();
         let result = result_item(reduce_sum_square(
             &pool,
             input.view(),
@@ -1190,7 +1190,7 @@ mod tests {
         assert_eq!(result, input.iter().map(|x| x * x).sum::<i32>());
 
         // Float tensor
-        let input: Tensor<f32> = tensor!([1.5, 2.5, 3.5, 4.5, 5.5]);
+        let input: Tensor<f32> = [1.5, 2.5, 3.5, 4.5, 5.5].into();
         let result = result_item(reduce_sum_square(
             &pool,
             input.view(),
@@ -1225,110 +1225,88 @@ mod tests {
         let cases = [
             // Simple case, largest=true
             Case {
-                input: tensor!([0., 1., 2.]),
+                input: [0., 1., 2.].into(),
                 k: 2,
-                expected: Ok((tensor!([2., 1.]), tensor!([2, 1]))),
+                expected: Ok((Tensor::from([2., 1.]), Tensor::from([2, 1]))),
                 ..Default::default()
             },
             // Simple case, largest=false
             Case {
-                input: tensor!([0., 1., 2.]),
+                input: [0., 1., 2.].into(),
                 k: 2,
                 largest: false,
-                expected: Ok((tensor!([0., 1.]), tensor!([0, 1]))),
+                expected: Ok((Tensor::from([0., 1.]), Tensor::from([0, 1]))),
                 ..Default::default()
             },
             // Special case where k=0
             Case {
-                input: tensor!([0., 1., 2.]),
+                input: [0., 1., 2.].into(),
                 k: 0,
-                expected: Ok((tensor!([]), tensor!([]))),
+                expected: Ok((Tensor::from([0.; 0]), Tensor::from([0; 0]))),
                 ..Default::default()
             },
             // Tie break by index when input values are equal.
             Case {
-                input: tensor!([1., 0., 2., 3., 1.]),
+                input: [1., 0., 2., 3., 1.].into(),
                 k: 5,
-                expected: Ok((tensor!([3., 2., 1., 1., 0.]), tensor!([3, 2, 0, 4, 1]))),
+                expected: Ok(([3., 2., 1., 1., 0.].into(), [3, 2, 0, 4, 1].into())),
                 ..Default::default()
             },
             // Tie break by index when input values are equal, largest=false
             Case {
-                input: tensor!([1., 0., 2., 3., 1.]),
+                input: [1., 0., 2., 3., 1.].into(),
                 k: 5,
                 largest: false,
-                expected: Ok((tensor!([0., 1., 1., 2., 3.]), tensor!([1, 0, 4, 2, 3]))),
+                expected: Ok(([0., 1., 1., 2., 3.].into(), [1, 0, 4, 2, 3].into())),
                 ..Default::default()
             },
             // NaN values
             Case {
-                input: tensor!([0., f32::NAN, 2.]),
+                input: [0., f32::NAN, 2.].into(),
                 k: 2,
-                expected: Ok((tensor!([f32::NAN, 2.]), tensor!([1, 2]))),
+                expected: Ok((Tensor::from([f32::NAN, 2.]), Tensor::from([1, 2]))),
                 ..Default::default()
             },
             // NaN values, with largest=false
             Case {
-                input: tensor!([0., f32::NAN, 2.]),
+                input: [0., f32::NAN, 2.].into(),
                 k: 3,
-                expected: Ok((tensor!([0., 2., f32::NAN]), tensor!([0, 2, 1]))),
+                expected: Ok(([0., 2., f32::NAN].into(), [0, 2, 1].into())),
                 largest: false,
                 ..Default::default()
             },
             // Invalid k value
             Case {
-                input: tensor!([0., 1., 2.]),
+                input: [0., 1., 2.].into(),
                 k: 4,
                 expected: Err(OpError::InvalidValue("k > dimension size")),
                 ..Default::default()
             },
             // Scalar input
             Case {
-                input: tensor!(0.),
+                input: Tensor::from(0.),
                 k: 2,
                 expected: Err(OpError::InvalidValue("Axis is invalid")),
                 ..Default::default()
             },
             // 2D input, take top-K over axis 1
             Case {
-                input: tensor!((3, 3); [
-                    0., 1., 2., //
-                    0., 1., 3., //
-                    0., 1., 4. //
-                ]),
+                input: [[0., 1., 2.], [0., 1., 3.], [0., 1., 4.]].into(),
                 k: 2,
                 expected: Ok((
-                    tensor!((3, 2); [
-                        2., 1., //
-                        3., 1., //
-                        4., 1. //
-                    ]),
-                    tensor!((3, 2); [
-                        2, 1, //
-                        2, 1, //
-                        2, 1 //
-                    ]),
+                    [[2., 1.], [3., 1.], [4., 1.]].into(),
+                    [[2, 1], [2, 1], [2, 1]].into(),
                 )),
                 ..Default::default()
             },
             // 2D input, take top-K over axis 0
             Case {
-                input: tensor!((3, 3); [
-                    0., 1., 2., //
-                    3., 4., 5., //
-                    6., 7., 8. //
-                ]),
+                input: Tensor::from([[0., 1., 2.], [3., 4., 5.], [6., 7., 8.]]),
                 k: 2,
                 axis: Some(0),
                 expected: Ok((
-                    tensor!((2, 3); [
-                        6., 7., 8., //
-                        3., 4., 5. //
-                    ]),
-                    tensor!((2, 3); [
-                        2, 2, 2, //
-                        1, 1, 1 //
-                    ]),
+                    [[6., 7., 8.], [3., 4., 5.]].into(),
+                    [[2, 2, 2], [1, 1, 1]].into(),
                 )),
                 ..Default::default()
             },

--- a/src/ops/resize.rs
+++ b/src/ops/resize.rs
@@ -702,7 +702,7 @@ mod tests {
             // Specify output size via `scales`
             Case {
                 image: Tensor::from_data(&[1, 1, 1, 1], vec![1.]),
-                scales: Some(Tensor::from_vec(vec![1., 1., 1., 1.])),
+                scales: Some(Tensor::from([1., 1., 1., 1.])),
                 sizes: None,
                 expected: CaseOutput::Shape(vec![1, 1, 1, 1]),
             },
@@ -710,7 +710,7 @@ mod tests {
             Case {
                 image: Tensor::from_data(&[1, 1, 1, 1], vec![1.]),
                 scales: None,
-                sizes: Some(Tensor::from_vec(vec![1, 1, 2, 2])),
+                sizes: Some(Tensor::from([1, 1, 2, 2])),
                 expected: CaseOutput::Shape(vec![1, 1, 2, 2]),
             },
             // At least one of `scales` or `sizes` must be provided
@@ -731,7 +731,7 @@ mod tests {
             // Invalid values for scales/sizes
             Case {
                 image: Tensor::from_data(&[1, 1, 1, 1], vec![1.]),
-                scales: Some(Tensor::from_vec(vec![1., 1., 1.])),
+                scales: Some(Tensor::from([1., 1., 1.])),
                 sizes: None,
                 expected: CaseOutput::Error(OpError::IncompatibleInputShapes(
                     "scales/sizes length should equal input rank",
@@ -739,7 +739,7 @@ mod tests {
             },
             Case {
                 image: Tensor::from_data(&[1, 1, 1, 1], vec![1.]),
-                scales: Some(Tensor::from_vec(vec![1., 1., -1., 1.])),
+                scales: Some(Tensor::from([1., 1., -1., 1.])),
                 sizes: None,
                 expected: CaseOutput::Error(OpError::InvalidValue("scales/sizes must be positive")),
             },
@@ -753,7 +753,7 @@ mod tests {
             // but not currently supported in our implementation.
             Case {
                 image: Tensor::from_data(&[1, 1, 2, 2], vec![0.2, 0.7, 0.3, 0.8]),
-                scales: Some(Tensor::from_vec(vec![2., 1., 3., 3.])),
+                scales: Some(Tensor::from([2., 1., 3., 3.])),
                 sizes: None,
                 expected: CaseOutput::Error(OpError::UnsupportedValue(
                     "only height and width dimensions can be resized",

--- a/src/ops/resize.rs
+++ b/src/ops/resize.rs
@@ -760,8 +760,8 @@ mod tests {
                 )),
             },
             Case {
-                image: Tensor::from_vec(vec![1., 1.]),
-                scales: Some(Tensor::from_vec(vec![1.])),
+                image: [1., 1.].into(),
+                scales: Some(Tensor::from([1.])),
                 sizes: None,
                 expected: CaseOutput::Error(OpError::InvalidValue("input must have 4 dims (NCHW)")),
             },

--- a/src/ops/split.rs
+++ b/src/ops/split.rs
@@ -70,7 +70,7 @@ impl Operator for Split {
 #[cfg(test)]
 mod tests {
     use rten_tensor::prelude::*;
-    use rten_tensor::tensor;
+    use rten_tensor::Tensor;
 
     use crate::ops::tests::new_pool;
     use crate::ops::{split, OpError};
@@ -79,7 +79,7 @@ mod tests {
     fn test_split() {
         let pool = new_pool();
 
-        let input = tensor!((5, 2); [0., 1., 2., 3., 4., 5., 6., 7., 8., 9.]);
+        let input = Tensor::from([[0., 1.], [2., 3.], [4., 5.], [6., 7.], [8., 9.]]);
 
         // Split with positive axis
         let splits = &[1, 1];
@@ -102,7 +102,7 @@ mod tests {
     fn test_split_invalid_inputs() {
         let pool = new_pool();
 
-        let input = tensor!((5, 2); [0., 1., 2., 3., 4., 5., 6., 7., 8., 9.]);
+        let input = Tensor::from([[0., 1.], [2., 3.], [4., 5.], [6., 7.], [8., 9.]]);
 
         let splits = &[1, 1];
         let result = split(&pool, input.view(), 2, &splits.into());

--- a/src/ops/trilu.rs
+++ b/src/ops/trilu.rs
@@ -57,7 +57,7 @@ impl Operator for Trilu {
 #[cfg(test)]
 mod tests {
     use rten_tensor::prelude::*;
-    use rten_tensor::{tensor, Tensor};
+    use rten_tensor::Tensor;
 
     use crate::ops::tests::new_pool;
     use crate::ops::{trilu, OpError};
@@ -77,119 +77,71 @@ mod tests {
             // k = 0, upper = true
             Case {
                 input: in_3x3.clone(),
-                expected: Tensor::from([
-                    [1, 2, 3], //
-                    [0, 5, 6], //
-                    [0, 0, 9],
-                ]),
+                expected: [[1, 2, 3], [0, 5, 6], [0, 0, 9]].into(),
                 k: 0,
                 upper: true,
             },
             // +ve k, upper = true
             Case {
                 input: in_3x3.clone(),
-                expected: Tensor::from([
-                    [0, 2, 3], //
-                    [0, 0, 6], //
-                    [0, 0, 0],
-                ]),
+                expected: [[0, 2, 3], [0, 0, 6], [0, 0, 0]].into(),
                 k: 1,
                 upper: true,
             },
             // -ve k, upper = true
             Case {
                 input: in_3x3.clone(),
-                expected: Tensor::from([
-                    [1, 2, 3], //
-                    [4, 5, 6], //
-                    [0, 8, 9],
-                ]),
+                expected: [[1, 2, 3], [4, 5, 6], [0, 8, 9]].into(),
                 k: -1,
                 upper: true,
             },
             // k = 0, upper = false
             Case {
                 input: in_3x3.clone(),
-                expected: Tensor::from([
-                    [1, 0, 0], //
-                    [4, 5, 0], //
-                    [7, 8, 9],
-                ]),
+                expected: [[1, 0, 0], [4, 5, 0], [7, 8, 9]].into(),
                 k: 0,
                 upper: false,
             },
             // +ve k, upper = false
             Case {
                 input: in_3x3.clone(),
-                expected: Tensor::from([
-                    [1, 2, 0], //
-                    [4, 5, 6], //
-                    [7, 8, 9],
-                ]),
+                expected: [[1, 2, 0], [4, 5, 6], [7, 8, 9]].into(),
                 k: 1,
                 upper: false,
             },
             // -ve k, upper = false
             Case {
                 input: in_3x3.clone(),
-                expected: Tensor::from([
-                    [0, 0, 0], //
-                    [4, 0, 0], //
-                    [7, 8, 0],
-                ]),
+                expected: [[0, 0, 0], [4, 0, 0], [7, 8, 0]].into(),
                 k: -1,
                 upper: false,
             },
             // Batch of matrices
             Case {
-                input: Tensor::from([
-                    [
-                        [1, 2, 3], //
-                        [4, 5, 6], //
-                        [7, 8, 9],
-                    ],
-                    [
-                        [9, 8, 7], //
-                        [6, 5, 4], //
-                        [3, 2, 1],
-                    ],
-                ]),
-                expected: Tensor::from([
-                    [
-                        [1, 2, 3], //
-                        [0, 5, 6], //
-                        [0, 0, 9],
-                    ],
-                    [
-                        [9, 8, 7], //
-                        [0, 5, 4], //
-                        [0, 0, 1],
-                    ],
-                ]),
+                input: [
+                    [[1, 2, 3], [4, 5, 6], [7, 8, 9]],
+                    [[9, 8, 7], [6, 5, 4], [3, 2, 1]],
+                ]
+                .into(),
+                expected: [
+                    [[1, 2, 3], [0, 5, 6], [0, 0, 9]],
+                    [[9, 8, 7], [0, 5, 4], [0, 0, 1]],
+                ]
+                .into(),
                 k: 0,
                 upper: true,
             },
             // Non-square (wide) matrix
             Case {
                 input: Tensor::arange(1, 16, None).into_shape([3, 5].as_slice()),
-                expected: Tensor::from([
-                    [1, 2, 3, 4, 5],  //
-                    [0, 7, 8, 9, 10], //
-                    [0, 0, 13, 14, 15],
-                ]),
+                expected: [[1, 2, 3, 4, 5], [0, 7, 8, 9, 10], [0, 0, 13, 14, 15]].into(),
                 k: 0,
                 upper: true,
             },
             // Non-square (tall) matrix
             Case {
                 input: Tensor::arange(1, 16, None).into_shape([5, 3].as_slice()),
-                expected: Tensor::from([
-                    [1, 2, 3], //
-                    [0, 5, 6], //
-                    [0, 0, 9], //
-                    [0, 0, 0], //
-                    [0, 0, 0],
-                ]),
+                expected: [[1, 2, 3], [0, 5, 6], [0, 0, 9], [0, 0, 0], [0, 0, 0]].into(),
                 k: 0,
                 upper: true,
             },
@@ -211,7 +163,7 @@ mod tests {
     #[test]
     fn test_trilu_invalid() {
         let pool = new_pool();
-        let input = tensor!([1]);
+        let input = Tensor::from([1]);
         let result = trilu(&pool, input.view(), 0, true /* upper */);
         assert_eq!(
             result,

--- a/src/ops/unary_elementwise.rs
+++ b/src/ops/unary_elementwise.rs
@@ -671,7 +671,7 @@ mod tests {
     use rten_tensor::prelude::*;
     use rten_tensor::rng::XorShiftRng;
     use rten_tensor::test_util::{eq_with_nans, expect_equal, expect_equal_with_tolerance};
-    use rten_tensor::{tensor, RandomSource, Tensor};
+    use rten_tensor::{RandomSource, Tensor};
 
     use crate::ops::tests::new_pool;
     use crate::ops::{
@@ -694,7 +694,7 @@ mod tests {
 
                 // Test inputs here chosen to be in the domain of inverse trig
                 // operators (ie. (-1, 1)).
-                let input = tensor!([0., 0.1, -0.1, 0.9, -0.9]);
+                let input = Tensor::from([0., 0.1, -0.1, 0.9, -0.9]);
                 let expected = input.map($gen_expected);
                 let result = $op(&pool, input.view());
                 expect_equal(&result, &expected)?;
@@ -747,14 +747,14 @@ mod tests {
         let pool = new_pool();
 
         // Float tensor
-        let x: Tensor<f32> = tensor!([1., -1., 0.]);
+        let x: Tensor<f32> = Tensor::from([1., -1., 0.]);
         let result = abs(&pool, x.view());
-        assert_eq!(result, tensor!([1., 1., 0.]));
+        assert_eq!(result, Tensor::from([1., 1., 0.]));
 
         // Int tensor
-        let x: Tensor<i32> = tensor!([1, -1, 0]);
+        let x: Tensor<i32> = Tensor::from([1, -1, 0]);
         let result = abs(&pool, x.view());
-        assert_eq!(result, tensor!([1, 1, 0]));
+        assert_eq!(result, Tensor::from([1, 1, 0]));
     }
 
     test_unary_op!(test_acos, acos, acos_in_place, |x: &f32| x.acos());
@@ -764,7 +764,7 @@ mod tests {
     #[test]
     fn test_ceil() {
         let pool = new_pool();
-        let input = tensor!([
+        let input = Tensor::from([
             1.,
             1.2,
             1.5,
@@ -772,9 +772,9 @@ mod tests {
             0.,
             f32::NAN,
             f32::NEG_INFINITY,
-            f32::INFINITY
+            f32::INFINITY,
         ]);
-        let expected = tensor!([
+        let expected = Tensor::from([
             1.,
             2.,
             2.,
@@ -782,7 +782,7 @@ mod tests {
             0.,
             f32::NAN,
             f32::NEG_INFINITY,
-            f32::INFINITY
+            f32::INFINITY,
         ]);
         let result = ceil(&pool, input.view());
         assert!(eq_with_nans(result.view(), expected.view()));
@@ -799,22 +799,22 @@ mod tests {
 
         let cases = [
             Case {
-                input: tensor!((2, 2); [-5., -2., 3., 20.]),
+                input: [[-5., -2.], [3., 20.]].into(),
                 min: Some(1.),
                 max: Some(5.),
-                expected: tensor!((2, 2); [1., 1., 3., 5.]),
+                expected: [[1., 1.], [3., 5.]].into(),
             },
             Case {
-                input: tensor!((2, 2); [-5., -2., 3., 20.]),
+                input: [[-5., -2.], [3., 20.]].into(),
                 min: Some(1.),
                 max: None,
-                expected: tensor!((2, 2); [1., 1., 3., 20.]),
+                expected: [[1., 1.], [3., 20.]].into(),
             },
             Case {
-                input: tensor!((2, 2); [-5., -2., 3., 20.]),
+                input: [[-5., -2.], [3., 20.]].into(),
                 min: None,
                 max: Some(5.),
-                expected: tensor!((2, 2); [-5., -2., 3., 5.]),
+                expected: [[-5., -2.], [3., 5.]].into(),
             },
         ];
 
@@ -846,7 +846,7 @@ mod tests {
 
         let pool = new_pool();
         for Case { alpha } in cases {
-            let input = tensor!([-5., -2., -1., -0.5, 0., 0.5, 1., 2., 5.]);
+            let input = Tensor::from([-5., -2., -1., -0.5, 0., 0.5, 1., 2., 5.]);
             let expected = input.map(|&x: &f32| if x >= 0. { x } else { alpha * (x.exp() - 1.) });
 
             let actual = elu(&pool, input.view(), alpha);
@@ -863,8 +863,8 @@ mod tests {
     #[test]
     fn test_erf() -> Result<(), Box<dyn Error>> {
         let pool = new_pool();
-        let input = tensor!([-2.0, -0.5, 0.5, 2.0]);
-        let expected = tensor!([
+        let input = Tensor::from([-2.0, -0.5, 0.5, 2.0]);
+        let expected = Tensor::from([
             -0.9953222650189527,
             -0.5204998778130465,
             0.5204998778130465,
@@ -890,8 +890,8 @@ mod tests {
         expect_equal_with_tolerance(&result, &expected, 1e-6, 0.)?;
 
         // Special values.
-        let input = tensor!([f32::NAN, 0., f32::INFINITY, -f32::INFINITY]);
-        let expected = tensor!([f32::NAN, 0., 1., -1.]);
+        let input = Tensor::from([f32::NAN, 0., f32::INFINITY, -f32::INFINITY]);
+        let expected = Tensor::from([f32::NAN, 0., 1., -1.]);
         let result = erf(&pool, input.view());
         assert!(eq_with_nans(result.view(), expected.view()));
 
@@ -900,8 +900,8 @@ mod tests {
 
     #[test]
     fn test_erf_in_place() -> Result<(), Box<dyn Error>> {
-        let mut input = tensor!([-2.0, -0.5, 0.5, 2.0]);
-        let expected = tensor!([
+        let mut input = Tensor::from([-2.0, -0.5, 0.5, 2.0]);
+        let expected = Tensor::from([
             -0.9953222650189527,
             -0.5204998778130465,
             0.5204998778130465,
@@ -915,12 +915,12 @@ mod tests {
     #[test]
     fn test_exp() -> Result<(), Box<dyn Error>> {
         let pool = new_pool();
-        let input = tensor!([-2.0, -0.5, 0.5, 2.0]);
-        let expected = tensor!([
+        let input = Tensor::from([-2.0, -0.5, 0.5, 2.0]);
+        let expected = Tensor::from([
             0.1353352832366127,
             0.6065306597126334,
             1.6487212707001282,
-            7.38905609893065
+            7.38905609893065,
         ]);
         let result = exp(&pool, input.view());
         expect_equal(&result, &expected)?;
@@ -929,12 +929,12 @@ mod tests {
 
     #[test]
     fn test_exp_in_place() -> Result<(), Box<dyn Error>> {
-        let mut input = tensor!([-2.0, -0.5, 0.5, 2.0]);
-        let expected = tensor!([
+        let mut input = Tensor::from([-2.0, -0.5, 0.5, 2.0]);
+        let expected = Tensor::from([
             0.1353352832366127,
             0.6065306597126334,
             1.6487212707001282,
-            7.38905609893065
+            7.38905609893065,
         ]);
         exp_in_place(input.view_mut());
         expect_equal(&input, &expected)?;
@@ -944,7 +944,7 @@ mod tests {
     #[test]
     fn test_floor() {
         let pool = new_pool();
-        let input = tensor!([
+        let input = Tensor::from([
             1.,
             1.2,
             1.5,
@@ -952,9 +952,9 @@ mod tests {
             0.,
             f32::NAN,
             f32::NEG_INFINITY,
-            f32::INFINITY
+            f32::INFINITY,
         ]);
-        let expected = tensor!([
+        let expected = Tensor::from([
             1.,
             1.,
             1.,
@@ -962,7 +962,7 @@ mod tests {
             0.,
             f32::NAN,
             f32::NEG_INFINITY,
-            f32::INFINITY
+            f32::INFINITY,
         ]);
         let result = floor(&pool, input.view());
         assert!(eq_with_nans(result.view(), expected.view()));
@@ -975,12 +975,12 @@ mod tests {
 
     #[test]
     fn test_hard_sigmoid() -> Result<(), Box<dyn Error>> {
-        let input = tensor!([-4., -3., -1., 0., 1., 3., 4.]);
+        let input = Tensor::from([-4., -3., -1., 0., 1., 3., 4.]);
         let alpha = 0.2;
         let beta = 0.5;
         let pool = new_pool();
         let result = hard_sigmoid(&pool, input.view(), alpha, beta);
-        let expected = tensor!([0., 0., -1. / 5. + 0.5, 0.5, 1. / 5. + 0.5, 1., 1.]);
+        let expected = Tensor::from([0., 0., -1. / 5. + 0.5, 0.5, 1. / 5. + 0.5, 1., 1.]);
         expect_equal(&result, &expected)?;
         Ok(())
     }
@@ -988,9 +988,9 @@ mod tests {
     #[test]
     fn test_hard_swish() -> Result<(), Box<dyn Error>> {
         let pool = new_pool();
-        let input = tensor!([-4., -3., -1., 0., 1., 3., 4.]);
+        let input = Tensor::from([-4., -3., -1., 0., 1., 3., 4.]);
         let result = hard_swish(&pool, input.view());
-        let expected = tensor!([0., 0., -1. / 3., 0., 2. / 3., 3., 4.]);
+        let expected = Tensor::from([0., 0., -1. / 3., 0., 2. / 3., 3., 4.]);
         expect_equal(&result, &expected)?;
         Ok(())
     }
@@ -1019,12 +1019,12 @@ mod tests {
     #[test]
     fn test_log() -> Result<(), Box<dyn Error>> {
         let pool = new_pool();
-        let input = tensor!([0.1, 0.5, 1., 10.]);
-        let expected = tensor!([
+        let input = Tensor::from([0.1, 0.5, 1., 10.]);
+        let expected = Tensor::from([
             -2.3025850929940455,
             -0.6931471805599453,
             0.,
-            2.302585092994046
+            2.302585092994046,
         ]);
         let result = log(&pool, input.view());
         expect_equal(&result, &expected)?;
@@ -1033,12 +1033,12 @@ mod tests {
 
     #[test]
     fn test_log_in_place() -> Result<(), Box<dyn Error>> {
-        let mut input = tensor!([0.1, 0.5, 1., 10.]);
-        let expected = tensor!([
+        let mut input = Tensor::from([0.1, 0.5, 1., 10.]);
+        let expected = Tensor::from([
             -2.3025850929940455,
             -0.6931471805599453,
             0.,
-            2.302585092994046
+            2.302585092994046,
         ]);
         log_in_place(input.view_mut());
         expect_equal(&input, &expected)?;
@@ -1048,16 +1048,16 @@ mod tests {
     #[test]
     fn test_neg() {
         let pool = new_pool();
-        let input = tensor!([0, 1, -1, 2]);
-        let expected = tensor!([0, -1, 1, -2]);
+        let input = Tensor::from([0, 1, -1, 2]);
+        let expected = Tensor::from([0, -1, 1, -2]);
         let result = neg(&pool, input.view());
         assert_eq!(result, expected);
     }
 
     #[test]
     fn test_neg_in_place() {
-        let mut input = tensor!([0, 1, -1, 2]);
-        let expected = tensor!([0, -1, 1, -2]);
+        let mut input = Tensor::from([0, 1, -1, 2]);
+        let expected = Tensor::from([0, -1, 1, -2]);
         neg_in_place(input.view_mut());
         assert_eq!(input, expected);
     }
@@ -1065,16 +1065,16 @@ mod tests {
     #[test]
     fn test_not() {
         let pool = new_pool();
-        let input = tensor!([0, 1, 1, 0]);
-        let expected = tensor!([1, 0, 0, 1]);
+        let input = Tensor::from([0, 1, 1, 0]);
+        let expected = Tensor::from([1, 0, 0, 1]);
         let result = not(&pool, input.view());
         assert_eq!(result, expected);
     }
 
     #[test]
     fn test_not_in_place() {
-        let mut input = tensor!([0, 1, 1, 0]);
-        let expected = tensor!([1, 0, 0, 1]);
+        let mut input = Tensor::from([0, 1, 1, 0]);
+        let expected = Tensor::from([1, 0, 0, 1]);
         not_in_place(input.view_mut());
         assert_eq!(input, expected);
     }
@@ -1082,7 +1082,7 @@ mod tests {
     #[test]
     fn test_reciprocal() {
         let pool = new_pool();
-        let input = tensor!([1., 2., 0.5, 0.]);
+        let input = Tensor::from([1., 2., 0.5, 0.]);
         let expected = input.map(|x| 1. / x);
         let result = reciprocal(&pool, input.view());
         assert_eq!(result, expected);
@@ -1108,8 +1108,8 @@ mod tests {
         let pool = new_pool();
 
         // Example from ONNX spec.
-        let input = tensor!([0.9, 2.5, 2.3, 1.5, -4.5]);
-        let expected = tensor!([1., 2., 2., 2., -4.]);
+        let input = Tensor::from([0.9, 2.5, 2.3, 1.5, -4.5]);
+        let expected = Tensor::from([1., 2., 2., 2., -4.]);
         let result = round(&pool, input.view());
         expect_equal(&result, &expected)?;
 
@@ -1118,7 +1118,7 @@ mod tests {
         expect_equal(&input, &expected)?;
 
         // Per spec, integral, zero, NaN and infinities are unchanged.
-        let input = tensor!([1., 0., -0., f32::NAN, f32::INFINITY, f32::NEG_INFINITY]);
+        let input = Tensor::from([1., 0., -0., f32::NAN, f32::INFINITY, f32::NEG_INFINITY]);
         let result = round(&pool, input.view());
         assert!(eq_with_nans(input.view(), result.view()));
 
@@ -1159,8 +1159,8 @@ mod tests {
     #[test]
     fn test_sqrt() -> Result<(), Box<dyn Error>> {
         let pool = new_pool();
-        let input = tensor!([4., 9., 16.]);
-        let expected = tensor!([2., 3., 4.]);
+        let input = Tensor::from([4., 9., 16.]);
+        let expected = Tensor::from([2., 3., 4.]);
         let result = sqrt(&pool, input.view());
         expect_equal(&result, &expected)?;
         Ok(())
@@ -1168,8 +1168,8 @@ mod tests {
 
     #[test]
     fn test_sqrt_in_place() -> Result<(), Box<dyn Error>> {
-        let mut input = tensor!([4., 9., 16.]);
-        let expected = tensor!([2., 3., 4.]);
+        let mut input = Tensor::from([4., 9., 16.]);
+        let expected = Tensor::from([2., 3., 4.]);
         sqrt_in_place(input.view_mut());
         expect_equal(&input, &expected)?;
         Ok(())


### PR DESCRIPTION
Replace `tensor!((shape); [elements])` with `nested_array.into()` (if type can be inferred) or `Tensor::from(nested_array)`. This is an effort to make the codebase more consistent by having fewer ways to create tensors from literals.