### PR TITLE
Make GEMM implementation generic over input and output matrix element types

### DIFF
--- a/src/gemm.rs
+++ b/src/gemm.rs
@@ -14,7 +14,7 @@ use rten_tensor::prelude::*;
 use rten_tensor::{Alloc, GlobalAlloc, Matrix, MatrixLayout, MatrixMut, NdTensorView};
 
 use crate::iter_util::{range_chunks, MaybeParIter};
-use crate::number::{cast_pod_mut_slice, cast_pod_slice, Identities};
+use crate::number::{cast_pod_mut_slice, cast_pod_slice, Identities, Pod};
 use crate::tensor_pool::ExtractBuffer;
 
 mod kernels;
@@ -121,12 +121,19 @@ impl<'a, T> GemmInputA<'a, T> {
 }
 
 /// Trait implemented by GEMM input types.
-pub trait GemmInT: Copy + Send + Sync + Identities {}
+pub trait GemmInT: Copy + Send + Sync + Identities + Pod {}
 impl GemmInT for f32 {}
 
 /// Trait implemented by GEMM output types.
 pub trait GemmOutT:
-    Copy + PartialEq + Send + Sync + Identities + Mul<Self, Output = Self> + Add<Self, Output = Self>
+    Copy
+    + PartialEq
+    + Send
+    + Sync
+    + Mul<Self, Output = Self>
+    + Add<Self, Output = Self>
+    + Identities
+    + Pod
 {
 }
 impl GemmOutT for f32 {}

