### PR TITLE
Add non-optimised `MatMulInteger` implementation

### DIFF
--- a/rten-convert/rten_convert/schema_generated.py
+++ b/rten-convert/rten_convert/schema_generated.py
@@ -115,6 +115,7 @@ class OperatorType(object):
     DequantizeLinear = 105
     QuantizeLinear = 106
     DynamicQuantizeLinear = 107
+    MatMulInteger = 108
 
 
 class RNNDirection(object):

--- a/src/model_builder.rs
+++ b/src/model_builder.rs
@@ -77,6 +77,7 @@ pub enum OpType<'a> {
     Log,
     LogSoftmax(LogSoftmax),
     MatMul,
+    MatMulInteger,
     Max,
     MaxPool(MaxPool),
     Mean,
@@ -614,6 +615,7 @@ impl<'mb, 'a> GraphBuilder<'mb, 'a> {
                 }
             ),
             OpType::MatMul => op!(MatMul),
+            OpType::MatMulInteger => op!(MatMulInteger),
             OpType::Max => op!(Max),
             OpType::MaxPool(args) => op_with_attrs!(MaxPool, MaxPoolAttrs, {
                 let pad_args = pad_args_from_padding(args.padding);

--- a/src/op_registry.rs
+++ b/src/op_registry.rs
@@ -133,6 +133,7 @@ impl OpRegistry {
         register_op!(LogSoftmax);
         register_op!(LSTM);
         register_op!(MatMul);
+        register_op!(MatMulInteger);
         register_op!(Max);
         register_op!(MaxPool);
         register_op!(Mean);
@@ -610,6 +611,7 @@ impl_read_op!(LSTM, attrs_as_lstmattrs, |attrs: sg::LSTMAttrs| {
     })
 });
 impl_read_op!(MatMul);
+impl_read_op!(MatMulInteger);
 impl_read_op!(Max);
 impl_read_op!(
     MaxPool,

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -82,7 +82,7 @@ pub use layout::{
     expand, flatten, reshape, squeeze, squeeze_in_place, Expand, Flatten, Reshape, Shape, Size,
     Squeeze, Transpose, Unsqueeze,
 };
-pub use matmul::{gemm_op, matmul, Gemm, MatMul};
+pub use matmul::{gemm_op, matmul, Gemm, MatMul, MatMulInteger};
 pub use non_max_suppression::{non_max_suppression, BoxOrder, NonMaxSuppression};
 pub use norm::{
     batch_norm, batch_norm_in_place, instance_normalization, layer_normalization, log_softmax,

--- a/src/schema.fbs
+++ b/src/schema.fbs
@@ -121,6 +121,7 @@ enum OperatorType: ubyte {
   DequantizeLinear,
   QuantizeLinear,
   DynamicQuantizeLinear,
+  MatMulInteger,
 }
 
 enum RNNDirection: ubyte {

--- a/src/schema_generated.rs
+++ b/src/schema_generated.rs
@@ -18,13 +18,13 @@ pub const ENUM_MIN_OPERATOR_TYPE: u8 = 0;
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
-pub const ENUM_MAX_OPERATOR_TYPE: u8 = 107;
+pub const ENUM_MAX_OPERATOR_TYPE: u8 = 108;
 #[deprecated(
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 108] = [
+pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 109] = [
     OperatorType::Add,
     OperatorType::ArgMin,
     OperatorType::ArgMax,
@@ -133,6 +133,7 @@ pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 108] = [
     OperatorType::DequantizeLinear,
     OperatorType::QuantizeLinear,
     OperatorType::DynamicQuantizeLinear,
+    OperatorType::MatMulInteger,
 ];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -248,9 +249,10 @@ impl OperatorType {
     pub const DequantizeLinear: Self = Self(105);
     pub const QuantizeLinear: Self = Self(106);
     pub const DynamicQuantizeLinear: Self = Self(107);
+    pub const MatMulInteger: Self = Self(108);
 
     pub const ENUM_MIN: u8 = 0;
-    pub const ENUM_MAX: u8 = 107;
+    pub const ENUM_MAX: u8 = 108;
     pub const ENUM_VALUES: &'static [Self] = &[
         Self::Add,
         Self::ArgMin,
@@ -360,6 +362,7 @@ impl OperatorType {
         Self::DequantizeLinear,
         Self::QuantizeLinear,
         Self::DynamicQuantizeLinear,
+        Self::MatMulInteger,
     ];
     /// Returns the variant's name or "" if unknown.
     pub fn variant_name(self) -> Option<&'static str> {
@@ -472,6 +475,7 @@ impl OperatorType {
             Self::DequantizeLinear => Some("DequantizeLinear"),
             Self::QuantizeLinear => Some("QuantizeLinear"),
             Self::DynamicQuantizeLinear => Some("DynamicQuantizeLinear"),
+            Self::MatMulInteger => Some("MatMulInteger"),
             _ => None,
         }
     }

--- a/tools/ort-quantize.py
+++ b/tools/ort-quantize.py
@@ -1,0 +1,13 @@
+from argparse import ArgumentParser
+
+import onnx
+from onnxruntime.quantization import quantize_dynamic
+
+parser = ArgumentParser()
+parser.add_argument("input")
+parser.add_argument("output", nargs="?")
+args = parser.parse_args()
+
+output = args.output or args.input.replace(".onnx", ".quant.onnx")
+
+quantize_dynamic(args.input, output)


### PR DESCRIPTION
Add a non-optimized implementation of the `MatMulInteger` operator.

With this it is possible to run a quantized GPT-2 model ... very slowly. Optimized kernels will follow in subsequent PRs.