### PR TITLE
Add an optimization pass to convert captured values to constants

### DIFF
--- a/src/constant_storage.rs
+++ b/src/constant_storage.rs
@@ -77,6 +77,18 @@ pub struct ArcSlice<T> {
     phantom: PhantomData<T>,
 }
 
+// Manual implementation of `ArcSlice<T>` avoids adding a `T: Clone` bound.
+impl<T> Clone for ArcSlice<T> {
+    fn clone(&self) -> ArcSlice<T> {
+        ArcSlice {
+            storage: self.storage.clone(),
+            byte_offset: self.byte_offset,
+            len: self.len,
+            phantom: PhantomData,
+        }
+    }
+}
+
 impl<T> ArcSlice<T> {
     /// Return an ArcSlice which references the subslice of `storage` specified
     /// by `data`.


### PR DESCRIPTION
Add a pass that converts captured values to local constants, if the capture
resolves to a constant node in a parent graph. This allows subsequent
optimizations which depend on values being constants to work.

In the TrOCR example that was recently added, the model is split into two
branches which each capture many weights as constants from the main graph.
This change allows LayerNormalization and Gelu fusion to work in the subgraphs.

This optimization could be done as part of model conversion instead, with the
constant nodes for the weights duplicated in each subgraph, but referencing the
same serialized weight data.

