### PR TITLE
Add partial implementation of `Einsum` and Segment Anything example

### DIFF
--- a/rten-convert/rten_convert/converter.py
+++ b/rten-convert/rten_convert/converter.py
@@ -709,6 +709,10 @@ def op_node_from_onnx_operator(
             op_reader.check_attr("exclusive", "int", 0)
             op_reader.check_attr("reverse", "int", 0)
 
+        case "Einsum":
+            attrs = sg.EinsumAttrsT()
+            attrs.equation = op_reader.require_attr("equation", "string")
+
         case "Elu":
             attrs = sg.EluAttrsT()
             attrs.alpha = op_reader.get_attr("alpha", "float", 1.0)

--- a/rten-convert/rten_convert/schema_generated.py
+++ b/rten-convert/rten_convert/schema_generated.py
@@ -110,6 +110,7 @@ class OperatorType(object):
     Softplus = 100
     GatherND = 101
     Gelu = 102
+    Einsum = 103
 
 
 class RNNDirection(object):
@@ -185,6 +186,7 @@ class OperatorAttrs(object):
     RandomNormalLikeAttrs = 35
     GatherNDAttrs = 36
     GeluAttrs = 37
+    EinsumAttrs = 38
 
 def OperatorAttrsCreator(unionType, table):
     from flatbuffers.table import Table
@@ -264,6 +266,8 @@ def OperatorAttrsCreator(unionType, table):
         return GatherNDAttrsT.InitFromBuf(table.Bytes, table.Pos)
     if unionType == OperatorAttrs().GeluAttrs:
         return GeluAttrsT.InitFromBuf(table.Bytes, table.Pos)
+    if unionType == OperatorAttrs().EinsumAttrs:
+        return EinsumAttrsT.InitFromBuf(table.Bytes, table.Pos)
     return None
 
 
@@ -1586,6 +1590,86 @@ class ConvTransposeAttrsT(object):
             ConvTransposeAttrsAddPads(builder, pads)
         convTransposeAttrs = ConvTransposeAttrsEnd(builder)
         return convTransposeAttrs
+
+
+class EinsumAttrs(object):
+    __slots__ = ['_tab']
+
+    @classmethod
+    def GetRootAs(cls, buf, offset=0):
+        n = flatbuffers.encode.Get(flatbuffers.packer.uoffset, buf, offset)
+        x = EinsumAttrs()
+        x.Init(buf, n + offset)
+        return x
+
+    @classmethod
+    def GetRootAsEinsumAttrs(cls, buf, offset=0):
+        """This method is deprecated. Please switch to GetRootAs."""
+        return cls.GetRootAs(buf, offset)
+    @classmethod
+    def EinsumAttrsBufferHasIdentifier(cls, buf, offset, size_prefixed=False):
+        return flatbuffers.util.BufferHasIdentifier(buf, offset, b"\x52\x54\x45\x4E", size_prefixed=size_prefixed)
+
+    # EinsumAttrs
+    def Init(self, buf, pos):
+        self._tab = flatbuffers.table.Table(buf, pos)
+
+    # EinsumAttrs
+    def Equation(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
+        if o != 0:
+            return self._tab.String(o + self._tab.Pos)
+        return None
+
+def EinsumAttrsStart(builder):
+    builder.StartObject(1)
+
+def EinsumAttrsAddEquation(builder, equation):
+    builder.PrependUOffsetTRelativeSlot(0, flatbuffers.number_types.UOffsetTFlags.py_type(equation), 0)
+
+def EinsumAttrsEnd(builder):
+    return builder.EndObject()
+
+
+
+class EinsumAttrsT(object):
+
+    # EinsumAttrsT
+    def __init__(self):
+        self.equation = None  # type: str
+
+    @classmethod
+    def InitFromBuf(cls, buf, pos):
+        einsumAttrs = EinsumAttrs()
+        einsumAttrs.Init(buf, pos)
+        return cls.InitFromObj(einsumAttrs)
+
+    @classmethod
+    def InitFromPackedBuf(cls, buf, pos=0):
+        n = flatbuffers.encode.Get(flatbuffers.packer.uoffset, buf, pos)
+        return cls.InitFromBuf(buf, pos+n)
+
+    @classmethod
+    def InitFromObj(cls, einsumAttrs):
+        x = EinsumAttrsT()
+        x._UnPack(einsumAttrs)
+        return x
+
+    # EinsumAttrsT
+    def _UnPack(self, einsumAttrs):
+        if einsumAttrs is None:
+            return
+        self.equation = einsumAttrs.Equation()
+
+    # EinsumAttrsT
+    def Pack(self, builder):
+        if self.equation is not None:
+            equation = builder.CreateString(self.equation)
+        EinsumAttrsStart(builder)
+        if self.equation is not None:
+            EinsumAttrsAddEquation(builder, equation)
+        einsumAttrs = EinsumAttrsEnd(builder)
+        return einsumAttrs
 
 
 class EluAttrs(object):
@@ -4585,7 +4669,7 @@ class OperatorNodeT(object):
     def __init__(self):
         self.type = 0  # type: int
         self.attrsType = 0  # type: int
-        self.attrs = None  # type: Union[None, ArgMaxAttrsT, AveragePoolAttrsT, BatchNormalizationAttrsT, CastAttrsT, ConcatAttrsT, ConstantOfShapeAttrsT, ConvAttrsT, ConvTransposeAttrsT, FlattenAttrsT, GatherAttrsT, GemmAttrsT, GRUAttrsT, LeakyReluAttrsT, LSTMAttrsT, MaxPoolAttrsT, ReduceMeanAttrsT, ReshapeAttrsT, ResizeAttrsT, SplitAttrsT, SoftmaxAttrsT, TransposeAttrsT, ModAttrsT, ScatterElementsAttrsT, OneHotAttrsT, TopKAttrsT, HardSigmoidAttrsT, TriluAttrsT, ScatterNDAttrsT, NonMaxSuppressionAttrsT, LayerNormalizationAttrsT, RandomUniformAttrsT, EluAttrsT, RandomUniformLikeAttrsT, RandomNormalAttrsT, RandomNormalLikeAttrsT, GatherNDAttrsT, GeluAttrsT]
+        self.attrs = None  # type: Union[None, ArgMaxAttrsT, AveragePoolAttrsT, BatchNormalizationAttrsT, CastAttrsT, ConcatAttrsT, ConstantOfShapeAttrsT, ConvAttrsT, ConvTransposeAttrsT, FlattenAttrsT, GatherAttrsT, GemmAttrsT, GRUAttrsT, LeakyReluAttrsT, LSTMAttrsT, MaxPoolAttrsT, ReduceMeanAttrsT, ReshapeAttrsT, ResizeAttrsT, SplitAttrsT, SoftmaxAttrsT, TransposeAttrsT, ModAttrsT, ScatterElementsAttrsT, OneHotAttrsT, TopKAttrsT, HardSigmoidAttrsT, TriluAttrsT, ScatterNDAttrsT, NonMaxSuppressionAttrsT, LayerNormalizationAttrsT, RandomUniformAttrsT, EluAttrsT, RandomUniformLikeAttrsT, RandomNormalAttrsT, RandomNormalLikeAttrsT, GatherNDAttrsT, GeluAttrsT, EinsumAttrsT]
         self.inputs = None  # type: List[int]
         self.outputs = None  # type: List[int]
 

--- a/rten-examples/Cargo.toml
+++ b/rten-examples/Cargo.toml
@@ -60,6 +60,10 @@ path = "src/yolo.rs"
 name = "depth_anything"
 path = "src/depth_anything.rs"
 
+[[bin]]
+name = "segment_anything"
+path = "src/segment_anything.rs"
+
 # Text
 [[bin]]
 name = "bert_qa"

--- a/rten-examples/README.md
+++ b/rten-examples/README.md
@@ -56,6 +56,7 @@ The examples have been chosen to cover common tasks and popular models.
 - **depth_anything** - Monocular depth estimation using [Depth Anything](https://github.com/LiheYoung/Depth-Anything)
 - **detr** - Object detection using [DETR](https://research.facebook.com/publications/end-to-end-object-detection-with-transformers/)
 - **distilvit** - Image captioning using [Mozilla's DistilViT](https://hacks.mozilla.org/2024/05/experimenting-with-local-alt-text-generation-in-firefox-nightly/)
+- **segment_anything** - Image segmentation using [Segment Anything](https://segment-anything.com)
 - **yolo** - Object detection using [YOLO v8](https://github.com/ultralytics/ultralytics)
 
 ### Text

--- a/rten-examples/src/segment_anything.rs
+++ b/rten-examples/src/segment_anything.rs
@@ -1,0 +1,217 @@
+use std::collections::VecDeque;
+use std::error::Error;
+
+use rten::{Dimension, FloatOperators, Model};
+use rten_imageio::{read_image, write_image};
+use rten_tensor::prelude::*;
+use rten_tensor::{NdTensor, Tensor};
+
+struct Args {
+    /// Path to image encoder model.
+    encoder_model: String,
+
+    /// Path to prompt encoder / mask decoder model.
+    decoder_model: String,
+
+    /// Path to input image to segment.
+    image: String,
+
+    /// (x, y) query points identifying the object(s) to generate segmentation
+    /// masks for.
+    points: Vec<(u32, u32)>,
+}
+
+fn parse_args() -> Result<Args, lexopt::Error> {
+    use lexopt::prelude::*;
+
+    let mut values = VecDeque::new();
+    let mut parser = lexopt::Parser::from_env();
+
+    while let Some(arg) = parser.next()? {
+        match arg {
+            Value(val) => values.push_back(val.string()?),
+            Long("help") => {
+                println!(
+                    "Segment an image.
+
+Usage: {bin_name} <encoder_model> <decoder_model> <image> <points>
+
+Args:
+
+  <encoder_model> - Image encoder model
+  <decoder_model> - Prompt decoder model
+  <image> - Image to process
+  <points> -
+
+    List of points identifying the object to segment.
+
+    This has the form `x1,y1;x2,y2;...`. At least one point must be provided.
+",
+                    bin_name = parser.bin_name().unwrap_or("segment_anything")
+                );
+                std::process::exit(0);
+            }
+            _ => return Err(arg.unexpected()),
+        }
+    }
+
+    let encoder_model = values.pop_front().ok_or("missing `encoder_model` arg")?;
+    let decoder_model = values.pop_front().ok_or("missing `decoder_model` arg")?;
+    let image = values.pop_front().ok_or("missing `image` arg")?;
+    let points_str = values.pop_front().ok_or("missing `points` arg")?;
+
+    let mut points: Vec<(u32, u32)> = Vec::new();
+    for xy_str in points_str.split(";") {
+        let Some(xy_coords) = xy_str.trim().split_once(",") else {
+            return Err(lexopt::Error::Custom(
+                "points should be x,y coordinate pairs".into(),
+            ));
+        };
+        let (Ok(x), Ok(y)) = (xy_coords.0.parse(), xy_coords.1.parse()) else {
+            return Err(lexopt::Error::Custom(
+                "points should be positive integer values".into(),
+            ));
+        };
+        points.push((x, y));
+    }
+
+    let args = Args {
+        image,
+        encoder_model,
+        decoder_model,
+        points,
+    };
+
+    Ok(args)
+}
+
+/// Perform image segmentation using Segment Anything [^1].
+///
+/// First export the ONNX model using Hugging Face's Optimum tool:
+///
+/// ```
+/// optimum-cli export onnx --model facebook/sam-vit-base sam-vit-base
+/// ```
+///
+/// Then convert the models to `.rten` format and run the demo, specifying a
+/// path to the image to segment and one or more points in the image identifying
+/// the object of interest.
+///
+/// ```
+/// rten-convert sam-vit-base/vision_encoder.onnx
+/// rten-convert sam-vit-base/prompt_encoder_mask_decoder.rten
+/// cargo run --release --bin segment_anything sam-vit-base/vision_encoder.rten sam-vit-base/prompt_encoder_mask_decoder.rten image.jpg points
+/// ```
+///
+/// Where `points` is a semi-colon separated list of x,y pixel coordinates
+/// identifying the objects to segment. For example `200,300;205,305` generates
+/// a segmentation mask for the object containing the points (200, 300) and
+/// (205, 305). At least one point must be specified.
+///
+/// ## Alternative models
+///
+/// The original SAM model uses a computationally expensive vision encoder
+/// paired with a lightweight prompt decoder. Since its release various teams
+/// have created alternatives with faster image encoders. For faster generation
+/// of image embeddings, you can try alternatives such as:
+///
+/// - [SlimSAM](https://huggingface.co/Zigeng/SlimSAM-uniform-50)
+///
+/// The process for exporting and converting the models is the same as for
+/// the `facebook/sam-vit-base` model.
+///
+/// [^1]: https://segment-anything.com
+fn main() -> Result<(), Box<dyn Error>> {
+    let args = parse_args()?;
+
+    println!("Loading model...");
+    let encoder_model = Model::load_file(args.encoder_model)?;
+    let decoder_model = Model::load_file(args.decoder_model)?;
+
+    println!("Reading image...");
+    let mut image: Tensor = read_image(&args.image)?.into();
+    let image_h = image.size(1);
+    let image_w = image.size(2);
+    image.insert_axis(0);
+
+    // Prepare the input image.
+    //
+    // This currently does the mandatory resizing of the input image, but
+    // doesn't normalize the pixel values.
+    let pixel_values_id = encoder_model.node_id("pixel_values")?;
+    let [input_h, input_w] = match encoder_model
+        .node_info(pixel_values_id)
+        .and_then(|ni| ni.shape())
+        .as_deref()
+    {
+        Some(&[_, _, Dimension::Fixed(h), Dimension::Fixed(w)]) => [h, w],
+        _ => [1024, 1024],
+    };
+    let image = image.resize_image([input_h, input_w])?;
+
+    // Generate image embeddings.
+    println!("Generating image embedding...");
+    let image_embeddings_id = encoder_model.node_id("image_embeddings")?;
+    let image_pos_embeddings_id = encoder_model.node_id("image_positional_embeddings")?;
+
+    let [image_embeddings, image_pos_embeddings] = encoder_model.run_n(
+        vec![(pixel_values_id, image.view().into())],
+        [image_embeddings_id, image_pos_embeddings_id],
+        None,
+    )?;
+
+    println!("Segmenting image with {} points...", args.points.len());
+
+    // Prepare decoder inputs.
+    let input_points_id = decoder_model.node_id("input_points")?;
+    let input_labels_id = decoder_model.node_id("input_labels")?;
+    let decoder_embeddings_id = decoder_model.node_id("image_embeddings")?;
+    let decoder_pos_embeddings_id = decoder_model.node_id("image_positional_embeddings")?;
+
+    let iou_scores_id = decoder_model.node_id("iou_scores")?;
+    let pred_masks_id = decoder_model.node_id("pred_masks")?;
+
+    let h_scale = input_h as f32 / image_h as f32;
+    let w_scale = input_w as f32 / image_w as f32;
+
+    let point_batch = 1;
+    let nb_points_per_image = args.points.len();
+    let input_points = NdTensor::from_fn(
+        [1, point_batch, nb_points_per_image, 2],
+        |[_, _, point, coord]| {
+            if coord == 0 {
+                args.points[point].0 as f32 * w_scale
+            } else {
+                args.points[point].1 as f32 * h_scale
+            }
+        },
+    );
+
+    const MATCH_POINT: i32 = 1;
+    const _NON_MATCH_POINT: i32 = 0;
+    const _BACKGROUND_POINT: i32 = -1;
+    let input_labels = NdTensor::<i32, 3>::full([1, point_batch, nb_points_per_image], MATCH_POINT);
+
+    // Run decoder and generate segmentation masks.
+    let [_iou_scores, pred_masks] = decoder_model.run_n(
+        vec![
+            (input_points_id, input_points.into()),
+            (input_labels_id, input_labels.into()),
+            (decoder_embeddings_id, image_embeddings.into()),
+            (decoder_pos_embeddings_id, image_pos_embeddings.into()),
+        ],
+        [iou_scores_id, pred_masks_id],
+        None,
+    )?;
+
+    // Resize the output mask to match the original image and save to disk.
+    let pred_masks: NdTensor<f32, 5> = pred_masks.try_into()?;
+    let [_batch, _point_batch, _mask, mask_h, mask_w] = pred_masks.shape();
+    let best_mask = pred_masks
+        .slice::<2, _>((0, 0, 0))
+        .reshaped([1, 1, mask_h, mask_w]);
+    let resized_mask = best_mask.resize_image([image_h, image_w])?;
+    write_image("segmented.png", resized_mask.slice::<3, _>(0).nd_view())?;
+
+    Ok(())
+}

--- a/src/model_builder.rs
+++ b/src/model_builder.rs
@@ -7,11 +7,11 @@ use crate::header::Header;
 use crate::number::LeBytes;
 use crate::ops::{
     ArgMax, ArgMin, AveragePool, BatchNormalization, BoxOrder, Cast, Concat, ConstantOfShape, Conv,
-    ConvTranspose, CoordTransformMode, DataType, Elu, Flatten, Gather, GatherElements, GatherND,
-    Gelu, Gemm, HardSigmoid, InstanceNormalization, LayerNormalization, LeakyRelu, LogSoftmax,
-    MaxPool, Mod, NearestMode, NonMaxSuppression, OneHot, Padding, ReduceMax, ReduceMean,
-    ReduceMin, ReduceProd, ReduceSum, ReduceSumSquare, Reshape, Resize, ResizeMode, Scalar,
-    ScatterElements, ScatterReduction, Softmax, Split, TopK, Transpose, Trilu,
+    ConvTranspose, CoordTransformMode, DataType, Einsum, Elu, Flatten, Gather, GatherElements,
+    GatherND, Gelu, Gemm, HardSigmoid, InstanceNormalization, LayerNormalization, LeakyRelu,
+    LogSoftmax, MaxPool, Mod, NearestMode, NonMaxSuppression, OneHot, Padding, ReduceMax,
+    ReduceMean, ReduceMin, ReduceProd, ReduceSum, ReduceSumSquare, Reshape, Resize, ResizeMode,
+    Scalar, ScatterElements, ScatterReduction, Softmax, Split, TopK, Transpose, Trilu,
 };
 use crate::schema_generated as sg;
 
@@ -39,6 +39,7 @@ pub enum OpType {
     ConvTranspose(ConvTranspose),
     Cos,
     Div,
+    Einsum(Einsum),
     Elu(Elu),
     Equal,
     Erf,
@@ -486,6 +487,16 @@ impl<'a> ModelBuilder<'a> {
             }),
             OpType::Cos => op!(Cos),
             OpType::Div => op!(Div),
+            OpType::Einsum(args) => {
+                let equation = self.builder.create_string(&args.equation);
+                op_with_attrs!(
+                    Einsum,
+                    EinsumAttrs,
+                    sg::EinsumAttrsArgs {
+                        equation: Some(equation)
+                    }
+                )
+            }
             OpType::Elu(args) => {
                 op_with_attrs!(Elu, EluAttrs, sg::EluAttrsArgs { alpha: args.alpha })
             }

--- a/src/op_registry.rs
+++ b/src/op_registry.rs
@@ -94,6 +94,7 @@ impl OpRegistry {
         register_op!(Cos);
         register_op!(CumSum);
         register_op!(Div);
+        register_op!(Einsum);
         register_op!(Elu);
         register_op!(Equal);
         register_op!(Erf);
@@ -455,6 +456,11 @@ impl_read_op!(
 impl_read_op!(Cos);
 impl_read_op!(CumSum);
 impl_read_op!(Div);
+impl_read_op!(Einsum, attrs_as_einsum_attrs, |attrs: sg::EinsumAttrs| {
+    Ok(ops::Einsum {
+        equation: attrs.equation().unwrap_or("").to_string(),
+    })
+});
 impl_read_op!(Elu, attrs_as_elu_attrs, |attrs: sg::EluAttrs| {
     Ok(ops::Elu {
         alpha: attrs.alpha(),

--- a/src/ops/einsum.rs
+++ b/src/ops/einsum.rs
@@ -1,0 +1,401 @@
+use rten_tensor::prelude::*;
+use rten_tensor::{Tensor, TensorView};
+
+use smallvec::SmallVec;
+
+use crate::ops::{matmul, InputList, IntoOpResult, OpError, Operator, OutputList};
+use crate::tensor_pool::TensorPool;
+
+/// A parsed equation for an Einsum operator.
+///
+/// Einsum expressions have the form `abc,def,...->xyz` where the `->xyz` part
+/// is optional. If ommitted, it is inferred as the alphabetically ordered
+/// set of letters from the left hand side that do not repeat.
+struct EinsumExpr {
+    inputs: Vec<String>,
+    output: String,
+}
+
+impl EinsumExpr {
+    /// Parse an [Einsum expression][einsum].
+    ///
+    /// [einsum]: https://onnx.ai/onnx/operators/onnx__Einsum.html
+    fn parse(expr: &str) -> Result<EinsumExpr, OpError> {
+        let mut parts = expr.trim().splitn(2, "->").map(|part| part.trim());
+
+        let lhs = match parts.next() {
+            Some(lhs) if !lhs.is_empty() => lhs,
+            _ => {
+                return Err(OpError::InvalidValue("Invalid equation"));
+            }
+        };
+
+        let inputs: Vec<_> = lhs.split(',').map(|term| term.trim().to_string()).collect();
+        if inputs.iter().any(|term| !is_valid_einsum_term(term)) {
+            return Err(OpError::InvalidValue(
+                "Einsum terms must contain only lowercase letters",
+            ));
+        }
+
+        let output: String = match parts.next() {
+            Some(rhs) => rhs.to_string(),
+            None => {
+                const N_LETTERS: usize = 26;
+
+                // Count occurences of each lowercase ASCII letter.
+                let mut char_count = [0; N_LETTERS];
+                for ch in inputs.iter().flat_map(|term| term.chars()) {
+                    let ascii_idx = ch as u8 - b'a';
+                    char_count[ascii_idx as usize] += 1;
+                }
+
+                // Generate output as sequence of alphabetically ordered
+                // letters which appear only once in the input.
+                let mut output = String::with_capacity(N_LETTERS);
+                for i in 0..N_LETTERS as u8 {
+                    if char_count[i as usize] == 1 {
+                        let ascii_ch = b'a' + i;
+                        output.push(ascii_ch as char);
+                    }
+                }
+
+                output
+            }
+        };
+
+        if !is_valid_einsum_term(&output) {
+            return Err(OpError::InvalidValue(
+                "Einsum terms must contain only lowercase letters",
+            ));
+        }
+
+        Ok(EinsumExpr { inputs, output })
+    }
+
+    /// Return the dimensions in the expression which are summed over.
+    fn reduced_dims(&self) -> Vec<char> {
+        let mut terms = Vec::new();
+        for in_term in &self.inputs {
+            for in_ch in in_term.chars() {
+                if !terms.contains(&in_ch) && !self.output.contains(in_ch) {
+                    terms.push(in_ch);
+                }
+            }
+        }
+        terms
+    }
+}
+
+fn is_valid_einsum_term(term: &str) -> bool {
+    term.chars().all(|c| c.is_ascii_lowercase())
+}
+
+#[derive(Debug)]
+pub struct Einsum {
+    pub equation: String,
+}
+
+impl Operator for Einsum {
+    fn name(&self) -> &str {
+        "Einsum"
+    }
+
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
+        let mut typed_inputs: SmallVec<[TensorView; 2]> = SmallVec::with_capacity(inputs.len());
+        for i in 0..inputs.len() {
+            typed_inputs.push(inputs.require_as(i)?);
+        }
+        einsum(pool, &typed_inputs, &self.equation).into_op_result()
+    }
+}
+
+pub fn einsum(pool: &TensorPool, inputs: &[TensorView], equation: &str) -> Result<Tensor, OpError> {
+    let equation = EinsumExpr::parse(equation)?;
+    if equation.inputs.len() != inputs.len() {
+        return Err(OpError::InvalidValue(
+            "Einsum equation input count does not match operator inputs",
+        ));
+    }
+
+    if inputs.len() == 1 {
+        let in_order = &equation.inputs[0];
+        let out_order = &equation.output;
+        if !is_valid_permute_spec(in_order, out_order) {
+            return Err(OpError::UnsupportedValue("Unsupported Einsum equation"));
+        }
+        let output = permuted_by_labels(&inputs[0], in_order, out_order).to_tensor_in(pool);
+        return Ok(output);
+    }
+
+    if inputs.len() != 2 {
+        return Err(OpError::UnsupportedValue(
+            "Einsum implementation only supports two inputs",
+        ));
+    }
+
+    let x = &inputs[0];
+    let y = &inputs[1];
+    let term1 = &equation.inputs[0];
+    let term2 = &equation.inputs[1];
+
+    let reduced_dims = equation.reduced_dims();
+    if reduced_dims.len() != 1 {
+        return Err(OpError::UnsupportedValue(
+            "Einsum only supports equations with one reduced dimension",
+        ));
+    }
+    let matmul_k = reduced_dims[0];
+
+    // Find a term that can be used as the `N` dimension of a matmul.
+    let Some(matmul_n) = term2.chars().find(|c| !term1.contains(*c)) else {
+        return Err(OpError::UnsupportedValue(
+            "Cannot evaluate Einsum using matmul",
+        ));
+    };
+
+    // Find a term that can be used as the `M` dimension of a matmul.
+    let Some(matmul_m) = term1.chars().rev().find(|c| !term2.contains(*c)) else {
+        return Err(OpError::UnsupportedValue(
+            "Cannot evaluate Einsum using matmul",
+        ));
+    };
+
+    // Find the terms that will be used as the batch dimensions of a matmul.
+    let batch_dims = term1
+        .chars()
+        .filter(|c| *c != matmul_k && *c != matmul_n && *c != matmul_m);
+
+    let mut x_order: String = batch_dims.clone().collect();
+    x_order.push(matmul_m);
+    x_order.push(matmul_k);
+
+    let mut y_order: String = batch_dims
+        .clone()
+        .filter(|bc| term2.contains(*bc))
+        .collect();
+    y_order.push(matmul_k);
+    y_order.push(matmul_n);
+
+    let mut out_order: String = batch_dims.collect();
+    out_order.push(matmul_m);
+    out_order.push(matmul_n);
+
+    let xp = permuted_by_labels(x, term1, &x_order);
+    let yp = permuted_by_labels(y, term2, &y_order);
+    let out = matmul(pool, xp, yp)?;
+
+    if out_order == equation.output {
+        Ok(out)
+    } else {
+        let out_permuted = permuted_by_labels(&out.view(), &out_order, &equation.output);
+        Ok(out_permuted.to_tensor_in(pool))
+    }
+}
+
+/// Return true if `src` and `dest` contain the same set of unique letters,
+/// ignoring the order.
+///
+/// Both strings are assumed to be short.
+fn is_valid_permute_spec(src: &str, dest: &str) -> bool {
+    if src.len() != dest.len() {
+        return false;
+    }
+    for src_ch in src.chars() {
+        let src_count = src.chars().filter(|c| *c == src_ch).count();
+        let dest_count = dest.chars().filter(|c| *c == src_ch).count();
+        if src_count != 1 || dest_count != 1 {
+            return false;
+        }
+    }
+    true
+}
+
+/// Permute a tensor by specifying label strings specifying the input and output
+/// order of dimensions.
+///
+/// For example `permute(tensor, "xy", "yx")` will transpose a matrix.
+fn permuted_by_labels<'a, T>(
+    tensor: &TensorView<'a, T>,
+    in_order: &str,
+    out_order: &str,
+) -> TensorView<'a, T> {
+    assert!(
+        is_valid_permute_spec(in_order, out_order),
+        "invalid permute spec {}->{}",
+        in_order,
+        out_order
+    );
+    assert!(
+        tensor.ndim() == in_order.len(),
+        "input order does not match tensor ndim"
+    );
+    let perm: Vec<usize> = out_order
+        .chars()
+        .map(|c| in_order.chars().position(|ic| ic == c).unwrap())
+        .collect();
+    tensor.permuted(&perm)
+}
+
+#[cfg(test)]
+mod tests {
+    use rten_tensor::prelude::*;
+    use rten_tensor::{Tensor, TensorView};
+
+    use crate::ops::tests::new_pool;
+    use crate::ops::{einsum, matmul, OpError};
+
+    #[test]
+    fn test_einsum() {
+        struct Case<'a> {
+            equation: &'a str,
+            inputs: Vec<TensorView<'a>>,
+            expected: Result<Tensor, OpError>,
+        }
+
+        let pool = new_pool();
+        let vec_a = Tensor::arange(1., 10., None);
+        let mat_a = Tensor::from([[1., 2., 3.], [4., 5., 6.]]);
+        let mat_b = Tensor::from([[1., 2., 3., 4.], [5., 6., 7., 8.], [9., 10., 11., 12.]]);
+        let matmul_ab = matmul(&pool, mat_a.view(), mat_b.view()).unwrap();
+        let matmul_ba = matmul_ab.transposed().to_tensor();
+
+        let bhwc = mat_a
+            .clone()
+            .into_shape([1, 1, mat_a.size(0), mat_a.size(1)]);
+        let hck = mat_b.clone().into_shape([1, mat_b.size(0), mat_b.size(1)]);
+
+        let bhwk = matmul_ab
+            .clone()
+            .into_shape([1, 1, mat_a.size(0), mat_b.size(1)]);
+
+        let cases = [
+            // Identity
+            Case {
+                equation: "ij->ij",
+                inputs: vec![mat_a.view()],
+                expected: Ok(mat_a.clone()),
+            },
+            // Transpose
+            Case {
+                equation: "ij->ji",
+                inputs: vec![mat_a.view()],
+                expected: Ok(mat_a.transposed().to_tensor()),
+            },
+            // Transpose with ignored spaces
+            Case {
+                equation: " ij -> ji ",
+                inputs: vec![mat_a.view()],
+                expected: Ok(mat_a.transposed().to_tensor()),
+            },
+            // Transpose with implicit output
+            Case {
+                equation: "ba",
+                inputs: vec![mat_a.view()],
+                expected: Ok(mat_a.transposed().to_tensor()),
+            },
+            // Matmul
+            Case {
+                equation: "ij,jk->ik",
+                inputs: vec![mat_a.view(), mat_b.view()],
+                expected: Ok(matmul_ab.clone()),
+            },
+            // Matmul with implicit output
+            Case {
+                equation: "ij,jk",
+                inputs: vec![mat_a.view(), mat_b.view()],
+                expected: Ok(matmul_ab.clone()),
+            },
+            // Matmul with transposed inputs
+            Case {
+                equation: "ji,kj->ik",
+                inputs: vec![mat_a.transposed(), mat_b.transposed()],
+                expected: Ok(matmul_ab),
+            },
+            // Matmul with transposed output
+            Case {
+                equation: "ij,jk->ki",
+                inputs: vec![mat_a.view(), mat_b.view()],
+                expected: Ok(matmul_ba),
+            },
+            // Matmul with batch dimensions.
+            // Example taken from image encoder of https://huggingface.co/facebook/sam-vit-base.
+            Case {
+                equation: "bhwc,hkc->bhwk",
+                inputs: vec![bhwc.as_dyn(), hck.permuted([0, 2, 1]).as_dyn()],
+                expected: Ok(bhwk.into_dyn()),
+            },
+            // Incorrect input count
+            Case {
+                equation: "ij,jk->ik",
+                inputs: vec![mat_a.view()],
+                expected: Err(OpError::InvalidValue(
+                    "Einsum equation input count does not match operator inputs",
+                )),
+            },
+            // Unsupported dot product
+            Case {
+                equation: "i,i->",
+                inputs: vec![vec_a.view(), vec_a.view()],
+                expected: Err(OpError::UnsupportedValue(
+                    "Cannot evaluate Einsum using matmul",
+                )),
+            },
+            // Unsupported matrix-vector product
+            Case {
+                equation: "ij,j->i",
+                inputs: vec![mat_a.view(), mat_b.slice_dyn(0)],
+                expected: Err(OpError::UnsupportedValue(
+                    "Cannot evaluate Einsum using matmul",
+                )),
+            },
+            // Unsupported vector-matrix product
+            Case {
+                equation: "j,jk->k",
+                inputs: vec![mat_a.slice_dyn(0), mat_b.view()],
+                expected: Err(OpError::UnsupportedValue(
+                    "Cannot evaluate Einsum using matmul",
+                )),
+            },
+            // Unsupported number of reduced dimensions
+            Case {
+                equation: "ij,kl->ijkl",
+                inputs: vec![mat_a.view(), mat_b.view()],
+                expected: Err(OpError::UnsupportedValue(
+                    "Einsum only supports equations with one reduced dimension",
+                )),
+            },
+            // Empty equation
+            Case {
+                equation: "",
+                inputs: vec![],
+                expected: Err(OpError::InvalidValue("Invalid equation")),
+            },
+            // Invalid input terms
+            Case {
+                equation: "IJ,JK",
+                inputs: vec![mat_a.view(), mat_b.view()],
+                expected: Err(OpError::InvalidValue(
+                    "Einsum terms must contain only lowercase letters",
+                )),
+            },
+            // Invalid output term
+            Case {
+                equation: "ij,jk->IK",
+                inputs: vec![mat_a.view(), mat_b.view()],
+                expected: Err(OpError::InvalidValue(
+                    "Einsum terms must contain only lowercase letters",
+                )),
+            },
+        ];
+
+        for Case {
+            equation,
+            inputs,
+            expected,
+        } in cases
+        {
+            let output = einsum(&pool, inputs.as_slice(), equation);
+            assert_eq!(output, expected);
+        }
+    }
+}

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -998,6 +998,12 @@ impl<'a> InputList<'a> {
     }
 }
 
+impl<'a> Default for InputList<'a> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<'a, I: Into<Input<'a>>> From<I> for InputList<'a> {
     fn from(val: I) -> InputList<'a> {
         InputList::from(&[val.into()])

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -32,6 +32,7 @@ mod binary_elementwise;
 mod concat;
 mod conv;
 mod convert;
+mod einsum;
 mod gather;
 mod generate;
 mod identity;
@@ -66,6 +67,7 @@ pub use binary_elementwise::{
 pub use concat::{concat, tile, Concat, Tile};
 pub use conv::{conv, conv_transpose, Conv, ConvTranspose};
 pub use convert::Cast;
+pub use einsum::{einsum, Einsum};
 pub use gather::{
     gather, gather_elements, gather_nd, scatter_elements, scatter_nd, Gather, GatherElements,
     GatherND, ScatterElements, ScatterND, ScatterReduction,

--- a/src/schema.fbs
+++ b/src/schema.fbs
@@ -116,6 +116,7 @@ enum OperatorType: ubyte {
   Softplus,
   GatherND,
   Gelu,
+  Einsum,
 }
 
 enum RNNDirection: ubyte {
@@ -198,6 +199,7 @@ union OperatorAttrs {
   RandomNormalLikeAttrs,
   GatherNDAttrs,
   GeluAttrs,
+  EinsumAttrs,
 }
 
 table ArgMaxAttrs {
@@ -265,6 +267,10 @@ table ConvTransposeAttrs {
 
   // Padding for spatial axes as [left, right] or [top, left, bottom, right]
   pads:[uint];
+}
+
+table EinsumAttrs {
+  equation:string;
 }
 
 table EluAttrs {

--- a/src/schema_generated.rs
+++ b/src/schema_generated.rs
@@ -18,13 +18,13 @@ pub const ENUM_MIN_OPERATOR_TYPE: u8 = 0;
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
-pub const ENUM_MAX_OPERATOR_TYPE: u8 = 102;
+pub const ENUM_MAX_OPERATOR_TYPE: u8 = 103;
 #[deprecated(
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 103] = [
+pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 104] = [
     OperatorType::Add,
     OperatorType::ArgMin,
     OperatorType::ArgMax,
@@ -128,6 +128,7 @@ pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 103] = [
     OperatorType::Softplus,
     OperatorType::GatherND,
     OperatorType::Gelu,
+    OperatorType::Einsum,
 ];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -238,9 +239,10 @@ impl OperatorType {
     pub const Softplus: Self = Self(100);
     pub const GatherND: Self = Self(101);
     pub const Gelu: Self = Self(102);
+    pub const Einsum: Self = Self(103);
 
     pub const ENUM_MIN: u8 = 0;
-    pub const ENUM_MAX: u8 = 102;
+    pub const ENUM_MAX: u8 = 103;
     pub const ENUM_VALUES: &'static [Self] = &[
         Self::Add,
         Self::ArgMin,
@@ -345,6 +347,7 @@ impl OperatorType {
         Self::Softplus,
         Self::GatherND,
         Self::Gelu,
+        Self::Einsum,
     ];
     /// Returns the variant's name or "" if unknown.
     pub fn variant_name(self) -> Option<&'static str> {
@@ -452,6 +455,7 @@ impl OperatorType {
             Self::Softplus => Some("Softplus"),
             Self::GatherND => Some("GatherND"),
             Self::Gelu => Some("Gelu"),
+            Self::Einsum => Some("Einsum"),
             _ => None,
         }
     }
@@ -1078,13 +1082,13 @@ pub const ENUM_MIN_OPERATOR_ATTRS: u8 = 0;
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
-pub const ENUM_MAX_OPERATOR_ATTRS: u8 = 37;
+pub const ENUM_MAX_OPERATOR_ATTRS: u8 = 38;
 #[deprecated(
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_OPERATOR_ATTRS: [OperatorAttrs; 38] = [
+pub const ENUM_VALUES_OPERATOR_ATTRS: [OperatorAttrs; 39] = [
     OperatorAttrs::NONE,
     OperatorAttrs::ArgMaxAttrs,
     OperatorAttrs::AveragePoolAttrs,
@@ -1123,6 +1127,7 @@ pub const ENUM_VALUES_OPERATOR_ATTRS: [OperatorAttrs; 38] = [
     OperatorAttrs::RandomNormalLikeAttrs,
     OperatorAttrs::GatherNDAttrs,
     OperatorAttrs::GeluAttrs,
+    OperatorAttrs::EinsumAttrs,
 ];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -1168,9 +1173,10 @@ impl OperatorAttrs {
     pub const RandomNormalLikeAttrs: Self = Self(35);
     pub const GatherNDAttrs: Self = Self(36);
     pub const GeluAttrs: Self = Self(37);
+    pub const EinsumAttrs: Self = Self(38);
 
     pub const ENUM_MIN: u8 = 0;
-    pub const ENUM_MAX: u8 = 37;
+    pub const ENUM_MAX: u8 = 38;
     pub const ENUM_VALUES: &'static [Self] = &[
         Self::NONE,
         Self::ArgMaxAttrs,
@@ -1210,6 +1216,7 @@ impl OperatorAttrs {
         Self::RandomNormalLikeAttrs,
         Self::GatherNDAttrs,
         Self::GeluAttrs,
+        Self::EinsumAttrs,
     ];
     /// Returns the variant's name or "" if unknown.
     pub fn variant_name(self) -> Option<&'static str> {
@@ -1252,6 +1259,7 @@ impl OperatorAttrs {
             Self::RandomNormalLikeAttrs => Some("RandomNormalLikeAttrs"),
             Self::GatherNDAttrs => Some("GatherNDAttrs"),
             Self::GeluAttrs => Some("GeluAttrs"),
+            Self::EinsumAttrs => Some("EinsumAttrs"),
             _ => None,
         }
     }
@@ -3334,6 +3342,115 @@ impl core::fmt::Debug for ConvTransposeAttrs<'_> {
         ds.field("strides", &self.strides());
         ds.field("auto_pad", &self.auto_pad());
         ds.field("pads", &self.pads());
+        ds.finish()
+    }
+}
+pub enum EinsumAttrsOffset {}
+#[derive(Copy, Clone, PartialEq)]
+
+pub struct EinsumAttrs<'a> {
+    pub _tab: flatbuffers::Table<'a>,
+}
+
+impl<'a> flatbuffers::Follow<'a> for EinsumAttrs<'a> {
+    type Inner = EinsumAttrs<'a>;
+    #[inline]
+    unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self {
+            _tab: flatbuffers::Table::new(buf, loc),
+        }
+    }
+}
+
+impl<'a> EinsumAttrs<'a> {
+    pub const VT_EQUATION: flatbuffers::VOffsetT = 4;
+
+    #[inline]
+    pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+        EinsumAttrs { _tab: table }
+    }
+    #[allow(unused_mut)]
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
+        args: &'args EinsumAttrsArgs<'args>,
+    ) -> flatbuffers::WIPOffset<EinsumAttrs<'bldr>> {
+        let mut builder = EinsumAttrsBuilder::new(_fbb);
+        if let Some(x) = args.equation {
+            builder.add_equation(x);
+        }
+        builder.finish()
+    }
+
+    #[inline]
+    pub fn equation(&self) -> Option<&'a str> {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab
+                .get::<flatbuffers::ForwardsUOffset<&str>>(EinsumAttrs::VT_EQUATION, None)
+        }
+    }
+}
+
+impl flatbuffers::Verifiable for EinsumAttrs<'_> {
+    #[inline]
+    fn run_verifier(
+        v: &mut flatbuffers::Verifier,
+        pos: usize,
+    ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+        use self::flatbuffers::Verifiable;
+        v.visit_table(pos)?
+            .visit_field::<flatbuffers::ForwardsUOffset<&str>>(
+                "equation",
+                Self::VT_EQUATION,
+                false,
+            )?
+            .finish();
+        Ok(())
+    }
+}
+pub struct EinsumAttrsArgs<'a> {
+    pub equation: Option<flatbuffers::WIPOffset<&'a str>>,
+}
+impl<'a> Default for EinsumAttrsArgs<'a> {
+    #[inline]
+    fn default() -> Self {
+        EinsumAttrsArgs { equation: None }
+    }
+}
+
+pub struct EinsumAttrsBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+    fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
+    start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> EinsumAttrsBuilder<'a, 'b, A> {
+    #[inline]
+    pub fn add_equation(&mut self, equation: flatbuffers::WIPOffset<&'b str>) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(EinsumAttrs::VT_EQUATION, equation);
+    }
+    #[inline]
+    pub fn new(
+        _fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
+    ) -> EinsumAttrsBuilder<'a, 'b, A> {
+        let start = _fbb.start_table();
+        EinsumAttrsBuilder {
+            fbb_: _fbb,
+            start_: start,
+        }
+    }
+    #[inline]
+    pub fn finish(self) -> flatbuffers::WIPOffset<EinsumAttrs<'a>> {
+        let o = self.fbb_.end_table(self.start_);
+        flatbuffers::WIPOffset::new(o.value())
+    }
+}
+
+impl core::fmt::Debug for EinsumAttrs<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut ds = f.debug_struct("EinsumAttrs");
+        ds.field("equation", &self.equation());
         ds.finish()
     }
 }
