### PR TITLE
Replace remaining uses of `slice` with `slice_with`

### DIFF
--- a/rten-imageproc/src/drawing.rs
+++ b/rten-imageproc/src/drawing.rs
@@ -465,7 +465,7 @@ impl<'a, T: Copy + Default> Painter<'a, T> {
     pub fn draw_polygon(&mut self, points: &[Point]) {
         for i in 0..3 {
             draw_polygon(
-                self.surface.slice_mut([i]),
+                self.surface.slice_with_mut([i]),
                 points,
                 self.state.stroke[i],
                 self.state.stroke_width,
@@ -600,9 +600,9 @@ mod tests {
         let expected_g = expected_r.map(|&x| if x == r { g } else { 0 });
         let expected_b = expected_r.map(|&x| if x == r { b } else { 0 });
 
-        compare_images(img.slice([0]), expected_r.view());
-        compare_images(img.slice([1]), expected_g.view());
-        compare_images(img.slice([2]), expected_b.view());
+        compare_images(img.slice_with([0]), expected_r.view());
+        compare_images(img.slice_with([1]), expected_g.view());
+        compare_images(img.slice_with([2]), expected_b.view());
     }
 
     #[test]

--- a/rten-imageproc/src/normalize.rs
+++ b/rten-imageproc/src/normalize.rs
@@ -32,7 +32,7 @@ pub fn normalize_image<const C: usize>(
 
     for chan in 0..n_chans {
         let inv_std_dev = 1. / std_dev[chan];
-        img.slice_mut::<2, _>(chan)
+        img.slice_with_mut(chan)
             .apply(|x| (x - mean[chan]) * inv_std_dev);
     }
 }

--- a/rten-tensor/src/tensor.rs
+++ b/rten-tensor/src/tensor.rs
@@ -2434,8 +2434,8 @@ mod tests {
         let mut transposed = tensor.view_mut();
 
         transposed.permute([1, 0]);
-        transposed.slice_mut(0).assign_array([1, 2]);
-        transposed.slice_mut(1).assign_array([3, 4]);
+        transposed.slice_with_mut(0).assign_array([1, 2]);
+        transposed.slice_with_mut(1).assign_array([3, 4]);
 
         assert_eq!(tensor.iter().copied().collect::<Vec<_>>(), [1, 3, 2, 4]);
     }

--- a/src/ops/conv/depthwise.rs
+++ b/src/ops/conv/depthwise.rs
@@ -83,11 +83,11 @@ fn conv_2d_depthwise_block<X, W, Y>(
     let [dilation_y, _dilation_x] = dilations;
 
     for c in chan_range.clone() {
-        let kernel_view = kernel.slice([c, 0]).weakly_checked_view();
+        let kernel_view = kernel.slice_with([c, 0]).weakly_checked_view();
 
         // For efficiency, use manual slicing in the inner loops to extract
         // input/output rows.
-        let mut out_chan = output.slice_mut::<2, _>([c - chan_range.start]);
+        let mut out_chan = output.slice_with_mut([c - chan_range.start]);
         let out_row_stride = out_chan.stride(0);
         let out_row_len = out_chan.size(1);
         let out_chan_data = out_chan.data_mut().unwrap();

--- a/src/ops/non_max_suppression.rs
+++ b/src/ops/non_max_suppression.rs
@@ -104,7 +104,7 @@ pub fn non_max_suppression(
                 continue;
             }
 
-            let [c0, c1, c2, c3] = boxes.slice((n, b)).to_array();
+            let [c0, c1, c2, c3] = boxes.slice_with((n, b)).to_array();
             let [top, left, bottom, right] = match box_order {
                 BoxOrder::TopLeftBottomRight => [c0, c1, c2, c3],
                 BoxOrder::CenterWidthHeight => {
@@ -172,7 +172,7 @@ pub fn non_max_suppression(
 
     let mut selected_indices = NdTensor::zeros_in(pool, [selected.len(), 3]);
     for (i, nms_box) in selected.into_iter().enumerate() {
-        selected_indices.slice_mut(i).assign_array([
+        selected_indices.slice_with_mut(i).assign_array([
             nms_box.batch_index as i32,
             nms_box.class as i32,
             nms_box.box_index as i32,
@@ -255,7 +255,7 @@ mod tests {
                     [cx, cy, w, h]
                 }
             };
-            out_boxes.slice_mut((0, i)).assign_array(coords);
+            out_boxes.slice_with_mut((0, i)).assign_array(coords);
             out_scores[[0, nms_box.class, i]] = nms_box.score;
         }
 
@@ -309,10 +309,10 @@ mod tests {
 
         assert_eq!(selected.size(0), 2);
 
-        let [batch, class, box_idx] = selected.slice(0).to_array();
+        let [batch, class, box_idx] = selected.slice_with(0).to_array();
         assert_eq!([batch, class, box_idx], [0, 0, 0]);
 
-        let [batch, class, box_idx] = selected.slice(1).to_array();
+        let [batch, class, box_idx] = selected.slice_with(1).to_array();
         assert_eq!([batch, class, box_idx], [0, 1, 2]);
     }
 
@@ -371,10 +371,10 @@ mod tests {
         // returned.
         assert_eq!(selected.size(0), 3);
 
-        let [batch, class, box_idx] = selected.slice(0).to_array();
+        let [batch, class, box_idx] = selected.slice_with(0).to_array();
         assert_eq!([batch, class, box_idx], [0, 0, 0]);
 
-        let [batch, class, box_idx] = selected.slice(1).to_array();
+        let [batch, class, box_idx] = selected.slice_with(1).to_array();
         assert_eq!([batch, class, box_idx], [0, 0, 1]);
     }
 
@@ -400,10 +400,10 @@ mod tests {
         // be returned from each class.
         assert!(selected.size(0) == 2);
 
-        let [batch, class, box_idx] = selected.slice(0).to_array();
+        let [batch, class, box_idx] = selected.slice_with(0).to_array();
         assert_eq!([batch, class, box_idx], [0, 0, 0]);
 
-        let [batch, class, box_idx] = selected.slice(1).to_array();
+        let [batch, class, box_idx] = selected.slice_with(1).to_array();
         assert_eq!([batch, class, box_idx], [0, 1, 2]);
     }
 
@@ -428,7 +428,7 @@ mod tests {
         // Only the box with score exceeding `score_threshold` will be returned.
         assert!(selected.size(0) == 1);
 
-        let [batch, class, box_idx] = selected.slice(0).to_array();
+        let [batch, class, box_idx] = selected.slice_with(0).to_array();
         assert_eq!([batch, class, box_idx], [0, 0, 0]);
     }
 


### PR DESCRIPTION
Continue the work to use static-rank tensors and automatic inference of sliced view rank, where possible.