### PR TITLE
Implement `If` operator

### DIFF
--- a/rten-convert/rten_convert/schema_generated.py
+++ b/rten-convert/rten_convert/schema_generated.py
@@ -111,6 +111,7 @@ class OperatorType(object):
     GatherND = 101
     Gelu = 102
     Einsum = 103
+    If = 104
 
 
 class RNNDirection(object):
@@ -187,6 +188,7 @@ class OperatorAttrs(object):
     GatherNDAttrs = 36
     GeluAttrs = 37
     EinsumAttrs = 38
+    IfAttrs = 39
 
 def OperatorAttrsCreator(unionType, table):
     from flatbuffers.table import Table
@@ -268,6 +270,8 @@ def OperatorAttrsCreator(unionType, table):
         return GeluAttrsT.InitFromBuf(table.Bytes, table.Pos)
     if unionType == OperatorAttrs().EinsumAttrs:
         return EinsumAttrsT.InitFromBuf(table.Bytes, table.Pos)
+    if unionType == OperatorAttrs().IfAttrs:
+        return IfAttrsT.InitFromBuf(table.Bytes, table.Pos)
     return None
 
 
@@ -2442,6 +2446,114 @@ class HardSigmoidAttrsT(object):
         HardSigmoidAttrsAddBeta(builder, self.beta)
         hardSigmoidAttrs = HardSigmoidAttrsEnd(builder)
         return hardSigmoidAttrs