--- a/src/gemm.rs
+++ b/src/gemm.rs
@@ -232,7 +232,7 @@ pub fn gemm(
 /// computational efficiency, which is normally does internally on each call,
 /// can be done just once for the reused input.
 pub struct GemmExecutor {
-    kernel: Box<dyn Kernel>,
+    kernel: Box<dyn Kernel<f32, f32, f32>>,
     kernel_type: KernelType,
 }
 
@@ -299,7 +299,9 @@ impl GemmExecutor {
     /// kernel is not supported.
     #[allow(dead_code)] // Currently only used in tests
     pub fn with_kernel(hint: KernelType) -> Option<GemmExecutor> {
-        fn make_kernel<K: Kernel + 'static>(kernel_type: KernelType) -> Option<GemmExecutor> {
+        fn make_kernel<K: Kernel<f32, f32, f32> + 'static>(
+            kernel_type: KernelType,
+        ) -> Option<GemmExecutor> {
             K::new().map(|kernel| GemmExecutor {
                 kernel: Box::new(kernel),
                 kernel_type,
@@ -653,7 +655,7 @@ impl<T> OutputTiles<T> {
 ///
 /// This operation is called "gemv" in BLAS APIs.
 fn gemv(
-    kernel: &dyn Kernel,
+    kernel: &dyn Kernel<f32, f32, f32>,
     a: NdTensorView<f32, 1>,
     b: Matrix,
     mut output_mat: MatrixMut,
@@ -735,7 +737,7 @@ fn gemv(
 ///       high-performance BLIS." ACM Transactions on Mathematical Software (TOMS)
 ///       43.2 (2016): 1-18. https://dl.acm.org/doi/pdf/10.1145/2925987
 fn gemm_impl(
-    kernel: &dyn Kernel,
+    kernel: &dyn Kernel<f32, f32, f32>,
     out_data: &mut [f32],
     out_row_stride: usize,
     a: GemmInputA,
@@ -943,7 +945,7 @@ fn gemm_impl(
 /// `is_first` indicates whether this is the first write to the output tiles
 /// in this block during the current GEMM operation.
 fn gemm_block(
-    kernel: &dyn Kernel,
+    kernel: &dyn Kernel<f32, f32, f32>,
     output: &OutputTiles<f32>,
     col_tiles: Range<usize>,
     row_tiles: Range<usize>,

--- a/src/gemm/kernels.rs
+++ b/src/gemm/kernels.rs
@@ -330,7 +330,7 @@ unsafe fn simd_gemm<S: SimdFloat, const MR: usize, const NR_REGS: usize>(
 /// instructions it uses are supported on the current system.
 ///
 /// [^1]: https://dl.acm.org/doi/pdf/10.1145/2925987
-pub unsafe trait Kernel: Sync {
+pub unsafe trait Kernel<LhsT, RhsT, OutT>: Sync {
     /// Construct a new instance of this kernel, if supported on the current
     /// system.
     fn new() -> Option<Self>
@@ -349,8 +349,8 @@ pub unsafe trait Kernel: Sync {
     /// Pack a block of the LHS / "A" input for use by this kernel.
     fn pack_a_block(
         &self,
-        out: &mut [MaybeUninit<f32>],
-        a: Matrix,
+        out: &mut [MaybeUninit<LhsT>],
+        a: Matrix<LhsT>,
         rows: Range<usize>,
         cols: Range<usize>,
     );
@@ -359,8 +359,8 @@ pub unsafe trait Kernel: Sync {
     /// by this kernel.
     fn pack_b_block(
         &self,
-        out: &mut [MaybeUninit<f32>],
-        b: Matrix,
+        out: &mut [MaybeUninit<RhsT>],
+        b: Matrix<RhsT>,
         rows: Range<usize>,
         cols: Range<usize>,
     );
@@ -375,13 +375,13 @@ pub unsafe trait Kernel: Sync {
     /// size.
     unsafe fn kernel(
         &self,
-        tile_ptr: *mut f32,
+        tile_ptr: *mut OutT,
         tile_row_stride: usize,
-        a: &[f32],
-        b: &[f32],
+        a: &[LhsT],
+        b: &[RhsT],
         depth: usize,
         alpha: f32,
-        beta: f32,
+        beta: OutT,
     );
 
     /// Compute an output block of a vector-matrix product ("gemv").
@@ -400,5 +400,5 @@ pub unsafe trait Kernel: Sync {
     ///
     /// The caller must ensure that the kernel is supported on the current
     /// system.
-    fn gemv_kernel(&self, out: &mut [f32], a: &[f32], b: Matrix, alpha: f32, beta: f32);
+    fn gemv_kernel(&self, out: &mut [OutT], a: &[LhsT], b: Matrix<RhsT>, alpha: f32, beta: OutT);
 }

--- a/src/gemm/kernels.rs
+++ b/src/gemm/kernels.rs
@@ -400,10 +400,5 @@ pub unsafe trait Kernel: Sync {
     ///
     /// The caller must ensure that the kernel is supported on the current
     /// system.
-    fn gemv_kernel(&self, out: &mut [f32], a: &[f32], b: Matrix, alpha: f32, beta: f32) {
-        // Safety - f32 "SIMD" type is always supported
-        unsafe {
-            simd_gemv::<f32, 4>(out, a, b, alpha, beta);
-        }
-    }
+    fn gemv_kernel(&self, out: &mut [f32], a: &[f32], b: Matrix, alpha: f32, beta: f32);
 }

--- a/src/gemm/kernels/aarch64.rs
+++ b/src/gemm/kernels/aarch64.rs
@@ -20,7 +20,7 @@ impl ArmNeonKernel {
 
 // Safety - We assume that Rust code on Arm is always compiled with Arm Neon
 // available.
-unsafe impl Kernel for ArmNeonKernel {
+unsafe impl Kernel<f32, f32, f32> for ArmNeonKernel {
     fn new() -> Option<Self> {
         Some(ArmNeonKernel { _private: () })
     }

--- a/src/gemm/kernels/aarch64.rs
+++ b/src/gemm/kernels/aarch64.rs
@@ -44,7 +44,7 @@ unsafe impl Kernel<f32, f32, f32> for ArmNeonKernel {
         rows: Range<usize>,
         cols: Range<usize>,
     ) {
-        pack_a_block::<{ Self::MR }>(out, a, rows, cols);
+        pack_a_block::<f32, { Self::MR }>(out, a, rows, cols);
     }
 
     fn pack_b_block(
@@ -54,7 +54,7 @@ unsafe impl Kernel<f32, f32, f32> for ArmNeonKernel {
         rows: Range<usize>,
         cols: Range<usize>,
     ) {
-        pack_b_block::<{ Self::NR }>(out, b, rows, cols);
+        pack_b_block::<f32, { Self::NR }>(out, b, rows, cols);
     }
 
     unsafe fn kernel(

--- a/src/gemm/kernels/generic.rs
+++ b/src/gemm/kernels/generic.rs
@@ -24,7 +24,7 @@ impl GenericKernel {
 }
 
 // Safety - Base kernel is always supported
-unsafe impl Kernel for GenericKernel {
+unsafe impl Kernel<f32, f32, f32> for GenericKernel {
     fn new() -> Option<Self> {
         Some(GenericKernel { _private: () })
     }

--- a/src/gemm/kernels/generic.rs
+++ b/src/gemm/kernels/generic.rs
@@ -3,7 +3,7 @@ use std::ops::Range;
 
 use rten_tensor::Matrix;
 
-use super::{simd_gemm, vec_count, Kernel};
+use super::{simd_gemm, simd_gemv, vec_count, Kernel};
 use crate::gemm::packing::{pack_a_block, pack_b_block};
 
 /// This is the base kernel that does not use architecture-specific intrinsics
@@ -75,5 +75,12 @@ unsafe impl Kernel for GenericKernel {
         const NR: usize = GenericKernel::NR;
         const NR_REGS: usize = vec_count::<f32>(NR);
         simd_gemm::<f32, MR, NR_REGS>(tile_ptr, tile_row_stride, a, b, depth, alpha, beta);
+    }
+
+    fn gemv_kernel(&self, out: &mut [f32], a: &[f32], b: Matrix, alpha: f32, beta: f32) {
+        // Safety - f32 "SIMD" type is always supported
+        unsafe {
+            simd_gemv::<f32, 4>(out, a, b, alpha, beta);
+        }
     }
 }

--- a/src/gemm/kernels/generic.rs
+++ b/src/gemm/kernels/generic.rs
@@ -1,0 +1,79 @@
+use std::mem::MaybeUninit;
+use std::ops::Range;
+
+use rten_tensor::Matrix;
+
+use super::{simd_gemm, vec_count, Kernel};
+use crate::gemm::packing::{pack_a_block, pack_b_block};
+
+/// This is the base kernel that does not use architecture-specific intrinsics
+/// but is autovectorization-friendly. It is expected to perform the same as
+/// a kernel using SSE intrinsics (or equivalent).
+#[derive(Default)]
+pub struct GenericKernel {
+    _private: (),
+}
+
+impl GenericKernel {
+    const MR: usize = 8;
+
+    // The base kernel will most likely be compiled to SSE or equivalent. SSE
+    // registers are 128 bits wide = 4 x f32, so this should be a multiple of
+    // that.
+    const NR: usize = 4;
+}
+
+// Safety - Base kernel is always supported
+unsafe impl Kernel for GenericKernel {
+    fn new() -> Option<Self> {
+        Some(GenericKernel { _private: () })
+    }
+
+    fn mr(&self) -> usize {
+        Self::MR
+    }
+
+    fn nr(&self) -> usize {
+        Self::NR
+    }
+
+    fn name(&self) -> &'static str {
+        "base"
+    }
+
+    fn pack_a_block(
+        &self,
+        out: &mut [MaybeUninit<f32>],
+        a: Matrix,
+        rows: Range<usize>,
+        cols: Range<usize>,
+    ) {
+        pack_a_block::<{ Self::MR }>(out, a, rows, cols);
+    }
+
+    fn pack_b_block(
+        &self,
+        out: &mut [MaybeUninit<f32>],
+        b: Matrix,
+        rows: Range<usize>,
+        cols: Range<usize>,
+    ) {
+        pack_b_block::<{ Self::NR }>(out, b, rows, cols);
+    }
+
+    unsafe fn kernel(
+        &self,
+        tile_ptr: *mut f32,
+        tile_row_stride: usize,
+        a: &[f32],
+        b: &[f32],
+        depth: usize,
+        alpha: f32,
+        beta: f32,
+    ) {
+        const MR: usize = GenericKernel::MR;
+        const NR: usize = GenericKernel::NR;
+        const NR_REGS: usize = vec_count::<f32>(NR);
+        simd_gemm::<f32, MR, NR_REGS>(tile_ptr, tile_row_stride, a, b, depth, alpha, beta);
+    }
+}

--- a/src/gemm/kernels/generic.rs
+++ b/src/gemm/kernels/generic.rs
@@ -48,7 +48,7 @@ unsafe impl Kernel<f32, f32, f32> for GenericKernel {
         rows: Range<usize>,
         cols: Range<usize>,
     ) {
-        pack_a_block::<{ Self::MR }>(out, a, rows, cols);
+        pack_a_block::<f32, { Self::MR }>(out, a, rows, cols);
     }
 
     fn pack_b_block(
@@ -58,7 +58,7 @@ unsafe impl Kernel<f32, f32, f32> for GenericKernel {
         rows: Range<usize>,
         cols: Range<usize>,
     ) {
-        pack_b_block::<{ Self::NR }>(out, b, rows, cols);
+        pack_b_block::<f32, { Self::NR }>(out, b, rows, cols);
     }
 
     unsafe fn kernel(

--- a/src/gemm/kernels/wasm.rs
+++ b/src/gemm/kernels/wasm.rs
@@ -20,7 +20,7 @@ impl WasmKernel {
 
 // Safety - Support for used WASM instructions is checked by the runtime when
 // the WASM binary is loaded.
-unsafe impl Kernel for WasmKernel {
+unsafe impl Kernel<f32, f32, f32> for WasmKernel {
     fn new() -> Option<Self> {
         #[cfg(target_feature = "simd128")]
         return Some(WasmKernel { _private: () });

--- a/src/gemm/kernels/wasm.rs
+++ b/src/gemm/kernels/wasm.rs
@@ -48,7 +48,7 @@ unsafe impl Kernel<f32, f32, f32> for WasmKernel {
         rows: Range<usize>,
         cols: Range<usize>,
     ) {
-        pack_a_block::<{ Self::MR }>(out, a, rows, cols);
+        pack_a_block::<f32, { Self::MR }>(out, a, rows, cols);
     }
 
     fn pack_b_block(
@@ -58,7 +58,7 @@ unsafe impl Kernel<f32, f32, f32> for WasmKernel {
         rows: Range<usize>,
         cols: Range<usize>,
     ) {
-        pack_b_block::<{ Self::NR }>(out, b, rows, cols);
+        pack_b_block::<f32, { Self::NR }>(out, b, rows, cols);
     }
 
     unsafe fn kernel(

--- a/src/gemm/kernels/x86_64.rs
+++ b/src/gemm/kernels/x86_64.rs
@@ -37,7 +37,7 @@ unsafe fn pack_a_block_avx<const MR: usize>(
     rows: Range<usize>,
     cols: Range<usize>,
 ) {
-    pack_a_block::<MR>(out, a, rows, cols);
+    pack_a_block::<f32, MR>(out, a, rows, cols);
 }
 
 /// Wrapper for `pack_b_block` which enables AVX instructions.
@@ -49,7 +49,7 @@ unsafe fn pack_b_block_avx<const NR: usize>(
     rows: Range<usize>,
     cols: Range<usize>,
 ) {
-    pack_b_block::<NR>(out, b, rows, cols);
+    pack_b_block::<f32, NR>(out, b, rows, cols);
 }
 
 // Safety - The `new` fn tests for AVX-2 / FMA support.

--- a/src/gemm/kernels/x86_64.rs
+++ b/src/gemm/kernels/x86_64.rs
@@ -53,7 +53,7 @@ unsafe fn pack_b_block_avx<const NR: usize>(
 }
 
 // Safety - The `new` fn tests for AVX-2 / FMA support.
-unsafe impl Kernel for FmaKernel {
+unsafe impl Kernel<f32, f32, f32> for FmaKernel {
     fn new() -> Option<Self> {
         let supported = is_x86_feature_detected!("avx2") && is_x86_feature_detected!("fma");
         supported.then_some(FmaKernel { _private: () })
@@ -151,7 +151,7 @@ impl Avx512Kernel {
 
 // Safety - The `new` fn checks for AVX-512 support.
 #[cfg(feature = "avx512")]
-unsafe impl Kernel for Avx512Kernel {
+unsafe impl Kernel<f32, f32, f32> for Avx512Kernel {
     fn new() -> Option<Self> {
         is_avx512_supported().then_some(Avx512Kernel { _private: () })
     }

--- a/src/gemm/packing.rs
+++ b/src/gemm/packing.rs
@@ -17,9 +17,9 @@ use rten_tensor::{Matrix, MatrixLayout, Storage};
 /// When this function returns, all elements of `out` will have been initialized
 /// either to a value from `a`, or zero.
 #[inline] // Allow caller to control `target_feature`s
-pub fn pack_a_block<const MR: usize>(
-    out: &mut [MaybeUninit<f32>],
-    a: Matrix,
+pub fn pack_a_block<T: Copy + Default, const MR: usize>(
+    out: &mut [MaybeUninit<T>],
+    a: Matrix<T>,
     rows: Range<usize>,
     cols: Range<usize>,
 ) {
@@ -81,7 +81,7 @@ pub fn pack_a_block<const MR: usize>(
                         let offset = a_row * row_stride + (cols.start + col) * col_stride;
                         unsafe { *a_data.get_unchecked(offset) }
                     } else {
-                        0.0
+                        T::default()
                     });
                 }
             }
@@ -103,9 +103,9 @@ pub fn pack_a_block<const MR: usize>(
 /// When this function returns, all elements of `out` will have been initialized
 /// either to a value from `b`, or zero.
 #[inline] // Allow caller to control `target_feature`s
-pub fn pack_b_block<const NR: usize>(
-    out: &mut [MaybeUninit<f32>],
-    b: Matrix,
+pub fn pack_b_block<T: Copy + Default, const NR: usize>(
+    out: &mut [MaybeUninit<T>],
+    b: Matrix<T>,
     rows: Range<usize>,
     cols: Range<usize>,
 ) {
@@ -177,7 +177,7 @@ pub fn pack_b_block<const NR: usize>(
                     out[out_row_offset + col].write(if out_col < b_cols {
                         unsafe { *b_data.get_unchecked(b_offset) }
                     } else {
-                        0.0
+                        T::default()
                     });
                 }
             }

--- a/src/number.rs
+++ b/src/number.rs
@@ -1,3 +1,5 @@
+use std::mem::MaybeUninit;
+
 /// Trait for int -> bool conversions.
 ///
 /// The conversion matches how these conversions work in most popular languages
@@ -194,9 +196,11 @@ impl_fastdiv!(usize);
 /// long as the byte sequence length is a multiple of the type's size.
 pub trait Pod: Copy {}
 impl Pod for i8 {}
-impl Pod for i32 {}
-impl Pod for f32 {}
 impl Pod for u8 {}
+impl Pod for f32 {}
+impl Pod for i32 {}
+impl Pod for u64 {}
+impl<T: Pod> Pod for MaybeUninit<T> {}
 
 /// Return the length of a slice transmuted from `Src` to `Dst`, or `None` if
 /// the transmute is not possible.
@@ -219,7 +223,7 @@ fn transmuted_slice_len<Src, Dst>(src: &[Src]) -> Option<usize> {
 ///
 /// Returns `None` if the source pointer is not correctly aligned for the
 /// destination type.
-pub fn cast_pod_slice<Src, Dst>(src: &[Src]) -> Option<&[Dst]> {
+pub fn cast_pod_slice<Src: Pod, Dst: Pod>(src: &[Src]) -> Option<&[Dst]> {
     let new_len = transmuted_slice_len::<_, Dst>(src)?;
 
     // Safety:
@@ -234,7 +238,7 @@ pub fn cast_pod_slice<Src, Dst>(src: &[Src]) -> Option<&[Dst]> {
 ///
 /// Returns `None` if the source pointer is not correctly aligned for the
 /// destination type.
-pub fn cast_pod_mut_slice<Src, Dst>(src: &mut [Src]) -> Option<&mut [Dst]> {
+pub fn cast_pod_mut_slice<Src: Pod, Dst: Pod>(src: &mut [Src]) -> Option<&mut [Dst]> {
     let new_len = transmuted_slice_len::<_, Dst>(src)?;
 
     // Safety:

--- a/src/number.rs
+++ b/src/number.rs
@@ -198,9 +198,93 @@ impl Pod for i32 {}
 impl Pod for f32 {}
 impl Pod for u8 {}
 
+/// Return the length of a slice transmuted from `Src` to `Dst`, or `None` if
+/// the transmute is not possible.
+fn transmuted_slice_len<Src, Dst>(src: &[Src]) -> Option<usize> {
+    if (src.as_ptr() as usize) % align_of::<Dst>() != 0 {
+        return None;
+    }
+
+    let src_byte_len = std::mem::size_of_val(src);
+    if src_byte_len % size_of::<Dst>() != 0 {
+        return None;
+    }
+
+    Some(src_byte_len / size_of::<Dst>())
+}
+
+/// Transmute a slice of elements from one [`Pod`] type to another.
+///
+/// This cast is safe because all bit patterns are valid for `Pod` elements.
+///
+/// Returns `None` if the source pointer is not correctly aligned for the
+/// destination type.
+pub fn cast_pod_slice<Src, Dst>(src: &[Src]) -> Option<&[Dst]> {
+    let new_len = transmuted_slice_len::<_, Dst>(src)?;
+
+    // Safety:
+    // - Pointer cast is safe since any bit pattern is valid for POD types
+    // - Length has been adjusted for `Dst` type
+    Some(unsafe { std::slice::from_raw_parts(src.as_ptr() as *const Dst, new_len) })
+}
+
+/// Transmute a mutable slice of elements from one [`Pod`] type to another.
+///
+/// This cast is safe because all bit patterns are valid for `Pod` elements.
+///
+/// Returns `None` if the source pointer is not correctly aligned for the
+/// destination type.
+pub fn cast_pod_mut_slice<Src, Dst>(src: &mut [Src]) -> Option<&mut [Dst]> {
+    let new_len = transmuted_slice_len::<_, Dst>(src)?;
+
+    // Safety:
+    // - Pointer cast is safe since any bit pattern is valid for POD types
+    // - Length has been adjusted for `Dst` type
+    Some(unsafe { std::slice::from_raw_parts_mut(src.as_mut_ptr() as *mut Dst, new_len) })
+}
+
 #[cfg(test)]
 mod tests {
-    use super::FastDiv;
+    use super::{cast_pod_mut_slice, cast_pod_slice, FastDiv};
+
+    #[test]
+    fn test_cast_pod_slice() {
+        // Convert to narrower type
+        let i32s = [1, 2, 3];
+        let i8s = cast_pod_slice::<i32, i8>(&i32s).unwrap();
+        assert_eq!(i8s.as_ptr(), i32s.as_ptr() as *const i8);
+        assert_eq!(i8s.len(), i32s.len() * 4);
+
+        // Convert back to wider type
+        let i32s_v2 = cast_pod_slice::<i8, i32>(&i8s).unwrap();
+        assert_eq!(i32s_v2, i32s);
+    }
+
+    #[test]
+    fn test_cast_pod_slice_fails_if_unaligned() {
+        let i8s = [1, 2, 3, 4, 5];
+        let i32s_a = cast_pod_slice::<i8, i32>(&i8s);
+        let i32s_b = cast_pod_slice::<i8, i32>(&i8s[1..]);
+
+        // At least one of `i32s_a` or `i32s_b`` will be incorrectly aligned for i32.
+        assert!(i32s_a.is_none() || i32s_b.is_none());
+    }
+
+    #[test]
+    fn test_cast_pod_slice_fails_if_size_not_multiple_of_dst_size() {
+        let i8s = [1, 2, 3, 4, 5];
+        let i32s = cast_pod_slice::<i8, i32>(&i8s);
+        assert!(i32s.is_none());
+    }
+
+    #[test]
+    fn test_cast_pod_mut_slice() {
+        let mut i32s = [1, 2, 3];
+        let i32s_ptr = i32s.as_ptr();
+        let i8s = cast_pod_mut_slice::<i32, i8>(&mut i32s).unwrap();
+        assert_eq!(i8s.as_ptr(), i32s_ptr as *const i8);
+        assert_eq!(i8s.len(), i32s.len() * 4);
+    }
 
     #[test]
     fn test_fast_div_divide() {

--- a/src/ops/conv/im2col.rs
+++ b/src/ops/conv/im2col.rs
@@ -353,7 +353,7 @@ unsafe impl<'a> VirtualMatrix for VirtualIm2Col<'a> {
                 const NR_REGS: usize = vec_count::<v128f>(KERNEL_WASM_NR);
                 self.pack_b_impl::<v128f, NR_REGS>(out, panel_width, rows, cols);
             },
-            (KernelType::Base, KERNEL_BASE_NR) => unsafe {
+            (KernelType::Generic, KERNEL_BASE_NR) => unsafe {
                 const NR_REGS: usize = vec_count::<f32>(KERNEL_BASE_NR);
                 self.pack_b_impl::<f32, NR_REGS>(out, panel_width, rows, cols);
             },

--- a/src/ops/conv/im2col.rs
+++ b/src/ops/conv/im2col.rs
@@ -310,7 +310,7 @@ const KERNEL_FMA_NR: usize = 16;
 const KERNEL_WASM_NR: usize = 8;
 
 // Safety: `pack_b` initializes the entire buffer passed to it.
-unsafe impl<'a> VirtualMatrix for VirtualIm2Col<'a> {
+unsafe impl<'a> VirtualMatrix<f32> for VirtualIm2Col<'a> {
     fn rows(&self) -> usize {
         self.row_offsets.chan.len()
     }


### PR DESCRIPTION
Refactor the `GemmExecutor` and `Kernel` interfaces to be generic over the element types of the A and B input matrices and output matrix.

This allows reusing a lot of the code for matmul operations with different element types. Currently only f32 is supported, but in future this should be helpful for supporting f16, bf16, i8, u8 etc. For quantised matmul the interfaces will need to change since additional quantisation parameters will need to be passed, such as the zero-point and scale for inputs.

The architecture-specific kernels still have to be implemented separately for each combination of types, as well as the code that instantiates a `GemmExecutor` for such a combination.