### PR TITLE
Avoid copying input in in-place Unsqueeze op

### DIFF
--- a/src/ops/layout.rs
+++ b/src/ops/layout.rs
@@ -537,7 +537,6 @@ pub fn unsqueeze_in_place<T: Clone>(
         sorted_axes
     };
 
-    input.make_contiguous();
     for axis in sorted_axes {
         input.insert_axis(axis);
     }


### PR DESCRIPTION
e56072e1e4092aa477b25e1c2e6c8a6aaca9450a revised the implementation to remove the use of `TensorBase::reshape`, which did require the input to be contiguous at the time (now it copies if needed) but didn't remove the use of `make_contiguous` which is not required for `insert_axis`.