+
+
+class IfAttrs(object):
+    __slots__ = ['_tab']
+
+    @classmethod
+    def GetRootAs(cls, buf, offset=0):
+        n = flatbuffers.encode.Get(flatbuffers.packer.uoffset, buf, offset)
+        x = IfAttrs()
+        x.Init(buf, n + offset)
+        return x
+
+    @classmethod
+    def GetRootAsIfAttrs(cls, buf, offset=0):
+        """This method is deprecated. Please switch to GetRootAs."""
+        return cls.GetRootAs(buf, offset)
+    @classmethod
+    def IfAttrsBufferHasIdentifier(cls, buf, offset, size_prefixed=False):
+        return flatbuffers.util.BufferHasIdentifier(buf, offset, b"\x52\x54\x45\x4E", size_prefixed=size_prefixed)
+
+    # IfAttrs
+    def Init(self, buf, pos):
+        self._tab = flatbuffers.table.Table(buf, pos)
+
+    # IfAttrs
+    def ThenBranch(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
+        if o != 0:
+            x = self._tab.Indirect(o + self._tab.Pos)
+            obj = Graph()
+            obj.Init(self._tab.Bytes, x)
+            return obj
+        return None
+
+    # IfAttrs
+    def ElseBranch(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(6))
+        if o != 0:
+            x = self._tab.Indirect(o + self._tab.Pos)
+            obj = Graph()
+            obj.Init(self._tab.Bytes, x)
+            return obj
+        return None
+
+def IfAttrsStart(builder):
+    builder.StartObject(2)
+
+def IfAttrsAddThenBranch(builder, thenBranch):
+    builder.PrependUOffsetTRelativeSlot(0, flatbuffers.number_types.UOffsetTFlags.py_type(thenBranch), 0)
+
+def IfAttrsAddElseBranch(builder, elseBranch):
+    builder.PrependUOffsetTRelativeSlot(1, flatbuffers.number_types.UOffsetTFlags.py_type(elseBranch), 0)
+
+def IfAttrsEnd(builder):
+    return builder.EndObject()
+
+
+try:
+    from typing import Optional
+except:
+    pass
+
+class IfAttrsT(object):
+
+    # IfAttrsT
+    def __init__(self):
+        self.thenBranch = None  # type: Optional[GraphT]
+        self.elseBranch = None  # type: Optional[GraphT]
+
+    @classmethod
+    def InitFromBuf(cls, buf, pos):
+        ifAttrs = IfAttrs()
+        ifAttrs.Init(buf, pos)
+        return cls.InitFromObj(ifAttrs)
+
+    @classmethod
+    def InitFromPackedBuf(cls, buf, pos=0):
+        n = flatbuffers.encode.Get(flatbuffers.packer.uoffset, buf, pos)
+        return cls.InitFromBuf(buf, pos+n)
+
+    @classmethod
+    def InitFromObj(cls, ifAttrs):
+        x = IfAttrsT()
+        x._UnPack(ifAttrs)
+        return x
+
+    # IfAttrsT
+    def _UnPack(self, ifAttrs):
+        if ifAttrs is None:
+            return
+        if ifAttrs.ThenBranch() is not None:
+            self.thenBranch = GraphT.InitFromObj(ifAttrs.ThenBranch())
+        if ifAttrs.ElseBranch() is not None:
+            self.elseBranch = GraphT.InitFromObj(ifAttrs.ElseBranch())
+
+    # IfAttrsT
+    def Pack(self, builder):
+        if self.thenBranch is not None:
+            thenBranch = self.thenBranch.Pack(builder)
+        if self.elseBranch is not None:
+            elseBranch = self.elseBranch.Pack(builder)
+        IfAttrsStart(builder)
+        if self.thenBranch is not None:
+            IfAttrsAddThenBranch(builder, thenBranch)
+        if self.elseBranch is not None:
+            IfAttrsAddElseBranch(builder, elseBranch)
+        ifAttrs = IfAttrsEnd(builder)
+        return ifAttrs
 
 
 class LeakyReluAttrs(object):
@@ -4669,7 +4781,7 @@ class OperatorNodeT(object):
     def __init__(self):
         self.type = 0  # type: int
         self.attrsType = 0  # type: int
-        self.attrs = None  # type: Union[None, ArgMaxAttrsT, AveragePoolAttrsT, BatchNormalizationAttrsT, CastAttrsT, ConcatAttrsT, ConstantOfShapeAttrsT, ConvAttrsT, ConvTransposeAttrsT, FlattenAttrsT, GatherAttrsT, GemmAttrsT, GRUAttrsT, LeakyReluAttrsT, LSTMAttrsT, MaxPoolAttrsT, ReduceMeanAttrsT, ReshapeAttrsT, ResizeAttrsT, SplitAttrsT, SoftmaxAttrsT, TransposeAttrsT, ModAttrsT, ScatterElementsAttrsT, OneHotAttrsT, TopKAttrsT, HardSigmoidAttrsT, TriluAttrsT, ScatterNDAttrsT, NonMaxSuppressionAttrsT, LayerNormalizationAttrsT, RandomUniformAttrsT, EluAttrsT, RandomUniformLikeAttrsT, RandomNormalAttrsT, RandomNormalLikeAttrsT, GatherNDAttrsT, GeluAttrsT, EinsumAttrsT]
+        self.attrs = None  # type: Union[None, ArgMaxAttrsT, AveragePoolAttrsT, BatchNormalizationAttrsT, CastAttrsT, ConcatAttrsT, ConstantOfShapeAttrsT, ConvAttrsT, ConvTransposeAttrsT, FlattenAttrsT, GatherAttrsT, GemmAttrsT, GRUAttrsT, LeakyReluAttrsT, LSTMAttrsT, MaxPoolAttrsT, ReduceMeanAttrsT, ReshapeAttrsT, ResizeAttrsT, SplitAttrsT, SoftmaxAttrsT, TransposeAttrsT, ModAttrsT, ScatterElementsAttrsT, OneHotAttrsT, TopKAttrsT, HardSigmoidAttrsT, TriluAttrsT, ScatterNDAttrsT, NonMaxSuppressionAttrsT, LayerNormalizationAttrsT, RandomUniformAttrsT, EluAttrsT, RandomUniformLikeAttrsT, RandomNormalAttrsT, RandomNormalLikeAttrsT, GatherNDAttrsT, GeluAttrsT, EinsumAttrsT, IfAttrsT]
         self.inputs = None  # type: List[int]
         self.outputs = None  # type: List[int]
 
@@ -5586,8 +5698,35 @@ class Graph(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(8))
         return o == 0
 
+    # Graph
+    def Captures(self, j):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(10))
+        if o != 0:
+            a = self._tab.Vector(o)
+            return self._tab.Get(flatbuffers.number_types.Uint32Flags, a + flatbuffers.number_types.UOffsetTFlags.py_type(j * 4))
+        return 0
+
+    # Graph
+    def CapturesAsNumpy(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(10))
+        if o != 0:
+            return self._tab.GetVectorAsNumpy(flatbuffers.number_types.Uint32Flags, o)
+        return 0
+
+    # Graph
+    def CapturesLength(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(10))
+        if o != 0:
+            return self._tab.VectorLen(o)
+        return 0
+
+    # Graph
+    def CapturesIsNone(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(10))
+        return o == 0
+
 def GraphStart(builder):
