### PR TITLE
Always set `auto_pad` attribute for pooling and convolution operators

### DIFF
--- a/rten-convert/rten_convert/converter.py
+++ b/rten-convert/rten_convert/converter.py
@@ -530,10 +530,9 @@ def read_pads(op_reader: ONNXOperatorReader, attrs: PadAttrs) -> None:
         case other:
             raise Exception(f"Unsupported auto_pad value {other}")
 
+    attrs.autoPad = auto_pad
     if auto_pad == sg.AutoPad.NotSet:
         attrs.pads = pads
-    else:
-        attrs.autoPad = auto_pad
 
 
 def read_strides(

--- a/src/schema.fbs
+++ b/src/schema.fbs
@@ -126,6 +126,10 @@ enum RNNDirection: ubyte {
   Bidirectional
 }
 
+// Values for `auto_pad` field. In ONNX the default for `auto_pad` is "NOTSET".
+// In this schema the default is `Same` for some operators for backwards
+// compatibility. The converter will however set it to `Fixed` if the `auto_pad`
+// attribute is missing in the ONNX model, preserving ONNX semantics.
 enum AutoPad: ubyte {
   // nb. ONNX defines `SAME_UPPER` and `SAME_LOWER`. This corresponds to
   // `SAME_UPPER` and TensorFlow / Keras's "same".


### PR DESCRIPTION
Fix a mistake from 917980b22 where the `auto_pad` attribute was only written to the model file if non-fixed padding was used. This caused operators to use "same" padding instead of "fixed" padding when the ONNX `auto_pad` attribute was set to `NOTSET`.

Fixes https://github.com/robertknight/rten/issues/332