### PR TITLE
Add missing conditionals for SIMD support in WASM builds

### DIFF
--- a/rten-simd/src/arch.rs
+++ b/rten-simd/src/arch.rs
@@ -10,6 +10,7 @@ mod x86_64;
 mod aarch64;
 
 #[cfg(target_arch = "wasm32")]
+#[cfg(target_feature = "simd128")]
 pub mod wasm;
 
 use crate::{SimdFloat, SimdInt};

--- a/src/gemm.rs
+++ b/src/gemm.rs
@@ -255,6 +255,7 @@ pub enum KernelType {
 
     /// Use the WASM SIMD kernel. WASM only.
     #[cfg(target_arch = "wasm32")]
+    #[cfg(target_feature = "simd128")]
     Wasm,
 }
 
@@ -275,6 +276,7 @@ impl GemmExecutor {
             return gemm;
         }
         #[cfg(target_arch = "wasm32")]
+        #[cfg(target_feature = "simd128")]
         if let Some(gemm) = Self::with_kernel(KernelType::Wasm) {
             return gemm;
         }
@@ -312,6 +314,7 @@ impl GemmExecutor {
             #[cfg(target_arch = "aarch64")]
             KernelType::ArmNeon => make_kernel::<kernels::aarch64::ArmNeonKernel>(hint),
             #[cfg(target_arch = "wasm32")]
+            #[cfg(target_feature = "simd128")]
             KernelType::Wasm => make_kernel::<kernels::wasm::WasmKernel>(hint),
             KernelType::Base => Some(Self::with_base_kernel()),
         }

--- a/src/gemm/kernels.rs
+++ b/src/gemm/kernels.rs
@@ -14,6 +14,7 @@ pub mod aarch64;
 pub mod x86_64;
 
 #[cfg(target_arch = "wasm32")]
+#[cfg(target_feature = "simd128")]
 pub mod wasm;
 
 /// Compute an output block of a vector-matrix product ("gemv" in BLAS APIs).

--- a/src/ops/conv/im2col.rs
+++ b/src/ops/conv/im2col.rs
@@ -306,6 +306,7 @@ const KERNEL_BASE_NR: usize = 4;
 const KERNEL_FMA_NR: usize = 16;
 
 #[cfg(target_arch = "wasm32")]
+#[cfg(target_feature = "simd128")]
 const KERNEL_WASM_NR: usize = 8;
 
 // Safety: `pack_b` initializes the entire buffer passed to it.


### PR DESCRIPTION
Fix an issue where SIMD instructions were present in WASM binaries even builds when the "simd128" target feature was not enabled.

Fix tested in the Ocrs repo with:

```
RUSTFLAGS="-C target-feature=+simd128" cargo build --release --target wasm32-wasi --package ocrs-cli
wasmtime -W simd=n -W relaxed-simd=n --dir . target/wasm32-wasi/release/ocrs.wasm --detect-model text-detection.rten --rec-model text-recognition.rten ocrs-cli/test-data/why-rust.png
```

See https://github.com/robertknight/ocrs/issues/113