### PR TITLE
Support "reflect" padding mode

### DIFF
--- a/rten-convert/rten_convert/converter.py
+++ b/rten-convert/rten_convert/converter.py
@@ -909,7 +909,8 @@ def op_node_from_onnx_operator(
             )
 
         case "Pad":
-            op_reader.check_attr("mode", "string", "constant")
+            attrs = sg.PadAttrsT()
+            attrs.mode = op_reader.get_enum_attr("mode", sg.PadMode, "constant")
 
         case "ScatterElements":
             attrs = sg.ScatterElementsAttrsT()

--- a/rten-convert/rten_convert/schema_generated.py
+++ b/rten-convert/rten_convert/schema_generated.py
@@ -189,6 +189,7 @@ class OperatorAttrs(object):
     GeluAttrs = 37
     EinsumAttrs = 38
     IfAttrs = 39
+    PadAttrs = 40
 
 def OperatorAttrsCreator(unionType, table):
     from flatbuffers.table import Table
@@ -272,6 +273,8 @@ def OperatorAttrsCreator(unionType, table):
         return EinsumAttrsT.InitFromBuf(table.Bytes, table.Pos)
     if unionType == OperatorAttrs().IfAttrs:
         return IfAttrsT.InitFromBuf(table.Bytes, table.Pos)
+    if unionType == OperatorAttrs().PadAttrs:
+        return PadAttrsT.InitFromBuf(table.Bytes, table.Pos)
     return None
 
 
@@ -294,6 +297,11 @@ def ScalarCreator(unionType, table):
 class NMSBoxOrder(object):
     TopLeftBottomRight = 0
     CenterWidthHeight = 1
+
+
+class PadMode(object):
+    Constant = 0
+    Reflect = 1
 
 
 class ScatterReduction(object):
@@ -3188,6 +3196,83 @@ class OneHotAttrsT(object):
         return oneHotAttrs
 
 
