### PR TITLE
Make im2col packing mostly generic

### DIFF
--- a/rten-simd/src/arch/aarch64.rs
+++ b/rten-simd/src/arch/aarch64.rs
@@ -3,15 +3,24 @@ use std::arch::aarch64::{
     vbslq_f32, vbslq_s32, vceqq_s32, vcgeq_f32, vcgeq_s32, vcgtq_s32, vcleq_f32, vcleq_s32,
     vcltq_f32, vcltq_s32, vcvtq_s32_f32, vdivq_f32, vdupq_n_f32, vdupq_n_s32, vfmaq_f32, vld1q_f32,
     vld1q_s32, vmaxq_f32, vmulq_f32, vreinterpretq_f32_s32, vshlq_n_s32, vst1q_f32, vst1q_s32,
-    vsubq_f32, vsubq_s32,
+    vst1q_u32, vsubq_f32, vsubq_s32,
 };
 
 use crate::{SimdFloat, SimdInt, SimdMask, SimdVal};
 
 impl SimdMask for uint32x4_t {
+    type Array = [bool; 4];
+
     #[inline]
     unsafe fn and(self, other: Self) -> Self {
         vandq_u32(self, other)
+    }
+
+    #[inline]
+    unsafe fn to_array(self) -> Self::Array {
+        let mut array = [0; 4];
+        vst1q_u32(array.as_mut_ptr(), self);
+        std::array::from_fn(|i| array[i] != 0)
     }
 }
 
@@ -22,6 +31,7 @@ impl SimdVal for int32x4_t {
 }
 
 impl SimdInt for int32x4_t {
+    type Array = [i32; 4];
     type Float = float32x4_t;
 
     #[inline]
@@ -92,6 +102,13 @@ impl SimdInt for int32x4_t {
     #[inline]
     unsafe fn store(self, ptr: *mut i32) {
         vst1q_s32(ptr, self)
+    }
+
+    #[inline]
+    unsafe fn to_array(self) -> Self::Array {
+        let mut array = [0; Self::LEN];
+        self.store(array.as_mut_ptr());
+        array
     }
 }
 

--- a/rten-simd/src/arch/scalar.rs
+++ b/rten-simd/src/arch/scalar.rs
@@ -1,9 +1,16 @@
 use crate::{SimdFloat, SimdInt, SimdMask, SimdVal};
 
 impl SimdMask for bool {
+    type Array = [bool; 1];
+
     #[inline]
     unsafe fn and(self, rhs: Self) -> Self {
         self & rhs
+    }
+
+    #[inline]
+    unsafe fn to_array(self) -> Self::Array {
+        [self]
     }
 }
 
@@ -15,6 +22,7 @@ impl SimdVal for i32 {
 
 /// Treat an `i32` as a single-lane SIMD "vector".
 impl SimdInt for i32 {
+    type Array = [i32; 1];
     type Float = f32;
 
     #[inline]
@@ -89,6 +97,11 @@ impl SimdInt for i32 {
     #[inline]
     unsafe fn store(self, ptr: *mut i32) {
         *ptr = self;
+    }
+
+    #[inline]
+    unsafe fn to_array(self) -> Self::Array {
+        [self]
     }
 }
 

--- a/rten-simd/src/arch/wasm.rs
+++ b/rten-simd/src/arch/wasm.rs
@@ -18,9 +18,18 @@ pub struct v128i(v128);
 pub struct v128f(v128);
 
 impl SimdMask for v128i {
+    type Array = [bool; 4];
+
     #[inline]
     unsafe fn and(self, other: Self) -> Self {
         Self(v128_and(self.0, other.0))
+    }
+
+    #[inline]
+    unsafe fn to_array(self) -> Self::Array {
+        let mut array = [0; Self::LEN];
+        self.store(array.as_mut_ptr());
+        std::array::from_fn(|i| array[i] != 0)
     }
 }
 
@@ -31,6 +40,7 @@ impl SimdVal for v128i {
 }
 
 impl SimdInt for v128i {
+    type Array = [i32; 4];
     type Float = v128f;
 
     #[inline]
@@ -96,6 +106,13 @@ impl SimdInt for v128i {
     #[inline]
     unsafe fn store(self, ptr: *mut i32) {
         v128_store(ptr as *mut v128, self.0)
+    }
+
+    #[inline]
+    unsafe fn to_array(self) -> Self::Array {
+        let mut array = [0; Self::LEN];
+        self.store(array.as_mut_ptr());
+        array
     }
 }
 

--- a/rten-simd/src/vec.rs
+++ b/rten-simd/src/vec.rs
@@ -68,8 +68,14 @@ pub const fn vec_count<S: SimdVal>(count: usize) -> usize {
 /// Trait implemented by SIMD masks.
 #[allow(clippy::missing_safety_doc)]
 pub trait SimdMask: Copy {
+    /// A representation of this mask as a bool array.
+    type Array: std::ops::Index<usize, Output = bool>;
+
     /// Return a bitwise AND of self and `rhs`.
     unsafe fn and(self, rhs: Self) -> Self;
+
+    /// Convert this SIMD mask to a boolean array.
+    unsafe fn to_array(self) -> Self::Array;
 }
 
 /// Trait for SIMD vectors containing 32-bit integers.
@@ -78,6 +84,9 @@ pub trait SimdInt: SimdVal {
     /// The type produced by an operation that converts each element in this
     /// vector to a float.
     type Float: SimdFloat<Int = Self, Mask = Self::Mask>;
+
+    /// The contents of a vector as an array.
+    type Array: std::ops::Index<usize, Output = i32>;
 
     /// Return a new vector with all elements set to zero.
     #[inline]
@@ -139,6 +148,9 @@ pub trait SimdInt: SimdVal {
     /// Safety: The caller must ensure `ptr` points to a buffer with space for
     /// at least `Self::LEN` values.
     unsafe fn store(self, ptr: *mut i32);
+
+    /// Return the contents of this vector as an array.
+    unsafe fn to_array(self) -> Self::Array;
 }
 
 /// Trait for SIMD vectors containing single-precision floats.

--- a/src/ops/conv.rs
+++ b/src/ops/conv.rs
@@ -97,7 +97,7 @@ pub fn conv<X, W, Y>(
     dilations: &[usize],
 ) -> Result<Tensor<Y>, OpError>
 where
-    X: std::ops::Mul<W, Output = Y> + GemmInT,
+    X: std::ops::Mul<W, Output = Y> + Default + GemmInT,
     W: GemmInT,
     Y: Default + std::ops::AddAssign<Y> + GemmOutT,
     GemmExecutor<W, X, Y>: Default,


### PR DESCRIPTION
This is a step towards implementing `ConvInteger` and supporting non-f32 float types in convolution.

Part of https://github.com/robertknight/rten/issues/347.