-    builder.StartObject(3)
+    builder.StartObject(4)
 
 def GraphAddNodes(builder, nodes):
     builder.PrependUOffsetTRelativeSlot(0, flatbuffers.number_types.UOffsetTFlags.py_type(nodes), 0)
@@ -5607,6 +5746,12 @@ def GraphAddOutputs(builder, outputs):
 def GraphStartOutputsVector(builder, numElems):
     return builder.StartVector(4, numElems, 4)
 
+def GraphAddCaptures(builder, captures):
+    builder.PrependUOffsetTRelativeSlot(3, flatbuffers.number_types.UOffsetTFlags.py_type(captures), 0)
+
+def GraphStartCapturesVector(builder, numElems):
+    return builder.StartVector(4, numElems, 4)
+
 def GraphEnd(builder):
     return builder.EndObject()
 
@@ -5623,6 +5768,7 @@ class GraphT(object):
         self.nodes = None  # type: List[NodeT]
         self.inputs = None  # type: List[int]
         self.outputs = None  # type: List[int]
+        self.captures = None  # type: List[int]
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -5667,6 +5813,13 @@ class GraphT(object):
                     self.outputs.append(graph.Outputs(i))
             else:
                 self.outputs = graph.OutputsAsNumpy()
+        if not graph.CapturesIsNone():
+            if np is None:
+                self.captures = []
+                for i in range(graph.CapturesLength()):
+                    self.captures.append(graph.Captures(i))
+            else:
+                self.captures = graph.CapturesAsNumpy()
 
     # GraphT
     def Pack(self, builder):
@@ -5694,6 +5847,14 @@ class GraphT(object):
                 for i in reversed(range(len(self.outputs))):
                     builder.PrependUint32(self.outputs[i])
                 outputs = builder.EndVector()
+        if self.captures is not None:
+            if np is not None and type(self.captures) is np.ndarray:
+                captures = builder.CreateNumpyVector(self.captures)
+            else:
+                GraphStartCapturesVector(builder, len(self.captures))
+                for i in reversed(range(len(self.captures))):
+                    builder.PrependUint32(self.captures[i])
+                captures = builder.EndVector()
         GraphStart(builder)
         if self.nodes is not None:
             GraphAddNodes(builder, nodes)
@@ -5701,6 +5862,8 @@ class GraphT(object):
             GraphAddInputs(builder, inputs)
         if self.outputs is not None:
             GraphAddOutputs(builder, outputs)
+        if self.captures is not None:
+            GraphAddCaptures(builder, captures)
         graph = GraphEnd(builder)
         return graph
 

--- a/src/ops/control_flow.rs
+++ b/src/ops/control_flow.rs
@@ -1,0 +1,81 @@
+use rten_tensor::TensorView;
+
+use crate::graph::{CaptureEnv, Graph, RunError};
+use crate::ops::{InputList, OpError, Operator, Output, OutputList};
+use crate::tensor_pool::TensorPool;
+
+fn output_list_from_vec(xs: Vec<Output>) -> OutputList {
+    xs.into_iter().collect()
+}
+
+fn run_error_from_op_error(error: OpError) -> RunError {
+    RunError::OperatorError {
+        name: "If".to_string(),
+        error,
+    }
+}
+
+pub struct If {
+    pub then_branch: Graph,
+    pub else_branch: Graph,
+}
+
+impl std::fmt::Debug for If {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(f, "If {{ ... }}")
+    }
+}
+
+impl Operator for If {
+    fn name(&self) -> &str {
+        "If"
+    }
+
+    fn run(&self, _pool: &TensorPool, _inputs: InputList) -> Result<OutputList, OpError> {
+        Err(OpError::InvalidValue(
+            "operator must be run with `run_subgraph`",
+        ))
+    }
+
+    fn has_subgraph(&self) -> bool {
+        true
+    }
+
+    fn run_subgraph(
+        &self,
+        // TODO - Use the pool for running the subgraph.
+        _pool: &TensorPool,
+        inputs: InputList,
+        captures: &CaptureEnv,
+    ) -> Result<OutputList, RunError> {
+        let cond: TensorView<i32> = inputs.require_as(0).map_err(run_error_from_op_error)?;
+        let Some(cond_bool) = cond.item().copied() else {
+            return Err(run_error_from_op_error(OpError::InvalidValue(
+                "cond must be a single value",
+            )));
+        };
+
+        // TODO - Propagate run options from parent graph.
+        let run_opts = None;
+
+        if cond_bool != 0 {
+            self.then_branch
+                .run_subgraph(
+                    Vec::new(),
+                    self.then_branch.output_ids(),
+                    captures,
+                    run_opts,
+                )
+                .map(output_list_from_vec)
+        } else {
+            self.else_branch
+                .run_subgraph(
+                    Vec::new(),
+                    self.else_branch.output_ids(),
+                    captures,
+                    run_opts,
+                )
+                .map(output_list_from_vec)
+        }
+    }
+}