+class PadAttrs(object):
+    __slots__ = ['_tab']
+
+    @classmethod
+    def GetRootAs(cls, buf, offset=0):
+        n = flatbuffers.encode.Get(flatbuffers.packer.uoffset, buf, offset)
+        x = PadAttrs()
+        x.Init(buf, n + offset)
+        return x
+
+    @classmethod
+    def GetRootAsPadAttrs(cls, buf, offset=0):
+        """This method is deprecated. Please switch to GetRootAs."""
+        return cls.GetRootAs(buf, offset)
+    @classmethod
+    def PadAttrsBufferHasIdentifier(cls, buf, offset, size_prefixed=False):
+        return flatbuffers.util.BufferHasIdentifier(buf, offset, b"\x52\x54\x45\x4E", size_prefixed=size_prefixed)
+
+    # PadAttrs
+    def Init(self, buf, pos):
+        self._tab = flatbuffers.table.Table(buf, pos)
+
+    # PadAttrs
+    def Mode(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
+        if o != 0:
+            return self._tab.Get(flatbuffers.number_types.Uint8Flags, o + self._tab.Pos)
+        return 0
+
+def PadAttrsStart(builder):
+    builder.StartObject(1)
+
+def PadAttrsAddMode(builder, mode):
+    builder.PrependUint8Slot(0, mode, 0)
+
+def PadAttrsEnd(builder):
+    return builder.EndObject()
+
+
+
+class PadAttrsT(object):
+
+    # PadAttrsT
+    def __init__(self):
+        self.mode = 0  # type: int
+
+    @classmethod
+    def InitFromBuf(cls, buf, pos):
+        padAttrs = PadAttrs()
+        padAttrs.Init(buf, pos)
+        return cls.InitFromObj(padAttrs)
+
+    @classmethod
+    def InitFromPackedBuf(cls, buf, pos=0):
+        n = flatbuffers.encode.Get(flatbuffers.packer.uoffset, buf, pos)
+        return cls.InitFromBuf(buf, pos+n)
+
+    @classmethod
+    def InitFromObj(cls, padAttrs):
+        x = PadAttrsT()
+        x._UnPack(padAttrs)
+        return x
+
+    # PadAttrsT
+    def _UnPack(self, padAttrs):
+        if padAttrs is None:
+            return
+        self.mode = padAttrs.Mode()
+
+    # PadAttrsT
+    def Pack(self, builder):
+        PadAttrsStart(builder)
+        PadAttrsAddMode(builder, self.mode)
+        padAttrs = PadAttrsEnd(builder)
+        return padAttrs
+
+
 class RandomNormalAttrs(object):
     __slots__ = ['_tab']
 
@@ -4781,7 +4866,7 @@ class OperatorNodeT(object):
     def __init__(self):
         self.type = 0  # type: int
         self.attrsType = 0  # type: int
-        self.attrs = None  # type: Union[None, ArgMaxAttrsT, AveragePoolAttrsT, BatchNormalizationAttrsT, CastAttrsT, ConcatAttrsT, ConstantOfShapeAttrsT, ConvAttrsT, ConvTransposeAttrsT, FlattenAttrsT, GatherAttrsT, GemmAttrsT, GRUAttrsT, LeakyReluAttrsT, LSTMAttrsT, MaxPoolAttrsT, ReduceMeanAttrsT, ReshapeAttrsT, ResizeAttrsT, SplitAttrsT, SoftmaxAttrsT, TransposeAttrsT, ModAttrsT, ScatterElementsAttrsT, OneHotAttrsT, TopKAttrsT, HardSigmoidAttrsT, TriluAttrsT, ScatterNDAttrsT, NonMaxSuppressionAttrsT, LayerNormalizationAttrsT, RandomUniformAttrsT, EluAttrsT, RandomUniformLikeAttrsT, RandomNormalAttrsT, RandomNormalLikeAttrsT, GatherNDAttrsT, GeluAttrsT, EinsumAttrsT, IfAttrsT]
+        self.attrs = None  # type: Union[None, ArgMaxAttrsT, AveragePoolAttrsT, BatchNormalizationAttrsT, CastAttrsT, ConcatAttrsT, ConstantOfShapeAttrsT, ConvAttrsT, ConvTransposeAttrsT, FlattenAttrsT, GatherAttrsT, GemmAttrsT, GRUAttrsT, LeakyReluAttrsT, LSTMAttrsT, MaxPoolAttrsT, ReduceMeanAttrsT, ReshapeAttrsT, ResizeAttrsT, SplitAttrsT, SoftmaxAttrsT, TransposeAttrsT, ModAttrsT, ScatterElementsAttrsT, OneHotAttrsT, TopKAttrsT, HardSigmoidAttrsT, TriluAttrsT, ScatterNDAttrsT, NonMaxSuppressionAttrsT, LayerNormalizationAttrsT, RandomUniformAttrsT, EluAttrsT, RandomUniformLikeAttrsT, RandomNormalAttrsT, RandomNormalLikeAttrsT, GatherNDAttrsT, GeluAttrsT, EinsumAttrsT, IfAttrsT, PadAttrsT]
         self.inputs = None  # type: List[int]
         self.outputs = None  # type: List[int]
 

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -87,7 +87,7 @@ pub use norm::{
     batch_norm, batch_norm_in_place, instance_normalization, layer_normalization, log_softmax,
     softmax, BatchNormalization, InstanceNormalization, LayerNormalization, LogSoftmax, Softmax,
 };
-pub use pad::{pad, Pad};
+pub use pad::{pad, Pad, PadMode};
 pub use pooling::{
     average_pool, global_average_pool, max_pool, AveragePool, GlobalAveragePool, MaxPool,
 };

--- a/src/ops/operators.rs
+++ b/src/ops/operators.rs
@@ -7,7 +7,7 @@ use crate::number::{Identities, IsInt};
 use crate::ops::OpError;
 use crate::ops::{
     arg_max, div, matmul, mul, pad, reduce_l2, reduce_max, reduce_mean, reduce_min, reduce_sum,
-    resize_image, softmax, topk,
+    resize_image, softmax, topk, PadMode,
 };
 use crate::tensor_pool::TensorPool;
 use crate::threading::thread_pool;
@@ -173,7 +173,7 @@ impl<T: Send, S: Storage<Elem = T>, L: MutLayout> Operators for TensorBase<S, L>
         Self::Elem: Copy,
     {
         let view = self.as_dyn();
-        use_thread_pool(move || pad(&TensorPool::new(), view, &padding, val))
+        use_thread_pool(move || pad(&TensorPool::new(), view, &padding, PadMode::Constant, val))
     }
 
     fn topk(

--- a/src/ops/pad.rs
+++ b/src/ops/pad.rs
@@ -5,10 +5,17 @@ use crate::ops::{Input, InputList, IntoOpResult, OpError, Operator, OutputList};
 use crate::static_dims;
 use crate::tensor_pool::TensorPool;
 
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum PadMode {
+    Constant,
+    Reflect,
+}
+
 pub fn pad<T: Copy>(
     pool: &TensorPool,
     input: TensorView<T>,
     padding: &NdTensorView<i32, 1>,
+    mode: PadMode,
     const_val: T,
 ) -> Result<Tensor<T>, OpError> {
     if padding.size(0) != input.ndim() * 2 {
@@ -31,26 +38,135 @@ pub fn pad<T: Copy>(
         })
         .collect();
 
-    let non_pad_region: Vec<SliceItem> = input
-        .shape()
-        .iter()
-        .enumerate()
-        .map(|(i, size)| {
-            let start_pad = padding[[i]] as usize;
-            (start_pad..start_pad + size).into()
-        })
-        .collect();
+    // Just copy the tensor if no padding is required.
+    if out_shape == input.shape() {
+        return Ok(input.to_tensor_in(pool));
+    }
 
-    let mut output = Tensor::full_in(pool, &out_shape, const_val);
-    output
-        .slice_mut_dyn(non_pad_region.as_slice())
-        .copy_from(&input);
+    let output = match mode {
+        PadMode::Constant => {
+            let non_pad_region: Vec<SliceItem> = input
+                .shape()
+                .iter()
+                .enumerate()
+                .map(|(i, size)| {
+                    let start_pad = padding[[i]] as usize;
+                    (start_pad..start_pad + size).into()
+                })
+                .collect();
+
+            let mut output = Tensor::full_in(pool, &out_shape, const_val);
+            output
+                .slice_mut_dyn(non_pad_region.as_slice())
+                .copy_from(&input);
+            output
+        }
+        PadMode::Reflect => {
+            const PAD_DIMS: usize = 2;
+            let batch_dims = input.ndim().saturating_sub(PAD_DIMS);
+            if out_shape[..batch_dims] != input.shape()[..batch_dims] {
+                return Err(OpError::UnsupportedValue(
+                    "Pad only supports reflect padding of last 2 dims",
+                ));
+            }
+
+            if input.shape()[batch_dims..].iter().any(|&size| size == 0) {
+                return Err(OpError::InvalidValue(
+                    "Padded dimension for reflect padding is empty",
+                ));
+            }
+
+            let pad_dims = input.ndim() - batch_dims;
+            let (pad_top, pad_left) = if pad_dims == 1 {
+                (0, padding[[0]] as usize)
+            } else {
+                (padding[[0]] as usize, padding[[1]] as usize)
+            };
+
+            let mut input = input.view();
+            let mut output = Tensor::uninit_in(pool, &out_shape);
+
+            // For inputs with fewer dims than the padding inner loop, insert
+            // extra 1-sized dims at the start.
+            while input.ndim() < PAD_DIMS {
+                input.insert_axis(0);
+                output.insert_axis(0);
+            }
+
+            for (mut out_img, in_img) in output
+                .inner_iter_mut::<PAD_DIMS>()
+                .zip(input.inner_iter::<PAD_DIMS>())
+            {
+                let out_rows = out_img.size(0);
+                let out_cols = out_img.size(1);
+
+                let src_rows = in_img.size(0);
+                let src_cols = in_img.size(1);
+
+                for y in 0..out_rows {
+                    let src_y = reflect_pad_src(y, src_rows, pad_top);
+
+                    for x in 0..out_cols {
+                        let src_x = reflect_pad_src(x, src_cols, pad_left);
+
+                        // Safety:
+                        //  - y and x are valid coords.
+                        //  - src_y and src_x are valid coords since
+                        //    `reflect_pad_src` returns values in [0, len)
+                        unsafe {
+                            out_img
+                                .get_unchecked_mut([y, x])
+                                .write(*in_img.get_unchecked([src_y, src_x]));
+                        }
+                    }
+                }
+            }
+
+            while output.ndim() > out_shape.len() {
+                output.remove_axis(0);
+            }
+
+            // Safety: We filled all elements of output.
+            unsafe { output.assume_init() }
+        }
+    };
 
     Ok(output)
 }
 
+/// Compute the coordinate for the source element when applying reflection
+/// padding along a single axis.
+///
+/// `x` is the destination coordinate, `len` is the size of the dimension and
+/// `pad_start` is the number of padding elements added at the start of the
+/// dimension.
+fn reflect_pad_src(x: usize, len: usize, pad_start: usize) -> usize {
+    let x = x as isize;
+    let len = len as isize;
+    let pad_start = pad_start as isize;
+
+    // Compute all possible values and then pick one, so this gets compiled to
+    // conditional moves instead of branches.
+    let src_x_start = pad_start - x;
+    let src_x_mid = x - pad_start;
+    let src_x_end = len - (x - len - pad_start) - 2;
+
+    let src_x = if x < pad_start {
+        src_x_start
+    } else if x < len + pad_start {
+        src_x_mid
+    } else {
+        src_x_end
+    };
+
+    // Use `rem_euclid` so that `src_x ∈ [0, len)` if src_x < 0.
+    src_x.rem_euclid(len) as usize
+}
+
 #[derive(Debug)]
-pub struct Pad {}
+pub struct Pad {
+    pub mode: PadMode,
+}
 
 impl Operator for Pad {
     fn name(&self) -> &str {
@@ -71,12 +187,12 @@ impl Operator for Pad {
 
         match input {
             Input::IntTensor(t) => {
-                let const_val = inputs.get_as_scalar::<i32>(2)?;
-                pad(pool, t, &pads, const_val.unwrap_or(0)).into_op_result()
+                let const_val = inputs.get_as_scalar::<i32>(2)?.unwrap_or(0);
+                pad(pool, t, &pads, self.mode, const_val).into_op_result()
             }
             Input::FloatTensor(t) => {
-                let const_val = inputs.get_as_scalar::<f32>(2)?;
-                pad(pool, t, &pads, const_val.unwrap_or(0.0)).into_op_result()
+                let const_val = inputs.get_as_scalar::<f32>(2)?.unwrap_or(0.);
+                pad(pool, t, &pads, self.mode, const_val).into_op_result()
             }
         }
     }
@@ -88,10 +204,10 @@ mod tests {
 
     use rten_tensor::prelude::*;
     use rten_tensor::test_util::expect_equal;
-    use rten_tensor::Tensor;
+    use rten_tensor::{NdTensor, Tensor};
 
     use crate::ops::tests::new_pool;
-    use crate::ops::{pad, OpError, Operator, Pad};
+    use crate::ops::{pad, OpError, Operator, Pad, PadMode};
 
     fn from_slice<T: Clone>(data: &[T]) -> Tensor<T> {
         Tensor::from_data(&[data.len()], data.to_vec())
@@ -110,18 +226,32 @@ mod tests {
             ],
         );
         let const_pads = &[1, 1, 1, 1];
-        let result = pad(&pool, input.view(), &const_pads.into(), 0.0).unwrap();
+        let result = pad(
+            &pool,
+            input.view(),
+            &const_pads.into(),
+            PadMode::Constant,
+            0.0,
+        )
+        .unwrap();
         expect_equal(&result, &expected)?;
 
         // Zero padding (no-op)
         let zero_pads = &[0, 0, 0, 0];
-        let result = pad(&pool, input.view(), &zero_pads.into(), 0.0).unwrap();
+        let result = pad(
+            &pool,
+            input.view(),
+            &zero_pads.into(),
+            PadMode::Constant,
+            0.0,
+        )
+        .unwrap();
         expect_equal(&result, &input)?;
 
         // Un-even padding
         let input = Tensor::from_data(&[1, 2, 2], vec![1, 2, 3, 4]);
         let pads = &[0, 0, 0, 0, 1, 0];
-        let result = pad(&pool, input.view(), &pads.into(), 0).unwrap();
+        let result = pad(&pool, input.view(), &pads.into(), PadMode::Constant, 0).unwrap();
         assert_eq!(result.shape(), &[1, 3, 2]);
         assert_eq!(result.data().unwrap(), &[1, 2, 3, 4, 0, 0]);
 
@@ -139,8 +269,116 @@ mod tests {
             ],
         );
         let const_pads = &[1, 1, 1, 1];
-        let result = pad(&pool, input.view(), &const_pads.into(), 9.).unwrap();
+        let result = pad(
+            &pool,
+            input.view(),
+            &const_pads.into(),
+            PadMode::Constant,
+            9.,
+        )
+        .unwrap();
         expect_equal(&result, &expected)?;
+        Ok(())
+    }
+
+    #[test]
+    fn test_pad_reflect() -> Result<(), Box<dyn Error>> {
+        struct Case {
+            input: Tensor,
+            pads: NdTensor<i32, 1>,
+            expected: Result<Tensor, OpError>,
+        }
+
+        let cases = [
+            // Test case from ONNX spec.
+            //
+            // Pad start columns of a 2D tensor.
+            Case {
+                input: [[1.0, 1.2], [2.3, 3.4], [4.5, 5.7]].into(),
+                pads: [0, 2, 0, 0].into(),
+                expected: Ok(Tensor::from([
+                    [1.0, 1.2, 1.0, 1.2],
+                    [2.3, 3.4, 2.3, 3.4],
+                    [4.5, 5.7, 4.5, 5.7],
+                ])),
+            },
+            // Pad end columns of a 2D tensor.
+            Case {
+                input: [[1.0, 1.2], [2.3, 3.4], [4.5, 5.7]].into(),
+                pads: [0, 0, 0, 2].into(),
+                expected: Ok(Tensor::from([
+                    [1.0, 1.2, 1.0, 1.2],
+                    [2.3, 3.4, 2.3, 3.4],
+                    [4.5, 5.7, 4.5, 5.7],
+                ])),
+            },
+            // Pad start and end columns of a 2D tensor.
+            Case {
+                input: [[1., 2., 3., 4., 5.]].into(),
+                pads: [0, 3, 0, 3].into(),
+                expected: Ok(Tensor::from([[4., 3., 2., 1., 2., 3., 4., 5., 4., 3., 2.]])),
+            },
+            // Pad start and end rows of a 2D tensor.
+            Case {
+                input: Tensor::from([1., 2., 3., 4., 5.]).into_shape([5, 1].as_slice()),
+                pads: [3, 0, 3, 0].into(),
+                expected: Ok(Tensor::from([4., 3., 2., 1., 2., 3., 4., 5., 4., 3., 2.])
+                    .into_shape([5 + 2 * 3, 1].as_slice())),
+            },
+            // Pad start and end of a 1D tensor.
+            Case {
+                input: [1., 2., 3., 4.].into(),
+                pads: [2, 2].into(),
+                expected: Ok(Tensor::from([3., 2., 1., 2., 3., 4., 3., 2.])),
+            },
+            // Scalar input. This is always a noop since there are no dimensions
+            // to pad.
+            Case {
+                input: Tensor::from(2.),
+                pads: NdTensor::from([]),
+                expected: Ok(Tensor::from(2.)),
+            },
+            // Pad end columns of a 3D tensor.
+            Case {
+                input: [[[1., 2., 3.]]].into(),
+                pads: [0, 0, 0, 0, 0, 2].into(),
+                expected: Ok(Tensor::from([[[1., 2., 3., 2., 1.]]])),
+            },
+            // Pad channel dimension of a 3D tensor.
+            Case {
+                input: [[[1., 2., 3.]]].into(),
+                pads: [0, 0, 0, 2, 0, 0].into(),
+                expected: Err(OpError::UnsupportedValue(
+                    "Pad only supports reflect padding of last 2 dims",
+                )),
+            },
+            // Pad zero-size dimension.
+            Case {
+                input: Tensor::zeros(&[3, 0]),
+                pads: NdTensor::from([0, 2, 0, 0]),
+                expected: Err(OpError::InvalidValue(
+                    "Padded dimension for reflect padding is empty",
+                )),
+            },
+        ];
+
+        let pool = new_pool();
+
+        for Case {
+            input,
+            pads,
+            expected,
+        } in cases
+        {
+            let result = pad(&pool, input.view(), &pads.view(), PadMode::Reflect, 0.);
+            match (result, expected) {
+                (Ok(result), Ok(expected)) => {
+                    expect_equal(&result, &expected)?;
+                }
+                (result, expected) => assert_eq!(result, expected),
+            }
+        }
+
         Ok(())
     }
 
@@ -156,7 +394,9 @@ mod tests {
         );
 
         let pool = new_pool();
-        let op = Pad {};
+        let op = Pad {
+            mode: PadMode::Constant,
+        };
         let result = op
             .run(&pool, (&input, &pads).into())
             .unwrap()
@@ -172,7 +412,9 @@ mod tests {
     fn test_pad_invalid_inputs() {
         let pool = new_pool();
         let input = Tensor::from_data(&[2, 2], vec![1.0, 2.0, 3.0, 4.0]);
-        let op = Pad {};
+        let op = Pad {
+            mode: PadMode::Constant,
+        };
 
         // Wrong padding vector length.
         let invalid_pads = from_slice(&[1]);

--- a/src/schema.fbs
+++ b/src/schema.fbs
@@ -202,6 +202,7 @@ union OperatorAttrs {
   GeluAttrs,
   EinsumAttrs,
   IfAttrs,
+  PadAttrs,
 }
 
 table ArgMaxAttrs {
@@ -356,6 +357,15 @@ table NonMaxSuppressionAttrs {
 
 table OneHotAttrs {
   axis:int;
+}
+
+enum PadMode: ubyte {
+  Constant,
+  Reflect,
+}
+
+table PadAttrs {
+  mode:PadMode;
 }
 
 table RandomNormalAttrs {

--- a/src/schema_generated.rs
+++ b/src/schema_generated.rs
@@ -1086,13 +1086,13 @@ pub const ENUM_MIN_OPERATOR_ATTRS: u8 = 0;
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
-pub const ENUM_MAX_OPERATOR_ATTRS: u8 = 39;
+pub const ENUM_MAX_OPERATOR_ATTRS: u8 = 40;
 #[deprecated(
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_OPERATOR_ATTRS: [OperatorAttrs; 40] = [
+pub const ENUM_VALUES_OPERATOR_ATTRS: [OperatorAttrs; 41] = [
     OperatorAttrs::NONE,
     OperatorAttrs::ArgMaxAttrs,
     OperatorAttrs::AveragePoolAttrs,
@@ -1133,6 +1133,7 @@ pub const ENUM_VALUES_OPERATOR_ATTRS: [OperatorAttrs; 40] = [
     OperatorAttrs::GeluAttrs,
     OperatorAttrs::EinsumAttrs,
     OperatorAttrs::IfAttrs,
+    OperatorAttrs::PadAttrs,
 ];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -1180,9 +1181,10 @@ impl OperatorAttrs {
     pub const GeluAttrs: Self = Self(37);
     pub const EinsumAttrs: Self = Self(38);
     pub const IfAttrs: Self = Self(39);
+    pub const PadAttrs: Self = Self(40);
 
     pub const ENUM_MIN: u8 = 0;
-    pub const ENUM_MAX: u8 = 39;
+    pub const ENUM_MAX: u8 = 40;
     pub const ENUM_VALUES: &'static [Self] = &[
         Self::NONE,
         Self::ArgMaxAttrs,
@@ -1224,6 +1226,7 @@ impl OperatorAttrs {
         Self::GeluAttrs,
         Self::EinsumAttrs,
         Self::IfAttrs,
+        Self::PadAttrs,
     ];
     /// Returns the variant's name or "" if unknown.
     pub fn variant_name(self) -> Option<&'static str> {
@@ -1268,6 +1271,7 @@ impl OperatorAttrs {
             Self::GeluAttrs => Some("GeluAttrs"),
             Self::EinsumAttrs => Some("EinsumAttrs"),
             Self::IfAttrs => Some("IfAttrs"),
+            Self::PadAttrs => Some("PadAttrs"),
             _ => None,
         }
     }
@@ -1511,6 +1515,95 @@ impl<'a> flatbuffers::Verifiable for NMSBoxOrder {
 }
 
 impl flatbuffers::SimpleToVerifyInSlice for NMSBoxOrder {}
+#[deprecated(
+    since = "2.0.0",
+    note = "Use associated constants instead. This will no longer be generated in 2021."
+)]
+pub const ENUM_MIN_PAD_MODE: u8 = 0;
+#[deprecated(
+    since = "2.0.0",
+    note = "Use associated constants instead. This will no longer be generated in 2021."
+)]
+pub const ENUM_MAX_PAD_MODE: u8 = 1;
+#[deprecated(
+    since = "2.0.0",
+    note = "Use associated constants instead. This will no longer be generated in 2021."
+)]
+#[allow(non_camel_case_types)]
+pub const ENUM_VALUES_PAD_MODE: [PadMode; 2] = [PadMode::Constant, PadMode::Reflect];
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[repr(transparent)]
+pub struct PadMode(pub u8);
+#[allow(non_upper_case_globals)]
+impl PadMode {
+    pub const Constant: Self = Self(0);
+    pub const Reflect: Self = Self(1);
+
+    pub const ENUM_MIN: u8 = 0;
+    pub const ENUM_MAX: u8 = 1;
+    pub const ENUM_VALUES: &'static [Self] = &[Self::Constant, Self::Reflect];
+    /// Returns the variant's name or "" if unknown.
+    pub fn variant_name(self) -> Option<&'static str> {
+        match self {
+            Self::Constant => Some("Constant"),
+            Self::Reflect => Some("Reflect"),
+            _ => None,
+        }
+    }
+}
+impl core::fmt::Debug for PadMode {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        if let Some(name) = self.variant_name() {
+            f.write_str(name)
+        } else {
+            f.write_fmt(format_args!("<UNKNOWN {:?}>", self.0))
+        }
+    }
+}
+impl<'a> flatbuffers::Follow<'a> for PadMode {
+    type Inner = Self;
+    #[inline]
+    unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        let b = flatbuffers::read_scalar_at::<u8>(buf, loc);
+        Self(b)
+    }
+}
+
+impl flatbuffers::Push for PadMode {
+    type Output = PadMode;
+    #[inline]
+    unsafe fn push(&self, dst: &mut [u8], _written_len: usize) {
+        flatbuffers::emplace_scalar::<u8>(dst, self.0);
+    }
+}
+
+impl flatbuffers::EndianScalar for PadMode {
+    type Scalar = u8;
+    #[inline]
+    fn to_little_endian(self) -> u8 {
+        self.0.to_le()
+    }
+    #[inline]
+    #[allow(clippy::wrong_self_convention)]
+    fn from_little_endian(v: u8) -> Self {
+        let b = u8::from_le(v);
+        Self(b)
+    }
+}
+
+impl<'a> flatbuffers::Verifiable for PadMode {
+    #[inline]
+    fn run_verifier(
+        v: &mut flatbuffers::Verifier,
+        pos: usize,
+    ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+        use self::flatbuffers::Verifiable;
+        u8::run_verifier(v, pos)
+    }
+}
+
+impl flatbuffers::SimpleToVerifyInSlice for PadMode {}
 #[deprecated(
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
@@ -5402,6 +5495,110 @@ impl core::fmt::Debug for OneHotAttrs<'_> {
         ds.finish()
     }
 }
