### PR TITLE
Support u8 and i8 tensors in operator inputs, outputs and model files

### DIFF
--- a/rten-cli/src/main.rs
+++ b/rten-cli/src/main.rs
@@ -348,6 +348,8 @@ fn run_with_random_input(
             let dtype = match output {
                 Output::FloatTensor(_) => "f32",
                 Output::Int32Tensor(_) => "i32",
+                Output::Int8Tensor(_) => "i8",
+                Output::UInt8Tensor(_) => "u8",
             };
             println!(
                 "  Output {i} \"{name}\" data type {} shape: {:?}",

--- a/rten-cli/src/main.rs
+++ b/rten-cli/src/main.rs
@@ -347,7 +347,7 @@ fn run_with_random_input(
         for (i, (output, name)) in outputs.iter().zip(output_names).enumerate() {
             let dtype = match output {
                 Output::FloatTensor(_) => "f32",
-                Output::IntTensor(_) => "i32",
+                Output::Int32Tensor(_) => "i32",
             };
             println!(
                 "  Output {i} \"{name}\" data type {} shape: {:?}",

--- a/rten-convert/rten_convert/converter.py
+++ b/rten-convert/rten_convert/converter.py
@@ -70,7 +70,7 @@ class ConstantNode(Node):
 
         # Verify that this is a data type that we'll be able to serialize later.
         match data.dtype:
-            case np.float32 | np.int32:
+            case np.float32 | np.int32 | np.int8 | np.uint8:
                 pass
             case _:
                 dtype_name: str = data.dtype.name  # type:ignore[union-attr]
@@ -439,11 +439,11 @@ def constant_node_from_onnx_initializer(
 
     match data.dtype.name:
         # Types that don't need to change
-        case "float32" | "int32":
+        case "float32" | "int8" | "int32" | "uint8":
             pass
 
         # Int types that can be widened to int32
-        case "bool" | "int8" | "int16":
+        case "bool" | "int16":
             data = data.astype(np.int32)
 
         # Types that need to be narrowed
@@ -1151,12 +1151,20 @@ def build_constant_node(
         case np.int32:
             inline_data_type = sg.ConstantData.Int32Data
             dtype = sg.ConstantDataType.Int32
+        case np.int8:
+            inline_data_type = sg.ConstantData.Int8Data
+            dtype = sg.ConstantDataType.Int8
+        case np.uint8:
+            inline_data_type = sg.ConstantData.UInt8Data
+            dtype = sg.ConstantDataType.UInt8
         case _:
             raise ValueError(f"Unsupported data array type {constant.data.dtype.name}")  # type:ignore[union-attr]
 
     # Store inline if we're generating the V1 format, or the tensor is small.
     # Small values are mostly parameters such as axes, slice ranges etc.
-    store_inline = tensor_data is None or n_elems <= 16
+    store_inline = (
+        tensor_data is None or n_elems <= 16
+    ) and inline_data_type is not None
     inline_data = None
     data_offset = None
 
@@ -1171,9 +1179,17 @@ def build_constant_node(
                 sg.Int32DataStart(builder)
                 sg.Int32DataAddData(builder, inline_data_vec)
                 inline_data = sg.Int32DataEnd(builder)
+            case np.int8:
+                sg.Int8DataStart(builder)
+                sg.Int8DataAddData(builder, inline_data_vec)
+                inline_data = sg.Int8DataEnd(builder)
+            case np.uint8:
+                sg.UInt8DataStart(builder)
+                sg.UInt8DataAddData(builder, inline_data_vec)
+                inline_data = sg.UInt8DataEnd(builder)
             case _:
                 raise ValueError(
-                    f"Unsupported data array type {constant.data.dtype.name}"  # type:ignore
+                    f"Unsupported data type for inline storage {constant.data.dtype.name}"  # type:ignore
                 )
     else:
         assert tensor_data

--- a/rten-convert/rten_convert/converter.py
+++ b/rten-convert/rten_convert/converter.py
@@ -1149,7 +1149,7 @@ def build_constant_node(
             inline_data_type = sg.ConstantData.FloatData
             dtype = sg.ConstantDataType.Float32
         case np.int32:
-            inline_data_type = sg.ConstantData.IntData
+            inline_data_type = sg.ConstantData.Int32Data
             dtype = sg.ConstantDataType.Int32
         case _:
             raise ValueError(f"Unsupported data array type {constant.data.dtype.name}")  # type:ignore[union-attr]
@@ -1168,9 +1168,9 @@ def build_constant_node(
                 sg.FloatDataAddData(builder, inline_data_vec)
                 inline_data = sg.FloatDataEnd(builder)
             case np.int32:
-                sg.IntDataStart(builder)
-                sg.IntDataAddData(builder, inline_data_vec)
-                inline_data = sg.IntDataEnd(builder)
+                sg.Int32DataStart(builder)
+                sg.Int32DataAddData(builder, inline_data_vec)
+                inline_data = sg.Int32DataEnd(builder)
             case _:
                 raise ValueError(
                     f"Unsupported data array type {constant.data.dtype.name}"  # type:ignore

--- a/rten-convert/rten_convert/schema_generated.py
+++ b/rten-convert/rten_convert/schema_generated.py
@@ -334,7 +334,7 @@ def NodeKindCreator(unionType, table):
 class ConstantData(object):
     NONE = 0
     FloatData = 1
-    IntData = 2
+    Int32Data = 2
 
 def ConstantDataCreator(unionType, table):
     from flatbuffers.table import Table
@@ -342,8 +342,8 @@ def ConstantDataCreator(unionType, table):
         return None
     if unionType == ConstantData().FloatData:
         return FloatDataT.InitFromBuf(table.Bytes, table.Pos)
-    if unionType == ConstantData().IntData:
-        return IntDataT.InitFromBuf(table.Bytes, table.Pos)
+    if unionType == ConstantData().Int32Data:
+        return Int32DataT.InitFromBuf(table.Bytes, table.Pos)
     return None
 
 
@@ -5061,29 +5061,29 @@ class FloatDataT(object):
         return floatData
 
 
-class IntData(object):
+class Int32Data(object):
     __slots__ = ['_tab']
 
     @classmethod
     def GetRootAs(cls, buf, offset=0):
         n = flatbuffers.encode.Get(flatbuffers.packer.uoffset, buf, offset)
-        x = IntData()
+        x = Int32Data()
         x.Init(buf, n + offset)
         return x
 
     @classmethod
-    def GetRootAsIntData(cls, buf, offset=0):
+    def GetRootAsInt32Data(cls, buf, offset=0):
         """This method is deprecated. Please switch to GetRootAs."""
         return cls.GetRootAs(buf, offset)
     @classmethod
-    def IntDataBufferHasIdentifier(cls, buf, offset, size_prefixed=False):
+    def Int32DataBufferHasIdentifier(cls, buf, offset, size_prefixed=False):
         return flatbuffers.util.BufferHasIdentifier(buf, offset, b"\x52\x54\x45\x4E", size_prefixed=size_prefixed)
 
-    # IntData
+    # Int32Data
     def Init(self, buf, pos):
         self._tab = flatbuffers.table.Table(buf, pos)
 
-    # IntData
+    # Int32Data
     def Data(self, j):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
         if o != 0:
@@ -5091,35 +5091,35 @@ class IntData(object):
             return self._tab.Get(flatbuffers.number_types.Int32Flags, a + flatbuffers.number_types.UOffsetTFlags.py_type(j * 4))
         return 0
 
-    # IntData
+    # Int32Data
     def DataAsNumpy(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
         if o != 0:
             return self._tab.GetVectorAsNumpy(flatbuffers.number_types.Int32Flags, o)
         return 0
 
-    # IntData
+    # Int32Data
     def DataLength(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
         if o != 0:
             return self._tab.VectorLen(o)
         return 0
 
-    # IntData
+    # Int32Data
     def DataIsNone(self):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
         return o == 0
 
-def IntDataStart(builder):
+def Int32DataStart(builder):
     builder.StartObject(1)
 
-def IntDataAddData(builder, data):
+def Int32DataAddData(builder, data):
     builder.PrependUOffsetTRelativeSlot(0, flatbuffers.number_types.UOffsetTFlags.py_type(data), 0)
 
-def IntDataStartDataVector(builder, numElems):
+def Int32DataStartDataVector(builder, numElems):
     return builder.StartVector(4, numElems, 4)
 
-def IntDataEnd(builder):
+def Int32DataEnd(builder):
     return builder.EndObject()
 
 
@@ -5128,17 +5128,17 @@ try:
 except:
     pass
 
-class IntDataT(object):
+class Int32DataT(object):
 
-    # IntDataT
+    # Int32DataT
     def __init__(self):
         self.data = None  # type: List[int]
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
-        intData = IntData()
-        intData.Init(buf, pos)
-        return cls.InitFromObj(intData)
+        int32Data = Int32Data()
+        int32Data.Init(buf, pos)
+        return cls.InitFromObj(int32Data)
 
     @classmethod
     def InitFromPackedBuf(cls, buf, pos=0):
@@ -5146,38 +5146,38 @@ class IntDataT(object):
         return cls.InitFromBuf(buf, pos+n)
 
     @classmethod
-    def InitFromObj(cls, intData):
-        x = IntDataT()
-        x._UnPack(intData)
+    def InitFromObj(cls, int32Data):
+        x = Int32DataT()
+        x._UnPack(int32Data)
         return x
 
-    # IntDataT
-    def _UnPack(self, intData):
-        if intData is None:
+    # Int32DataT
+    def _UnPack(self, int32Data):
+        if int32Data is None:
             return
-        if not intData.DataIsNone():
+        if not int32Data.DataIsNone():
             if np is None:
                 self.data = []
-                for i in range(intData.DataLength()):
-                    self.data.append(intData.Data(i))
+                for i in range(int32Data.DataLength()):
+                    self.data.append(int32Data.Data(i))
             else:
-                self.data = intData.DataAsNumpy()
+                self.data = int32Data.DataAsNumpy()
 
-    # IntDataT
+    # Int32DataT
     def Pack(self, builder):
         if self.data is not None:
             if np is not None and type(self.data) is np.ndarray:
                 data = builder.CreateNumpyVector(self.data)
             else:
-                IntDataStartDataVector(builder, len(self.data))
+                Int32DataStartDataVector(builder, len(self.data))
                 for i in reversed(range(len(self.data))):
                     builder.PrependInt32(self.data[i])
                 data = builder.EndVector()
-        IntDataStart(builder)
+        Int32DataStart(builder)
         if self.data is not None:
-            IntDataAddData(builder, data)
-        intData = IntDataEnd(builder)
-        return intData
+            Int32DataAddData(builder, data)
+        int32Data = Int32DataEnd(builder)
+        return int32Data
 
 
 class ConstantNode(object):
@@ -5296,7 +5296,7 @@ class ConstantNodeT(object):
     def __init__(self):
         self.shape = None  # type: List[int]
         self.dataType = 0  # type: int
-        self.data = None  # type: Union[None, FloatDataT, IntDataT]
+        self.data = None  # type: Union[None, FloatDataT, Int32DataT]
         self.dtype = None  # type: Optional[int]
         self.dataOffset = None  # type: Optional[int]
 

--- a/rten-convert/rten_convert/schema_generated.py
+++ b/rten-convert/rten_convert/schema_generated.py
@@ -335,6 +335,8 @@ class ConstantData(object):
     NONE = 0
     FloatData = 1
     Int32Data = 2
+    Int8Data = 3
+    UInt8Data = 4
 
 def ConstantDataCreator(unionType, table):
     from flatbuffers.table import Table
@@ -344,12 +346,18 @@ def ConstantDataCreator(unionType, table):
         return FloatDataT.InitFromBuf(table.Bytes, table.Pos)
     if unionType == ConstantData().Int32Data:
         return Int32DataT.InitFromBuf(table.Bytes, table.Pos)
+    if unionType == ConstantData().Int8Data:
+        return Int8DataT.InitFromBuf(table.Bytes, table.Pos)
+    if unionType == ConstantData().UInt8Data:
+        return UInt8DataT.InitFromBuf(table.Bytes, table.Pos)
     return None
 
 
 class ConstantDataType(object):
     Int32 = 0
     Float32 = 1
+    Int8 = 2
+    UInt8 = 3
 
 
 class ArgMaxAttrs(object):
@@ -5061,6 +5069,125 @@ class FloatDataT(object):
         return floatData
 
 
+class Int8Data(object):
+    __slots__ = ['_tab']
+
+    @classmethod
+    def GetRootAs(cls, buf, offset=0):
+        n = flatbuffers.encode.Get(flatbuffers.packer.uoffset, buf, offset)
+        x = Int8Data()
+        x.Init(buf, n + offset)
+        return x
+
+    @classmethod
+    def GetRootAsInt8Data(cls, buf, offset=0):
+        """This method is deprecated. Please switch to GetRootAs."""
+        return cls.GetRootAs(buf, offset)
+    @classmethod
+    def Int8DataBufferHasIdentifier(cls, buf, offset, size_prefixed=False):
+        return flatbuffers.util.BufferHasIdentifier(buf, offset, b"\x52\x54\x45\x4E", size_prefixed=size_prefixed)
+
+    # Int8Data
+    def Init(self, buf, pos):
+        self._tab = flatbuffers.table.Table(buf, pos)
+
+    # Int8Data
+    def Data(self, j):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
+        if o != 0:
+            a = self._tab.Vector(o)
+            return self._tab.Get(flatbuffers.number_types.Int8Flags, a + flatbuffers.number_types.UOffsetTFlags.py_type(j * 1))
+        return 0
+
+    # Int8Data
+    def DataAsNumpy(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
+        if o != 0:
+            return self._tab.GetVectorAsNumpy(flatbuffers.number_types.Int8Flags, o)
+        return 0
+
+    # Int8Data
+    def DataLength(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
+        if o != 0:
+            return self._tab.VectorLen(o)
+        return 0
+
+    # Int8Data
+    def DataIsNone(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
+        return o == 0
+
+def Int8DataStart(builder):
+    builder.StartObject(1)
+
+def Int8DataAddData(builder, data):
+    builder.PrependUOffsetTRelativeSlot(0, flatbuffers.number_types.UOffsetTFlags.py_type(data), 0)
+
+def Int8DataStartDataVector(builder, numElems):
+    return builder.StartVector(1, numElems, 1)
+
+def Int8DataEnd(builder):
+    return builder.EndObject()
+
+
+try:
+    from typing import List
+except:
+    pass
+
+class Int8DataT(object):
+
+    # Int8DataT
+    def __init__(self):
+        self.data = None  # type: List[int]
+
+    @classmethod
+    def InitFromBuf(cls, buf, pos):
+        int8Data = Int8Data()
+        int8Data.Init(buf, pos)
+        return cls.InitFromObj(int8Data)
+
+    @classmethod
+    def InitFromPackedBuf(cls, buf, pos=0):
+        n = flatbuffers.encode.Get(flatbuffers.packer.uoffset, buf, pos)
+        return cls.InitFromBuf(buf, pos+n)
+
+    @classmethod
+    def InitFromObj(cls, int8Data):
+        x = Int8DataT()
+        x._UnPack(int8Data)
+        return x
+
+    # Int8DataT
+    def _UnPack(self, int8Data):
+        if int8Data is None:
+            return
+        if not int8Data.DataIsNone():
+            if np is None:
+                self.data = []
+                for i in range(int8Data.DataLength()):
+                    self.data.append(int8Data.Data(i))
+            else:
+                self.data = int8Data.DataAsNumpy()
+
+    # Int8DataT
+    def Pack(self, builder):
+        if self.data is not None:
+            if np is not None and type(self.data) is np.ndarray:
+                data = builder.CreateNumpyVector(self.data)
+            else:
+                Int8DataStartDataVector(builder, len(self.data))
+                for i in reversed(range(len(self.data))):
+                    builder.PrependByte(self.data[i])
+                data = builder.EndVector()
+        Int8DataStart(builder)
+        if self.data is not None:
+            Int8DataAddData(builder, data)
+        int8Data = Int8DataEnd(builder)
+        return int8Data
+
+
 class Int32Data(object):
     __slots__ = ['_tab']
 
@@ -5180,6 +5307,125 @@ class Int32DataT(object):
         return int32Data
 
 
+class UInt8Data(object):
+    __slots__ = ['_tab']
+
+    @classmethod
+    def GetRootAs(cls, buf, offset=0):
+        n = flatbuffers.encode.Get(flatbuffers.packer.uoffset, buf, offset)
+        x = UInt8Data()
+        x.Init(buf, n + offset)
+        return x
+
+    @classmethod
+    def GetRootAsUInt8Data(cls, buf, offset=0):
+        """This method is deprecated. Please switch to GetRootAs."""
+        return cls.GetRootAs(buf, offset)
+    @classmethod
+    def UInt8DataBufferHasIdentifier(cls, buf, offset, size_prefixed=False):
+        return flatbuffers.util.BufferHasIdentifier(buf, offset, b"\x52\x54\x45\x4E", size_prefixed=size_prefixed)
+
+    # UInt8Data
+    def Init(self, buf, pos):
+        self._tab = flatbuffers.table.Table(buf, pos)
+
+    # UInt8Data
+    def Data(self, j):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
+        if o != 0:
+            a = self._tab.Vector(o)
+            return self._tab.Get(flatbuffers.number_types.Uint8Flags, a + flatbuffers.number_types.UOffsetTFlags.py_type(j * 1))
+        return 0
+
+    # UInt8Data
+    def DataAsNumpy(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
+        if o != 0:
+            return self._tab.GetVectorAsNumpy(flatbuffers.number_types.Uint8Flags, o)
+        return 0
+
+    # UInt8Data
+    def DataLength(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
+        if o != 0:
+            return self._tab.VectorLen(o)
+        return 0
+
+    # UInt8Data
+    def DataIsNone(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
+        return o == 0
+
+def UInt8DataStart(builder):
+    builder.StartObject(1)
+
+def UInt8DataAddData(builder, data):
+    builder.PrependUOffsetTRelativeSlot(0, flatbuffers.number_types.UOffsetTFlags.py_type(data), 0)
+
+def UInt8DataStartDataVector(builder, numElems):
+    return builder.StartVector(1, numElems, 1)
+
+def UInt8DataEnd(builder):
+    return builder.EndObject()
+
+
+try:
+    from typing import List
+except:
+    pass
+
+class UInt8DataT(object):
+
+    # UInt8DataT
+    def __init__(self):
+        self.data = None  # type: List[int]
+
+    @classmethod
+    def InitFromBuf(cls, buf, pos):
+        uint8Data = UInt8Data()
+        uint8Data.Init(buf, pos)
+        return cls.InitFromObj(uint8Data)
+
+    @classmethod
+    def InitFromPackedBuf(cls, buf, pos=0):
+        n = flatbuffers.encode.Get(flatbuffers.packer.uoffset, buf, pos)
+        return cls.InitFromBuf(buf, pos+n)
+
+    @classmethod
+    def InitFromObj(cls, uint8Data):
+        x = UInt8DataT()
+        x._UnPack(uint8Data)
+        return x
+
+    # UInt8DataT
+    def _UnPack(self, uint8Data):
+        if uint8Data is None:
+            return
+        if not uint8Data.DataIsNone():
+            if np is None:
+                self.data = []
+                for i in range(uint8Data.DataLength()):
+                    self.data.append(uint8Data.Data(i))
+            else:
+                self.data = uint8Data.DataAsNumpy()
+
+    # UInt8DataT
+    def Pack(self, builder):
+        if self.data is not None:
+            if np is not None and type(self.data) is np.ndarray:
+                data = builder.CreateNumpyVector(self.data)
+            else:
+                UInt8DataStartDataVector(builder, len(self.data))
+                for i in reversed(range(len(self.data))):
+                    builder.PrependUint8(self.data[i])
+                data = builder.EndVector()
+        UInt8DataStart(builder)
+        if self.data is not None:
+            UInt8DataAddData(builder, data)
+        uint8Data = UInt8DataEnd(builder)
+        return uint8Data
+
+
 class ConstantNode(object):
     __slots__ = ['_tab']
 
@@ -5296,7 +5542,7 @@ class ConstantNodeT(object):
     def __init__(self):
         self.shape = None  # type: List[int]
         self.dataType = 0  # type: int
-        self.data = None  # type: Union[None, FloatDataT, Int32DataT]
+        self.data = None  # type: Union[None, FloatDataT, Int32DataT, Int8DataT, UInt8DataT]
         self.dtype = None  # type: Optional[int]
         self.dataOffset = None  # type: Optional[int]
 

--- a/rten-convert/rten_convert/tensor_data.py
+++ b/rten-convert/rten_convert/tensor_data.py
@@ -34,6 +34,8 @@ class TensorDataBuilder:
         match array.dtype:
             case np.float32 | np.int32:
                 element_size = 4
+            case np.int8 | np.uint8:
+                element_size = 1
             case _:
                 raise ValueError("Unsupported NumPy array type {}".format(array.dtype))
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -183,7 +183,7 @@ impl Constant {
     pub fn as_input(&self) -> Input {
         match self {
             Constant::Float(f) => Input::FloatTensor(f.view()),
-            Constant::Int(i) => Input::IntTensor(i.view()),
+            Constant::Int(i) => Input::Int32Tensor(i.view()),
         }
     }
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -152,14 +152,18 @@ impl<T> ConstantNode<T> {
 
 pub enum Constant {
     Float(ConstantNode<f32>),
-    Int(ConstantNode<i32>),
+    Int32(ConstantNode<i32>),
+    Int8(ConstantNode<i8>),
+    UInt8(ConstantNode<u8>),
 }
 
 impl Constant {
     pub fn name(&self) -> Option<&str> {
         match self {
             Constant::Float(f) => f.name.as_deref(),
-            Constant::Int(i) => i.name.as_deref(),
+            Constant::Int32(i) => i.name.as_deref(),
+            Constant::Int8(i) => i.name.as_deref(),
+            Constant::UInt8(i) => i.name.as_deref(),
         }
     }
 
@@ -168,14 +172,18 @@ impl Constant {
     pub fn clone_ref(&self) -> Option<Constant> {
         match self {
             Constant::Float(f) => f.clone_ref().map(Constant::Float),
-            Constant::Int(i) => i.clone_ref().map(Constant::Int),
+            Constant::Int32(i) => i.clone_ref().map(Constant::Int32),
+            Constant::Int8(i) => i.clone_ref().map(Constant::Int8),
+            Constant::UInt8(i) => i.clone_ref().map(Constant::UInt8),
         }
     }
 
     fn layout(&self) -> &DynLayout {
         match self {
             Constant::Float(f) => f.layout(),
-            Constant::Int(i) => i.layout(),
+            Constant::Int32(i) => i.layout(),
+            Constant::Int8(i) => i.layout(),
+            Constant::UInt8(i) => i.layout(),
         }
     }
 
@@ -183,22 +191,27 @@ impl Constant {
     pub fn as_input(&self) -> Input {
         match self {
             Constant::Float(f) => Input::FloatTensor(f.view()),
-            Constant::Int(i) => Input::Int32Tensor(i.view()),
+            Constant::Int32(i) => Input::Int32Tensor(i.view()),
+            Constant::Int8(i) => Input::Int8Tensor(i.view()),
+            Constant::UInt8(i) => Input::UInt8Tensor(i.view()),
         }
     }
 }
 
-impl From<ConstantNode<f32>> for Constant {
-    fn from(node: ConstantNode<f32>) -> Constant {
-        Constant::Float(node)
-    }
+macro_rules! impl_constant_node {
+    ($scalar_type:ty, $variant:ident) => {
+        impl From<ConstantNode<$scalar_type>> for Constant {
+            fn from(node: ConstantNode<$scalar_type>) -> Constant {
+                Constant::$variant(node)
+            }
+        }
+    };
 }
 
-impl From<ConstantNode<i32>> for Constant {
-    fn from(node: ConstantNode<i32>) -> Constant {
-        Constant::Int(node)
-    }
-}
+impl_constant_node!(f32, Float);
+impl_constant_node!(i32, Int32);
+impl_constant_node!(i8, Int8);
+impl_constant_node!(u8, UInt8);
 
 /// Extract typed data from a [`Constant`].
 pub trait TypedConstant<T> {
@@ -233,7 +246,9 @@ macro_rules! impl_typed_constant {
 }
 
 impl_typed_constant!(f32, Float);
-impl_typed_constant!(i32, Int);
+impl_typed_constant!(i32, Int32);
+impl_typed_constant!(i8, Int8);
+impl_typed_constant!(u8, UInt8);
 
 pub enum Node {
     Operator(OperatorNode),

--- a/src/model.rs
+++ b/src/model.rs
@@ -563,7 +563,7 @@ impl Model {
                 let const_data =
                     constant_data_from_flatbuffers_vec(storage, float_data.data(), &shape);
                 graph.add_constant(name, const_data)
-            } else if let Some(int_data) = constant.data_as_int_data() {
+            } else if let Some(int_data) = constant.data_as_int_32_data() {
                 let const_data =
                     constant_data_from_flatbuffers_vec(storage, int_data.data(), &shape);
                 graph.add_constant(name, const_data)

--- a/src/model.rs
+++ b/src/model.rs
@@ -550,6 +550,16 @@ impl Model {
                         constant_data_from_storage_offset::<f32>(storage, &shape, data_offset)?;
                     graph.add_constant(name, const_data)
                 }
+                Some(sg::ConstantDataType::Int8) => {
+                    let const_data =
+                        constant_data_from_storage_offset::<i8>(storage, &shape, data_offset)?;
+                    graph.add_constant(name, const_data)
+                }
+                Some(sg::ConstantDataType::UInt8) => {
+                    let const_data =
+                        constant_data_from_storage_offset::<u8>(storage, &shape, data_offset)?;
+                    graph.add_constant(name, const_data)
+                }
                 _ => {
                     return Err(ModelLoadError::GraphError(
                         "unsupported data type for external constant".to_string(),
@@ -566,6 +576,14 @@ impl Model {
             } else if let Some(int_data) = constant.data_as_int_32_data() {
                 let const_data =
                     constant_data_from_flatbuffers_vec(storage, int_data.data(), &shape);
+                graph.add_constant(name, const_data)
+            } else if let Some(int8_data) = constant.data_as_int_8_data() {
+                let const_data =
+                    constant_data_from_flatbuffers_vec(storage, int8_data.data(), &shape);
+                graph.add_constant(name, const_data)
+            } else if let Some(uint8_data) = constant.data_as_uint_8_data() {
+                let const_data =
+                    constant_data_from_flatbuffers_vec(storage, uint8_data.data(), &shape);
                 graph.add_constant(name, const_data)
             } else {
                 return Err(ModelLoadError::GraphError(

--- a/src/model_builder.rs
+++ b/src/model_builder.rs
@@ -184,7 +184,7 @@ macro_rules! impl_to_constant_data {
     };
 }
 impl_to_constant_data!(f32, Float32, FloatData, FloatDataArgs);
-impl_to_constant_data!(i32, Int32, IntData, IntDataArgs);
+impl_to_constant_data!(i32, Int32, Int32Data, Int32DataArgs);
 
 enum NodeData<'a> {
     Constant(WIPOffset<sg::ConstantNode<'a>>),

--- a/src/model_builder.rs
+++ b/src/model_builder.rs
@@ -990,12 +990,14 @@ impl TensorDataBuilder {
         let padding = offset.next_multiple_of(align) - offset;
         self.data.extend(std::iter::repeat(0).take(padding));
 
+        let start_offset = self.data.len();
+
         for x in data {
             let bytes = x.to_le_bytes();
             self.data.extend(bytes.as_ref());
         }
 
-        offset
+        start_offset
     }
 
     /// Consume the builder and return the finalized tensor data buffer.

--- a/src/number.rs
+++ b/src/number.rs
@@ -86,6 +86,8 @@ macro_rules! impl_le_bytes {
     };
 }
 
+impl_le_bytes!(i8, 1);
+impl_le_bytes!(u8, 1);
 impl_le_bytes!(i32, 4);
 impl_le_bytes!(f32, 4);
 impl_le_bytes!(u32, 4);
@@ -191,8 +193,10 @@ impl_fastdiv!(usize);
 /// This means an arbitrary byte sequence can be converted to this type, as
 /// long as the byte sequence length is a multiple of the type's size.
 pub trait Pod: Copy {}
+impl Pod for i8 {}
 impl Pod for i32 {}
 impl Pod for f32 {}
+impl Pod for u8 {}
 
 #[cfg(test)]
 mod tests {

--- a/src/ops/binary_elementwise.rs
+++ b/src/ops/binary_elementwise.rs
@@ -352,7 +352,7 @@ macro_rules! run_typed_op {
                 let b = $inputs.require_as::<f32>(1)?;
                 $op_func($pool, a, b).into_op_result()
             }
-            Input::IntTensor(a) => {
+            Input::Int32Tensor(a) => {
                 let b = $inputs.require_as::<i32>(1)?;
                 $op_func($pool, a, b).into_op_result()
             }
@@ -378,7 +378,7 @@ macro_rules! run_typed_op_in_place {
                     $op_func($pool, a.view(), b.view()).map(|t| t.into())
                 }
             }
-            Output::IntTensor(mut a) => {
+            Output::Int32Tensor(mut a) => {
                 let b = $other.require_as::<i32>(0)?;
                 if can_run_binary_op_in_place(&a, &b) {
                     $in_place_op_func(a.view_mut(), b.view());
@@ -684,7 +684,7 @@ impl Operator for Mod {
                 let b = inputs.require_as::<f32>(1)?;
                 mod_op(pool, a, b, mode).into_op_result()
             }
-            Input::IntTensor(a) => {
+            Input::Int32Tensor(a) => {
                 let b = inputs.require_as::<i32>(1)?;
                 mod_op(pool, a, b, mode).into_op_result()
             }
@@ -945,7 +945,7 @@ impl Operator for Where {
                 let y: TensorView = y.try_into()?;
                 where_op(pool, condition, x, y).into_op_result()
             }
-            Input::IntTensor(x) => {
+            Input::Int32Tensor(x) => {
                 let y: TensorView<i32> = y.try_into()?;
                 where_op(pool, condition, x, y).into_op_result()
             }

--- a/src/ops/binary_elementwise.rs
+++ b/src/ops/binary_elementwise.rs
@@ -356,6 +356,7 @@ macro_rules! run_typed_op {
                 let b = $inputs.require_as::<i32>(1)?;
                 $op_func($pool, a, b).into_op_result()
             }
+            _ => Err(OpError::UnsupportedType),
         }
     }};
     ($inputs:expr, $op_func:ident) => {
@@ -387,6 +388,7 @@ macro_rules! run_typed_op_in_place {
                     $op_func($pool, a.view(), b.view()).map(|t| t.into())
                 }
             }
+            _ => Err(OpError::UnsupportedType),
         }
     }};
 }
@@ -688,6 +690,7 @@ impl Operator for Mod {
                 let b = inputs.require_as::<i32>(1)?;
                 mod_op(pool, a, b, mode).into_op_result()
             }
+            _ => Err(OpError::UnsupportedType),
         }
     }
 }
@@ -949,6 +952,7 @@ impl Operator for Where {
                 let y: TensorView<i32> = y.try_into()?;
                 where_op(pool, condition, x, y).into_op_result()
             }
+            _ => Err(OpError::UnsupportedType),
         }
     }
 }

--- a/src/ops/concat.rs
+++ b/src/ops/concat.rs
@@ -116,6 +116,7 @@ impl Operator for Concat {
                 let typed_inputs = typed_inputs::<i32>(&inputs)?;
                 concat(pool, &typed_inputs, self.axis).into_op_result()
             }
+            _ => Err(OpError::UnsupportedType),
         }
     }
 
@@ -147,6 +148,7 @@ impl Operator for Concat {
                 let typed_inputs = typed_inputs(&rest)?;
                 concat_in_place(pool, first, &typed_inputs, self.axis).map(|t| t.into())
             }
+            _ => Err(OpError::UnsupportedType),
         }
     }
 }
@@ -266,6 +268,7 @@ impl Operator for Tile {
         match input {
             Input::Int32Tensor(input) => tile(pool, input, repeats).into_op_result(),
             Input::FloatTensor(input) => tile(pool, input, repeats).into_op_result(),
+            _ => Err(OpError::UnsupportedType),
         }
     }
 
@@ -290,6 +293,7 @@ impl Operator for Tile {
         match output {
             Output::Int32Tensor(input) => tile(pool, input.view(), repeats).map(|t| t.into()),
             Output::FloatTensor(input) => tile(pool, input.view(), repeats).map(|t| t.into()),
+            _ => Err(OpError::UnsupportedType),
         }
     }
 }

--- a/src/ops/concat.rs
+++ b/src/ops/concat.rs
@@ -112,7 +112,7 @@ impl Operator for Concat {
                 let typed_inputs = typed_inputs::<f32>(&inputs)?;
                 concat(pool, &typed_inputs, self.axis).into_op_result()
             }
-            Input::IntTensor(_) => {
+            Input::Int32Tensor(_) => {
                 let typed_inputs = typed_inputs::<i32>(&inputs)?;
                 concat(pool, &typed_inputs, self.axis).into_op_result()
             }
@@ -143,7 +143,7 @@ impl Operator for Concat {
                 let typed_inputs = typed_inputs(&rest)?;
                 concat_in_place(pool, first, &typed_inputs, self.axis).map(|t| t.into())
             }
-            Output::IntTensor(first) => {
+            Output::Int32Tensor(first) => {
                 let typed_inputs = typed_inputs(&rest)?;
                 concat_in_place(pool, first, &typed_inputs, self.axis).map(|t| t.into())
             }
@@ -264,7 +264,7 @@ impl Operator for Tile {
         let repeats = static_dims!(repeats, 1)?;
 
         match input {
-            Input::IntTensor(input) => tile(pool, input, repeats).into_op_result(),
+            Input::Int32Tensor(input) => tile(pool, input, repeats).into_op_result(),
             Input::FloatTensor(input) => tile(pool, input, repeats).into_op_result(),
         }
     }
@@ -288,7 +288,7 @@ impl Operator for Tile {
         }
 
         match output {
-            Output::IntTensor(input) => tile(pool, input.view(), repeats).map(|t| t.into()),
+            Output::Int32Tensor(input) => tile(pool, input.view(), repeats).map(|t| t.into()),
             Output::FloatTensor(input) => tile(pool, input.view(), repeats).map(|t| t.into()),
         }
     }

--- a/src/ops/convert.rs
+++ b/src/ops/convert.rs
@@ -6,12 +6,12 @@ use crate::tensor_pool::TensorPool;
 fn cast(pool: &TensorPool, input: Input, dtype: DataType) -> Output {
     match dtype {
         DataType::Int32 => match input {
-            Input::IntTensor(t) => t.map_in(pool, |x| *x).into(),
+            Input::Int32Tensor(t) => t.map_in(pool, |x| *x).into(),
             Input::FloatTensor(t) => t.map_in(pool, |x| *x as i32).into(),
         },
         DataType::Float => match input {
             Input::FloatTensor(t) => t.map_in(pool, |x| *x).into(),
-            Input::IntTensor(t) => t.map_in(pool, |x| *x as f32).into(),
+            Input::Int32Tensor(t) => t.map_in(pool, |x| *x as f32).into(),
         },
     }
 }
@@ -42,7 +42,7 @@ impl Operator for Cast {
         _: InputList,
     ) -> Result<Output, OpError> {
         match (input, self.to) {
-            (Output::IntTensor(t), DataType::Int32) => Ok(t.into()),
+            (Output::Int32Tensor(t), DataType::Int32) => Ok(t.into()),
             (Output::FloatTensor(t), DataType::Float) => Ok(t.into()),
             (input, _) => {
                 let converted = cast(pool, input.as_input(), self.to);

--- a/src/ops/fused.rs
+++ b/src/ops/fused.rs
@@ -34,6 +34,7 @@ impl PermuteSpec {
                     t.transpose();
                 }
             }
+            _ => return Err(OpError::UnsupportedType),
         }
 
         Ok(())

--- a/src/ops/fused.rs
+++ b/src/ops/fused.rs
@@ -20,7 +20,7 @@ impl PermuteSpec {
         };
 
         match input {
-            Input::IntTensor(ref mut t) => {
+            Input::Int32Tensor(ref mut t) => {
                 if let Some(perm) = self.perm.as_ref() {
                     t.permute(perm);
                 } else {

--- a/src/ops/gather.rs
+++ b/src/ops/gather.rs
@@ -89,7 +89,7 @@ impl Operator for Gather {
         let input = inputs.require(0)?;
         let indices = inputs.require_as::<i32>(1)?;
         match input {
-            Input::IntTensor(input) => gather(pool, input, self.axis, indices).into_op_result(),
+            Input::Int32Tensor(input) => gather(pool, input, self.axis, indices).into_op_result(),
             Input::FloatTensor(input) => gather(pool, input, self.axis, indices).into_op_result(),
         }
     }
@@ -232,7 +232,7 @@ impl Operator for GatherElements {
         let input = inputs.require(0)?;
         let indices = inputs.require_as::<i32>(1)?;
         match input {
-            Input::IntTensor(input) => {
+            Input::Int32Tensor(input) => {
                 gather_elements(pool, input, indices, self.axis).into_op_result()
             }
             Input::FloatTensor(input) => {
@@ -329,7 +329,7 @@ impl Operator for GatherND {
         let input = inputs.require(0)?;
         let indices = inputs.require_as::<i32>(1)?;
         match input {
-            Input::IntTensor(input) => {
+            Input::Int32Tensor(input) => {
                 gather_nd(pool, input, indices, self.batch_dims).into_op_result()
             }
             Input::FloatTensor(input) => {
@@ -441,7 +441,7 @@ impl Operator for ScatterElements {
         let updates = inputs.require(2)?;
 
         match (data, updates) {
-            (Input::IntTensor(data), Input::IntTensor(updates)) => {
+            (Input::Int32Tensor(data), Input::Int32Tensor(updates)) => {
                 scatter_elements(pool, data, indices, updates, self.axis, self.reduction)
                     .into_op_result()
             }
@@ -539,7 +539,7 @@ impl Operator for ScatterND {
         let updates = inputs.require(2)?;
 
         match (data, updates) {
-            (Input::IntTensor(data), Input::IntTensor(updates)) => {
+            (Input::Int32Tensor(data), Input::Int32Tensor(updates)) => {
                 scatter_nd(pool, data, indices, updates, self.reduction).into_op_result()
             }
             (Input::FloatTensor(data), Input::FloatTensor(updates)) => {

--- a/src/ops/gather.rs
+++ b/src/ops/gather.rs
@@ -91,6 +91,7 @@ impl Operator for Gather {
         match input {
             Input::Int32Tensor(input) => gather(pool, input, self.axis, indices).into_op_result(),
             Input::FloatTensor(input) => gather(pool, input, self.axis, indices).into_op_result(),
+            _ => Err(OpError::UnsupportedType),
         }
     }
 }
@@ -238,6 +239,7 @@ impl Operator for GatherElements {
             Input::FloatTensor(input) => {
                 gather_elements(pool, input, indices, self.axis).into_op_result()
             }
+            _ => Err(OpError::UnsupportedType),
         }
     }
 }
@@ -335,6 +337,7 @@ impl Operator for GatherND {
             Input::FloatTensor(input) => {
                 gather_nd(pool, input, indices, self.batch_dims).into_op_result()
             }
+            _ => Err(OpError::UnsupportedType),
         }
     }
 }
@@ -449,7 +452,7 @@ impl Operator for ScatterElements {
                 scatter_elements(pool, data, indices, updates, self.axis, self.reduction)
                     .into_op_result()
             }
-            _ => Err(OpError::IncorrectInputType),
+            _ => Err(OpError::UnsupportedType),
         }
     }
 }
@@ -545,7 +548,7 @@ impl Operator for ScatterND {
             (Input::FloatTensor(data), Input::FloatTensor(updates)) => {
                 scatter_nd(pool, data, indices, updates, self.reduction).into_op_result()
             }
-            _ => Err(OpError::IncorrectInputType),
+            _ => Err(OpError::UnsupportedType),
         }
     }
 }

--- a/src/ops/generate.rs
+++ b/src/ops/generate.rs
@@ -108,6 +108,7 @@ impl Operator for OneHot {
                 let (on_value, off_value) = extract_on_off_values(values)?;
                 onehot(pool, indices, self.axis, depth, on_value, off_value).into_op_result()
             }
+            _ => Err(OpError::UnsupportedType),
         }
     }
 }
@@ -159,6 +160,7 @@ impl Operator for Range {
                 let delta = delta.try_into()?;
                 range::<i32>(start, limit, delta).into_op_result()
             }
+            _ => Err(OpError::UnsupportedType),
         }
     }
 }

--- a/src/ops/generate.rs
+++ b/src/ops/generate.rs
@@ -98,7 +98,7 @@ impl Operator for OneHot {
         let values = inputs.require(2)?;
 
         match values {
-            Input::IntTensor(values) => {
+            Input::Int32Tensor(values) => {
                 let values = static_dims!(values, 1)?;
                 let (on_value, off_value) = extract_on_off_values(values)?;
                 onehot(pool, indices, self.axis, depth, on_value, off_value).into_op_result()
@@ -153,7 +153,7 @@ impl Operator for Range {
                 let delta = delta.try_into()?;
                 range::<f32>(start, limit, delta).into_op_result()
             }
-            Input::IntTensor(_) => {
+            Input::Int32Tensor(_) => {
                 let start = start.try_into()?;
                 let limit = limit.try_into()?;
                 let delta = delta.try_into()?;

--- a/src/ops/identity.rs
+++ b/src/ops/identity.rs
@@ -19,7 +19,7 @@ impl Operator for Identity {
     fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let input = inputs.require(0)?;
         let result: Output = match input {
-            Input::IntTensor(t) => identity(pool, t).into(),
+            Input::Int32Tensor(t) => identity(pool, t).into(),
             Input::FloatTensor(t) => identity(pool, t).into(),
         };
         result.into_op_result()

--- a/src/ops/identity.rs
+++ b/src/ops/identity.rs
@@ -21,6 +21,7 @@ impl Operator for Identity {
         let result: Output = match input {
             Input::Int32Tensor(t) => identity(pool, t).into(),
             Input::FloatTensor(t) => identity(pool, t).into(),
+            _ => return Err(OpError::UnsupportedType),
         };
         result.into_op_result()
     }

--- a/src/ops/layout.rs
+++ b/src/ops/layout.rs
@@ -96,7 +96,7 @@ impl Operator for Expand {
 
         match input {
             Input::FloatTensor(input) => expand(pool, input, &shape).into_op_result(),
-            Input::IntTensor(input) => expand(pool, input, &shape).into_op_result(),
+            Input::Int32Tensor(input) => expand(pool, input, &shape).into_op_result(),
         }
     }
 
@@ -122,7 +122,7 @@ impl Operator for Expand {
 
         let output: Output = match input {
             Output::FloatTensor(input) => expand_to(pool, input.view(), &out_shape).into(),
-            Output::IntTensor(input) => expand_to(pool, input.view(), &out_shape).into(),
+            Output::Int32Tensor(input) => expand_to(pool, input.view(), &out_shape).into(),
         };
         Ok(output)
     }
@@ -171,7 +171,7 @@ impl Operator for Flatten {
 
         match input {
             Input::FloatTensor(input) => flatten(pool, input, self.axis).into_op_result(),
-            Input::IntTensor(input) => flatten(pool, input, self.axis).into_op_result(),
+            Input::Int32Tensor(input) => flatten(pool, input, self.axis).into_op_result(),
         }
     }
 
@@ -186,7 +186,7 @@ impl Operator for Flatten {
         _: InputList,
     ) -> Result<Output, OpError> {
         match input {
-            Output::IntTensor(mut output) => {
+            Output::Int32Tensor(mut output) => {
                 flatten_in_place(pool, &mut output, self.axis)?;
                 Ok(output.into())
             }
@@ -310,7 +310,7 @@ impl Operator for Reshape {
         let shape = static_dims!(shape, 1)?;
 
         match input {
-            Input::IntTensor(t) => reshape(pool, t, &shape, self.allow_zero).into_op_result(),
+            Input::Int32Tensor(t) => reshape(pool, t, &shape, self.allow_zero).into_op_result(),
             Input::FloatTensor(t) => reshape(pool, t, &shape, self.allow_zero).into_op_result(),
         }
     }
@@ -329,7 +329,7 @@ impl Operator for Reshape {
         let shape = static_dims!(shape, 1)?;
 
         match input {
-            Output::IntTensor(mut output) => {
+            Output::Int32Tensor(mut output) => {
                 reshape_in_place(pool, &mut output, &shape, self.allow_zero)?;
                 Ok(output.into())
             }
@@ -444,7 +444,7 @@ impl Operator for Squeeze {
 
         match input {
             Input::FloatTensor(t) => squeeze(pool, t, axes).into_op_result(),
-            Input::IntTensor(t) => squeeze(pool, t, axes).into_op_result(),
+            Input::Int32Tensor(t) => squeeze(pool, t, axes).into_op_result(),
         }
     }
 
@@ -466,7 +466,7 @@ impl Operator for Squeeze {
                 squeeze_in_place(&mut t, axes)?;
                 t.into()
             }
-            Output::IntTensor(mut t) => {
+            Output::Int32Tensor(mut t) => {
                 squeeze_in_place(&mut t, axes)?;
                 t.into()
             }
@@ -513,7 +513,7 @@ impl Operator for Transpose {
         let perm_slice = self.perm.as_deref();
         match input {
             Input::FloatTensor(input) => transpose(pool, input, perm_slice).into_op_result(),
-            Input::IntTensor(input) => transpose(pool, input, perm_slice).into_op_result(),
+            Input::Int32Tensor(input) => transpose(pool, input, perm_slice).into_op_result(),
         }
     }
 }
@@ -567,7 +567,7 @@ impl Operator for Unsqueeze {
 
         match input {
             Input::FloatTensor(input) => unsqueeze(pool, input, &axes).into_op_result(),
-            Input::IntTensor(input) => unsqueeze(pool, input, &axes).into_op_result(),
+            Input::Int32Tensor(input) => unsqueeze(pool, input, &axes).into_op_result(),
         }
     }
 
@@ -586,7 +586,7 @@ impl Operator for Unsqueeze {
 
         match output {
             Output::FloatTensor(t) => unsqueeze_in_place(t, &axes).map(Output::FloatTensor),
-            Output::IntTensor(t) => unsqueeze_in_place(t, &axes).map(Output::IntTensor),
+            Output::Int32Tensor(t) => unsqueeze_in_place(t, &axes).map(Output::Int32Tensor),
         }
     }
 }

--- a/src/ops/layout.rs
+++ b/src/ops/layout.rs
@@ -97,6 +97,7 @@ impl Operator for Expand {
         match input {
             Input::FloatTensor(input) => expand(pool, input, &shape).into_op_result(),
             Input::Int32Tensor(input) => expand(pool, input, &shape).into_op_result(),
+            _ => Err(OpError::UnsupportedType),
         }
     }
 
@@ -123,6 +124,7 @@ impl Operator for Expand {
         let output: Output = match input {
             Output::FloatTensor(input) => expand_to(pool, input.view(), &out_shape).into(),
             Output::Int32Tensor(input) => expand_to(pool, input.view(), &out_shape).into(),
+            _ => return Err(OpError::UnsupportedType),
         };
         Ok(output)
     }
@@ -172,6 +174,7 @@ impl Operator for Flatten {
         match input {
             Input::FloatTensor(input) => flatten(pool, input, self.axis).into_op_result(),
             Input::Int32Tensor(input) => flatten(pool, input, self.axis).into_op_result(),
+            _ => Err(OpError::UnsupportedType),
         }
     }
 
@@ -194,6 +197,7 @@ impl Operator for Flatten {
                 flatten_in_place(pool, &mut output, self.axis)?;
                 Ok(output.into())
             }
+            _ => Err(OpError::UnsupportedType),
         }
     }
 }
@@ -312,6 +316,7 @@ impl Operator for Reshape {
         match input {
             Input::Int32Tensor(t) => reshape(pool, t, &shape, self.allow_zero).into_op_result(),
             Input::FloatTensor(t) => reshape(pool, t, &shape, self.allow_zero).into_op_result(),
+            _ => Err(OpError::UnsupportedType),
         }
     }
 
@@ -337,6 +342,7 @@ impl Operator for Reshape {
                 reshape_in_place(pool, &mut output, &shape, self.allow_zero)?;
                 Ok(output.into())
             }
+            _ => Err(OpError::UnsupportedType),
         }
     }
 }
@@ -445,6 +451,7 @@ impl Operator for Squeeze {
         match input {
             Input::FloatTensor(t) => squeeze(pool, t, axes).into_op_result(),
             Input::Int32Tensor(t) => squeeze(pool, t, axes).into_op_result(),
+            _ => Err(OpError::UnsupportedType),
         }
     }
 
@@ -461,17 +468,17 @@ impl Operator for Squeeze {
         let axes = other.get_as(0)?;
         let axes = axes.map(|axes| static_dims!(axes, 1)).transpose()?;
 
-        let result = match input {
+        match input {
             Output::FloatTensor(mut t) => {
                 squeeze_in_place(&mut t, axes)?;
-                t.into()
+                Ok(t.into())
             }
             Output::Int32Tensor(mut t) => {
                 squeeze_in_place(&mut t, axes)?;
-                t.into()
+                Ok(t.into())
             }
-        };
-        Ok(result)
+            _ => Err(OpError::UnsupportedType),
+        }
     }
 }
 
@@ -514,6 +521,7 @@ impl Operator for Transpose {
         match input {
             Input::FloatTensor(input) => transpose(pool, input, perm_slice).into_op_result(),
             Input::Int32Tensor(input) => transpose(pool, input, perm_slice).into_op_result(),
+            _ => Err(OpError::UnsupportedType),
         }
     }
 }
@@ -568,6 +576,7 @@ impl Operator for Unsqueeze {
         match input {
             Input::FloatTensor(input) => unsqueeze(pool, input, &axes).into_op_result(),
             Input::Int32Tensor(input) => unsqueeze(pool, input, &axes).into_op_result(),
+            _ => Err(OpError::UnsupportedType),
         }
     }
 
@@ -587,6 +596,7 @@ impl Operator for Unsqueeze {
         match output {
             Output::FloatTensor(t) => unsqueeze_in_place(t, &axes).map(Output::FloatTensor),
             Output::Int32Tensor(t) => unsqueeze_in_place(t, &axes).map(Output::Int32Tensor),
+            _ => Err(OpError::UnsupportedType),
         }
     }
 }

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -236,54 +236,31 @@ impl<'a> Layout for Input<'a> {
     }
 }
 
-impl<'a> TryFrom<Input<'a>> for TensorView<'a, f32> {
-    type Error = OpError;
-
-    fn try_from(input: Input<'a>) -> Result<TensorView<'a, f32>, Self::Error> {
-        match input {
-            Input::FloatTensor(t) => Ok(t),
-            _ => Err(OpError::IncorrectInputType),
-        }
-    }
-}
-
-impl<'a> TryFrom<Input<'a>> for TensorView<'a, i32> {
-    type Error = OpError;
-
-    fn try_from(input: Input<'a>) -> Result<TensorView<'a, i32>, Self::Error> {
-        match input {
-            Input::Int32Tensor(t) => Ok(t),
-            _ => Err(OpError::IncorrectInputType),
-        }
-    }
-}
-
-impl<'a> TryFrom<Input<'a>> for f32 {
-    type Error = OpError;
-
-    fn try_from(input: Input<'a>) -> Result<f32, Self::Error> {
-        let tensor: TensorView<'a, _> = input.try_into()?;
-        tensor
-            .item()
-            .copied()
-            .ok_or(OpError::InvalidValue("Expected scalar value"))
-    }
-}
-
-impl<'a> TryFrom<Input<'a>> for i32 {
-    type Error = OpError;
-
-    fn try_from(input: Input<'a>) -> Result<i32, Self::Error> {
-        let tensor: TensorView<'a, _> = input.try_into()?;
-        tensor
-            .item()
-            .copied()
-            .ok_or(OpError::InvalidValue("Expected scalar value"))
-    }
-}
-
 macro_rules! impl_input_conversions {
     ($variant:ident, $element_type:ty) => {
+        impl<'a> TryFrom<Input<'a>> for TensorView<'a, $element_type> {
+            type Error = OpError;
+
+            fn try_from(input: Input<'a>) -> Result<TensorView<'a, $element_type>, Self::Error> {
+                match input {
+                    Input::$variant(t) => Ok(t),
+                    _ => Err(OpError::IncorrectInputType),
+                }
+            }
+        }
+
+        impl<'a> TryFrom<Input<'a>> for $element_type {
+            type Error = OpError;
+
+            fn try_from(input: Input<'a>) -> Result<$element_type, Self::Error> {
+                let tensor: TensorView<'a, _> = input.try_into()?;
+                tensor
+                    .item()
+                    .copied()
+                    .ok_or(OpError::InvalidValue("Expected scalar value"))
+            }
+        }
+
         impl<'a> From<&'a Tensor<$element_type>> for Input<'a> {
             fn from(t: &'a Tensor<$element_type>) -> Input {
                 Input::$variant(t.view())

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -176,21 +176,21 @@ pub enum DataType {
 #[derive(Clone)]
 pub enum Input<'a> {
     FloatTensor(TensorView<'a, f32>),
-    IntTensor(TensorView<'a, i32>),
+    Int32Tensor(TensorView<'a, i32>),
 }
 
 impl<'a> Input<'a> {
     pub fn to_output(&self) -> Output {
         match self {
             Input::FloatTensor(t) => t.to_tensor().into(),
-            Input::IntTensor(t) => t.to_tensor().into(),
+            Input::Int32Tensor(t) => t.to_tensor().into(),
         }
     }
 
     fn layout(&self) -> &DynLayout {
         match self {
             Input::FloatTensor(t) => t.layout(),
-            Input::IntTensor(t) => t.layout(),
+            Input::Int32Tensor(t) => t.layout(),
         }
     }
 }
@@ -252,7 +252,7 @@ impl<'a> TryFrom<Input<'a>> for TensorView<'a, i32> {
 
     fn try_from(input: Input<'a>) -> Result<TensorView<'a, i32>, Self::Error> {
         match input {
-            Input::IntTensor(t) => Ok(t),
+            Input::Int32Tensor(t) => Ok(t),
             _ => Err(OpError::IncorrectInputType),
         }
     }
@@ -305,13 +305,13 @@ macro_rules! impl_input_conversions {
 }
 
 impl_input_conversions!(FloatTensor, f32);
-impl_input_conversions!(IntTensor, i32);
+impl_input_conversions!(Int32Tensor, i32);
 
 impl<'a> From<&'a Output> for Input<'a> {
     fn from(output: &'a Output) -> Input {
         match output {
             Output::FloatTensor(t) => Input::FloatTensor(t.view()),
-            Output::IntTensor(t) => Input::IntTensor(t.view()),
+            Output::Int32Tensor(t) => Input::Int32Tensor(t.view()),
         }
     }
 }
@@ -321,14 +321,14 @@ impl<'a> From<&'a Output> for Input<'a> {
 #[derive(Debug, Clone, PartialEq)]
 pub enum Output {
     FloatTensor(Tensor<f32>),
-    IntTensor(Tensor<i32>),
+    Int32Tensor(Tensor<i32>),
 }
 
 impl Output {
     pub fn as_input(&self) -> Input {
         match self {
             Self::FloatTensor(ft) => Input::FloatTensor(ft.view()),
-            Self::IntTensor(it) => Input::IntTensor(it.view()),
+            Self::Int32Tensor(it) => Input::Int32Tensor(it.view()),
         }
     }
 
@@ -336,12 +336,12 @@ impl Output {
     pub(crate) fn add_to_pool(self, pool: &TensorPool) {
         match self {
             Self::FloatTensor(t) => t.extract_buffer().map(|buf| pool.add(buf)),
-            Self::IntTensor(t) => t.extract_buffer().map(|buf| pool.add(buf)),
+            Self::Int32Tensor(t) => t.extract_buffer().map(|buf| pool.add(buf)),
         };
     }
 
     pub fn into_int(self) -> Option<Tensor<i32>> {
-        if let Output::IntTensor(t) = self {
+        if let Output::Int32Tensor(t) = self {
             Some(t)
         } else {
             None
@@ -349,7 +349,7 @@ impl Output {
     }
 
     pub fn as_int_ref(&self) -> Option<&Tensor<i32>> {
-        if let Output::IntTensor(t) = self {
+        if let Output::Int32Tensor(t) = self {
             Some(t)
         } else {
             None
@@ -374,7 +374,7 @@ impl Output {
 
     fn layout(&self) -> &DynLayout {
         match self {
-            Output::IntTensor(t) => t.layout(),
+            Output::Int32Tensor(t) => t.layout(),
             Output::FloatTensor(t) => t.layout(),
         }
     }
@@ -478,7 +478,7 @@ macro_rules! impl_output_conversions {
 }
 
 impl_output_conversions!(FloatTensor, f32);
-impl_output_conversions!(IntTensor, i32);
+impl_output_conversions!(Int32Tensor, i32);
 
 /// A value that is either a tensor view ([`Input`]) or an owned tensor
 /// ([`Output`]). The names originate from the usage of these types as model
@@ -1160,7 +1160,7 @@ mod tests {
     fn test_input_from_tensor() {
         let tensor = NdTensor::<i32, 3>::zeros([1, 2, 3]);
         let input: Input = tensor.view().into();
-        assert!(matches!(input, Input::IntTensor(_)));
+        assert!(matches!(input, Input::Int32Tensor(_)));
         assert_eq!(input.shape(), &[1, 2, 3]);
 
         let tensor = NdTensor::<f32, 2>::zeros([5, 5]);

--- a/src/ops/pad.rs
+++ b/src/ops/pad.rs
@@ -197,6 +197,7 @@ impl Operator for Pad {
                 let const_val = inputs.get_as_scalar::<f32>(2)?.unwrap_or(0.);
                 pad(pool, t, &pads, self.mode, const_val).into_op_result()
             }
+            _ => Err(OpError::UnsupportedType),
         }
     }
 }

--- a/src/ops/pad.rs
+++ b/src/ops/pad.rs
@@ -189,7 +189,7 @@ impl Operator for Pad {
         }
 
         match input {
-            Input::IntTensor(t) => {
+            Input::Int32Tensor(t) => {
                 let const_val = inputs.get_as_scalar::<i32>(2)?.unwrap_or(0);
                 pad(pool, t, &pads, self.mode, const_val).into_op_result()
             }

--- a/src/ops/reduce.rs
+++ b/src/ops/reduce.rs
@@ -74,6 +74,7 @@ macro_rules! dispatch_reduce_op {
                 $keep_dims,
             )
             .into_op_result(),
+            _ => Err(OpError::UnsupportedType),
         }
     };
 }
@@ -88,6 +89,7 @@ macro_rules! dispatch_single_axis_reduce_op {
             Input::Int32Tensor(input) => {
                 $reduce_op($pool, input, $axis, $keep_dims).into_op_result()
             }
+            _ => Err(OpError::UnsupportedType),
         }
     };
 }
@@ -197,6 +199,7 @@ impl Operator for CumSum {
         match input {
             Input::Int32Tensor(input) => cum_sum(pool, input, axis as isize).into_op_result(),
             Input::FloatTensor(input) => cum_sum(pool, input, axis as isize).into_op_result(),
+            _ => Err(OpError::UnsupportedType),
         }
     }
 }
@@ -238,6 +241,7 @@ impl Operator for NonZero {
         match input {
             Input::Int32Tensor(input) => nonzero(pool, input).into_op_result(),
             Input::FloatTensor(input) => nonzero(pool, input).into_op_result(),
+            _ => Err(OpError::UnsupportedType),
         }
     }
 }
@@ -815,6 +819,7 @@ impl Operator for TopK {
                     topk(pool, values, k, self.axis, self.largest, self.sorted)?;
                 Ok([values.into(), indices.into()].into_iter().collect())
             }
+            _ => Err(OpError::UnsupportedType),
         }
     }
 }

--- a/src/ops/reduce.rs
+++ b/src/ops/reduce.rs
@@ -67,7 +67,7 @@ macro_rules! dispatch_reduce_op {
                 $keep_dims,
             )
             .into_op_result(),
-            Input::IntTensor(input) => $reduce_op(
+            Input::Int32Tensor(input) => $reduce_op(
                 $pool,
                 input,
                 $axes.as_ref().map(|axis| &axis[..]),
@@ -85,7 +85,9 @@ macro_rules! dispatch_single_axis_reduce_op {
             Input::FloatTensor(input) => {
                 $reduce_op($pool, input, $axis, $keep_dims).into_op_result()
             }
-            Input::IntTensor(input) => $reduce_op($pool, input, $axis, $keep_dims).into_op_result(),
+            Input::Int32Tensor(input) => {
+                $reduce_op($pool, input, $axis, $keep_dims).into_op_result()
+            }
         }
     };
 }
@@ -193,7 +195,7 @@ impl Operator for CumSum {
         let input = inputs.require(0)?;
         let axis: i32 = inputs.require_as_scalar(1)?;
         match input {
-            Input::IntTensor(input) => cum_sum(pool, input, axis as isize).into_op_result(),
+            Input::Int32Tensor(input) => cum_sum(pool, input, axis as isize).into_op_result(),
             Input::FloatTensor(input) => cum_sum(pool, input, axis as isize).into_op_result(),
         }
     }
@@ -234,7 +236,7 @@ impl Operator for NonZero {
     fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let input = inputs.require(0)?;
         match input {
-            Input::IntTensor(input) => nonzero(pool, input).into_op_result(),
+            Input::Int32Tensor(input) => nonzero(pool, input).into_op_result(),
             Input::FloatTensor(input) => nonzero(pool, input).into_op_result(),
         }
     }
@@ -808,7 +810,7 @@ impl Operator for TopK {
                     topk(pool, values, k, self.axis, self.largest, self.sorted)?;
                 Ok([values.into(), indices.into()].into_iter().collect())
             }
-            Input::IntTensor(values) => {
+            Input::Int32Tensor(values) => {
                 let (values, indices) =
                     topk(pool, values, k, self.axis, self.largest, self.sorted)?;
                 Ok([values.into(), indices.into()].into_iter().collect())

--- a/src/ops/slice.rs
+++ b/src/ops/slice.rs
@@ -111,7 +111,7 @@ impl Operator for Slice {
             Input::FloatTensor(input) => {
                 slice(pool, input, &starts, &ends, axes.as_ref(), steps.as_ref()).map(|t| t.into())
             }
-            Input::IntTensor(input) => {
+            Input::Int32Tensor(input) => {
                 slice(pool, input, &starts, &ends, axes.as_ref(), steps.as_ref()).map(|t| t.into())
             }
         };
@@ -161,7 +161,7 @@ impl Operator for Slice {
         }
 
         match input {
-            Output::IntTensor(mut output) => {
+            Output::Int32Tensor(mut output) => {
                 slice_in_place(&mut output, &starts, &ends, axes.as_ref())?;
                 Ok(output.into())
             }

--- a/src/ops/slice.rs
+++ b/src/ops/slice.rs
@@ -114,6 +114,7 @@ impl Operator for Slice {
             Input::Int32Tensor(input) => {
                 slice(pool, input, &starts, &ends, axes.as_ref(), steps.as_ref()).map(|t| t.into())
             }
+            _ => Err(OpError::UnsupportedType),
         };
         result.into_op_result()
     }
@@ -169,6 +170,7 @@ impl Operator for Slice {
                 slice_in_place(&mut output, &starts, &ends, axes.as_ref())?;
                 Ok(output.into())
             }
+            _ => Err(OpError::UnsupportedType),
         }
     }
 }

--- a/src/ops/trilu.rs
+++ b/src/ops/trilu.rs
@@ -49,7 +49,7 @@ impl Operator for Trilu {
 
         match input {
             Input::FloatTensor(input) => trilu(pool, input, k, self.upper).into_op_result(),
-            Input::IntTensor(input) => trilu(pool, input, k, self.upper).into_op_result(),
+            Input::Int32Tensor(input) => trilu(pool, input, k, self.upper).into_op_result(),
         }
     }
 }

--- a/src/ops/trilu.rs
+++ b/src/ops/trilu.rs
@@ -50,6 +50,7 @@ impl Operator for Trilu {
         match input {
             Input::FloatTensor(input) => trilu(pool, input, k, self.upper).into_op_result(),
             Input::Int32Tensor(input) => trilu(pool, input, k, self.upper).into_op_result(),
+            _ => Err(OpError::UnsupportedType),
         }
     }
 }

--- a/src/ops/unary_elementwise.rs
+++ b/src/ops/unary_elementwise.rs
@@ -82,6 +82,7 @@ macro_rules! unary_numeric_op {
                 match input {
                     Input::FloatTensor(input) => $view_impl(pool, input).into_op_result(),
                     Input::Int32Tensor(input) => $view_impl(pool, input).into_op_result(),
+                    _ => Err(OpError::UnsupportedType),
                 }
             }
 
@@ -104,6 +105,7 @@ macro_rules! unary_numeric_op {
                         $mut_impl(input.view_mut());
                         Ok(input.into())
                     }
+                    _ => Err(OpError::UnsupportedType),
                 }
             }
         }
@@ -352,6 +354,7 @@ impl Operator for Clip {
                 let max = inputs.get_as_scalar(2)?;
                 clip(pool, input, min, max).into_op_result()
             }
+            _ => Err(OpError::UnsupportedType),
         }
     }
 
@@ -378,6 +381,7 @@ impl Operator for Clip {
                 clip_in_place(&mut input, min, max);
                 Ok(input.into())
             }
+            _ => Err(OpError::UnsupportedType),
         }
     }
 }

--- a/src/ops/unary_elementwise.rs
+++ b/src/ops/unary_elementwise.rs
@@ -81,7 +81,7 @@ macro_rules! unary_numeric_op {
                 let input = inputs.require(0)?;
                 match input {
                     Input::FloatTensor(input) => $view_impl(pool, input).into_op_result(),
-                    Input::IntTensor(input) => $view_impl(pool, input).into_op_result(),
+                    Input::Int32Tensor(input) => $view_impl(pool, input).into_op_result(),
                 }
             }
 
@@ -100,7 +100,7 @@ macro_rules! unary_numeric_op {
                         $mut_impl(input.view_mut());
                         Ok(input.into())
                     }
-                    Output::IntTensor(mut input) => {
+                    Output::Int32Tensor(mut input) => {
                         $mut_impl(input.view_mut());
                         Ok(input.into())
                     }
@@ -347,7 +347,7 @@ impl Operator for Clip {
                 let max = inputs.get_as_scalar(2)?;
                 clip(pool, input, min, max).into_op_result()
             }
-            Input::IntTensor(input) => {
+            Input::Int32Tensor(input) => {
                 let min = inputs.get_as_scalar(1)?;
                 let max = inputs.get_as_scalar(2)?;
                 clip(pool, input, min, max).into_op_result()
@@ -372,7 +372,7 @@ impl Operator for Clip {
                 clip_in_place(&mut input, min, max);
                 Ok(input.into())
             }
-            Output::IntTensor(mut input) => {
+            Output::Int32Tensor(mut input) => {
                 let min = other.get_as_scalar(0)?;
                 let max = other.get_as_scalar(1)?;
                 clip_in_place(&mut input, min, max);

--- a/src/ops/variadic_elementwise.rs
+++ b/src/ops/variadic_elementwise.rs
@@ -64,6 +64,7 @@ macro_rules! run_typed_op {
                 let inputs: Vec<TensorView<i32>> = typed_views(&$inputs)?;
                 $op($pool, &inputs).into_op_result()
             }
+            _ => Err(OpError::UnsupportedType),
         }
     }};
 }

--- a/src/ops/variadic_elementwise.rs
+++ b/src/ops/variadic_elementwise.rs
@@ -60,7 +60,7 @@ macro_rules! run_typed_op {
                 let inputs: Vec<TensorView<f32>> = typed_views(&$inputs)?;
                 $op($pool, &inputs).into_op_result()
             }
-            Input::IntTensor(_) => {
+            Input::Int32Tensor(_) => {
                 let inputs: Vec<TensorView<i32>> = typed_views(&$inputs)?;
                 $op($pool, &inputs).into_op_result()
             }

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -373,7 +373,7 @@ impl GraphOptimizer {
                 .map(|name| name.to_string());
             let const_id = match output {
                 Output::FloatTensor(tensor) => graph.add_constant(const_name.as_deref(), tensor),
-                Output::IntTensor(tensor) => graph.add_constant(const_name.as_deref(), tensor),
+                Output::Int32Tensor(tensor) => graph.add_constant(const_name.as_deref(), tensor),
             };
             graph.replace_value(value_node_id, const_id);
         }

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -371,9 +371,13 @@ impl GraphOptimizer {
                 .get_node(value_node_id)
                 .and_then(|n| n.name())
                 .map(|name| name.to_string());
+            let const_name = const_name.as_deref();
+
             let const_id = match output {
-                Output::FloatTensor(tensor) => graph.add_constant(const_name.as_deref(), tensor),
-                Output::Int32Tensor(tensor) => graph.add_constant(const_name.as_deref(), tensor),
+                Output::FloatTensor(tensor) => graph.add_constant(const_name, tensor),
+                Output::Int32Tensor(tensor) => graph.add_constant(const_name, tensor),
+                Output::Int8Tensor(tensor) => graph.add_constant(const_name, tensor),
+                Output::UInt8Tensor(tensor) => graph.add_constant(const_name, tensor),
             };
             graph.replace_value(value_node_id, const_id);
         }
@@ -683,7 +687,7 @@ mod tests {
                 _ => None,
             })
             .unwrap();
-        let Constant::Int(const_int) = replaced_node else {
+        let Constant::Int32(const_int) = replaced_node else {
             return Err("constant not an int".into());
         };
         assert_eq!(const_int.view(), Tensor::from([5, 7, 9]));

--- a/src/schema.fbs
+++ b/src/schema.fbs
@@ -475,14 +475,14 @@ table OperatorNode {
 // Data for constants stored inline in a model.
 union ConstantData {
   FloatData,
-  IntData,
+  Int32Data,
 }
 
 table FloatData {
   data: [float32] (required);
 }
 
-table IntData {
+table Int32Data {
   data: [int32] (required);
 }
 

--- a/src/schema.fbs
+++ b/src/schema.fbs
@@ -476,19 +476,31 @@ table OperatorNode {
 union ConstantData {
   FloatData,
   Int32Data,
+  Int8Data,
+  UInt8Data,
 }
 
 table FloatData {
   data: [float32] (required);
 }
 
+table Int8Data {
+  data: [byte] (required);
+}
+
 table Int32Data {
   data: [int32] (required);
+}
+
+table UInt8Data {
+  data: [ubyte] (required);
 }
 
 enum ConstantDataType: ushort {
   Int32, // Signed 32-bit int
   Float32, // IEEE-754 32-bit float
+  Int8,
+  UInt8,
 }
 
 // Graph node for a constant tensor value, whose data is part of the model.

--- a/src/schema_generated.rs
+++ b/src/schema_generated.rs
@@ -1829,7 +1829,7 @@ pub const ENUM_MAX_CONSTANT_DATA: u8 = 2;
 pub const ENUM_VALUES_CONSTANT_DATA: [ConstantData; 3] = [
     ConstantData::NONE,
     ConstantData::FloatData,
-    ConstantData::IntData,
+    ConstantData::Int32Data,
 ];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -1839,17 +1839,17 @@ pub struct ConstantData(pub u8);
 impl ConstantData {
     pub const NONE: Self = Self(0);
     pub const FloatData: Self = Self(1);
-    pub const IntData: Self = Self(2);
+    pub const Int32Data: Self = Self(2);
 
     pub const ENUM_MIN: u8 = 0;
     pub const ENUM_MAX: u8 = 2;
-    pub const ENUM_VALUES: &'static [Self] = &[Self::NONE, Self::FloatData, Self::IntData];
+    pub const ENUM_VALUES: &'static [Self] = &[Self::NONE, Self::FloatData, Self::Int32Data];
     /// Returns the variant's name or "" if unknown.
     pub fn variant_name(self) -> Option<&'static str> {
         match self {
             Self::NONE => Some("NONE"),
             Self::FloatData => Some("FloatData"),
-            Self::IntData => Some("IntData"),
+            Self::Int32Data => Some("Int32Data"),
             _ => None,
         }
     }
@@ -8824,15 +8824,15 @@ impl core::fmt::Debug for FloatData<'_> {
         ds.finish()
     }
 }
-pub enum IntDataOffset {}
+pub enum Int32DataOffset {}
 #[derive(Copy, Clone, PartialEq)]
 
-pub struct IntData<'a> {
+pub struct Int32Data<'a> {
     pub _tab: flatbuffers::Table<'a>,
 }
 
-impl<'a> flatbuffers::Follow<'a> for IntData<'a> {
-    type Inner = IntData<'a>;
+impl<'a> flatbuffers::Follow<'a> for Int32Data<'a> {
+    type Inner = Int32Data<'a>;
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
@@ -8841,19 +8841,19 @@ impl<'a> flatbuffers::Follow<'a> for IntData<'a> {
     }
 }
 
-impl<'a> IntData<'a> {
+impl<'a> Int32Data<'a> {
     pub const VT_DATA: flatbuffers::VOffsetT = 4;
 
     #[inline]
     pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
-        IntData { _tab: table }
+        Int32Data { _tab: table }
     }
     #[allow(unused_mut)]
     pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
         _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
-        args: &'args IntDataArgs<'args>,
-    ) -> flatbuffers::WIPOffset<IntData<'bldr>> {
-        let mut builder = IntDataBuilder::new(_fbb);
+        args: &'args Int32DataArgs<'args>,
+    ) -> flatbuffers::WIPOffset<Int32Data<'bldr>> {
+        let mut builder = Int32DataBuilder::new(_fbb);
         if let Some(x) = args.data {
             builder.add_data(x);
         }
@@ -8868,7 +8868,7 @@ impl<'a> IntData<'a> {
         unsafe {
             self._tab
                 .get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, i32>>>(
-                    IntData::VT_DATA,
+                    Int32Data::VT_DATA,
                     None,
                 )
                 .unwrap()
@@ -8876,7 +8876,7 @@ impl<'a> IntData<'a> {
     }
 }
 
-impl flatbuffers::Verifiable for IntData<'_> {
+impl flatbuffers::Verifiable for Int32Data<'_> {
     #[inline]
     fn run_verifier(
         v: &mut flatbuffers::Verifier,
@@ -8893,47 +8893,47 @@ impl flatbuffers::Verifiable for IntData<'_> {
         Ok(())
     }
 }
-pub struct IntDataArgs<'a> {
+pub struct Int32DataArgs<'a> {
     pub data: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, i32>>>,
 }
-impl<'a> Default for IntDataArgs<'a> {
+impl<'a> Default for Int32DataArgs<'a> {
     #[inline]
     fn default() -> Self {
-        IntDataArgs {
+        Int32DataArgs {
             data: None, // required field
         }
     }
 }
 
-pub struct IntDataBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+pub struct Int32DataBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
     fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
     start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
-impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> IntDataBuilder<'a, 'b, A> {
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> Int32DataBuilder<'a, 'b, A> {
     #[inline]
     pub fn add_data(&mut self, data: flatbuffers::WIPOffset<flatbuffers::Vector<'b, i32>>) {
         self.fbb_
-            .push_slot_always::<flatbuffers::WIPOffset<_>>(IntData::VT_DATA, data);
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(Int32Data::VT_DATA, data);
     }
     #[inline]
-    pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> IntDataBuilder<'a, 'b, A> {
+    pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> Int32DataBuilder<'a, 'b, A> {
         let start = _fbb.start_table();
-        IntDataBuilder {
+        Int32DataBuilder {
             fbb_: _fbb,
             start_: start,
         }
     }
     #[inline]
-    pub fn finish(self) -> flatbuffers::WIPOffset<IntData<'a>> {
+    pub fn finish(self) -> flatbuffers::WIPOffset<Int32Data<'a>> {
         let o = self.fbb_.end_table(self.start_);
-        self.fbb_.required(o, IntData::VT_DATA, "data");
+        self.fbb_.required(o, Int32Data::VT_DATA, "data");
         flatbuffers::WIPOffset::new(o.value())
     }
 }
 
-impl core::fmt::Debug for IntData<'_> {
+impl core::fmt::Debug for Int32Data<'_> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        let mut ds = f.debug_struct("IntData");
+        let mut ds = f.debug_struct("Int32Data");
         ds.field("data", &self.data());
         ds.finish()
     }
@@ -9060,13 +9060,13 @@ impl<'a> ConstantNode<'a> {
 
     #[inline]
     #[allow(non_snake_case)]
-    pub fn data_as_int_data(&self) -> Option<IntData<'a>> {
-        if self.data_type() == ConstantData::IntData {
+    pub fn data_as_int_32_data(&self) -> Option<Int32Data<'a>> {
+        if self.data_type() == ConstantData::Int32Data {
             self.data().map(|t| {
                 // Safety:
                 // Created from a valid Table for this object
                 // Which contains a valid union in this slot
-                unsafe { IntData::init_from_table(t) }
+                unsafe { Int32Data::init_from_table(t) }
             })
         } else {
             None
@@ -9099,9 +9099,9 @@ impl flatbuffers::Verifiable for ConstantNode<'_> {
                             "ConstantData::FloatData",
                             pos,
                         ),
-                    ConstantData::IntData => v
-                        .verify_union_variant::<flatbuffers::ForwardsUOffset<IntData>>(
-                            "ConstantData::IntData",
+                    ConstantData::Int32Data => v
+                        .verify_union_variant::<flatbuffers::ForwardsUOffset<Int32Data>>(
+                            "ConstantData::Int32Data",
                             pos,
                         ),
                     _ => Ok(()),
@@ -9200,8 +9200,8 @@ impl core::fmt::Debug for ConstantNode<'_> {
                     )
                 }
             }
-            ConstantData::IntData => {
-                if let Some(x) = self.data_as_int_data() {
+            ConstantData::Int32Data => {
+                if let Some(x) = self.data_as_int_32_data() {
                     ds.field("data", &x)
                 } else {
                     ds.field(

--- a/src/schema_generated.rs
+++ b/src/schema_generated.rs
@@ -1820,16 +1820,18 @@ pub const ENUM_MIN_CONSTANT_DATA: u8 = 0;
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
-pub const ENUM_MAX_CONSTANT_DATA: u8 = 2;
+pub const ENUM_MAX_CONSTANT_DATA: u8 = 4;
 #[deprecated(
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_CONSTANT_DATA: [ConstantData; 3] = [
+pub const ENUM_VALUES_CONSTANT_DATA: [ConstantData; 5] = [
     ConstantData::NONE,
     ConstantData::FloatData,
     ConstantData::Int32Data,
+    ConstantData::Int8Data,
+    ConstantData::UInt8Data,
 ];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -1840,16 +1842,26 @@ impl ConstantData {
     pub const NONE: Self = Self(0);
     pub const FloatData: Self = Self(1);
     pub const Int32Data: Self = Self(2);
+    pub const Int8Data: Self = Self(3);
+    pub const UInt8Data: Self = Self(4);
 
     pub const ENUM_MIN: u8 = 0;
-    pub const ENUM_MAX: u8 = 2;
-    pub const ENUM_VALUES: &'static [Self] = &[Self::NONE, Self::FloatData, Self::Int32Data];
+    pub const ENUM_MAX: u8 = 4;
+    pub const ENUM_VALUES: &'static [Self] = &[
+        Self::NONE,
+        Self::FloatData,
+        Self::Int32Data,
+        Self::Int8Data,
+        Self::UInt8Data,
+    ];
     /// Returns the variant's name or "" if unknown.
     pub fn variant_name(self) -> Option<&'static str> {
         match self {
             Self::NONE => Some("NONE"),
             Self::FloatData => Some("FloatData"),
             Self::Int32Data => Some("Int32Data"),
+            Self::Int8Data => Some("Int8Data"),
+            Self::UInt8Data => Some("UInt8Data"),
             _ => None,
         }
     }
@@ -1917,14 +1929,18 @@ pub const ENUM_MIN_CONSTANT_DATA_TYPE: u16 = 0;
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
-pub const ENUM_MAX_CONSTANT_DATA_TYPE: u16 = 1;
+pub const ENUM_MAX_CONSTANT_DATA_TYPE: u16 = 3;
 #[deprecated(
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_CONSTANT_DATA_TYPE: [ConstantDataType; 2] =
-    [ConstantDataType::Int32, ConstantDataType::Float32];
+pub const ENUM_VALUES_CONSTANT_DATA_TYPE: [ConstantDataType; 4] = [
+    ConstantDataType::Int32,
+    ConstantDataType::Float32,
+    ConstantDataType::Int8,
+    ConstantDataType::UInt8,
+];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
@@ -1933,15 +1949,19 @@ pub struct ConstantDataType(pub u16);
 impl ConstantDataType {
     pub const Int32: Self = Self(0);
     pub const Float32: Self = Self(1);
+    pub const Int8: Self = Self(2);
+    pub const UInt8: Self = Self(3);
 
     pub const ENUM_MIN: u16 = 0;
-    pub const ENUM_MAX: u16 = 1;
-    pub const ENUM_VALUES: &'static [Self] = &[Self::Int32, Self::Float32];
+    pub const ENUM_MAX: u16 = 3;
+    pub const ENUM_VALUES: &'static [Self] = &[Self::Int32, Self::Float32, Self::Int8, Self::UInt8];
     /// Returns the variant's name or "" if unknown.
     pub fn variant_name(self) -> Option<&'static str> {
         match self {
             Self::Int32 => Some("Int32"),
             Self::Float32 => Some("Float32"),
+            Self::Int8 => Some("Int8"),
+            Self::UInt8 => Some("UInt8"),
             _ => None,
         }
     }
@@ -8824,6 +8844,120 @@ impl core::fmt::Debug for FloatData<'_> {
         ds.finish()
     }
 }
+pub enum Int8DataOffset {}
+#[derive(Copy, Clone, PartialEq)]
+
+pub struct Int8Data<'a> {
+    pub _tab: flatbuffers::Table<'a>,
+}
+
+impl<'a> flatbuffers::Follow<'a> for Int8Data<'a> {
+    type Inner = Int8Data<'a>;
+    #[inline]
+    unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self {
+            _tab: flatbuffers::Table::new(buf, loc),
+        }
+    }
+}
+
+impl<'a> Int8Data<'a> {
+    pub const VT_DATA: flatbuffers::VOffsetT = 4;
+
+    #[inline]
+    pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+        Int8Data { _tab: table }
+    }
+    #[allow(unused_mut)]
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
+        args: &'args Int8DataArgs<'args>,
+    ) -> flatbuffers::WIPOffset<Int8Data<'bldr>> {
+        let mut builder = Int8DataBuilder::new(_fbb);
+        if let Some(x) = args.data {
+            builder.add_data(x);
+        }
+        builder.finish()
+    }
+
+    #[inline]
+    pub fn data(&self) -> flatbuffers::Vector<'a, i8> {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab
+                .get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, i8>>>(
+                    Int8Data::VT_DATA,
+                    None,
+                )
+                .unwrap()
+        }
+    }
+}
+
+impl flatbuffers::Verifiable for Int8Data<'_> {
+    #[inline]
+    fn run_verifier(
+        v: &mut flatbuffers::Verifier,
+        pos: usize,
+    ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+        use self::flatbuffers::Verifiable;
+        v.visit_table(pos)?
+            .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, i8>>>(
+                "data",
+                Self::VT_DATA,
+                true,
+            )?
+            .finish();
+        Ok(())
+    }
+}
+pub struct Int8DataArgs<'a> {
+    pub data: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, i8>>>,
+}
+impl<'a> Default for Int8DataArgs<'a> {
+    #[inline]
+    fn default() -> Self {
+        Int8DataArgs {
+            data: None, // required field
+        }
+    }
+}
+
+pub struct Int8DataBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+    fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
+    start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> Int8DataBuilder<'a, 'b, A> {
+    #[inline]
+    pub fn add_data(&mut self, data: flatbuffers::WIPOffset<flatbuffers::Vector<'b, i8>>) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(Int8Data::VT_DATA, data);
+    }
+    #[inline]
+    pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> Int8DataBuilder<'a, 'b, A> {
+        let start = _fbb.start_table();
+        Int8DataBuilder {
+            fbb_: _fbb,
+            start_: start,
+        }
+    }
+    #[inline]
+    pub fn finish(self) -> flatbuffers::WIPOffset<Int8Data<'a>> {
+        let o = self.fbb_.end_table(self.start_);
+        self.fbb_.required(o, Int8Data::VT_DATA, "data");
+        flatbuffers::WIPOffset::new(o.value())
+    }
+}
+
+impl core::fmt::Debug for Int8Data<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut ds = f.debug_struct("Int8Data");
+        ds.field("data", &self.data());
+        ds.finish()
+    }
+}
 pub enum Int32DataOffset {}
 #[derive(Copy, Clone, PartialEq)]
 
@@ -8934,6 +9068,120 @@ impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> Int32DataBuilder<'a, 'b, A> {
 impl core::fmt::Debug for Int32Data<'_> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let mut ds = f.debug_struct("Int32Data");
+        ds.field("data", &self.data());
+        ds.finish()
+    }
+}
+pub enum UInt8DataOffset {}
+#[derive(Copy, Clone, PartialEq)]
+
+pub struct UInt8Data<'a> {
+    pub _tab: flatbuffers::Table<'a>,
+}
+
+impl<'a> flatbuffers::Follow<'a> for UInt8Data<'a> {
+    type Inner = UInt8Data<'a>;
+    #[inline]
+    unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self {
+            _tab: flatbuffers::Table::new(buf, loc),
+        }
+    }
+}
+
+impl<'a> UInt8Data<'a> {
+    pub const VT_DATA: flatbuffers::VOffsetT = 4;
+
+    #[inline]
+    pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+        UInt8Data { _tab: table }
+    }
+    #[allow(unused_mut)]
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
+        args: &'args UInt8DataArgs<'args>,
+    ) -> flatbuffers::WIPOffset<UInt8Data<'bldr>> {
+        let mut builder = UInt8DataBuilder::new(_fbb);
+        if let Some(x) = args.data {
+            builder.add_data(x);
+        }
+        builder.finish()
+    }
+
+    #[inline]
+    pub fn data(&self) -> flatbuffers::Vector<'a, u8> {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab
+                .get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u8>>>(
+                    UInt8Data::VT_DATA,
+                    None,
+                )
+                .unwrap()
+        }
+    }
+}
+
+impl flatbuffers::Verifiable for UInt8Data<'_> {
+    #[inline]
+    fn run_verifier(
+        v: &mut flatbuffers::Verifier,
+        pos: usize,
+    ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+        use self::flatbuffers::Verifiable;
+        v.visit_table(pos)?
+            .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, u8>>>(
+                "data",
+                Self::VT_DATA,
+                true,
+            )?
+            .finish();
+        Ok(())
+    }
+}
+pub struct UInt8DataArgs<'a> {
+    pub data: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u8>>>,
+}
+impl<'a> Default for UInt8DataArgs<'a> {
+    #[inline]
+    fn default() -> Self {
+        UInt8DataArgs {
+            data: None, // required field
+        }
+    }
+}
+
+pub struct UInt8DataBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+    fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
+    start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> UInt8DataBuilder<'a, 'b, A> {
+    #[inline]
+    pub fn add_data(&mut self, data: flatbuffers::WIPOffset<flatbuffers::Vector<'b, u8>>) {
+        self.fbb_
+            .push_slot_always::<flatbuffers::WIPOffset<_>>(UInt8Data::VT_DATA, data);
+    }
+    #[inline]
+    pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> UInt8DataBuilder<'a, 'b, A> {
+        let start = _fbb.start_table();
+        UInt8DataBuilder {
+            fbb_: _fbb,
+            start_: start,
+        }
+    }
+    #[inline]
+    pub fn finish(self) -> flatbuffers::WIPOffset<UInt8Data<'a>> {
+        let o = self.fbb_.end_table(self.start_);
+        self.fbb_.required(o, UInt8Data::VT_DATA, "data");
+        flatbuffers::WIPOffset::new(o.value())
+    }
+}
+
+impl core::fmt::Debug for UInt8Data<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut ds = f.debug_struct("UInt8Data");
         ds.field("data", &self.data());
         ds.finish()
     }
@@ -9072,6 +9320,36 @@ impl<'a> ConstantNode<'a> {
             None
         }
     }
