### PR TITLE
Support ranges with unknown index count in `slice_with`

### DIFF
--- a/rten-tensor/src/iterators.rs
+++ b/rten-tensor/src/iterators.rs
@@ -779,7 +779,7 @@ impl<'a, T, L: MutLayout> Iterator for InnerIterDyn<'a, T, L> {
     fn next(&mut self) -> Option<Self::Item> {
         self.outer_indices.next().map(|idx| {
             let slice_items = to_slice_items(&idx);
-            self.view.slice_dyn(slice_items.as_slice())
+            self.view.slice_with(slice_items.as_slice())
         })
     }
 

--- a/rten-tensor/src/tensor.rs
+++ b/rten-tensor/src/tensor.rs
@@ -3544,7 +3544,7 @@ mod tests {
         // Slice dynamic-rank array. The rank of the slice is dynamic.
         let mut data = Tensor::from([[[1, 2, 3], [4, 5, 6]]]);
         let mut row = data.slice_with_mut((0, 0));
-        row[[0]] = 10;
+        row[[0usize]] = 10;
         assert_eq!(row.shape(), [3usize]);
         assert_eq!(row.data().unwrap(), &[10, 2, 3]);
     }

--- a/src/ops/reduce.rs
+++ b/src/ops/reduce.rs
@@ -352,7 +352,7 @@ fn reduce<T: Copy, R: Reducer<T>>(
                             SliceItem::Index(idx as isize)
                         }
                     }));
-                    let slice = input.slice_dyn(inner_range.as_slice());
+                    let slice = input.slice_with(inner_range.as_slice());
                     let reduced = reducer.reduce(slice.iter().copied());
                     reduced_data.push(reduced);
                 }

--- a/src/ops/split.rs
+++ b/src/ops/split.rs
@@ -40,7 +40,7 @@ pub fn split<T: Copy>(
 
             split_start += split_size;
 
-            input.slice_dyn(slice_range.as_slice()).to_tensor_in(pool)
+            input.slice_with(slice_range.as_slice()).to_tensor_in(pool)
         })
         .collect();
 


### PR DESCRIPTION
Support slicing tensors with ranges that have a runtime-determined index count in `TensorBase::slice_with`. In such cases the resulting view has a dynamic-rank layout. This allows this method to replace existing usage of `slice_dyn`.