### PR TITLE
Add `TensorBase::slice_with` method

### DIFF
--- a/rten-generate/src/generator.rs
+++ b/rten-generate/src/generator.rs
@@ -602,7 +602,7 @@ impl<'a> Generator<'a> {
 
         // Sample output token.
         let logits: NdTensor<f32, 3> = outputs.remove(0).try_into().map_err(wrap_error)?;
-        let next_id = self.sampler.sample(logits.slice::<1, _>((0, -1)));
+        let next_id = self.sampler.sample(logits.slice_with((0, -1)));
 
         // Update the self-attention key-value cache.
         //

--- a/rten-generate/src/sampler.rs
+++ b/rten-generate/src/sampler.rs
@@ -97,11 +97,7 @@ impl Sampler for TopKSampler {
         let topk_index = multinomial(&mut self.rng.borrow_mut(), probs.nd_view())
             .expect("probs should be non-empty and sum to 1");
 
-        let token_id = topk_indices
-            .slice::<0, _>(topk_index)
-            .item()
-            .copied()
-            .unwrap();
+        let token_id = topk_indices.slice_with(topk_index).item().copied().unwrap();
         token_id as TokenId
     }
 }

--- a/rten-tensor/src/copy.rs
+++ b/rten-tensor/src/copy.rs
@@ -205,8 +205,8 @@ pub fn copy_into_slice<'a, T: Clone>(
         let mut dest = NdTensorViewMut::from_data(src.shape(), dest);
         for i0 in 0..src.size(0) {
             for i1 in 0..src.size(1) {
-                let src = src.slice::<2, _>([i0, i1]);
-                let dest = dest.slice_mut::<2, _>([i0, i1]);
+                let src = src.slice_with([i0, i1]);
+                let dest = dest.slice_with_mut([i0, i1]);
                 copy_blocked(src, dest);
             }
         }

--- a/rten-tensor/src/lib.rs
+++ b/rten-tensor/src/lib.rs
@@ -48,6 +48,7 @@ mod overlap;
 mod slice_range;
 mod storage;
 mod tensor;