+
+    #[inline]
+    #[allow(non_snake_case)]
+    pub fn data_as_int_8_data(&self) -> Option<Int8Data<'a>> {
+        if self.data_type() == ConstantData::Int8Data {
+            self.data().map(|t| {
+                // Safety:
+                // Created from a valid Table for this object
+                // Which contains a valid union in this slot
+                unsafe { Int8Data::init_from_table(t) }
+            })
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    #[allow(non_snake_case)]
+    pub fn data_as_uint_8_data(&self) -> Option<UInt8Data<'a>> {
+        if self.data_type() == ConstantData::UInt8Data {
+            self.data().map(|t| {
+                // Safety:
+                // Created from a valid Table for this object
+                // Which contains a valid union in this slot
+                unsafe { UInt8Data::init_from_table(t) }
+            })
+        } else {
+            None
+        }
+    }
 }
 
 impl flatbuffers::Verifiable for ConstantNode<'_> {
@@ -9102,6 +9380,16 @@ impl flatbuffers::Verifiable for ConstantNode<'_> {
                     ConstantData::Int32Data => v
                         .verify_union_variant::<flatbuffers::ForwardsUOffset<Int32Data>>(
                             "ConstantData::Int32Data",
+                            pos,
+                        ),
+                    ConstantData::Int8Data => v
+                        .verify_union_variant::<flatbuffers::ForwardsUOffset<Int8Data>>(
+                            "ConstantData::Int8Data",
+                            pos,
+                        ),
+                    ConstantData::UInt8Data => v
+                        .verify_union_variant::<flatbuffers::ForwardsUOffset<UInt8Data>>(
+                            "ConstantData::UInt8Data",
                             pos,
                         ),
                     _ => Ok(()),
