### PR TITLE
Account for operator dependencies due to subgraph captures in planning and temp value reference counting

### DIFF
--- a/src/ops/control_flow.rs
+++ b/src/ops/control_flow.rs
@@ -1,4 +1,5 @@
 use rten_tensor::TensorView;
+use smallvec::SmallVec;
 
 use crate::graph::{CaptureEnv, Graph, RunError, RunOptions};
 use crate::ops::{InputList, OpError, Operator, Output, OutputList};
@@ -37,8 +38,8 @@ impl Operator for If {
         ))
     }
 
-    fn has_subgraph(&self) -> bool {
-        true
+    fn subgraphs(&self) -> SmallVec<[&Graph; 2]> {
+        [&self.then_branch, &self.else_branch].into()
     }
 
     fn run_subgraph(

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -26,7 +26,7 @@ use rten_tensor::{
 };
 
 use crate::downcast::impl_downcastdyn;
-use crate::graph::{CaptureEnv, RunError, RunOptions};
+use crate::graph::{CaptureEnv, Graph, RunError, RunOptions};
 use crate::tensor_pool::{ExtractBuffer, TensorPool};
 
 mod binary_elementwise;
@@ -883,7 +883,12 @@ pub trait Operator: Any + Debug {
 
     /// Return true if this operator executes a subgraph.
     fn has_subgraph(&self) -> bool {
-        false
+        !self.subgraphs().is_empty()
+    }
+
+    /// Return a list of subgraphs used by this operator.
+    fn subgraphs(&self) -> SmallVec<[&Graph; 2]> {
+        SmallVec::new()
     }
 
     /// Execute the operator with the given inputs and captured values.


### PR DESCRIPTION
When creating an execution plan and initializing and updating the ref counts for temporary values, consider operator dependencies arising from values captured by the operator's subgraphs in addition to the input node ID list.

This affects:

- Creation of the execution plan given a set of output IDs
- Initializing and updating ref counts for temporary values in `Graph::run_plan`
- Plan pruning during partial evaluation by `Graph::partial_run`

Part of https://github.com/robertknight/rten/issues/308.