--- a/src/schema.fbs
+++ b/src/schema.fbs
@@ -117,6 +117,7 @@ enum OperatorType: ubyte {
   GatherND,
   Gelu,
   Einsum,
+  If,
 }
 
 enum RNNDirection: ubyte {
@@ -200,6 +201,7 @@ union OperatorAttrs {
   GatherNDAttrs,
   GeluAttrs,
   EinsumAttrs,
+  IfAttrs,
 }
 
 table ArgMaxAttrs {
@@ -313,6 +315,11 @@ table GRUAttrs {
 table HardSigmoidAttrs {
   alpha:float;
   beta:float;
+}
+
+table IfAttrs {
+  then_branch:Graph;
+  else_branch:Graph;
 }
 
 table LeakyReluAttrs {
@@ -508,7 +515,10 @@ table Node {
   data:NodeKind;
 }
 
-// Dataflow graph for the model
+// Graph describing a sequence of operations in a model.
+//
+// This is analagous to the body of a function or closure in a programming
+// language.
 table Graph {
   // Nodes are sorted in topological order. This means that if a node references
   // other nodes (eg. an operator node referencing inputs), the referents must
@@ -520,6 +530,10 @@ table Graph {
 
   // IDs of output nodes
   outputs:[uint];
+
+  // IDs of nodes which capture their values from the enclosing scope when
+  // this graph is run as a subgraph.
+  captures:[uint];
 }
 
 table Metadata {

--- a/src/schema_generated.rs
+++ b/src/schema_generated.rs
@@ -18,13 +18,13 @@ pub const ENUM_MIN_OPERATOR_TYPE: u8 = 0;
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
-pub const ENUM_MAX_OPERATOR_TYPE: u8 = 103;
+pub const ENUM_MAX_OPERATOR_TYPE: u8 = 104;
 #[deprecated(
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 104] = [
+pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 105] = [
     OperatorType::Add,
     OperatorType::ArgMin,
     OperatorType::ArgMax,
@@ -129,6 +129,7 @@ pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 104] = [
     OperatorType::GatherND,
     OperatorType::Gelu,
     OperatorType::Einsum,
+    OperatorType::If,
 ];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -240,9 +241,10 @@ impl OperatorType {
     pub const GatherND: Self = Self(101);
     pub const Gelu: Self = Self(102);
     pub const Einsum: Self = Self(103);
+    pub const If: Self = Self(104);
 
     pub const ENUM_MIN: u8 = 0;
-    pub const ENUM_MAX: u8 = 103;
+    pub const ENUM_MAX: u8 = 104;
     pub const ENUM_VALUES: &'static [Self] = &[
         Self::Add,
         Self::ArgMin,
@@ -348,6 +350,7 @@ impl OperatorType {
         Self::GatherND,
         Self::Gelu,
         Self::Einsum,
+        Self::If,
     ];
     /// Returns the variant's name or "" if unknown.
     pub fn variant_name(self) -> Option<&'static str> {
@@ -456,6 +459,7 @@ impl OperatorType {
             Self::GatherND => Some("GatherND"),
             Self::Gelu => Some("Gelu"),
             Self::Einsum => Some("Einsum"),
+            Self::If => Some("If"),
             _ => None,
         }
     }
@@ -1082,13 +1086,13 @@ pub const ENUM_MIN_OPERATOR_ATTRS: u8 = 0;
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
-pub const ENUM_MAX_OPERATOR_ATTRS: u8 = 38;
+pub const ENUM_MAX_OPERATOR_ATTRS: u8 = 39;
 #[deprecated(
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_OPERATOR_ATTRS: [OperatorAttrs; 39] = [
+pub const ENUM_VALUES_OPERATOR_ATTRS: [OperatorAttrs; 40] = [
     OperatorAttrs::NONE,
     OperatorAttrs::ArgMaxAttrs,
     OperatorAttrs::AveragePoolAttrs,
@@ -1128,6 +1132,7 @@ pub const ENUM_VALUES_OPERATOR_ATTRS: [OperatorAttrs; 39] = [
     OperatorAttrs::GatherNDAttrs,
     OperatorAttrs::GeluAttrs,
     OperatorAttrs::EinsumAttrs,
+    OperatorAttrs::IfAttrs,
 ];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -1174,9 +1179,10 @@ impl OperatorAttrs {
     pub const GatherNDAttrs: Self = Self(36);
     pub const GeluAttrs: Self = Self(37);
     pub const EinsumAttrs: Self = Self(38);
+    pub const IfAttrs: Self = Self(39);
 
     pub const ENUM_MIN: u8 = 0;
-    pub const ENUM_MAX: u8 = 38;
+    pub const ENUM_MAX: u8 = 39;
     pub const ENUM_VALUES: &'static [Self] = &[
         Self::NONE,
         Self::ArgMaxAttrs,
@@ -1217,6 +1223,7 @@ impl OperatorAttrs {
         Self::GatherNDAttrs,
         Self::GeluAttrs,
         Self::EinsumAttrs,
+        Self::IfAttrs,
     ];
     /// Returns the variant's name or "" if unknown.
     pub fn variant_name(self) -> Option<&'static str> {
@@ -1260,6 +1267,7 @@ impl OperatorAttrs {
             Self::GatherNDAttrs => Some("GatherNDAttrs"),
             Self::GeluAttrs => Some("GeluAttrs"),
             Self::EinsumAttrs => Some("EinsumAttrs"),
+            Self::IfAttrs => Some("IfAttrs"),
             _ => None,
         }
     }
@@ -4502,6 +4510,146 @@ impl core::fmt::Debug for HardSigmoidAttrs<'_> {
         let mut ds = f.debug_struct("HardSigmoidAttrs");
         ds.field("alpha", &self.alpha());
         ds.field("beta", &self.beta());
+        ds.finish()
+    }
+}
+pub enum IfAttrsOffset {}
+#[derive(Copy, Clone, PartialEq)]
+
+pub struct IfAttrs<'a> {
+    pub _tab: flatbuffers::Table<'a>,
+}
+
+impl<'a> flatbuffers::Follow<'a> for IfAttrs<'a> {
+    type Inner = IfAttrs<'a>;
+    #[inline]
+    unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self {
+            _tab: flatbuffers::Table::new(buf, loc),
+        }
+    }
+}
+
+impl<'a> IfAttrs<'a> {
+    pub const VT_THEN_BRANCH: flatbuffers::VOffsetT = 4;
+    pub const VT_ELSE_BRANCH: flatbuffers::VOffsetT = 6;
+
+    #[inline]
+    pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+        IfAttrs { _tab: table }
+    }
+    #[allow(unused_mut)]
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
+        args: &'args IfAttrsArgs<'args>,
+    ) -> flatbuffers::WIPOffset<IfAttrs<'bldr>> {
+        let mut builder = IfAttrsBuilder::new(_fbb);
+        if let Some(x) = args.else_branch {
+            builder.add_else_branch(x);
+        }
+        if let Some(x) = args.then_branch {
+            builder.add_then_branch(x);
+        }
+        builder.finish()
+    }
+
+    #[inline]
+    pub fn then_branch(&self) -> Option<Graph<'a>> {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab
+                .get::<flatbuffers::ForwardsUOffset<Graph>>(IfAttrs::VT_THEN_BRANCH, None)
+        }
+    }
+    #[inline]
+    pub fn else_branch(&self) -> Option<Graph<'a>> {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab
+                .get::<flatbuffers::ForwardsUOffset<Graph>>(IfAttrs::VT_ELSE_BRANCH, None)
+        }
+    }
+}
+
+impl flatbuffers::Verifiable for IfAttrs<'_> {
+    #[inline]
+    fn run_verifier(
+        v: &mut flatbuffers::Verifier,
+        pos: usize,
+    ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+        use self::flatbuffers::Verifiable;
+        v.visit_table(pos)?
+            .visit_field::<flatbuffers::ForwardsUOffset<Graph>>(
+                "then_branch",
+                Self::VT_THEN_BRANCH,
+                false,
+            )?
+            .visit_field::<flatbuffers::ForwardsUOffset<Graph>>(
+                "else_branch",
+                Self::VT_ELSE_BRANCH,
+                false,
+            )?
+            .finish();
+        Ok(())
+    }
+}
+pub struct IfAttrsArgs<'a> {
+    pub then_branch: Option<flatbuffers::WIPOffset<Graph<'a>>>,
+    pub else_branch: Option<flatbuffers::WIPOffset<Graph<'a>>>,
+}
+impl<'a> Default for IfAttrsArgs<'a> {
+    #[inline]
+    fn default() -> Self {
+        IfAttrsArgs {
+            then_branch: None,
+            else_branch: None,
+        }
+    }
+}
+
+pub struct IfAttrsBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+    fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
+    start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> IfAttrsBuilder<'a, 'b, A> {
+    #[inline]
+    pub fn add_then_branch(&mut self, then_branch: flatbuffers::WIPOffset<Graph<'b>>) {
+        self.fbb_.push_slot_always::<flatbuffers::WIPOffset<Graph>>(
+            IfAttrs::VT_THEN_BRANCH,
+            then_branch,
+        );
+    }
+    #[inline]
+    pub fn add_else_branch(&mut self, else_branch: flatbuffers::WIPOffset<Graph<'b>>) {
+        self.fbb_.push_slot_always::<flatbuffers::WIPOffset<Graph>>(
+            IfAttrs::VT_ELSE_BRANCH,
+            else_branch,
+        );
+    }
+    #[inline]
+    pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> IfAttrsBuilder<'a, 'b, A> {
+        let start = _fbb.start_table();
+        IfAttrsBuilder {
+            fbb_: _fbb,
+            start_: start,
+        }
+    }
+    #[inline]
+    pub fn finish(self) -> flatbuffers::WIPOffset<IfAttrs<'a>> {
+        let o = self.fbb_.end_table(self.start_);
+        flatbuffers::WIPOffset::new(o.value())
+    }
+}
+
+impl core::fmt::Debug for IfAttrs<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut ds = f.debug_struct("IfAttrs");
+        ds.field("then_branch", &self.then_branch());
+        ds.field("else_branch", &self.else_branch());
         ds.finish()
     }
 }
