### PR TITLE
Use `u32` everywhere to represent token IDs

### DIFF
--- a/rten-examples/src/gpt2.rs
+++ b/rten-examples/src/gpt2.rs
@@ -103,11 +103,6 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let prompt = args.prompt.as_str();
     let encoded_prompt = tokenizer.encode(prompt.into(), Default::default())?;
-    let token_ids: Vec<u32> = encoded_prompt
-        .token_ids()
-        .iter()
-        .map(|id| *id as u32)
-        .collect();
 
     // The output starts with the user's prompt.
     print!("{}", prompt);
@@ -115,7 +110,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut metrics = Metrics::new();
     let temperature = 1.0;
     let generator = Generator::from_model(&model)?
-        .with_prompt(&token_ids)
+        .with_prompt(encoded_prompt.token_ids())
         .with_sampler(TopKSampler::new(args.top_k, temperature))
         .take(args.output_length)
         .profile(&mut metrics)

--- a/rten-examples/src/qwen2_chat.rs
+++ b/rten-examples/src/qwen2_chat.rs
@@ -91,7 +91,7 @@ fn encode_message(
             MessageChunk::Token(tok_id) => token_ids.push(*tok_id),
             MessageChunk::Text(text) => {
                 let encoded = tokenizer.encode((*text).into(), Default::default())?;
-                token_ids.extend(encoded.token_ids().iter().map(|id| *id as u32));
+                token_ids.extend(encoded.token_ids());
             }
         }
     }
@@ -129,9 +129,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     let tokenizer_config = fs::read_to_string(&args.tokenizer_config)?;
     let tokenizer = Tokenizer::from_json(&tokenizer_config)?;
 
