### PR TITLE
Implement QuantizeLinear, DequantizeLinear, DynamicQuantizeLinear ops

### DIFF
--- a/rten-convert/rten_convert/converter.py
+++ b/rten-convert/rten_convert/converter.py
@@ -719,6 +719,10 @@ def op_node_from_onnx_operator(
             op_reader.check_attr("exclusive", "int", 0)
             op_reader.check_attr("reverse", "int", 0)
 
+        case "DequantizeLinear":
+            attrs = sg.DequantizeLinearAttrsT()
+            attrs.axis = op_reader.get_attr("axis", "int", 1)
+
         case "Einsum":
             attrs = sg.EinsumAttrsT()
             attrs.equation = op_reader.require_attr("equation", "string")

--- a/rten-convert/rten_convert/converter.py
+++ b/rten-convert/rten_convert/converter.py
@@ -559,6 +559,30 @@ def read_dilations(
     return dilations
 
 
+def convert_data_type(onnx_dtype: int) -> int:
+    """
+    Convert a data type enum value from ONNX to RTen.
+
+    :param onnx_dtype: Data type from `TensorProto.DataType`.
+    :return: Value from `sg.DataType`
+    """
+    match onnx_dtype:
+        case TensorProto.DataType.FLOAT:  # type:ignore[attr-defined]
+            return sg.DataType.Float
+        case (
+            TensorProto.DataType.BOOL  # type:ignore[attr-defined]
+            | TensorProto.DataType.INT32  # type:ignore[attr-defined]
+            | TensorProto.DataType.INT64  # type:ignore[attr-defined]
+        ):
+            return sg.DataType.Int32
+        case TensorProto.DataType.INT8:  # type:ignore[attr-defined]
+            return sg.DataType.Int8
+        case TensorProto.DataType.UINT8:  # type:ignore[attr-defined]
+            return sg.DataType.UInt8
+        case _:
+            raise Exception(f"Unsupported data type {onnx_dtype}")
+
+
 def op_node_from_onnx_operator(
     onnx_op: onnx.OperatorProto,
     node_index_from_name: dict[str, int],
@@ -645,17 +669,7 @@ def op_node_from_onnx_operator(
         case "Cast":
             attrs = sg.CastAttrsT()
             to = op_reader.get_attr("to", "int", TensorProto.DataType.FLOAT)  # type:ignore[attr-defined]
-            match to:
-                case TensorProto.DataType.FLOAT:  # type:ignore[attr-defined]
-                    attrs.to = sg.DataType.Float
-                case (
-                    TensorProto.DataType.BOOL  # type:ignore[attr-defined]
-                    | TensorProto.DataType.INT32  # type:ignore[attr-defined]
-                    | TensorProto.DataType.INT64  # type:ignore[attr-defined]
-                ):
-                    attrs.to = sg.DataType.Int32
-                case _:
-                    raise Exception(f"Unsupported target type for cast {to}")
+            attrs.to = convert_data_type(to)
 
         case "Clip":
             op_reader.generate_input_from_attr(1, "min", "float")
@@ -914,6 +928,14 @@ def op_node_from_onnx_operator(
         case "Pad":
             attrs = sg.PadAttrsT()
             attrs.mode = op_reader.get_enum_attr("mode", sg.PadMode, "constant")
+
+        case "QuantizeLinear":
+            attrs = sg.QuantizeLinearAttrsT()
+            attrs.axis = op_reader.get_attr("axis", "int", 1)
+
+            output_dtype = op_reader.get_attr("output_dtype", "int", None)
+            if output_dtype is not None:
+                attrs.outputDtype = convert_data_type(output_dtype)
 
         case "ScatterElements":
             attrs = sg.ScatterElementsAttrsT()

--- a/rten-convert/rten_convert/schema_generated.py
+++ b/rten-convert/rten_convert/schema_generated.py
@@ -114,6 +114,7 @@ class OperatorType(object):
     If = 104
     DequantizeLinear = 105
     QuantizeLinear = 106
+    DynamicQuantizeLinear = 107
 
 
 class RNNDirection(object):

--- a/rten-convert/rten_convert/schema_generated.py
+++ b/rten-convert/rten_convert/schema_generated.py
@@ -112,6 +112,7 @@ class OperatorType(object):
     Gelu = 102
     Einsum = 103
     If = 104
+    DequantizeLinear = 105
 
 
 class RNNDirection(object):
@@ -190,6 +191,7 @@ class OperatorAttrs(object):
     EinsumAttrs = 38
     IfAttrs = 39
     PadAttrs = 40
+    DequantizeLinearAttrs = 41
 
 def OperatorAttrsCreator(unionType, table):
     from flatbuffers.table import Table
@@ -275,6 +277,8 @@ def OperatorAttrsCreator(unionType, table):
         return IfAttrsT.InitFromBuf(table.Bytes, table.Pos)
     if unionType == OperatorAttrs().PadAttrs:
         return PadAttrsT.InitFromBuf(table.Bytes, table.Pos)
+    if unionType == OperatorAttrs().DequantizeLinearAttrs:
+        return DequantizeLinearAttrsT.InitFromBuf(table.Bytes, table.Pos)
     return None
 
 
@@ -1610,6 +1614,83 @@ class ConvTransposeAttrsT(object):
             ConvTransposeAttrsAddPads(builder, pads)
         convTransposeAttrs = ConvTransposeAttrsEnd(builder)
         return convTransposeAttrs
+
+
+class DequantizeLinearAttrs(object):
+    __slots__ = ['_tab']
+
+    @classmethod
+    def GetRootAs(cls, buf, offset=0):
+        n = flatbuffers.encode.Get(flatbuffers.packer.uoffset, buf, offset)
+        x = DequantizeLinearAttrs()
+        x.Init(buf, n + offset)
+        return x
+
+    @classmethod
+    def GetRootAsDequantizeLinearAttrs(cls, buf, offset=0):
+        """This method is deprecated. Please switch to GetRootAs."""
+        return cls.GetRootAs(buf, offset)
+    @classmethod
+    def DequantizeLinearAttrsBufferHasIdentifier(cls, buf, offset, size_prefixed=False):
+        return flatbuffers.util.BufferHasIdentifier(buf, offset, b"\x52\x54\x45\x4E", size_prefixed=size_prefixed)
+
+    # DequantizeLinearAttrs
+    def Init(self, buf, pos):
+        self._tab = flatbuffers.table.Table(buf, pos)
+
+    # DequantizeLinearAttrs
+    def Axis(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
+        if o != 0:
+            return self._tab.Get(flatbuffers.number_types.Int32Flags, o + self._tab.Pos)
+        return 0
+
+def DequantizeLinearAttrsStart(builder):
+    builder.StartObject(1)
+
+def DequantizeLinearAttrsAddAxis(builder, axis):
+    builder.PrependInt32Slot(0, axis, 0)
+
+def DequantizeLinearAttrsEnd(builder):
+    return builder.EndObject()
+
+
+
+class DequantizeLinearAttrsT(object):
+
+    # DequantizeLinearAttrsT
+    def __init__(self):
+        self.axis = 0  # type: int
+
+    @classmethod
+    def InitFromBuf(cls, buf, pos):
+        dequantizeLinearAttrs = DequantizeLinearAttrs()
+        dequantizeLinearAttrs.Init(buf, pos)
+        return cls.InitFromObj(dequantizeLinearAttrs)
+
+    @classmethod
+    def InitFromPackedBuf(cls, buf, pos=0):
+        n = flatbuffers.encode.Get(flatbuffers.packer.uoffset, buf, pos)
+        return cls.InitFromBuf(buf, pos+n)
+
+    @classmethod
+    def InitFromObj(cls, dequantizeLinearAttrs):
+        x = DequantizeLinearAttrsT()
+        x._UnPack(dequantizeLinearAttrs)
+        return x
+
+    # DequantizeLinearAttrsT
+    def _UnPack(self, dequantizeLinearAttrs):
+        if dequantizeLinearAttrs is None:
+            return
+        self.axis = dequantizeLinearAttrs.Axis()
+
+    # DequantizeLinearAttrsT
+    def Pack(self, builder):
+        DequantizeLinearAttrsStart(builder)
+        DequantizeLinearAttrsAddAxis(builder, self.axis)
+        dequantizeLinearAttrs = DequantizeLinearAttrsEnd(builder)
+        return dequantizeLinearAttrs
 
 
 class EinsumAttrs(object):
@@ -4874,7 +4955,7 @@ class OperatorNodeT(object):
     def __init__(self):
         self.type = 0  # type: int
         self.attrsType = 0  # type: int
-        self.attrs = None  # type: Union[None, ArgMaxAttrsT, AveragePoolAttrsT, BatchNormalizationAttrsT, CastAttrsT, ConcatAttrsT, ConstantOfShapeAttrsT, ConvAttrsT, ConvTransposeAttrsT, FlattenAttrsT, GatherAttrsT, GemmAttrsT, GRUAttrsT, LeakyReluAttrsT, LSTMAttrsT, MaxPoolAttrsT, ReduceMeanAttrsT, ReshapeAttrsT, ResizeAttrsT, SplitAttrsT, SoftmaxAttrsT, TransposeAttrsT, ModAttrsT, ScatterElementsAttrsT, OneHotAttrsT, TopKAttrsT, HardSigmoidAttrsT, TriluAttrsT, ScatterNDAttrsT, NonMaxSuppressionAttrsT, LayerNormalizationAttrsT, RandomUniformAttrsT, EluAttrsT, RandomUniformLikeAttrsT, RandomNormalAttrsT, RandomNormalLikeAttrsT, GatherNDAttrsT, GeluAttrsT, EinsumAttrsT, IfAttrsT, PadAttrsT]
+        self.attrs = None  # type: Union[None, ArgMaxAttrsT, AveragePoolAttrsT, BatchNormalizationAttrsT, CastAttrsT, ConcatAttrsT, ConstantOfShapeAttrsT, ConvAttrsT, ConvTransposeAttrsT, FlattenAttrsT, GatherAttrsT, GemmAttrsT, GRUAttrsT, LeakyReluAttrsT, LSTMAttrsT, MaxPoolAttrsT, ReduceMeanAttrsT, ReshapeAttrsT, ResizeAttrsT, SplitAttrsT, SoftmaxAttrsT, TransposeAttrsT, ModAttrsT, ScatterElementsAttrsT, OneHotAttrsT, TopKAttrsT, HardSigmoidAttrsT, TriluAttrsT, ScatterNDAttrsT, NonMaxSuppressionAttrsT, LayerNormalizationAttrsT, RandomUniformAttrsT, EluAttrsT, RandomUniformLikeAttrsT, RandomNormalAttrsT, RandomNormalLikeAttrsT, GatherNDAttrsT, GeluAttrsT, EinsumAttrsT, IfAttrsT, PadAttrsT, DequantizeLinearAttrsT]
         self.inputs = None  # type: List[int]
         self.outputs = None  # type: List[int]
 

--- a/rten-convert/rten_convert/schema_generated.py
+++ b/rten-convert/rten_convert/schema_generated.py
@@ -113,6 +113,7 @@ class OperatorType(object):
     Einsum = 103
     If = 104
     DequantizeLinear = 105
+    QuantizeLinear = 106
 
 
 class RNNDirection(object):
@@ -129,6 +130,8 @@ class AutoPad(object):
 class DataType(object):
     Int32 = 0
     Float = 1
+    Int8 = 2
+    UInt8 = 3
 
 
 class CoordTransformMode(object):
@@ -192,6 +195,7 @@ class OperatorAttrs(object):
     IfAttrs = 39
     PadAttrs = 40
     DequantizeLinearAttrs = 41
+    QuantizeLinearAttrs = 42
 
 def OperatorAttrsCreator(unionType, table):
     from flatbuffers.table import Table
@@ -279,6 +283,8 @@ def OperatorAttrsCreator(unionType, table):
         return PadAttrsT.InitFromBuf(table.Bytes, table.Pos)
     if unionType == OperatorAttrs().DequantizeLinearAttrs:
         return DequantizeLinearAttrsT.InitFromBuf(table.Bytes, table.Pos)
+    if unionType == OperatorAttrs().QuantizeLinearAttrs:
+        return QuantizeLinearAttrsT.InitFromBuf(table.Bytes, table.Pos)
     return None
 
 
@@ -3362,6 +3368,96 @@ class PadAttrsT(object):
         return padAttrs
 
 
+class QuantizeLinearAttrs(object):
+    __slots__ = ['_tab']
+
+    @classmethod
+    def GetRootAs(cls, buf, offset=0):
+        n = flatbuffers.encode.Get(flatbuffers.packer.uoffset, buf, offset)
+        x = QuantizeLinearAttrs()
+        x.Init(buf, n + offset)
+        return x
+
+    @classmethod
+    def GetRootAsQuantizeLinearAttrs(cls, buf, offset=0):
+        """This method is deprecated. Please switch to GetRootAs."""
+        return cls.GetRootAs(buf, offset)
+    @classmethod
+    def QuantizeLinearAttrsBufferHasIdentifier(cls, buf, offset, size_prefixed=False):
+        return flatbuffers.util.BufferHasIdentifier(buf, offset, b"\x52\x54\x45\x4E", size_prefixed=size_prefixed)
+
+    # QuantizeLinearAttrs
+    def Init(self, buf, pos):
+        self._tab = flatbuffers.table.Table(buf, pos)
+
+    # QuantizeLinearAttrs
+    def Axis(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
+        if o != 0:
+            return self._tab.Get(flatbuffers.number_types.Int32Flags, o + self._tab.Pos)
+        return 0
+
+    # QuantizeLinearAttrs
+    def OutputDtype(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(6))
+        if o != 0:
+            return self._tab.Get(flatbuffers.number_types.Uint8Flags, o + self._tab.Pos)
+        return None
+
+def QuantizeLinearAttrsStart(builder):
+    builder.StartObject(2)
+
+def QuantizeLinearAttrsAddAxis(builder, axis):
+    builder.PrependInt32Slot(0, axis, 0)
+
+def QuantizeLinearAttrsAddOutputDtype(builder, outputDtype):
+    builder.PrependUint8Slot(1, outputDtype, None)
+
+def QuantizeLinearAttrsEnd(builder):
+    return builder.EndObject()
+
+
+
+class QuantizeLinearAttrsT(object):
+
+    # QuantizeLinearAttrsT
+    def __init__(self):
+        self.axis = 0  # type: int
+        self.outputDtype = None  # type: Optional[int]
+
+    @classmethod
+    def InitFromBuf(cls, buf, pos):
+        quantizeLinearAttrs = QuantizeLinearAttrs()
+        quantizeLinearAttrs.Init(buf, pos)
+        return cls.InitFromObj(quantizeLinearAttrs)
+
+    @classmethod
+    def InitFromPackedBuf(cls, buf, pos=0):
+        n = flatbuffers.encode.Get(flatbuffers.packer.uoffset, buf, pos)
+        return cls.InitFromBuf(buf, pos+n)
+
+    @classmethod
+    def InitFromObj(cls, quantizeLinearAttrs):
+        x = QuantizeLinearAttrsT()
+        x._UnPack(quantizeLinearAttrs)
+        return x
+
+    # QuantizeLinearAttrsT
+    def _UnPack(self, quantizeLinearAttrs):
+        if quantizeLinearAttrs is None:
+            return
+        self.axis = quantizeLinearAttrs.Axis()
+        self.outputDtype = quantizeLinearAttrs.OutputDtype()
+
+    # QuantizeLinearAttrsT
+    def Pack(self, builder):
+        QuantizeLinearAttrsStart(builder)
+        QuantizeLinearAttrsAddAxis(builder, self.axis)
+        QuantizeLinearAttrsAddOutputDtype(builder, self.outputDtype)
+        quantizeLinearAttrs = QuantizeLinearAttrsEnd(builder)
+        return quantizeLinearAttrs
+
+
 class RandomNormalAttrs(object):
     __slots__ = ['_tab']
 
@@ -4955,7 +5051,7 @@ class OperatorNodeT(object):
     def __init__(self):
         self.type = 0  # type: int
         self.attrsType = 0  # type: int
-        self.attrs = None  # type: Union[None, ArgMaxAttrsT, AveragePoolAttrsT, BatchNormalizationAttrsT, CastAttrsT, ConcatAttrsT, ConstantOfShapeAttrsT, ConvAttrsT, ConvTransposeAttrsT, FlattenAttrsT, GatherAttrsT, GemmAttrsT, GRUAttrsT, LeakyReluAttrsT, LSTMAttrsT, MaxPoolAttrsT, ReduceMeanAttrsT, ReshapeAttrsT, ResizeAttrsT, SplitAttrsT, SoftmaxAttrsT, TransposeAttrsT, ModAttrsT, ScatterElementsAttrsT, OneHotAttrsT, TopKAttrsT, HardSigmoidAttrsT, TriluAttrsT, ScatterNDAttrsT, NonMaxSuppressionAttrsT, LayerNormalizationAttrsT, RandomUniformAttrsT, EluAttrsT, RandomUniformLikeAttrsT, RandomNormalAttrsT, RandomNormalLikeAttrsT, GatherNDAttrsT, GeluAttrsT, EinsumAttrsT, IfAttrsT, PadAttrsT, DequantizeLinearAttrsT]
+        self.attrs = None  # type: Union[None, ArgMaxAttrsT, AveragePoolAttrsT, BatchNormalizationAttrsT, CastAttrsT, ConcatAttrsT, ConstantOfShapeAttrsT, ConvAttrsT, ConvTransposeAttrsT, FlattenAttrsT, GatherAttrsT, GemmAttrsT, GRUAttrsT, LeakyReluAttrsT, LSTMAttrsT, MaxPoolAttrsT, ReduceMeanAttrsT, ReshapeAttrsT, ResizeAttrsT, SplitAttrsT, SoftmaxAttrsT, TransposeAttrsT, ModAttrsT, ScatterElementsAttrsT, OneHotAttrsT, TopKAttrsT, HardSigmoidAttrsT, TriluAttrsT, ScatterNDAttrsT, NonMaxSuppressionAttrsT, LayerNormalizationAttrsT, RandomUniformAttrsT, EluAttrsT, RandomUniformLikeAttrsT, RandomNormalAttrsT, RandomNormalLikeAttrsT, GatherNDAttrsT, GeluAttrsT, EinsumAttrsT, IfAttrsT, PadAttrsT, DequantizeLinearAttrsT, QuantizeLinearAttrsT]
         self.inputs = None  # type: List[int]
         self.outputs = None  # type: List[int]
 

--- a/rten-tensor/src/lib.rs
+++ b/rten-tensor/src/lib.rs
@@ -106,7 +106,7 @@ pub use layout::{
 pub use slice_range::{to_slice_items, DynSliceItems, IntoSliceItems, SliceItem, SliceRange};
 
 pub use tensor::{
-    AsView, Matrix, MatrixMut, NdTensor, NdTensorView, NdTensorViewMut, Tensor, TensorBase,
+    AsView, Matrix, MatrixMut, NdTensor, NdTensorView, NdTensorViewMut, Scalar, Tensor, TensorBase,
     TensorView, TensorViewMut, WeaklyCheckedView,
 };
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -1269,12 +1269,20 @@ mod tests {
 
         let const_u8_val = Tensor::from([0u8, 1, 2, 3, 4]);
         let const_u8 = graph_builder.add_constant(const_u8_val.view());
+
+        let const_f32_val = const_u8_val.map(|x| *x as f32);
+        let const_f32 = graph_builder.add_constant(const_f32_val.view());
+
         let scale_val = Tensor::from(1.);
         let scale = graph_builder.add_constant(scale_val.view());
         let zero_point_val = Tensor::from(0u8);
         let zero_point = graph_builder.add_constant(zero_point_val.view());
         add_operator!(DequantizeLinear, [const_u8, scale, zero_point], {
             axis: 0,
+        });
+        add_operator!(QuantizeLinear, [const_f32, scale, zero_point], {
+            axis: 0,
+            output_dtype: None,
         });
 
         add_operator!(Div, [input_node, input_node]);

--- a/src/model.rs
+++ b/src/model.rs
@@ -1266,6 +1266,17 @@ mod tests {
             padding: [0, 0, 0, 0].into(),
         });
         add_operator!(Cos, [input_node]);
+
+        let const_u8_val = Tensor::from([0u8, 1, 2, 3, 4]);
+        let const_u8 = graph_builder.add_constant(const_u8_val.view());
+        let scale_val = Tensor::from(1.);
+        let scale = graph_builder.add_constant(scale_val.view());
+        let zero_point_val = Tensor::from(0u8);
+        let zero_point = graph_builder.add_constant(zero_point_val.view());
+        add_operator!(DequantizeLinear, [const_u8, scale, zero_point], {
+            axis: 0,
+        });
+
         add_operator!(Div, [input_node, input_node]);
         add_operator!(Elu, [input_node], { alpha: 1.0 });
         add_operator!(Equal, [input_node, input_node]);

--- a/src/model_builder.rs
+++ b/src/model_builder.rs
@@ -48,6 +48,7 @@ pub enum OpType<'a> {
     Cos,
     DequantizeLinear(DequantizeLinear),
     Div,
+    DynamicQuantizeLinear,
     Einsum(Einsum),
     Elu(Elu),
     Equal,
@@ -503,6 +504,7 @@ impl<'mb, 'a> GraphBuilder<'mb, 'a> {
                 }
             ),
             OpType::Div => op!(Div),
+            OpType::DynamicQuantizeLinear => op!(DynamicQuantizeLinear),
             OpType::Einsum(args) => {
                 let equation = self.builder.create_string(&args.equation);
                 op_with_attrs!(

--- a/src/op_registry.rs
+++ b/src/op_registry.rs
@@ -100,6 +100,7 @@ impl OpRegistry {
         register_op!(ConvTranspose);
         register_op!(Cos);
         register_op!(CumSum);
+        register_op!(DequantizeLinear);
         register_op!(Div);
         register_op!(Einsum);
         register_op!(Elu);
@@ -466,6 +467,7 @@ impl_read_op!(
 );
 impl_read_op!(Cos);
 impl_read_op!(CumSum);
+impl_read_op!(DequantizeLinear, attrs_as_dequantize_linear_attrs, axis);
 impl_read_op!(Div);
 impl_read_op!(Einsum, attrs_as_einsum_attrs, |attrs: sg::EinsumAttrs| {
     Ok(ops::Einsum {

--- a/src/op_registry.rs
+++ b/src/op_registry.rs
@@ -102,6 +102,7 @@ impl OpRegistry {
         register_op!(CumSum);
         register_op!(DequantizeLinear);
         register_op!(Div);
+        register_op!(DynamicQuantizeLinear);
         register_op!(Einsum);
         register_op!(Elu);
         register_op!(Equal);
@@ -476,6 +477,7 @@ impl_read_op!(Cos);
 impl_read_op!(CumSum);
 impl_read_op!(DequantizeLinear, attrs_as_dequantize_linear_attrs, axis);
 impl_read_op!(Div);
+impl_read_op!(DynamicQuantizeLinear);
 impl_read_op!(Einsum, attrs_as_einsum_attrs, |attrs: sg::EinsumAttrs| {
     Ok(ops::Einsum {
         equation: attrs.equation().unwrap_or("").to_string(),

--- a/src/ops/convert.rs
+++ b/src/ops/convert.rs
@@ -15,6 +15,7 @@ fn cast(pool: &TensorPool, input: Input, dtype: DataType) -> Result<Output, OpEr
             Input::Int32Tensor(t) => Ok(t.map_in(pool, |x| *x as f32).into()),
             _ => Err(OpError::UnsupportedType),
         },
+        _ => Err(OpError::UnsupportedValue("Unsupported cast")),
     }
 }
 

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -92,7 +92,7 @@ pub use pad::{pad, Pad, PadMode};
 pub use pooling::{
     average_pool, global_average_pool, max_pool, AveragePool, GlobalAveragePool, MaxPool,
 };
-pub use quantize::{dequantize_linear, DequantizeLinear};
+pub use quantize::{dequantize_linear, quantize_linear, DequantizeLinear, QuantizeLinear};
 
 #[cfg(feature = "random")]
 pub use random::{RandomNormal, RandomNormalLike, RandomUniform, RandomUniformLike};
@@ -171,6 +171,8 @@ impl<S: AsRef<[usize]>> From<S> for Padding {
 pub enum DataType {
     Int32,
     Float,
+    Int8,
+    UInt8,
 }
 
 /// Enum of the different types of tensor view that can be used as a model or

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -92,7 +92,10 @@ pub use pad::{pad, Pad, PadMode};
 pub use pooling::{
     average_pool, global_average_pool, max_pool, AveragePool, GlobalAveragePool, MaxPool,
 };
-pub use quantize::{dequantize_linear, quantize_linear, DequantizeLinear, QuantizeLinear};
+pub use quantize::{
+    dequantize_linear, dynamic_quantize_linear, quantize_linear, DequantizeLinear,
+    DynamicQuantizeLinear, QuantizeLinear,
+};
 
 #[cfg(feature = "random")]
 pub use random::{RandomNormal, RandomNormalLike, RandomUniform, RandomUniformLike};

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -44,6 +44,7 @@ mod non_max_suppression;
 mod norm;
 mod pad;
 mod pooling;
+mod quantize;
 
 #[cfg(feature = "random")]
 mod random;
@@ -91,6 +92,7 @@ pub use pad::{pad, Pad, PadMode};
 pub use pooling::{
     average_pool, global_average_pool, max_pool, AveragePool, GlobalAveragePool, MaxPool,
 };
+pub use quantize::{dequantize_linear, DequantizeLinear};
 
 #[cfg(feature = "random")]
 pub use random::{RandomNormal, RandomNormalLike, RandomUniform, RandomUniformLike};

--- a/src/ops/quantize.rs
+++ b/src/ops/quantize.rs
@@ -1,0 +1,226 @@
+use rten_tensor::prelude::*;
+use rten_tensor::{NdTensor, NdTensorView, Scalar, Tensor, TensorView};
+
+use crate::ops::{resolve_axis, Input, InputList, IntoOpResult, OpError, Operator, OutputList};
+use crate::tensor_pool::TensorPool;
+
+/// Convert a quantized tensor element to a higher precision value.
+pub trait Dequantize<To> {
+    /// Dequantize self according to `(self - zero_point) * scale`.
+    fn dequantize(self, scale: To, zero_point: Self) -> To;
+}
+
+impl Dequantize<f32> for u8 {
+    fn dequantize(self, scale: f32, zero_point: u8) -> f32 {
+        // Promote to i32 to avoid underflow.
+        let x = (self as i32) - zero_point as i32;
+        (x as f32) * scale
+    }
+}
+
+impl Dequantize<f32> for i8 {
+    fn dequantize(self, scale: f32, zero_point: i8) -> f32 {
+        // Promote to i32 to avoid underflow.
+        let x = (self as i32) - zero_point as i32;
+        (x as f32) * scale
+    }
+}
+
+pub fn dequantize_linear<T: Copy + Default + Dequantize<f32> + Scalar>(
+    pool: &TensorPool,
+    input: TensorView<T>,
+    scale: TensorView<f32>,
+    zero_point: Option<TensorView<T>>,
+    axis: isize,
+) -> Result<Tensor<f32>, OpError> {
+    if let Some(zero_point) = zero_point.as_ref() {
+        if zero_point.shape() != scale.shape() {
+            return Err(OpError::InvalidValue(
+                "scale and zero_point must have same shape",
+            ));
+        }
+    }
+
+    match scale.ndim() {
+        0 => {
+            let scale = scale.item().unwrap();
+            let zero_point = zero_point.and_then(|z| z.item()).unwrap();
+
+            Ok(input.map_in(pool, |x| x.dequantize(*scale, *zero_point)))
+        }
+        1 => {
+            let axis = resolve_axis(input.ndim(), axis)?;
+            let scale: NdTensorView<f32, 1> = scale.try_into().unwrap();
+            let zero = NdTensor::from(T::default());
+            let zero_point: NdTensorView<T, 1> = zero_point
+                .map(|zp| {
+                    let zp_vec: NdTensorView<T, 1> = zp.try_into().unwrap();
+                    zp_vec
+                })
+                .unwrap_or(zero.broadcast(scale.shape()));
+
+            let mut output = Tensor::uninit_in(pool, input.shape());
+            output
+                .axis_iter_mut(axis)
+                .zip(input.axis_iter(axis))
+                .zip(scale.iter())
+                .zip(zero_point.iter())
+                .for_each(|(((mut out_slice, in_slice), &scale), &zero_point)| {
+                    for (y, &x) in out_slice.iter_mut().zip(in_slice.iter()) {
+                        y.write(x.dequantize(scale, zero_point));
+                    }
+                });
+
+            // Safety: All elements are initialized
+            Ok(unsafe { output.assume_init() })
+        }
+        _ => Err(OpError::UnsupportedValue(
+            "Blocked dequantization is not supported",
+        )),
+    }
+}
+
+#[derive(Debug)]
+pub struct DequantizeLinear {
+    pub axis: isize,
+}
+
+impl Operator for DequantizeLinear {
+    fn name(&self) -> &str {
+        "DequantizeLinear"
+    }
+
+    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
+        let input = inputs.require(0)?;
+        let scale = inputs.require_as(1)?;
+
+        match input {
+            Input::Int8Tensor(x) => {
+                let zero_point = inputs.get_as(2)?;
+                dequantize_linear(pool, x, scale, zero_point, self.axis).into_op_result()
+            }
+            Input::UInt8Tensor(x) => {
+                let zero_point = inputs.get_as(2)?;
+                dequantize_linear(pool, x, scale, zero_point, self.axis).into_op_result()
+            }
+            _ => Err(OpError::UnsupportedType),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::error::Error;
+
+    use rten_tensor::prelude::*;
+    use rten_tensor::Tensor;
+
+    use super::dequantize_linear;
+    use crate::ops::tests::new_pool;
+    use crate::ops::{OpError, Output};
+
+    #[test]
+    fn test_dequantize_linear() -> Result<(), Box<dyn Error>> {
+        struct Case {
+            axis: isize,
+            input: Output,
+            scale: Tensor<f32>,
+            zero_point: Option<Output>,
+            expected: Result<Tensor<f32>, OpError>,
+        }
+
+        let cases = [
+            // Per-tensor dequantization (u8)
+            Case {
+                axis: 1,
+                input: Tensor::from([20u8, 30, 40]).into(),
+                scale: Tensor::from(0.5),
+                zero_point: Some(Tensor::from(10u8).into()),
+                expected: Ok(Tensor::from([5., 10., 15.])),
+            },
+            // Per-tensor dequantization (i8)
+            Case {
+                axis: 1,
+                input: Tensor::from([20i8, 30, 40]).into(),
+                scale: Tensor::from(0.5),
+                zero_point: Some(Tensor::from(10i8).into()),
+                expected: Ok(Tensor::from([5., 10., 15.])),
+            },
+            // Per-row dequantization for a matrix
+            Case {
+                axis: 0,
+                input: Tensor::from([[10u8, 20], [30, 40]]).into(),
+                scale: Tensor::from([0.5, 2.]),
+                zero_point: Some(Tensor::from([10u8, 20]).into()),
+                expected: Ok(Tensor::from([[0., 5.], [20., 40.]])),
+            },
+            // Mismatched scale and zero-point shape
+            Case {
+                axis: 0,
+                input: Tensor::from([10u8]).into(),
+                scale: Tensor::from([0.5, 2.]),
+                zero_point: Some(Tensor::from([1u8, 2, 3]).into()),
+                expected: Err(OpError::InvalidValue(
+                    "scale and zero_point must have same shape",
+                )),
+            },
+            // Blocked dequantization
+            Case {
+                axis: 0,
+                input: Tensor::from([[10u8, 20], [30, 40]]).into(),
+                scale: Tensor::from([[1., 2.], [3., 4.]]),
+                zero_point: Some(Tensor::from([[1u8, 2], [3, 4]]).into()),
+                expected: Err(OpError::UnsupportedValue(
+                    "Blocked dequantization is not supported",
+                )),
+            },
+            // Empty
+            Case {
+                axis: 0,
+                input: Tensor::<u8>::zeros(&[0]).into(),
+                scale: Tensor::zeros(&[0]),
+                zero_point: Some(Tensor::<u8>::zeros(&[0]).into()),
+                expected: Ok(Tensor::zeros(&[0])),
+            },
+        ];
+
+        let pool = new_pool();
+        for Case {
+            input,
+            scale,
+            zero_point,
+            axis,
+            expected,
+        } in cases
+        {
+            let result = match input {
+                Output::UInt8Tensor(input) => {
+                    let zero_point: Option<Tensor<u8>> =
+                        zero_point.map(|zp| zp.try_into().unwrap());
+                    dequantize_linear(
+                        &pool,
+                        input.view(),
+                        scale.view(),
+                        zero_point.as_ref().map(|zp| zp.view()),
+                        axis,
+                    )
+                }
+                Output::Int8Tensor(input) => {
+                    let zero_point: Option<Tensor<i8>> =
+                        zero_point.map(|zp| zp.try_into().unwrap());
+                    dequantize_linear(
+                        &pool,
+                        input.view(),
+                        scale.view(),
+                        zero_point.as_ref().map(|zp| zp.view()),
+                        axis,
+                    )
+                }
+                _ => panic!("unsupported quantized type"),
+            };
+            assert_eq!(result, expected);
+        }
+
+        Ok(())
+    }
+}

--- a/src/schema.fbs
+++ b/src/schema.fbs
@@ -118,6 +118,7 @@ enum OperatorType: ubyte {
   Gelu,
   Einsum,
   If,
+  DequantizeLinear,
 }
 
 enum RNNDirection: ubyte {
@@ -207,6 +208,7 @@ union OperatorAttrs {
   EinsumAttrs,
   IfAttrs,
   PadAttrs,
+  DequantizeLinearAttrs,
 }
 
 table ArgMaxAttrs {
@@ -274,6 +276,10 @@ table ConvTransposeAttrs {
 
   // Padding for spatial axes as [left, right] or [top, left, bottom, right]
   pads:[uint];
+}
+
+table DequantizeLinearAttrs {
+  axis:int;
 }
 
 table EinsumAttrs {

--- a/src/schema.fbs
+++ b/src/schema.fbs
@@ -119,6 +119,7 @@ enum OperatorType: ubyte {
   Einsum,
   If,
   DequantizeLinear,
+  QuantizeLinear,
 }
 
 enum RNNDirection: ubyte {
@@ -140,7 +141,9 @@ enum AutoPad: ubyte {
 
 enum DataType: ubyte {
   Int32,
-  Float
+  Float,
+  Int8,
+  UInt8,
 }
 
 // Coordinate transform modes for Resize operator.
@@ -209,6 +212,7 @@ union OperatorAttrs {
   IfAttrs,
   PadAttrs,
   DequantizeLinearAttrs,
+  QuantizeLinearAttrs,
 }
 
 table ArgMaxAttrs {
@@ -376,6 +380,11 @@ enum PadMode: ubyte {
 
 table PadAttrs {
   mode:PadMode;
+}
+
+table QuantizeLinearAttrs {
+  axis:int;
+  output_dtype:DataType = null;
 }
 
 table RandomNormalAttrs {

--- a/src/schema.fbs
+++ b/src/schema.fbs
@@ -120,6 +120,7 @@ enum OperatorType: ubyte {
   If,
   DequantizeLinear,
   QuantizeLinear,
+  DynamicQuantizeLinear,
 }
 
 enum RNNDirection: ubyte {

--- a/src/schema_generated.rs
+++ b/src/schema_generated.rs
@@ -18,13 +18,13 @@ pub const ENUM_MIN_OPERATOR_TYPE: u8 = 0;
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
-pub const ENUM_MAX_OPERATOR_TYPE: u8 = 104;
+pub const ENUM_MAX_OPERATOR_TYPE: u8 = 105;
 #[deprecated(
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 105] = [
+pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 106] = [
     OperatorType::Add,
     OperatorType::ArgMin,
     OperatorType::ArgMax,
@@ -130,6 +130,7 @@ pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 105] = [
     OperatorType::Gelu,
     OperatorType::Einsum,
     OperatorType::If,
+    OperatorType::DequantizeLinear,
 ];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -242,9 +243,10 @@ impl OperatorType {
     pub const Gelu: Self = Self(102);
     pub const Einsum: Self = Self(103);
     pub const If: Self = Self(104);
+    pub const DequantizeLinear: Self = Self(105);
 
     pub const ENUM_MIN: u8 = 0;
-    pub const ENUM_MAX: u8 = 104;
+    pub const ENUM_MAX: u8 = 105;
     pub const ENUM_VALUES: &'static [Self] = &[
         Self::Add,
         Self::ArgMin,
@@ -351,6 +353,7 @@ impl OperatorType {
         Self::Gelu,
         Self::Einsum,
         Self::If,
+        Self::DequantizeLinear,
     ];
     /// Returns the variant's name or "" if unknown.
     pub fn variant_name(self) -> Option<&'static str> {
@@ -460,6 +463,7 @@ impl OperatorType {
             Self::Gelu => Some("Gelu"),
             Self::Einsum => Some("Einsum"),
             Self::If => Some("If"),
+            Self::DequantizeLinear => Some("DequantizeLinear"),
             _ => None,
         }
     }
@@ -1086,13 +1090,13 @@ pub const ENUM_MIN_OPERATOR_ATTRS: u8 = 0;
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
-pub const ENUM_MAX_OPERATOR_ATTRS: u8 = 40;
+pub const ENUM_MAX_OPERATOR_ATTRS: u8 = 41;
 #[deprecated(
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_OPERATOR_ATTRS: [OperatorAttrs; 41] = [
+pub const ENUM_VALUES_OPERATOR_ATTRS: [OperatorAttrs; 42] = [
     OperatorAttrs::NONE,
     OperatorAttrs::ArgMaxAttrs,
     OperatorAttrs::AveragePoolAttrs,
@@ -1134,6 +1138,7 @@ pub const ENUM_VALUES_OPERATOR_ATTRS: [OperatorAttrs; 41] = [
     OperatorAttrs::EinsumAttrs,
     OperatorAttrs::IfAttrs,
     OperatorAttrs::PadAttrs,
+    OperatorAttrs::DequantizeLinearAttrs,
 ];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -1182,9 +1187,10 @@ impl OperatorAttrs {
     pub const EinsumAttrs: Self = Self(38);
     pub const IfAttrs: Self = Self(39);
     pub const PadAttrs: Self = Self(40);
+    pub const DequantizeLinearAttrs: Self = Self(41);
 
     pub const ENUM_MIN: u8 = 0;
-    pub const ENUM_MAX: u8 = 40;
+    pub const ENUM_MAX: u8 = 41;
     pub const ENUM_VALUES: &'static [Self] = &[
         Self::NONE,
         Self::ArgMaxAttrs,
@@ -1227,6 +1233,7 @@ impl OperatorAttrs {
         Self::EinsumAttrs,
         Self::IfAttrs,
         Self::PadAttrs,
+        Self::DequantizeLinearAttrs,
     ];
     /// Returns the variant's name or "" if unknown.
     pub fn variant_name(self) -> Option<&'static str> {
@@ -1272,6 +1279,7 @@ impl OperatorAttrs {
             Self::EinsumAttrs => Some("EinsumAttrs"),
             Self::IfAttrs => Some("IfAttrs"),
             Self::PadAttrs => Some("PadAttrs"),
+            Self::DequantizeLinearAttrs => Some("DequantizeLinearAttrs"),
             _ => None,
         }
     }
@@ -3463,6 +3471,110 @@ impl core::fmt::Debug for ConvTransposeAttrs<'_> {
         ds.field("strides", &self.strides());
         ds.field("auto_pad", &self.auto_pad());
         ds.field("pads", &self.pads());
+        ds.finish()
+    }
+}
+pub enum DequantizeLinearAttrsOffset {}
+#[derive(Copy, Clone, PartialEq)]
+
+pub struct DequantizeLinearAttrs<'a> {
+    pub _tab: flatbuffers::Table<'a>,
+}
+
+impl<'a> flatbuffers::Follow<'a> for DequantizeLinearAttrs<'a> {
+    type Inner = DequantizeLinearAttrs<'a>;
+    #[inline]
+    unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self {
+            _tab: flatbuffers::Table::new(buf, loc),
+        }
+    }
+}
+
+impl<'a> DequantizeLinearAttrs<'a> {
+    pub const VT_AXIS: flatbuffers::VOffsetT = 4;
+
+    #[inline]
+    pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+        DequantizeLinearAttrs { _tab: table }
+    }
+    #[allow(unused_mut)]
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
+        args: &'args DequantizeLinearAttrsArgs,
+    ) -> flatbuffers::WIPOffset<DequantizeLinearAttrs<'bldr>> {
+        let mut builder = DequantizeLinearAttrsBuilder::new(_fbb);
+        builder.add_axis(args.axis);
+        builder.finish()
+    }
+
+    #[inline]
+    pub fn axis(&self) -> i32 {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab
+                .get::<i32>(DequantizeLinearAttrs::VT_AXIS, Some(0))
+                .unwrap()
+        }
+    }
+}
+
+impl flatbuffers::Verifiable for DequantizeLinearAttrs<'_> {
+    #[inline]
+    fn run_verifier(
+        v: &mut flatbuffers::Verifier,
+        pos: usize,
+    ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+        use self::flatbuffers::Verifiable;
+        v.visit_table(pos)?
+            .visit_field::<i32>("axis", Self::VT_AXIS, false)?
+            .finish();
+        Ok(())
+    }
+}
+pub struct DequantizeLinearAttrsArgs {
+    pub axis: i32,
+}
+impl<'a> Default for DequantizeLinearAttrsArgs {
+    #[inline]
+    fn default() -> Self {
+        DequantizeLinearAttrsArgs { axis: 0 }
+    }
+}
+
+pub struct DequantizeLinearAttrsBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+    fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
+    start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> DequantizeLinearAttrsBuilder<'a, 'b, A> {
+    #[inline]
+    pub fn add_axis(&mut self, axis: i32) {
+        self.fbb_
+            .push_slot::<i32>(DequantizeLinearAttrs::VT_AXIS, axis, 0);
+    }
+    #[inline]
+    pub fn new(
+        _fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
+    ) -> DequantizeLinearAttrsBuilder<'a, 'b, A> {
+        let start = _fbb.start_table();
+        DequantizeLinearAttrsBuilder {
+            fbb_: _fbb,
+            start_: start,
+        }
+    }
+    #[inline]
+    pub fn finish(self) -> flatbuffers::WIPOffset<DequantizeLinearAttrs<'a>> {
+        let o = self.fbb_.end_table(self.start_);
+        flatbuffers::WIPOffset::new(o.value())
+    }
+}
+
+impl core::fmt::Debug for DequantizeLinearAttrs<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut ds = f.debug_struct("DequantizeLinearAttrs");
+        ds.field("axis", &self.axis());
         ds.finish()
     }
 }
@@ -8182,6 +8294,21 @@ impl<'a> OperatorNode<'a> {
             None
         }
     }
+
+    #[inline]
+    #[allow(non_snake_case)]
+    pub fn attrs_as_dequantize_linear_attrs(&self) -> Option<DequantizeLinearAttrs<'a>> {
+        if self.attrs_type() == OperatorAttrs::DequantizeLinearAttrs {
+            self.attrs().map(|t| {
+                // Safety:
+                // Created from a valid Table for this object
+                // Which contains a valid union in this slot
+                unsafe { DequantizeLinearAttrs::init_from_table(t) }
+            })
+        } else {
+            None
+        }
+    }
 }
 
 impl flatbuffers::Verifiable for OperatorNode<'_> {
@@ -8235,6 +8362,7 @@ impl flatbuffers::Verifiable for OperatorNode<'_> {
           OperatorAttrs::EinsumAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<EinsumAttrs>>("OperatorAttrs::EinsumAttrs", pos),
           OperatorAttrs::IfAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<IfAttrs>>("OperatorAttrs::IfAttrs", pos),
           OperatorAttrs::PadAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<PadAttrs>>("OperatorAttrs::PadAttrs", pos),
+          OperatorAttrs::DequantizeLinearAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<DequantizeLinearAttrs>>("OperatorAttrs::DequantizeLinearAttrs", pos),
           _ => Ok(()),
         }
      })?
@@ -8712,6 +8840,16 @@ impl core::fmt::Debug for OperatorNode<'_> {
             }
             OperatorAttrs::PadAttrs => {
                 if let Some(x) = self.attrs_as_pad_attrs() {
+                    ds.field("attrs", &x)
+                } else {
+                    ds.field(
+                        "attrs",
+                        &"InvalidFlatbuffer: Union discriminant does not match value.",
+                    )
+                }
+            }
+            OperatorAttrs::DequantizeLinearAttrs => {
+                if let Some(x) = self.attrs_as_dequantize_linear_attrs() {
                     ds.field("attrs", &x)
                 } else {
                     ds.field(

--- a/src/schema_generated.rs
+++ b/src/schema_generated.rs
@@ -18,13 +18,13 @@ pub const ENUM_MIN_OPERATOR_TYPE: u8 = 0;
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
-pub const ENUM_MAX_OPERATOR_TYPE: u8 = 106;
+pub const ENUM_MAX_OPERATOR_TYPE: u8 = 107;
 #[deprecated(
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 107] = [
+pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 108] = [
     OperatorType::Add,
     OperatorType::ArgMin,
     OperatorType::ArgMax,
@@ -132,6 +132,7 @@ pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 107] = [
     OperatorType::If,
     OperatorType::DequantizeLinear,
     OperatorType::QuantizeLinear,
+    OperatorType::DynamicQuantizeLinear,
 ];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -246,9 +247,10 @@ impl OperatorType {
     pub const If: Self = Self(104);
     pub const DequantizeLinear: Self = Self(105);
     pub const QuantizeLinear: Self = Self(106);
+    pub const DynamicQuantizeLinear: Self = Self(107);
 
     pub const ENUM_MIN: u8 = 0;
-    pub const ENUM_MAX: u8 = 106;
+    pub const ENUM_MAX: u8 = 107;
     pub const ENUM_VALUES: &'static [Self] = &[
         Self::Add,
         Self::ArgMin,
@@ -357,6 +359,7 @@ impl OperatorType {
         Self::If,
         Self::DequantizeLinear,
         Self::QuantizeLinear,
+        Self::DynamicQuantizeLinear,
     ];
     /// Returns the variant's name or "" if unknown.
     pub fn variant_name(self) -> Option<&'static str> {
@@ -468,6 +471,7 @@ impl OperatorType {
             Self::If => Some("If"),
             Self::DequantizeLinear => Some("DequantizeLinear"),
             Self::QuantizeLinear => Some("QuantizeLinear"),
+            Self::DynamicQuantizeLinear => Some("DynamicQuantizeLinear"),
             _ => None,
         }
     }

--- a/src/schema_generated.rs
+++ b/src/schema_generated.rs
@@ -18,13 +18,13 @@ pub const ENUM_MIN_OPERATOR_TYPE: u8 = 0;
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
-pub const ENUM_MAX_OPERATOR_TYPE: u8 = 105;
+pub const ENUM_MAX_OPERATOR_TYPE: u8 = 106;
 #[deprecated(
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 106] = [
+pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 107] = [
     OperatorType::Add,
     OperatorType::ArgMin,
     OperatorType::ArgMax,
@@ -131,6 +131,7 @@ pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 106] = [
     OperatorType::Einsum,
     OperatorType::If,
     OperatorType::DequantizeLinear,
+    OperatorType::QuantizeLinear,
 ];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -244,9 +245,10 @@ impl OperatorType {
     pub const Einsum: Self = Self(103);
     pub const If: Self = Self(104);
     pub const DequantizeLinear: Self = Self(105);
+    pub const QuantizeLinear: Self = Self(106);
 
     pub const ENUM_MIN: u8 = 0;
-    pub const ENUM_MAX: u8 = 105;
+    pub const ENUM_MAX: u8 = 106;
     pub const ENUM_VALUES: &'static [Self] = &[
         Self::Add,
         Self::ArgMin,
@@ -354,6 +356,7 @@ impl OperatorType {
         Self::Einsum,
         Self::If,
         Self::DequantizeLinear,
+        Self::QuantizeLinear,
     ];
     /// Returns the variant's name or "" if unknown.
     pub fn variant_name(self) -> Option<&'static str> {
@@ -464,6 +467,7 @@ impl OperatorType {
             Self::Einsum => Some("Einsum"),
             Self::If => Some("If"),
             Self::DequantizeLinear => Some("DequantizeLinear"),
+            Self::QuantizeLinear => Some("QuantizeLinear"),
             _ => None,
         }
     }
@@ -713,13 +717,18 @@ pub const ENUM_MIN_DATA_TYPE: u8 = 0;
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
-pub const ENUM_MAX_DATA_TYPE: u8 = 1;
+pub const ENUM_MAX_DATA_TYPE: u8 = 3;
 #[deprecated(
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_DATA_TYPE: [DataType; 2] = [DataType::Int32, DataType::Float];
+pub const ENUM_VALUES_DATA_TYPE: [DataType; 4] = [
+    DataType::Int32,
+    DataType::Float,
+    DataType::Int8,
+    DataType::UInt8,
+];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
@@ -728,15 +737,19 @@ pub struct DataType(pub u8);
 impl DataType {
     pub const Int32: Self = Self(0);
     pub const Float: Self = Self(1);
+    pub const Int8: Self = Self(2);
+    pub const UInt8: Self = Self(3);
 
     pub const ENUM_MIN: u8 = 0;
-    pub const ENUM_MAX: u8 = 1;
-    pub const ENUM_VALUES: &'static [Self] = &[Self::Int32, Self::Float];
+    pub const ENUM_MAX: u8 = 3;
+    pub const ENUM_VALUES: &'static [Self] = &[Self::Int32, Self::Float, Self::Int8, Self::UInt8];
     /// Returns the variant's name or "" if unknown.
     pub fn variant_name(self) -> Option<&'static str> {
         match self {
             Self::Int32 => Some("Int32"),
             Self::Float => Some("Float"),
+            Self::Int8 => Some("Int8"),
+            Self::UInt8 => Some("UInt8"),
             _ => None,
         }
     }
@@ -1090,13 +1103,13 @@ pub const ENUM_MIN_OPERATOR_ATTRS: u8 = 0;
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
-pub const ENUM_MAX_OPERATOR_ATTRS: u8 = 41;
+pub const ENUM_MAX_OPERATOR_ATTRS: u8 = 42;
 #[deprecated(
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_OPERATOR_ATTRS: [OperatorAttrs; 42] = [
+pub const ENUM_VALUES_OPERATOR_ATTRS: [OperatorAttrs; 43] = [
     OperatorAttrs::NONE,
     OperatorAttrs::ArgMaxAttrs,
     OperatorAttrs::AveragePoolAttrs,
@@ -1139,6 +1152,7 @@ pub const ENUM_VALUES_OPERATOR_ATTRS: [OperatorAttrs; 42] = [
     OperatorAttrs::IfAttrs,
     OperatorAttrs::PadAttrs,
     OperatorAttrs::DequantizeLinearAttrs,
+    OperatorAttrs::QuantizeLinearAttrs,
 ];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -1188,9 +1202,10 @@ impl OperatorAttrs {
     pub const IfAttrs: Self = Self(39);
     pub const PadAttrs: Self = Self(40);
     pub const DequantizeLinearAttrs: Self = Self(41);
+    pub const QuantizeLinearAttrs: Self = Self(42);
 
     pub const ENUM_MIN: u8 = 0;
-    pub const ENUM_MAX: u8 = 41;
+    pub const ENUM_MAX: u8 = 42;
     pub const ENUM_VALUES: &'static [Self] = &[
         Self::NONE,
         Self::ArgMaxAttrs,
@@ -1234,6 +1249,7 @@ impl OperatorAttrs {
         Self::IfAttrs,
         Self::PadAttrs,
         Self::DequantizeLinearAttrs,
+        Self::QuantizeLinearAttrs,
     ];
     /// Returns the variant's name or "" if unknown.
     pub fn variant_name(self) -> Option<&'static str> {
@@ -1280,6 +1296,7 @@ impl OperatorAttrs {
             Self::IfAttrs => Some("IfAttrs"),
             Self::PadAttrs => Some("PadAttrs"),
             Self::DequantizeLinearAttrs => Some("DequantizeLinearAttrs"),
+            Self::QuantizeLinearAttrs => Some("QuantizeLinearAttrs"),
             _ => None,
         }
     }
@@ -5731,6 +5748,135 @@ impl core::fmt::Debug for PadAttrs<'_> {
         ds.finish()
     }
 }
+pub enum QuantizeLinearAttrsOffset {}
+#[derive(Copy, Clone, PartialEq)]
+
+pub struct QuantizeLinearAttrs<'a> {
+    pub _tab: flatbuffers::Table<'a>,
+}
+
+impl<'a> flatbuffers::Follow<'a> for QuantizeLinearAttrs<'a> {
+    type Inner = QuantizeLinearAttrs<'a>;
+    #[inline]
+    unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self {
+            _tab: flatbuffers::Table::new(buf, loc),
+        }
+    }
+}
+
+impl<'a> QuantizeLinearAttrs<'a> {
+    pub const VT_AXIS: flatbuffers::VOffsetT = 4;
+    pub const VT_OUTPUT_DTYPE: flatbuffers::VOffsetT = 6;
+
+    #[inline]
+    pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+        QuantizeLinearAttrs { _tab: table }
+    }
+    #[allow(unused_mut)]
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
+        args: &'args QuantizeLinearAttrsArgs,
+    ) -> flatbuffers::WIPOffset<QuantizeLinearAttrs<'bldr>> {
+        let mut builder = QuantizeLinearAttrsBuilder::new(_fbb);
+        builder.add_axis(args.axis);
+        if let Some(x) = args.output_dtype {
+            builder.add_output_dtype(x);
+        }
+        builder.finish()
+    }
+
+    #[inline]
+    pub fn axis(&self) -> i32 {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab
+                .get::<i32>(QuantizeLinearAttrs::VT_AXIS, Some(0))
+                .unwrap()
+        }
+    }
+    #[inline]
+    pub fn output_dtype(&self) -> Option<DataType> {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab
+                .get::<DataType>(QuantizeLinearAttrs::VT_OUTPUT_DTYPE, None)
+        }
+    }
+}
+
+impl flatbuffers::Verifiable for QuantizeLinearAttrs<'_> {
+    #[inline]
+    fn run_verifier(
+        v: &mut flatbuffers::Verifier,
+        pos: usize,
+    ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+        use self::flatbuffers::Verifiable;
+        v.visit_table(pos)?
+            .visit_field::<i32>("axis", Self::VT_AXIS, false)?
+            .visit_field::<DataType>("output_dtype", Self::VT_OUTPUT_DTYPE, false)?
+            .finish();
+        Ok(())
+    }
+}
+pub struct QuantizeLinearAttrsArgs {
+    pub axis: i32,
+    pub output_dtype: Option<DataType>,
+}
+impl<'a> Default for QuantizeLinearAttrsArgs {
+    #[inline]
+    fn default() -> Self {
+        QuantizeLinearAttrsArgs {
+            axis: 0,
+            output_dtype: None,
+        }
+    }
+}
+
+pub struct QuantizeLinearAttrsBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+    fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
+    start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> QuantizeLinearAttrsBuilder<'a, 'b, A> {
+    #[inline]
+    pub fn add_axis(&mut self, axis: i32) {
+        self.fbb_
+            .push_slot::<i32>(QuantizeLinearAttrs::VT_AXIS, axis, 0);
+    }
+    #[inline]
+    pub fn add_output_dtype(&mut self, output_dtype: DataType) {
+        self.fbb_
+            .push_slot_always::<DataType>(QuantizeLinearAttrs::VT_OUTPUT_DTYPE, output_dtype);
+    }
+    #[inline]
+    pub fn new(
+        _fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
+    ) -> QuantizeLinearAttrsBuilder<'a, 'b, A> {
+        let start = _fbb.start_table();
+        QuantizeLinearAttrsBuilder {
+            fbb_: _fbb,
+            start_: start,
+        }
+    }
+    #[inline]
+    pub fn finish(self) -> flatbuffers::WIPOffset<QuantizeLinearAttrs<'a>> {
+        let o = self.fbb_.end_table(self.start_);
+        flatbuffers::WIPOffset::new(o.value())
+    }
+}
+
+impl core::fmt::Debug for QuantizeLinearAttrs<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut ds = f.debug_struct("QuantizeLinearAttrs");
+        ds.field("axis", &self.axis());
+        ds.field("output_dtype", &self.output_dtype());
+        ds.finish()
+    }
+}
 pub enum RandomNormalAttrsOffset {}
 #[derive(Copy, Clone, PartialEq)]
 