@@ -7787,6 +7935,21 @@ impl<'a> OperatorNode<'a> {
             None
         }
     }
+
+    #[inline]
+    #[allow(non_snake_case)]
+    pub fn attrs_as_if_attrs(&self) -> Option<IfAttrs<'a>> {
+        if self.attrs_type() == OperatorAttrs::IfAttrs {
+            self.attrs().map(|t| {
+                // Safety:
+                // Created from a valid Table for this object
+                // Which contains a valid union in this slot
+                unsafe { IfAttrs::init_from_table(t) }
+            })
+        } else {
+            None
+        }
+    }
 }
 
 impl flatbuffers::Verifiable for OperatorNode<'_> {
@@ -7838,6 +8001,7 @@ impl flatbuffers::Verifiable for OperatorNode<'_> {
           OperatorAttrs::GatherNDAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<GatherNDAttrs>>("OperatorAttrs::GatherNDAttrs", pos),
           OperatorAttrs::GeluAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<GeluAttrs>>("OperatorAttrs::GeluAttrs", pos),
           OperatorAttrs::EinsumAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<EinsumAttrs>>("OperatorAttrs::EinsumAttrs", pos),
+          OperatorAttrs::IfAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<IfAttrs>>("OperatorAttrs::IfAttrs", pos),
           _ => Ok(()),
         }
      })?