+pub enum PadAttrsOffset {}
+#[derive(Copy, Clone, PartialEq)]
+
+pub struct PadAttrs<'a> {
+    pub _tab: flatbuffers::Table<'a>,
+}
+
+impl<'a> flatbuffers::Follow<'a> for PadAttrs<'a> {
+    type Inner = PadAttrs<'a>;
+    #[inline]
+    unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self {
+            _tab: flatbuffers::Table::new(buf, loc),
+        }
+    }
+}
+
+impl<'a> PadAttrs<'a> {
+    pub const VT_MODE: flatbuffers::VOffsetT = 4;
+
+    #[inline]
+    pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+        PadAttrs { _tab: table }
+    }
+    #[allow(unused_mut)]
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
+        args: &'args PadAttrsArgs,
+    ) -> flatbuffers::WIPOffset<PadAttrs<'bldr>> {
+        let mut builder = PadAttrsBuilder::new(_fbb);
+        builder.add_mode(args.mode);
+        builder.finish()
+    }
+
+    #[inline]
+    pub fn mode(&self) -> PadMode {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab
+                .get::<PadMode>(PadAttrs::VT_MODE, Some(PadMode::Constant))
+                .unwrap()
+        }
+    }
+}
+
+impl flatbuffers::Verifiable for PadAttrs<'_> {
+    #[inline]
+    fn run_verifier(
+        v: &mut flatbuffers::Verifier,
+        pos: usize,
+    ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+        use self::flatbuffers::Verifiable;
+        v.visit_table(pos)?
+            .visit_field::<PadMode>("mode", Self::VT_MODE, false)?
+            .finish();
+        Ok(())
+    }
+}
+pub struct PadAttrsArgs {
+    pub mode: PadMode,
+}
+impl<'a> Default for PadAttrsArgs {
+    #[inline]
+    fn default() -> Self {
+        PadAttrsArgs {
+            mode: PadMode::Constant,
+        }
+    }
+}
+
+pub struct PadAttrsBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+    fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
+    start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> PadAttrsBuilder<'a, 'b, A> {
+    #[inline]
+    pub fn add_mode(&mut self, mode: PadMode) {
+        self.fbb_
+            .push_slot::<PadMode>(PadAttrs::VT_MODE, mode, PadMode::Constant);
+    }
+    #[inline]
+    pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> PadAttrsBuilder<'a, 'b, A> {
+        let start = _fbb.start_table();
+        PadAttrsBuilder {
+            fbb_: _fbb,
+            start_: start,
+        }
+    }
+    #[inline]
+    pub fn finish(self) -> flatbuffers::WIPOffset<PadAttrs<'a>> {
+        let o = self.fbb_.end_table(self.start_);
+        flatbuffers::WIPOffset::new(o.value())
+    }
+}
+
+impl core::fmt::Debug for PadAttrs<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut ds = f.debug_struct("PadAttrs");
+        ds.field("mode", &self.mode());
+        ds.finish()
+    }
+}
 pub enum RandomNormalAttrsOffset {}
 #[derive(Copy, Clone, PartialEq)]
 
