### PR TITLE
Add flag to rten CLI to load model using mmap

### DIFF
--- a/rten-cli/Cargo.toml
+++ b/rten-cli/Cargo.toml
@@ -11,7 +11,7 @@ include = ["/src", "/README.md"]
 
 [dependencies]
 fastrand = "2.0.2"
-rten = { path = "../", version = "0.13.0", features=["random"] }
+rten = { path = "../", version = "0.13.0", features=["mmap", "random"] }
 rten-tensor = { path = "../rten-tensor", version = "0.13.0" }
 lexopt = "0.3.0"
 


### PR DESCRIPTION
This is useful for testing the performance of loading a model with mmap vs by reading the model into a buffer.