@@ -8295,6 +8459,16 @@ impl core::fmt::Debug for OperatorNode<'_> {
             }
             OperatorAttrs::EinsumAttrs => {
                 if let Some(x) = self.attrs_as_einsum_attrs() {
+                    ds.field("attrs", &x)
+                } else {
+                    ds.field(
+                        "attrs",
+                        &"InvalidFlatbuffer: Union discriminant does not match value.",
+                    )
+                }
+            }
+            OperatorAttrs::IfAttrs => {
+                if let Some(x) = self.attrs_as_if_attrs() {
                     ds.field("attrs", &x)
                 } else {
                     ds.field(
@@ -9331,6 +9505,7 @@ impl<'a> Graph<'a> {
     pub const VT_NODES: flatbuffers::VOffsetT = 4;
     pub const VT_INPUTS: flatbuffers::VOffsetT = 6;
     pub const VT_OUTPUTS: flatbuffers::VOffsetT = 8;
+    pub const VT_CAPTURES: flatbuffers::VOffsetT = 10;
 
     #[inline]
     pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
@@ -9342,6 +9517,9 @@ impl<'a> Graph<'a> {
         args: &'args GraphArgs<'args>,
     ) -> flatbuffers::WIPOffset<Graph<'bldr>> {
         let mut builder = GraphBuilder::new(_fbb);
+        if let Some(x) = args.captures {
+            builder.add_captures(x);
+        }
         if let Some(x) = args.outputs {
             builder.add_outputs(x);
         }
@@ -9391,6 +9569,19 @@ impl<'a> Graph<'a> {
                 )
         }
     }
+    #[inline]
+    pub fn captures(&self) -> Option<flatbuffers::Vector<'a, u32>> {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab
+                .get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u32>>>(
+                    Graph::VT_CAPTURES,
+                    None,
+                )
+        }
+    }
 }
 
 impl flatbuffers::Verifiable for Graph<'_> {
