### PR TITLE
Propagate graph run options to subgraphs

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -978,6 +978,7 @@ impl Graph {
                     &pool,
                     InputList::from_optional(&op_inputs),
                     &capture_env,
+                    Some(opts.clone()),
                 );
                 result
             } else {
@@ -1343,7 +1344,7 @@ mod tests {
     use smallvec::smallvec;
 
     use super::{CachedPlan, CaptureEnv};
-    use crate::graph::{Dimension, Graph, Node, RunError, TypedConstant};
+    use crate::graph::{Dimension, Graph, Node, RunError, RunOptions, TypedConstant};
     use crate::ops::{
         Add, Concat, Conv, If, InputList, IntoOpResult, Mul, OpError, Operator, Output, OutputList,
         Relu, Shape,
@@ -2141,6 +2142,7 @@ mod tests {
             _pool: &TensorPool,
             inputs: InputList,
             captures: &CaptureEnv,
+            options: Option<RunOptions>,
         ) -> Result<OutputList, RunError> {
             let inputs = self
                 .graph
@@ -2150,7 +2152,7 @@ mod tests {
                 .zip(inputs.iter().map(|i| i.into()))
                 .collect();
             self.graph
-                .run_subgraph(inputs, self.graph.output_ids(), captures, None)
+                .run_subgraph(inputs, self.graph.output_ids(), captures, options)
                 .map(|xs| xs.into_iter().collect())
         }
     }

--- a/src/ops/control_flow.rs
+++ b/src/ops/control_flow.rs
@@ -1,6 +1,6 @@
 use rten_tensor::TensorView;
 
-use crate::graph::{CaptureEnv, Graph, RunError};
+use crate::graph::{CaptureEnv, Graph, RunError, RunOptions};
 use crate::ops::{InputList, OpError, Operator, Output, OutputList};
 use crate::tensor_pool::TensorPool;
 
@@ -47,6 +47,7 @@ impl Operator for If {
         _pool: &TensorPool,
         inputs: InputList,
         captures: &CaptureEnv,
+        run_opts: Option<RunOptions>,
     ) -> Result<OutputList, RunError> {
         let cond: TensorView<i32> = inputs.require_as(0).map_err(run_error_from_op_error)?;
         let Some(cond_bool) = cond.item().copied() else {
@@ -54,9 +55,6 @@ impl Operator for If {
                 "cond must be a single value",
             )));
         };
-
-        // TODO - Propagate run options from parent graph.
-        let run_opts = None;
 
         if cond_bool != 0 {
             self.then_branch

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -26,7 +26,7 @@ use rten_tensor::{
 };
 
 use crate::downcast::impl_downcastdyn;
-use crate::graph::{CaptureEnv, RunError};
+use crate::graph::{CaptureEnv, RunError, RunOptions};
 use crate::tensor_pool::{ExtractBuffer, TensorPool};
 
 mod binary_elementwise;
@@ -902,6 +902,7 @@ pub trait Operator: Any + Debug {
         pool: &TensorPool,
         input: InputList,
         #[allow(unused)] captures: &CaptureEnv,
+        #[allow(unused)] run_opts: Option<RunOptions>,
     ) -> Result<OutputList, RunError> {
         self.run(pool, input)
             .map_err(|error| RunError::OperatorError {


### PR DESCRIPTION
When timing reports or verbose logging is enabled, this causes the logging to be printed for subgraphs as well as the main graph.

`RunOptions` is currently a tiny 4-byte struct, so it is fine to just clone it.

Part of https://github.com/robertknight/rten/issues/308.