### PR TITLE
Support using matmul for Einsum equations with 3 or more inputs

### DIFF
--- a/src/tensor_pool.rs
+++ b/src/tensor_pool.rs
@@ -232,11 +232,12 @@ impl<'a, T, L: MutLayout> ExtractBuffer for TensorBase<CowData<'a, T>, L> {
     }
 }
 
-/// Trait for wrapping a container in a [PoolRef] which automatically returns
+/// Trait for wrapping a container in a [`PoolRef`] which automatically returns
 /// the container's data buffer to a pool when it goes out of scope.
 pub trait AutoReturn {
-    /// Wrap `self` in a [PoolRef]. When the returned [PoolRef] is dropped,
-    /// `self` will be returned to `pool`.
+    /// Wrap `self` in a [`PoolRef`].
+    ///
+    /// When the returned ref is dropped, `self` will be returned to the pool.
     fn auto_return(self, pool: &TensorPool) -> PoolRef<Self>
     where
         Self: Sized + ExtractBuffer;


### PR DESCRIPTION
Previously Einsum equations with more than two inputs were handled via a fallback to a naive implementation that was much less efficient than a matmul if a reduction was required. In this commit, equations are split into a path where each step handles one or two inputs. Each step will use matmul, multiply or reduce-sum as appropriate.

The generated path always processes inputs in left-to-right order. This can be much less efficient than the optimal contraction order. Using a better algorithm is left as a future exercise.

Part of https://github.com/robertknight/rten/issues/298.