### PR TITLE
Expand supported equations in Einsum

### DIFF
--- a/rten-tensor/src/layout.rs
+++ b/rten-tensor/src/layout.rs
@@ -1212,6 +1212,11 @@ pub trait ResizeLayout: MutLayout {
     /// the same stride as the dimension that follows it.
     fn insert_axis(&mut self, index: usize);
 
+    /// Remove a size-1 axis at the given index.
+    ///
+    /// Panics if the axis does not have a size of 1.
+    fn remove_axis(&mut self, index: usize);
+
     /// Merge consecutive axes where possible.
     ///
     /// This "simplifies" the layout by minimizing the number of dimensions
@@ -1222,6 +1227,12 @@ pub trait ResizeLayout: MutLayout {
 impl ResizeLayout for DynLayout {
     fn insert_axis(&mut self, index: usize) {
         self.insert_dim(index)
+    }
+
+    fn remove_axis(&mut self, index: usize) {
+        assert!(self.size(index) == 1);
+        self.shape_and_strides.remove(index);
+        self.shape_and_strides.remove(self.ndim() + index);
     }
 
     fn merge_axes(&mut self) {

--- a/rten-tensor/src/tensor.rs
+++ b/rten-tensor/src/tensor.rs
@@ -168,6 +168,14 @@ pub trait AsView: Layout {
     where
         Self::Layout: ResizeLayout;
 
+    /// Remove a size-1 axis at the given index.
+    ///
+    /// This will panic if the index is out of bounds or the size of the index
+    /// is not 1.
+    fn remove_axis(&mut self, index: usize)
+    where
+        Self::Layout: ResizeLayout;
+
     /// Return the scalar value in this tensor if it has 0 dimensions.
     fn item(&self) -> Option<&Self::Elem> {
         self.view().item()
@@ -1641,6 +1649,13 @@ impl<T, S: Storage<Elem = T>, L: MutLayout + Clone> AsView for TensorBase<S, L> 
         L: ResizeLayout,
     {
         self.layout.insert_axis(index)
+    }
+
+    fn remove_axis(&mut self, index: usize)
+    where
+        L: ResizeLayout,
+    {
+        self.layout.remove_axis(index)
     }
 
     fn merge_axes(&mut self)
@@ -3192,6 +3207,15 @@ mod tests {
 
         assert_eq!(permuted.shape(), [3, 2]);
         assert_eq!(permuted.to_vec(), &[1., 4., 2., 5., 3., 8.]);
+    }
+
+    #[test]
+    fn test_remove_axis() {
+        let mut tensor = Tensor::arange(0., 16., None).into_shape([1, 2, 1, 8, 1].as_slice());
+        tensor.remove_axis(0);
+        tensor.remove_axis(1);
+        tensor.remove_axis(2);
+        assert_eq!(tensor.shape(), [2, 8]);
     }
 
     #[test]

--- a/src/ops/einsum.rs
+++ b/src/ops/einsum.rs
@@ -3,7 +3,9 @@ use rten_tensor::{Tensor, TensorView};
 
 use smallvec::SmallVec;
 
-use crate::ops::{matmul, InputList, IntoOpResult, OpError, Operator, OutputList};
+use crate::ops::{
+    matmul, mul, mul_in_place, reduce_sum, InputList, IntoOpResult, OpError, Operator, OutputList,
+};
 use crate::tensor_pool::TensorPool;
 
 /// A parsed equation for an Einsum operator.
@@ -26,11 +28,16 @@ impl EinsumExpr {
         let lhs = match parts.next() {
             Some(lhs) if !lhs.is_empty() => lhs,
             _ => {
-                return Err(OpError::InvalidValue("Invalid equation"));
+                return Err(OpError::InvalidValue(
+                    "Einsum equation must have at least one term",
+                ));
             }
         };
 
-        let inputs: Vec<_> = lhs.split(',').map(|term| term.trim().to_string()).collect();
+        let inputs: Vec<String> = lhs
+            .split(',')
+            .map(|term| non_whitespace_chars(term).collect())
+            .collect();
         if inputs.iter().any(|term| !is_valid_einsum_term(term)) {
             return Err(OpError::InvalidValue(
                 "Einsum terms must contain only lowercase letters",
@@ -38,7 +45,7 @@ impl EinsumExpr {
         }
 
         let output: String = match parts.next() {
-            Some(rhs) => rhs.to_string(),
+            Some(rhs) => non_whitespace_chars(rhs).collect(),
             None => {
                 const N_LETTERS: usize = 26;
 
@@ -90,6 +97,10 @@ fn is_valid_einsum_term(term: &str) -> bool {
     term.chars().all(|c| c.is_ascii_lowercase())
 }
 
+fn non_whitespace_chars(s: &str) -> impl Iterator<Item = char> + '_ {
+    s.chars().filter(|c| !c.is_ascii_whitespace())
+}
+
 #[derive(Debug)]
 pub struct Einsum {
     pub equation: String,
@@ -113,24 +124,26 @@ pub fn einsum(pool: &TensorPool, inputs: &[TensorView], equation: &str) -> Resul
     let equation = EinsumExpr::parse(equation)?;
     if equation.inputs.len() != inputs.len() {
         return Err(OpError::InvalidValue(
-            "Einsum equation input count does not match operator inputs",
+            "Number of terms in Einsum equation does not match input tensor count",
         ));
     }
-
-    if inputs.len() == 1 {
-        let in_order = &equation.inputs[0];
-        let out_order = &equation.output;
-        if !is_valid_permute_spec(in_order, out_order) {
-            return Err(OpError::UnsupportedValue("Unsupported Einsum equation"));
+    for (term, view) in equation.inputs.iter().zip(inputs) {
+        if term.len() != view.ndim() {
+            return Err(OpError::InvalidValue(
+                "Einsum term dimension count does not match input tensor",
+            ));
         }
-        let output = permuted_by_labels(&inputs[0], in_order, out_order).to_tensor_in(pool);
-        return Ok(output);
     }
 
-    if inputs.len() != 2 {
-        return Err(OpError::UnsupportedValue(
-            "Einsum implementation only supports two inputs",
-        ));
+    // For einsum equations with a single input or no reduced dimensions, the
+    // naive implementation is efficient.
+    //
+    // For einsum equations with more than two inputs or multiple reduced
+    // dimensions we fall back to the naive implementation, but this is far
+    // from optimal.
+    let reduced_dims = equation.reduced_dims();
+    if inputs.len() != 2 || reduced_dims.len() != 1 {
+        return naive_einsum(pool, inputs, &equation);
     }
 
     let x = &inputs[0];
@@ -138,32 +151,24 @@ pub fn einsum(pool: &TensorPool, inputs: &[TensorView], equation: &str) -> Resul
     let term1 = &equation.inputs[0];
     let term2 = &equation.inputs[1];
 
-    let reduced_dims = equation.reduced_dims();
-    if reduced_dims.len() != 1 {
-        return Err(OpError::UnsupportedValue(
-            "Einsum only supports equations with one reduced dimension",
-        ));
-    }
     let matmul_k = reduced_dims[0];
 
-    // Find a term that can be used as the `N` dimension of a matmul.
-    let Some(matmul_n) = term2.chars().find(|c| !term1.contains(*c)) else {
-        return Err(OpError::UnsupportedValue(
-            "Cannot evaluate Einsum using matmul",
-        ));
-    };
-
-    // Find a term that can be used as the `M` dimension of a matmul.
-    let Some(matmul_m) = term1.chars().rev().find(|c| !term2.contains(*c)) else {
-        return Err(OpError::UnsupportedValue(
-            "Cannot evaluate Einsum using matmul",
-        ));
-    };
+    // Find terms that can be used as the `N` and `M` dimensions of a matmul.
+    //
+    // If there aren't suitable dimensions, we'll insert them. Upper-case
+    // letters are used to denote inserted dimensions since these cannot
+    // conflict with dimensions in the einsum equation.
+    let matmul_n = term2.chars().find(|c| !term1.contains(*c)).unwrap_or('N');
+    let matmul_m = term1
+        .chars()
+        .rev()
+        .find(|c| !term2.contains(*c))
+        .unwrap_or('M');
 
     // Find the terms that will be used as the batch dimensions of a matmul.
     let batch_dims = term1
         .chars()
-        .filter(|c| *c != matmul_k && *c != matmul_n && *c != matmul_m);
+        .filter(|c| !reduced_dims.contains(c) && *c != matmul_n && *c != matmul_m);
 
     let mut x_order: String = batch_dims.clone().collect();
     x_order.push(matmul_m);
@@ -177,27 +182,34 @@ pub fn einsum(pool: &TensorPool, inputs: &[TensorView], equation: &str) -> Resul
     y_order.push(matmul_n);
 
     let mut out_order: String = batch_dims.collect();
-    out_order.push(matmul_m);
-    out_order.push(matmul_n);
+    if matmul_m.is_ascii_lowercase() {
+        out_order.push(matmul_m);
+    }
+    if matmul_n.is_ascii_lowercase() {
+        out_order.push(matmul_n);
+    }
 
-    let xp = permuted_by_labels(x, term1, &x_order);
-    let yp = permuted_by_labels(y, term2, &y_order);
-    let out = matmul(pool, xp, yp)?;
+    let xp = permute_and_insert_axes(x, term1, &x_order);
+    let yp = permute_and_insert_axes(y, term2, &y_order);
+    let mut out = matmul(pool, xp, yp)?;
+
+    if !matmul_m.is_ascii_lowercase() {
+        out.remove_axis(out.ndim() - 2);
+    }
+    if !matmul_n.is_ascii_lowercase() {
+        out.remove_axis(out.ndim() - 1);
+    }
 
     if out_order == equation.output {
         Ok(out)
     } else {
-        let out_permuted = permuted_by_labels(&out.view(), &out_order, &equation.output);
+        let out_permuted = permute_and_insert_axes(&out.view(), &out_order, &equation.output);
         Ok(out_permuted.to_tensor_in(pool))
     }
 }
 
-/// Return true if `src` and `dest` contain the same set of unique letters,
-/// ignoring the order.
-///
-/// Both strings are assumed to be short.
-fn is_valid_permute_spec(src: &str, dest: &str) -> bool {
-    if src.len() != dest.len() {
+fn is_valid_permute_insert_spec(src: &str, dest: &str) -> bool {
+    if src.len() > dest.len() {
         return false;
     }
     for src_ch in src.chars() {
@@ -210,18 +222,25 @@ fn is_valid_permute_spec(src: &str, dest: &str) -> bool {
     true
 }
 
-/// Permute a tensor by specifying label strings specifying the input and output
+/// Permute a tensor by using label strings to specify the input and output
 /// order of dimensions.
 ///
-/// For example `permute(tensor, "xy", "yx")` will transpose a matrix.
-fn permuted_by_labels<'a, T>(
+/// All dimensions listed in the input order must occur in the output order. The
+/// output order may contain dimensions that are missing from the input order.
+/// In that case a 1-sized dimension will be inserted.
+///
+/// Examples of input and output orders:
+///
+/// `"xy", "yx"` - Transpose a matrix
+/// `"x", "axb"` - Insert two 1-sized dimensions
+fn permute_and_insert_axes<'a, T>(
     tensor: &TensorView<'a, T>,
     in_order: &str,
     out_order: &str,
 ) -> TensorView<'a, T> {
     assert!(
-        is_valid_permute_spec(in_order, out_order),
-        "invalid permute spec {}->{}",
+        is_valid_permute_insert_spec(in_order, out_order),
+        "invalid permute-and-insert spec {}->{}",
         in_order,
         out_order
     );
@@ -231,9 +250,66 @@ fn permuted_by_labels<'a, T>(
     );
     let perm: Vec<usize> = out_order
         .chars()
-        .map(|c| in_order.chars().position(|ic| ic == c).unwrap())
+        .filter_map(|c| in_order.chars().position(|ic| ic == c))
         .collect();
-    tensor.permuted(&perm)
+    let mut permuted = tensor.permuted(&perm);
+
+    for (i, c) in out_order.chars().enumerate() {
+        if !in_order.contains(c) {
+            permuted.insert_axis(i);
+        }
+    }
+
+    permuted
+}
+
+/// Simple non-optimized Einsum implementation.
+///
+/// This uses a combination of transpose, multiplication and reduce-sum
+/// operations. It is efficient for cases where only multiplication or only
+/// reduction (plus transpose) is needed. It is not efficient when both
+/// multiplication and reduction are needed. Such cases are much more
+/// efficiently handled as matrix multiplication.
+fn naive_einsum(
+    pool: &TensorPool,
+    inputs: &[TensorView],
+    equation: &EinsumExpr,
+) -> Result<Tensor, OpError> {
+    // Re-arrange input views as `[output_dims][reduced_dims]`.
+    let reduced_dims = equation.reduced_dims();
+    let common_order: String = equation
+        .output
+        .chars()
+        .chain(reduced_dims.iter().copied())
+        .collect();
+    let mut broadcasted_inputs: Vec<_> = inputs
+        .iter()
+        .zip(&equation.inputs)
+        .map(|(inp, term)| permute_and_insert_axes(inp, term, &common_order))
+        .collect();
+
+    // Multiply corresponding elements of each input.
+    let mut output = broadcasted_inputs.remove(0).to_tensor_in(pool);
+    for rhs in broadcasted_inputs.into_iter() {
+        if rhs.can_broadcast_to(output.shape()) {
+            mul_in_place(output.view_mut(), rhs)
+        } else {
+            output = mul(pool, output.view(), rhs)?;
+        }
+    }
+
+    // Sum over the reduced dimensions.
+    if reduced_dims.is_empty() {
+        return Ok(output);
+    }
+
+    let reduced_dim_indices: Vec<i32> = (0..reduced_dims.len()).map(|i| i as i32 - 1).collect();
+    return reduce_sum(
+        pool,
+        output.view(),
+        Some(reduced_dim_indices.as_slice()),
+        false, /* keep_dims */
+    );
 }
 
 #[cfg(test)]
@@ -242,7 +318,7 @@ mod tests {
     use rten_tensor::{Tensor, TensorView};
 
     use crate::ops::tests::new_pool;
-    use crate::ops::{einsum, matmul, OpError};
+    use crate::ops::{einsum, matmul, mul, reduce_sum, OpError};
 
     #[test]
     fn test_einsum() {
@@ -253,11 +329,24 @@ mod tests {
         }
 
         let pool = new_pool();
+
         let vec_a = Tensor::arange(1., 10., None);
+        let vec_b = Tensor::arange(1., 5., None);
+
         let mat_a = Tensor::from([[1., 2., 3.], [4., 5., 6.]]);
         let mat_b = Tensor::from([[1., 2., 3., 4.], [5., 6., 7., 8.], [9., 10., 11., 12.]]);
         let matmul_ab = matmul(&pool, mat_a.view(), mat_b.view()).unwrap();
         let matmul_ba = matmul_ab.transposed().to_tensor();
+        let outer_mat_ab = mul(
+            &pool,
+            mat_a
+                .reshaped([mat_a.size(0), mat_a.size(1), 1, 1])
+                .as_dyn(),
+            mat_b
+                .reshaped([1, 1, mat_b.size(0), mat_b.size(1)])
+                .as_dyn(),
+        )
+        .unwrap();
 
         let bhwc = mat_a
             .clone()
@@ -272,6 +361,12 @@ mod tests {
             // Identity
             Case {
                 equation: "ij->ij",
+                inputs: vec![mat_a.view()],
+                expected: Ok(mat_a.clone()),
+            },
+            // Spaces between letters
+            Case {
+                equation: "i j -> i j",
                 inputs: vec![mat_a.view()],
                 expected: Ok(mat_a.clone()),
             },
@@ -292,6 +387,46 @@ mod tests {
                 equation: "ba",
                 inputs: vec![mat_a.view()],
                 expected: Ok(mat_a.transposed().to_tensor()),
+            },
+            // Reduction of a single input
+            Case {
+                equation: "ij->i",
+                inputs: vec![mat_a.view()],
+                expected: Ok(reduce_sum(
+                    &pool,
+                    mat_a.view(),
+                    Some(&[-1]),
+                    false, /* keep_dims */
+                )
+                .unwrap()),
+            },
+            // Outer product of two vectors
+            Case {
+                equation: "i,j->ij",
+                inputs: vec![vec_a.view(), vec_b.view()],
+                expected: Ok(mul(
+                    &pool,
+                    vec_a.reshaped([vec_a.len(), 1]).as_dyn(),
+                    vec_b.reshaped([1, vec_b.len()]).as_dyn(),
+                )
+                .unwrap()),
+            },
+            // Outer product of two matrices
+            Case {
+                equation: "ij,kl->ijkl",
+                inputs: vec![mat_a.view(), mat_b.view()],
+                expected: Ok(outer_mat_ab),
+            },
+            // Outer product with transpose
+            Case {
+                equation: "a,b->ba",
+                inputs: vec![vec_a.view(), vec_b.view()],
+                expected: Ok(mul(
+                    &pool,
+                    vec_b.reshaped([vec_b.len(), 1]).as_dyn(),
+                    vec_a.reshaped([1, vec_a.len()]).as_dyn(),
+                )
+                .unwrap()),
             },
             // Matmul
             Case {
@@ -329,46 +464,57 @@ mod tests {
                 equation: "ij,jk->ik",
                 inputs: vec![mat_a.view()],
                 expected: Err(OpError::InvalidValue(
-                    "Einsum equation input count does not match operator inputs",
+                    "Number of terms in Einsum equation does not match input tensor count",
                 )),
             },
-            // Unsupported dot product
+            // Dot product
             Case {
                 equation: "i,i->",
                 inputs: vec![vec_a.view(), vec_a.view()],
-                expected: Err(OpError::UnsupportedValue(
-                    "Cannot evaluate Einsum using matmul",
-                )),
+                expected: Ok(Tensor::from(vec_a.iter().map(|a| a * a).sum::<f32>())),
             },
-            // Unsupported matrix-vector product
+            // Matrix-vector product
             Case {
                 equation: "ij,j->i",
-                inputs: vec![mat_a.view(), mat_b.slice_dyn(0)],
-                expected: Err(OpError::UnsupportedValue(
-                    "Cannot evaluate Einsum using matmul",
-                )),
+                inputs: vec![mat_a.view(), mat_b.slice_dyn((.., 0))],
+                expected: Ok(matmul(&pool, mat_a.view(), mat_b.slice_dyn((.., ..1)))
+                    .unwrap()
+                    .into_shape([mat_a.size(0)].as_slice())),
             },
-            // Unsupported vector-matrix product
+            // Vector-matrix product
             Case {
                 equation: "j,jk->k",
                 inputs: vec![mat_a.slice_dyn(0), mat_b.view()],
-                expected: Err(OpError::UnsupportedValue(
-                    "Cannot evaluate Einsum using matmul",
-                )),
+                expected: Ok(matmul(&pool, mat_a.slice_dyn((..1, ..)), mat_b.view())
+                    .unwrap()
+                    .into_shape([mat_b.size(1)].as_slice())),
             },
-            // Unsupported number of reduced dimensions
+            // Reduction over multiple dimensions
             Case {
-                equation: "ij,kl->ijkl",
-                inputs: vec![mat_a.view(), mat_b.view()],
-                expected: Err(OpError::UnsupportedValue(
-                    "Einsum only supports equations with one reduced dimension",
+                equation: "ij,ij->",
+                inputs: vec![mat_a.view(), mat_a.view()],
+                expected: Ok(Tensor::from(mat_a.iter().map(|x| x * x).sum::<f32>())),
+            },
+            // Reduction over multiple dimensions where the reduced dimensions
+            // are not present in all tensors.
+            Case {
+                equation: "ij,j->",
+                inputs: vec![mat_a.view(), mat_b.slice_dyn((.., 0))],
+                expected: Ok(Tensor::from(
+                    mat_a
+                        .iter()
+                        .zip(mat_b.slice_dyn((.., 0)).broadcast(mat_a.shape()).iter())
+                        .map(|(x, y)| x * y)
+                        .sum::<f32>(),
                 )),
             },
             // Empty equation
             Case {
                 equation: "",
                 inputs: vec![],
-                expected: Err(OpError::InvalidValue("Invalid equation")),
+                expected: Err(OpError::InvalidValue(
+                    "Einsum equation must have at least one term",
+                )),
             },
             // Invalid input terms
             Case {
@@ -386,6 +532,20 @@ mod tests {
                     "Einsum terms must contain only lowercase letters",
                 )),
             },
+            // Mismatch between input ndim and term dimension count
+            Case {
+                equation: "ij",
+                inputs: vec![vec_a.view()],
+                expected: Err(OpError::InvalidValue(
+                    "Einsum term dimension count does not match input tensor",
+                )),
+            },
+            // Three input dot product
+            Case {
+                equation: "i,i,i->",
+                inputs: vec![vec_a.view(), vec_a.view(), vec_a.view()],
+                expected: Ok(Tensor::from(vec_a.map(|x| x * x * x).iter().sum::<f32>())),
+            },
         ];
 
         for Case {
@@ -395,7 +555,11 @@ mod tests {
         } in cases
         {
             let output = einsum(&pool, inputs.as_slice(), equation);
-            assert_eq!(output, expected);
+            assert_eq!(
+                output, expected,
+                "result mismatch for equation {}",
+                equation
+            );
         }
     }
 }


### PR DESCRIPTION
This expands the supported equations, however some cases are handled with a naive/inefficient implementation.

Support:

 - Reducing a single input
 - Equations that involve no reductions (eg. outer products)
 - Equations that involve vector-vector or vector-matrix dot products

   When we don't have a suitable dimension for the M or N inputs of a matmul,
   insert temporary axes and them remove them afterwards.
 - Equations that involve more than one reduced dimension or more than
   two inputs.

   These cases are currently handled by a naive implementation which is much
   less efficient than matrix multiplication.
