### PR TITLE
Optimize `LayerNormalization` using fusion, in-place operations and more efficient reductions

### DIFF
--- a/rten-tensor/src/iterators.rs
+++ b/rten-tensor/src/iterators.rs
@@ -491,7 +491,15 @@ impl Iterator for LaneRanges {
             offset..offset + (self.dim_size - 1) * self.dim_stride + 1
         })
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.offsets.size_hint()
+    }
 }
+
+impl ExactSizeIterator for LaneRanges {}
+
+impl FusedIterator for LaneRanges {}
 
 /// Iterator over 1D slices of a tensor along a target dimension of size N.
 ///
@@ -535,6 +543,8 @@ impl<'a, T> Iterator for Lane<'a, T> {
 
 impl<'a, T> ExactSizeIterator for Lane<'a, T> {}
 
+impl<'a, T> FusedIterator for Lane<'a, T> {}
+
 impl<'a, T> Lanes<'a, T> {
     /// Create an iterator which yields all possible slices over the `dim`
     /// dimension of `tensor`.
@@ -560,7 +570,15 @@ impl<'a, T> Iterator for Lanes<'a, T> {
             size: self.size,
         })
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.ranges.size_hint()
+    }
 }
+
+impl<'a, T> ExactSizeIterator for Lanes<'a, T> {}
+
+impl<'a, T> FusedIterator for Lanes<'a, T> {}
 
 /// Mutable version of [Lanes].
 ///

--- a/src/ops/norm.rs
+++ b/src/ops/norm.rs
@@ -5,7 +5,7 @@ use rten_tensor::{NdTensorView, Tensor, TensorView};
 use rten_vecmath::vec_softmax_in_place;
 use smallvec::SmallVec;
 
-use crate::ops::{add, mul, reduce_mean, sub};
+use crate::ops::{add_in_place, mul_in_place, reduce_mean, sub};
 use crate::ops::{resolve_axis, InputList, IntoOpResult, OpError, Operator, Output, OutputList};
 use crate::slice_reductions::{slice_max, slice_sum};
 use crate::static_dims;
@@ -276,29 +276,25 @@ pub fn layer_normalization(
         true, /* keep_dims */
     )?
     .auto_return(pool);
-    let d = sub(pool, input, mean.view())?.auto_return(pool);
-    let dd = mul(pool, d.view(), d.view())?.auto_return(pool);
-    let var = reduce_mean(
+    let mut normalized = sub(pool, input, mean.view())?.auto_return(pool);
+    let centered_square = normalized.map_in(pool, |x| x * x).auto_return(pool);
+    let mut inverse_std_dev = reduce_mean(
         pool,
-        dd.view(),
+        centered_square.view(),
         Some(normalized_axes.as_slice()),
         true, /* keep_dims */
     )?
     .auto_return(pool);
-    let inverse_std_dev = var
-        .map_in(pool, |x| 1. / (x + epsilon).sqrt())
-        .auto_return(pool);
-    let normalized = mul(pool, d.view(), inverse_std_dev.view())?.auto_return(pool);
+    inverse_std_dev.apply(|x| 1. / (x + epsilon).sqrt());
+    mul_in_place(normalized.view_mut(), inverse_std_dev.view());
 
     // Second step: Shift and scale input.
-    let normalized_scaled = mul(pool, normalized.view(), scale)?.auto_return(pool);
-    let output = if let Some(bias) = bias {
-        add(pool, normalized_scaled.view(), bias)?.auto_return(pool)
-    } else {
-        normalized_scaled
-    };
+    mul_in_place(normalized.view_mut(), scale);
+    if let Some(bias) = bias {
+        add_in_place(normalized.view_mut(), bias);
+    }
 
-    Ok(output.take())
+    Ok(normalized.take())
 }
 
 #[derive(Debug)]

--- a/src/ops/reduce.rs
+++ b/src/ops/reduce.rs
@@ -286,9 +286,11 @@ fn reduce<T: Copy, R: Reducer<T>>(
             if resolved_axes.len() == 1 {
                 // Fast path for reducing a single axis.
                 let resolved_axis = resolved_axes[0];
-                for slice in input.lanes(resolved_axis) {
-                    reduced_data.push(reducer.reduce(slice.copied()));
-                }
+                reduced_data.extend(
+                    input
+                        .lanes(resolved_axis)
+                        .map(|lane| reducer.reduce(lane.copied())),
+                );
             } else {
                 // Slow case when we have to step through each index
                 let outer_range: Vec<_> = (0..input.ndim())


### PR DESCRIPTION
This PR contains a series of optimizations to the LayerNormalization operator, which also benefit ReduceMean and ReduceSum:

- Use a more efficient method of extending the output Vec when reducing over non-unit stride axes in `Reduce*` operations. As part of this, impl ExactSizedIterator and FusedIterator for the `Lanes`/`Lane` iterators in rten-tensor
- Fuse the `1. / (mean(x^2) + epsilon).sqrt()` step ("inverse Root Mean Squared") in LayerNormalization. This will also be useful in a future RMSNorm operator.
- Use in-place operations to reduce the number of temporary buffers used in LayerNormalization
- Apply the technique used to improve ILP/vectorization for summing slices to summing of non-unit stride tensor lanes

Using the `vision_encoder.onnx` model from https://huggingface.co/facebook/sam-vit-base, this reduces time spent in `LayerNormalization` operations from ~280ms to ~150ms.