@@ -7950,6 +8147,21 @@ impl<'a> OperatorNode<'a> {
             None
         }
     }
+
+    #[inline]
+    #[allow(non_snake_case)]
+    pub fn attrs_as_pad_attrs(&self) -> Option<PadAttrs<'a>> {
+        if self.attrs_type() == OperatorAttrs::PadAttrs {
+            self.attrs().map(|t| {
+                // Safety:
+                // Created from a valid Table for this object
+                // Which contains a valid union in this slot
+                unsafe { PadAttrs::init_from_table(t) }
+            })
+        } else {
+            None
+        }
+    }
 }
 
 impl flatbuffers::Verifiable for OperatorNode<'_> {
@@ -8002,6 +8214,7 @@ impl flatbuffers::Verifiable for OperatorNode<'_> {
           OperatorAttrs::GeluAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<GeluAttrs>>("OperatorAttrs::GeluAttrs", pos),
           OperatorAttrs::EinsumAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<EinsumAttrs>>("OperatorAttrs::EinsumAttrs", pos),
           OperatorAttrs::IfAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<IfAttrs>>("OperatorAttrs::IfAttrs", pos),
+          OperatorAttrs::PadAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<PadAttrs>>("OperatorAttrs::PadAttrs", pos),
           _ => Ok(()),
         }
      })?
@@ -8469,6 +8682,16 @@ impl core::fmt::Debug for OperatorNode<'_> {
             }
             OperatorAttrs::IfAttrs => {
                 if let Some(x) = self.attrs_as_if_attrs() {
+                    ds.field("attrs", &x)
+                } else {
+                    ds.field(
+                        "attrs",
+                        &"InvalidFlatbuffer: Union discriminant does not match value.",
+                    )
+                }
+            }
+            OperatorAttrs::PadAttrs => {
+                if let Some(x) = self.attrs_as_pad_attrs() {
                     ds.field("attrs", &x)
                 } else {
                     ds.field(


### PR DESCRIPTION
For efficiency and simplicity, reflection padding is only supported for the last
2 dimensions of the input. Any additional dimensions are treated as batch
dimensions which must have the same size in the input and output.

PyTorch has a constraint that the amount of padding must be less than the size
of a dimension, which is useful since it avoids the need for padding to wrap
around by taking an expensive modulus of the dimension size. NumPy however
allows wrap-around, and the example in the ONNX spec relies on this. In this
implementation, wrap-around is supported but it might be necessary to split the
cases in future for efficiency, to avoid a modulus in the common case where the
padding size is less than the dimension size.