-    let im_start_token = tokenizer.encoder().get_token_id("<|im_start|>")? as u32;
-    let im_end_token = tokenizer.encoder().get_token_id("<|im_end|>")? as u32;
-    let end_of_text_token = tokenizer.encoder().get_token_id("<|endoftext|>")? as u32;
+    let im_start_token = tokenizer.encoder().get_token_id("<|im_start|>")?;
+    let im_end_token = tokenizer.encoder().get_token_id("<|im_end|>")?;
+    let end_of_text_token = tokenizer.encoder().get_token_id("<|endoftext|>")?;
 
     // From `chat_template` in tokenizer_config.json.
     let prompt_tokens = encode_message(

--- a/rten-generate/src/generator.rs
+++ b/rten-generate/src/generator.rs
@@ -38,6 +38,9 @@ pub enum GeneratorError {
     DecodeError(TokenizerError),
 }
 
+/// Integer type used to represent token IDs.
+pub type TokenId = u32;
+
 impl fmt::Display for GeneratorError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
@@ -189,7 +192,7 @@ pub struct Generator<'a> {
     varying_inputs: Vec<(NodeId, &'a dyn Fn(usize, Range<usize>) -> InputOrOutput<'a>)>,
 
     /// Input token IDs for the next run of the model.
-    input_ids: Vec<u32>,
+    input_ids: Vec<TokenId>,
 
     // Input node IDs
     input_ids_input: NodeId,
@@ -392,7 +395,7 @@ impl<'a> Generator<'a> {
     ///
     /// To add new inputs after the initial generation, use
     /// [`append_prompt`](Self::append_prompt) instead.
-    pub fn with_prompt(mut self, prompt: &[u32]) -> Self {
+    pub fn with_prompt(mut self, prompt: &[TokenId]) -> Self {
         self.input_ids = prompt.to_vec();
         self
     }
@@ -401,7 +404,7 @@ impl<'a> Generator<'a> {
     ///
     /// This is useful in applications such as chat where the model's input
     /// alternates between encoded user input and model-generated output.
-    pub fn append_prompt(&mut self, prompt: &[u32]) {
+    pub fn append_prompt(&mut self, prompt: &[TokenId]) {
         self.input_ids.extend(prompt);
     }
 
@@ -438,7 +441,7 @@ impl<'a> Generator<'a> {
     }
 
     /// Run the model and generate the next token.
-    fn generate_next_token(&mut self) -> Result<u32, GeneratorError> {
+    fn generate_next_token(&mut self) -> Result<TokenId, GeneratorError> {
         fn wrap_error<E>(e: E) -> GeneratorError
         where
             E: Into<Box<dyn Error>>,
@@ -546,10 +549,10 @@ impl<'a> Generator<'a> {
 }
 
 /// Output items from a [`Generator`].
-pub type GeneratorItem = Result<u32, GeneratorError>;
+pub type GeneratorItem = Result<TokenId, GeneratorError>;
 
 impl<'a> Iterator for Generator<'a> {
-    type Item = Result<u32, GeneratorError>;
+    type Item = Result<TokenId, GeneratorError>;
 
     /// Run the model and generate the next output token.
     fn next(&mut self) -> Option<Self::Item> {

--- a/rten-generate/src/text_decoder.rs
+++ b/rten-generate/src/text_decoder.rs
@@ -48,7 +48,7 @@ impl<'a, G: Iterator<Item = GeneratorItem>> Iterator for TextDecoder<'a, G> {
                 Err(err) => return Some(Err(err)),
             };
 
-            token_buf.push(token as usize);
+            token_buf.push(token);
 
             let text = self.tokenizer.encoder().decode(&token_buf);
             match text {
@@ -73,14 +73,14 @@ mod tests {
     use std::collections::HashMap;
 
     use rten_text::tokenizers::patterns::GPT2;
-    use rten_text::tokenizers::{Bpe, Tokenizer, WordPiece};
+    use rten_text::tokenizers::{Bpe, TokenId, Tokenizer, WordPiece};
 
     use crate::{GeneratorError, GeneratorUtils};
 
     /// Create a simple WordPiece tokenizer. This is essentially just a lookup
     /// from token ID to string.
     fn create_tokenizer() -> Tokenizer {
-        let vocab: HashMap<String, usize> = [("one", 1), ("two", 2), ("three", 3)]
+        let vocab: HashMap<String, TokenId> = [("one", 1), ("two", 2), ("three", 3)]
             .into_iter()
             .map(|(s, id)| (s.to_string(), id))
             .collect();

--- a/rten-text/src/tokenizers/json.rs
+++ b/rten-text/src/tokenizers/json.rs
@@ -3,12 +3,13 @@
 
 use std::collections::HashMap;
 
+use super::TokenId;
 use serde::Deserialize;
 
 #[derive(Deserialize)]
 pub(crate) struct AddedToken {
     pub content: String,
-    pub id: u32,
+    pub id: TokenId,
 }
 
 #[derive(Deserialize)]
@@ -29,13 +30,13 @@ pub(crate) enum Normalizer {
 #[derive(Deserialize)]
 pub(crate) struct WordPieceModel {
     /// Mapping from token text to token ID.
-    pub vocab: HashMap<String, usize>,
+    pub vocab: HashMap<String, TokenId>,
 }
 
 #[derive(Deserialize)]
 pub(crate) struct BpeModel {
     /// Mapping from token text to token ID.
-    pub vocab: HashMap<String, usize>,
+    pub vocab: HashMap<String, TokenId>,
 
     /// List of `<token_a> [SPACE] <token_b>` containing tokens to merge.
     pub merges: Vec<String>,

--- a/rten-text/tests/reftest.rs
+++ b/rten-text/tests/reftest.rs
@@ -6,24 +6,26 @@ use std::path::PathBuf;
 
 use rten_text::normalizer::{Normalizer, NormalizerOptions};
 use rten_text::tokenizers::patterns::GPT2 as GPT2_SPLIT_PATTERN;
-use rten_text::tokenizers::{Bpe, Tokenizer, TokenizerOptions, WordPiece, WordPieceOptions};
+use rten_text::tokenizers::{
+    Bpe, TokenId, Tokenizer, TokenizerOptions, WordPiece, WordPieceOptions,
+};
 use serde::Deserialize;
 
 /// Load a vocabulary from a text file with one token per line (ie. the
 /// vocab.txt files that come with Hugging Face models).
-fn read_vocab_text_file(path: &str) -> Result<HashMap<String, usize>, io::Error> {
+fn read_vocab_text_file(path: &str) -> Result<HashMap<String, TokenId>, io::Error> {
     let content = read_test_file(path)?;
     Ok(content
         .lines()
         .enumerate()
-        .map(|(i, line)| (line.to_string(), i))
+        .map(|(i, line)| (line.to_string(), i as TokenId))
         .collect())
 }
 
 /// Struct representing the JSON files in `reftests/`.
 #[derive(Deserialize)]
 struct ReferenceTokenization {
-    token_ids: Vec<usize>,
+    token_ids: Vec<TokenId>,
 }
 
 impl ReferenceTokenization {
@@ -44,7 +46,7 @@ fn read_test_file(path: &str) -> Result<String, io::Error> {
 
 /// Compare two slices of token IDs and return an error if there are any
 /// mismatches.
-fn compare_tokens(actual: &[usize], expected: &[usize]) -> Result<(), Box<dyn Error>> {
+fn compare_tokens(actual: &[TokenId], expected: &[TokenId]) -> Result<(), Box<dyn Error>> {
     for (i, (actual, expected)) in actual.iter().zip(expected.iter()).enumerate() {
         if actual != expected {
             return Err(


### PR DESCRIPTION
Previously rten-text used `usize` for token IDs and rten-generate used `u32`, requiring extra conversions. Settle on `u32` everywhere since all tokenizers that I'm aware of have hundreds of thousands of tokens at most.