@@ -8309,6 +8455,21 @@ impl<'a> OperatorNode<'a> {
             None
         }
     }
+
+    #[inline]
+    #[allow(non_snake_case)]
+    pub fn attrs_as_quantize_linear_attrs(&self) -> Option<QuantizeLinearAttrs<'a>> {
+        if self.attrs_type() == OperatorAttrs::QuantizeLinearAttrs {
+            self.attrs().map(|t| {
+                // Safety:
+                // Created from a valid Table for this object
+                // Which contains a valid union in this slot
+                unsafe { QuantizeLinearAttrs::init_from_table(t) }
+            })
+        } else {
+            None
+        }
+    }
 }
 
 impl flatbuffers::Verifiable for OperatorNode<'_> {
@@ -8363,6 +8524,7 @@ impl flatbuffers::Verifiable for OperatorNode<'_> {
           OperatorAttrs::IfAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<IfAttrs>>("OperatorAttrs::IfAttrs", pos),
           OperatorAttrs::PadAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<PadAttrs>>("OperatorAttrs::PadAttrs", pos),
           OperatorAttrs::DequantizeLinearAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<DequantizeLinearAttrs>>("OperatorAttrs::DequantizeLinearAttrs", pos),
+          OperatorAttrs::QuantizeLinearAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<QuantizeLinearAttrs>>("OperatorAttrs::QuantizeLinearAttrs", pos),
           _ => Ok(()),
         }
      })?
@@ -8850,6 +9012,16 @@ impl core::fmt::Debug for OperatorNode<'_> {
             }
             OperatorAttrs::DequantizeLinearAttrs => {
                 if let Some(x) = self.attrs_as_dequantize_linear_attrs() {
+                    ds.field("attrs", &x)
+                } else {
+                    ds.field(
+                        "attrs",
+                        &"InvalidFlatbuffer: Union discriminant does not match value.",
+                    )
+                }
+            }
+            OperatorAttrs::QuantizeLinearAttrs => {
+                if let Some(x) = self.attrs_as_quantize_linear_attrs() {
                     ds.field("attrs", &x)
                 } else {
                     ds.field(


### PR DESCRIPTION
Implement the quantization operators used by the "[tensor oriented](https://onnxruntime.ai/docs/performance/model-optimizations/quantization.html)" quantization method.

In the initial implementation scalar and per-axis quantization are supported, but not blocked quantization.