@@ -9202,6 +9490,26 @@ impl core::fmt::Debug for ConstantNode<'_> {
             }
             ConstantData::Int32Data => {
                 if let Some(x) = self.data_as_int_32_data() {
+                    ds.field("data", &x)
+                } else {
+                    ds.field(
+                        "data",
+                        &"InvalidFlatbuffer: Union discriminant does not match value.",
+                    )
+                }
+            }
+            ConstantData::Int8Data => {
+                if let Some(x) = self.data_as_int_8_data() {
+                    ds.field("data", &x)
+                } else {
+                    ds.field(
+                        "data",
+                        &"InvalidFlatbuffer: Union discriminant does not match value.",
+                    )
+                }
+            }
+            ConstantData::UInt8Data => {
+                if let Some(x) = self.data_as_uint_8_data() {
                     ds.field("data", &x)
                 } else {
                     ds.field(

--- a/src/wasm_api.rs
+++ b/src/wasm_api.rs
@@ -164,7 +164,7 @@ impl Tensor {
     #[wasm_bindgen(js_name = intData)]
     pub fn int_data(&self) -> Option<Vec<i32>> {
         match *self.data {
-            Output::IntTensor(ref t) => Some(t.to_vec()),
+            Output::Int32Tensor(ref t) => Some(t.to_vec()),
             _ => None,
         }
     }


### PR DESCRIPTION
This is the first step in adding 8-bit quantization support. It adds support for u8 and i8 tensors in:

- RTen model files
- Operator inputs
- Operator outputs

Int8 support has not been added to most operators yet. Done naively this would require two instantiations of the code for u8 and i8 tensors even though many operators could use the same code for both. This could be addressed with https://github.com/robertknight/rten/issues/244. For the moment I am adding support for i8 and u8 tensors to operators on an as-needed basis.