@@ -7655,6 +7772,21 @@ impl<'a> OperatorNode<'a> {
             None
         }
     }
+
+    #[inline]
+    #[allow(non_snake_case)]
+    pub fn attrs_as_einsum_attrs(&self) -> Option<EinsumAttrs<'a>> {
+        if self.attrs_type() == OperatorAttrs::EinsumAttrs {
+            self.attrs().map(|t| {
+                // Safety:
+                // Created from a valid Table for this object
+                // Which contains a valid union in this slot
+                unsafe { EinsumAttrs::init_from_table(t) }
+            })
+        } else {
+            None
+        }
+    }
 }
 
 impl flatbuffers::Verifiable for OperatorNode<'_> {
@@ -7705,6 +7837,7 @@ impl flatbuffers::Verifiable for OperatorNode<'_> {
           OperatorAttrs::RandomNormalLikeAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<RandomNormalLikeAttrs>>("OperatorAttrs::RandomNormalLikeAttrs", pos),
           OperatorAttrs::GatherNDAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<GatherNDAttrs>>("OperatorAttrs::GatherNDAttrs", pos),
           OperatorAttrs::GeluAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<GeluAttrs>>("OperatorAttrs::GeluAttrs", pos),
+          OperatorAttrs::EinsumAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<EinsumAttrs>>("OperatorAttrs::EinsumAttrs", pos),
           _ => Ok(()),
         }
      })?
@@ -8152,6 +8285,16 @@ impl core::fmt::Debug for OperatorNode<'_> {
             }
             OperatorAttrs::GeluAttrs => {
                 if let Some(x) = self.attrs_as_gelu_attrs() {
+                    ds.field("attrs", &x)
+                } else {
+                    ds.field(
+                        "attrs",
+                        &"InvalidFlatbuffer: Union discriminant does not match value.",
+                    )
+                }
+            }
+            OperatorAttrs::EinsumAttrs => {
+                if let Some(x) = self.attrs_as_einsum_attrs() {
                     ds.field("attrs", &x)
                 } else {
                     ds.field(


### PR DESCRIPTION
Add an initial version of the `Einsum` operator, and a Segment Anything model example, whose image encoder model requires it.

The initial Einsum implementation is limited to equations that can be efficiently executed as a single matrix multiplication, with permutations of the inputs and outputs if needed.

The example uses the [sam-vit-base](https://huggingface.co/facebook/sam-vit-base) model variant in its documentation, but I have also tested with [sam-vit-large](https://huggingface.co/facebook/sam-vit-large) and [slimsam](https://huggingface.co/nielsr/slimsam-50-uniform).