### PR TITLE
Remove derived `Default` impl for GEMM kernels

### DIFF
--- a/src/gemm/kernels/aarch64.rs
+++ b/src/gemm/kernels/aarch64.rs
@@ -9,7 +9,6 @@ use super::simd_generic::{simd_gemm, simd_gemv};
 use super::Kernel;
 use crate::gemm::packing::{pack_a_block, pack_b_block};
 
-#[derive(Default)]
 pub struct ArmNeonKernel {
     _private: (),
 }

--- a/src/gemm/kernels/generic.rs
+++ b/src/gemm/kernels/generic.rs
@@ -11,7 +11,6 @@ use crate::gemm::packing::{pack_a_block, pack_b_block};
 /// This is the base kernel that does not use architecture-specific intrinsics
 /// but is autovectorization-friendly. It is expected to perform the same as
 /// a kernel using SSE intrinsics (or equivalent).
-#[derive(Default)]
 pub struct GenericKernel {
     _private: (),
 }

--- a/src/gemm/kernels/wasm.rs
+++ b/src/gemm/kernels/wasm.rs
@@ -9,7 +9,6 @@ use super::simd_generic::{simd_gemm, simd_gemv};
 use super::Kernel;
 use crate::gemm::packing::{pack_a_block, pack_b_block};
 
-#[derive(Default)]
 pub struct WasmKernel {
     _private: (),
 }

--- a/src/gemm/kernels/x86_64.rs
+++ b/src/gemm/kernels/x86_64.rs
@@ -16,7 +16,6 @@ use super::Kernel;
 use crate::gemm::packing::{pack_a_block, pack_b_block};
 
 /// Optimized kernel for x64 CPUs that support AVX + FMA instructions.
-#[derive(Default)]
 pub struct FmaKernel {
     _private: (),
 }
@@ -132,7 +131,6 @@ unsafe impl Kernel<f32, f32, f32> for FmaKernel {
 
 /// Optimized kernel for x64 CPUs that support AVX 512 instructions.
 #[cfg(feature = "avx512")]
-#[derive(Default)]
 pub struct Avx512Kernel {
     _private: (),
 }


### PR DESCRIPTION
Kernels are only supposed to be constructible via the `new` method which returns `None` if the kernel is not supported on the current system. Having a derived `Default` impl provided a way to instantiate the kernels even on systems where they are not supported.