### PR TITLE
Fix markdown error in ctc module

### DIFF
--- a/src/ctc.rs
+++ b/src/ctc.rs
@@ -8,7 +8,7 @@ use rten_tensor::{NdTensor, NdTensorView};
 
 use crate::Operators;
 
-/// Connectionist Temporal Classification (CTC) [^1][^2] sequence decoder.
+/// Connectionist Temporal Classification (CTC) [^1] [^2] sequence decoder.
 ///
 /// The decoder takes an input of shape `[sequence, n_labels]`, where the values
 /// are log probabilities of a label, and infers the most likely sequence of


### PR DESCRIPTION
Fix an error reported by `make docs` about unportable markdown in ctc.rs after upgrading to Rust v1.81.