### PR TITLE
Support u8 tensors in `Gather` operator

### DIFF
--- a/rten-examples/src/rmbg.rs
+++ b/rten-examples/src/rmbg.rs
@@ -95,7 +95,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let std_dev = [1.0, 1.0, 1.0];
     normalize_image(normalized_image.view_mut(), mean, std_dev);
 
-    let [_, orig_height, orig_width] = image.shape().try_into()?;
+    let [_, orig_height, orig_width] = image.shape();
 
     let mut normalized_image = normalized_image.into_dyn();
     normalized_image.insert_axis(0); // Add batch dim

--- a/src/ops/gather.rs
+++ b/src/ops/gather.rs
@@ -91,6 +91,7 @@ impl Operator for Gather {
         match input {
             Input::Int32Tensor(input) => gather(pool, input, self.axis, indices).into_op_result(),
             Input::FloatTensor(input) => gather(pool, input, self.axis, indices).into_op_result(),
+            Input::UInt8Tensor(input) => gather(pool, input, self.axis, indices).into_op_result(),
             _ => Err(OpError::UnsupportedType),
         }
     }


### PR DESCRIPTION
This is used when gathering embedding vectors from quantized models.

Also fix a clippy warning that I missed in recent PRs.