### PR TITLE
Fix conversion of shapes for scalar tensors

### DIFF
--- a/rten-convert/rten_convert/converter.py
+++ b/rten-convert/rten_convert/converter.py
@@ -493,7 +493,7 @@ def constant_node_from_onnx_constant_op(onnx_op: onnx.OperatorProto) -> Constant
 
 
 def value_node_from_onnx_value(value: onnx.ValueInfoProto) -> ValueNode:
-    if value.type.tensor_type.shape.dim:
+    if value.type.tensor_type.HasField("shape"):
         dims = [d.dim_param or d.dim_value for d in value.type.tensor_type.shape.dim]
     else:
         dims = None


### PR DESCRIPTION
If a tensor shape was present for an ONNX value node but was an empty list, indicating a scalar value, no shape was saved in the rten model. This is because a falsy check was used and empty lists are falsy in Python.

The issue was encountered with the `sr` (sample rate) input to the [Silero VAD](https://github.com/snakers4/silero-vad/tree/master/src/silero_vad/data) models.