### PR TITLE
Return input to pool in `run_in_place` fallback for Cast operator

### DIFF
--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -864,8 +864,9 @@ pub trait Operator: Any + Debug {
     ///
     /// Operators may fall back to allocating a new output if some property of
     /// the input data or shapes means in-place operation is not possible. In
-    /// that case they should allocate the output from `pool`. The pool should
-    /// also be used for any temporary buffers created during execution.
+    /// this case they should return the input buffer to the pool, and allocate
+    /// the new output buffer from it. The pool should also be used for any
+    /// temporary buffers created during execution.
     fn run_in_place(
         &self,
         _pool: &TensorPool,


### PR DESCRIPTION
If the Cast operator is run in place but has to copy its input, return the original input to the pool, avoiding the overhead of freeing it with the system allocator.

Also refactor the cast to avoid constructing an `InputList` and unpacking an `OutputList`.