@@ -9414,6 +9605,11 @@ impl flatbuffers::Verifiable for Graph<'_> {
                 Self::VT_OUTPUTS,
                 false,
             )?
+            .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, u32>>>(
+                "captures",
+                Self::VT_CAPTURES,
+                false,
+            )?
             .finish();
         Ok(())
     }
@@ -9424,6 +9620,7 @@ pub struct GraphArgs<'a> {
     >,
     pub inputs: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u32>>>,
     pub outputs: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u32>>>,
+    pub captures: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u32>>>,
 }
 impl<'a> Default for GraphArgs<'a> {
     #[inline]
@@ -9432,6 +9629,7 @@ impl<'a> Default for GraphArgs<'a> {
             nodes: None,
             inputs: None,
             outputs: None,
+            captures: None,
         }
     }
 }
@@ -9462,6 +9660,11 @@ impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> GraphBuilder<'a, 'b, A> {
             .push_slot_always::<flatbuffers::WIPOffset<_>>(Graph::VT_OUTPUTS, outputs);
     }
     #[inline]
+    pub fn add_captures(&mut self, captures: flatbuffers::WIPOffset<flatbuffers::Vector<'b, u32>>) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(Graph::VT_CAPTURES, captures);
+    }
+    #[inline]
     pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> GraphBuilder<'a, 'b, A> {
         let start = _fbb.start_table();
         GraphBuilder {
@@ -9482,6 +9685,7 @@ impl core::fmt::Debug for Graph<'_> {
         ds.field("nodes", &self.nodes());
         ds.field("inputs", &self.inputs());
         ds.field("outputs", &self.outputs());
+        ds.field("captures", &self.captures());
         ds.finish()
     }
 }


### PR DESCRIPTION
Implement the [If](https://onnx.ai/onnx/operators/onnx__If.html#l-onnx-doc-if) operator. This is the first control flow operator that is being supported in RTen, so most of the changes are the infrastructure needed to support operators which run subgraphs as part of their execution.

**TODO:**

- [x] Tests for `If` operator deserialization
- [x] Tests for nested subgraphs
- [x] Rework `CaptureEnv::get_input` to avoid using a local value node if it is a capture
- [x] Rework the hack in the model converter that stores a `Graph` object in an `IfAttrsT`

**Deferred to subsequent PRs**

- Ensure that constant propagation in rten-generate doesn't eliminate inputs that are needed as captured values on subsequent runs. This affects the `encoder_hidden_states` input in TrOCR (see https://github.com/robertknight/rten/pull/304).
- Investigate error when running Silero VAD model that uses the If operator extensively. From an initial glance it looks like the issue is that planning doesn't take into account dependencies an operator may have due to captures in its subgraphs