+pub mod type_num;
 
 /// Trait for sources of random data for tensors, for use with [`Tensor::rand`].
 pub trait RandomSource<T> {

--- a/rten-tensor/src/tensor.rs
+++ b/rten-tensor/src/tensor.rs
@@ -3657,8 +3657,8 @@ mod tests {
     #[test]
     fn test_to_array() {
         let tensor = NdTensor::arange(1., 5., None).into_shape([2, 2]);
-        let col0: [f32; 2] = tensor.view().transposed().slice::<1, _>(0).to_array();
-        let col1: [f32; 2] = tensor.view().transposed().slice::<1, _>(1).to_array();
+        let col0: [f32; 2] = tensor.view().transposed().slice_with(0).to_array();
+        let col1: [f32; 2] = tensor.view().transposed().slice_with(1).to_array();
         assert_eq!(col0, [1., 3.]);
         assert_eq!(col1, [2., 4.]);
     }

--- a/rten-tensor/src/type_num.rs
+++ b/rten-tensor/src/type_num.rs
@@ -1,0 +1,250 @@
+//! Traits and types for compile-time arithmetic.
+//!
+//! These types are used in various tensor methods, such as
+//! [`slice_with`](crate::TensorBase::slice_with), as part of computing the
+//! layout of the result at compile time.
+
+use std::ops::{Range, RangeFrom, RangeFull, RangeTo};
+
+/// Type representing the integer value 0.
+pub struct U0 {}
+
+/// Type representing the integer value 1.
+pub struct U1 {}
+
+/// Type representing the integer value 2.
+pub struct U2 {}
+
+/// Type representing the integer value 3.
+pub struct U3 {}
+
+/// Type representing the integer value 4.
+pub struct U4 {}
+
+/// Type representing the integer value 5.
+pub struct U5 {}
+
+/// Trait providing the integer value of a `U<N>` type (eg. [`U0`]).
+pub trait ConstUInt {
+    const VALUE: usize;
+}
+
+macro_rules! impl_const_int {
+    ($type:ty, $val:literal) => {
+        impl ConstUInt for $type {
+            const VALUE: usize = $val;
+        }
+    };
+}
+impl_const_int!(U0, 0);
+impl_const_int!(U1, 1);
+impl_const_int!(U2, 2);
+impl_const_int!(U3, 3);
+impl_const_int!(U4, 4);
+impl_const_int!(U5, 5);
+
+/// Trait that computes the sum of [`ConstUInt`] types.
+///
+/// It is implemented for 2-tuples, as well as arrays of either `U0` or `U1`.
+pub trait Add {
+    type Result: ConstUInt;
+}
+
+macro_rules! impl_add {
+    ($lhs:ty, $rhs:ty, $result:ty) => {
+        impl Add for ($lhs, $rhs) {
+            type Result = $result;
+        }
+
+        impl Add for ($rhs, $lhs) {
+            type Result = $result;
+        }
+    };
+
+    ($lhs:ty, $result:ty) => {
+        impl Add for ($lhs, $lhs) {
+            type Result = $result;
+        }
+    };
+}
+
+// Implement addition of 2-tuples up to a value of 5.
+impl_add!(U0, U0);
+impl_add!(U0, U1, U1);
+impl_add!(U0, U2, U2);
+impl_add!(U0, U3, U3);
+impl_add!(U0, U4, U4);
+impl_add!(U0, U5, U5);
+impl_add!(U1, U2);
+impl_add!(U1, U2, U3);
+impl_add!(U1, U3, U4);
+impl_add!(U1, U4, U5);
+impl_add!(U2, U4);
+impl_add!(U2, U3, U5);
+
+// Implement addition of bits for values up to 5.
+impl<const N: usize> Add for [U0; N] {
+    type Result = U0;
+}
+
+macro_rules! impl_add_ones {
+    ($count:literal, $type:ty) => {
+        impl Add for [U1; $count] {
+            type Result = $type;
+        }
+    };
+}
+impl_add_ones!(0, U0);
+impl_add_ones!(1, U1);
+impl_add_ones!(2, U2);
+impl_add_ones!(3, U3);
+impl_add_ones!(4, U4);
+impl_add_ones!(5, U5);
+
+/// Marker trait indicating whether a value is an index or a range.
+pub trait IsIndex {
+    /// Associated type that is either [`U0`] or [`U1`] indicating whether this
+    /// type is an index.
+    type IsIndex: ConstUInt;
+}
+
+macro_rules! impl_is_index {
+    ($type:ty, true) => {
+        impl IsIndex for $type {
+            type IsIndex = U1;
+        }
+    };
+}
+
+impl_is_index!(usize, true);
+impl_is_index!(isize, true);
+impl_is_index!(i32, true);
+
+impl<T> IsIndex for Range<T> {
+    type IsIndex = U0;
+}
+
+impl IsIndex for RangeFull {
+    type IsIndex = U0;
+}
+
+impl<T> IsIndex for RangeTo<T> {
+    type IsIndex = U0;
+}
+
+impl<T> IsIndex for RangeFrom<T> {
+    type IsIndex = U0;
+}
+
+/// Trait that counts the number of items in a sequence which are indices, as
+/// opposed to ranges.
+///
+/// This trait is a helper used by slicing methods in
+/// [`TensorBase`](crate::TensorBase) to infer the rank of a view after slicing
+/// with a range.
+///
+/// The trait is implemented for scalar values, ranges and tuples up to length 5.
+///
+/// ```
+/// use rten_tensor::type_num::IndexCount;
+/// assert_eq!((.., 1..2).index_count(), 0);
+/// assert_eq!((0, 1..2).index_count(), 1);
+/// assert_eq!((0, 1).index_count(), 2);
+/// ```
+pub trait IndexCount {
+    /// Type representing the count value.
+    type Count: ConstUInt;
+
+    /// Returns [`Count`](IndexCount::Count) as a numeric value.
+    fn index_count(&self) -> usize {
+        Self::Count::VALUE
+    }
+}
+
+impl IndexCount for usize {
+    type Count = U1;
+}
+
+impl<T> IndexCount for Range<T> {
+    type Count = U0;
+}
+
+impl<T> IndexCount for RangeTo<T> {
+    type Count = U0;
+}
+
+impl<T> IndexCount for RangeFrom<T> {
+    type Count = U0;
+}
+
+impl IndexCount for RangeFull {
+    type Count = U0;
+}
+
+impl<T: IsIndex> IndexCount for (T,) {
+    type Count = T::IsIndex;
+}
+
+impl<T1: IsIndex, T2: IsIndex> IndexCount for (T1, T2)
+where
+    (T1::IsIndex, T2::IsIndex): Add,
+{
+    type Count = <(T1::IsIndex, T2::IsIndex) as Add>::Result;
+}
+
+impl<T1: IsIndex, T2: IsIndex, T3: IsIndex> IndexCount for (T1, T2, T3)
+where
+    (T1, T2): IndexCount,
+    (<(T1, T2) as IndexCount>::Count, T3::IsIndex): Add,
+{
+    type Count = <(<(T1, T2) as IndexCount>::Count, T3::IsIndex) as Add>::Result;
+}
+
+impl<T1: IsIndex, T2: IsIndex, T3: IsIndex, T4: IsIndex> IndexCount for (T1, T2, T3, T4)
+where
+    (T1, T2, T3): IndexCount,
+    (<(T1, T2, T3) as IndexCount>::Count, T4::IsIndex): Add,
+{
+    type Count = <(<(T1, T2, T3) as IndexCount>::Count, T4::IsIndex) as Add>::Result;
+}
+
+impl<T1: IsIndex, T2: IsIndex, T3: IsIndex, T4: IsIndex, T5: IsIndex> IndexCount
+    for (T1, T2, T3, T4, T5)
+where
+    (T1, T2, T3, T4): IndexCount,
+    (<(T1, T2, T3, T4) as IndexCount>::Count, T5::IsIndex): Add,
+{
+    type Count = <(<(T1, T2, T3, T4) as IndexCount>::Count, T5::IsIndex) as Add>::Result;
+}
+
+impl<T: IsIndex, const N: usize> IndexCount for [T; N]
+where
+    [T::IsIndex; N]: Add,
+{
+    type Count = <[T::IsIndex; N] as Add>::Result;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::IndexCount;
+
+    #[test]
+    fn test_index_count() {
+        // Single values
+        assert_eq!((0).index_count(), 1);
+        assert_eq!((..).index_count(), 0);
+        assert_eq!((..1).index_count(), 0);
+        assert_eq!((1..).index_count(), 0);
+        assert_eq!((1..2).index_count(), 0);
+
+        // Tuples
+        assert_eq!((0,).index_count(), 1);
+        assert_eq!((0, ..).index_count(), 1);
+        assert_eq!((0, .., 2).index_count(), 2);
+        assert_eq!((0, .., 2, ..).index_count(), 2);
+        assert_eq!((0, .., 2, .., 3).index_count(), 3);
+
+        // Arrays
+        assert_eq!([1, 2, 3].index_count(), 3);
+    }
+}

--- a/src/gemm.rs
+++ b/src/gemm.rs
@@ -722,7 +722,7 @@ fn gemv<LhsT: GemmInT, RhsT: GemmInT, OutT: GemmOutT>(
             for (k_block, a_block) in
                 range_chunks(0..a_cols, k_block_size).zip(a_data.chunks(k_block_size))
             {
-                let b_block = b.slice::<2, _>((k_block, col_block.clone()));
+                let b_block = b.slice_with((k_block, col_block.clone()));
                 kernel.gemv_kernel(out_chunk, a_block, b_block, alpha, effective_beta);
 
                 // Reset `beta` so that subsequent updates for each column
@@ -815,7 +815,7 @@ fn gemm_impl<LhsT: GemmInT, RhsT: GemmInT, OutT: GemmOutT>(
     if let (1, GemmInputA::Unpacked(a), GemmInputB::Unpacked(b)) = (a.rows(), a, b) {
         gemv(
             kernel,
-            a.slice::<1, _>(0),
+            a.slice_with(0),
             b,
             output_mat.view_mut(),
             alpha,

--- a/src/gemm/kernels/simd_generic.rs
+++ b/src/gemm/kernels/simd_generic.rs
@@ -148,7 +148,7 @@ unsafe fn simd_gemv_transposed<S: SimdFloat>(
         simd_gemv_fallback(
             &mut out[last_col_tile.clone()],
             a,
-            b.slice::<2, _>((.., last_col_tile)),
+            b.slice_with((.., last_col_tile)),
             alpha,
             beta,
         );

--- a/src/ops/conv/depthwise.rs
+++ b/src/ops/conv/depthwise.rs
@@ -92,7 +92,7 @@ fn conv_2d_depthwise_block<X, W, Y>(
         let out_row_len = out_chan.size(1);
         let out_chan_data = out_chan.data_mut().unwrap();
 
-        let in_chan = input.slice::<2, _>([c]);
+        let in_chan = input.slice_with([c]);
         let in_row_stride = in_chan.stride(0);
         let in_row_len = in_chan.size(1);
         let in_chan_data = in_chan.data().unwrap();
@@ -204,8 +204,8 @@ where
 
     let n_init = AtomicUsize::new(0);
     for n in 0..batch {
-        let mut out_chans = output.slice_mut::<3, _>(n);
-        let input = input.slice::<3, _>(n);
+        let mut out_chans = output.slice_with_mut(n);
+        let input = input.slice_with(n);
 
         out_chans
             .axis_chunks_mut(0, channel_chunk_size)

--- a/src/ops/non_max_suppression.rs
+++ b/src/ops/non_max_suppression.rs
@@ -93,7 +93,7 @@ pub fn non_max_suppression(
     for n in 0..batch {
         for b in 0..n_boxes {
             let (max_score_cls, max_score) = scores
-                .slice::<1, _>((n, .., b))
+                .slice_with((n, .., b))
                 .iter()
                 .copied()
                 .enumerate()


### PR DESCRIPTION
Add new slicing methods, `slice_with` and `slice_with_mut` that infer the rank of the returned views automatically at compile time. This is more ergonomic to use than the existing `slice` method and avoids the possibility of specifying the wrong dimension count, or changing the rank of the sliced type and forgetting to update the slicing operation.

Eventually this may replace both `slice` and `slice_dyn`, but it has been added as a new API initially to allow incremental adoption downstream and also allow some iteration on the details.