### PR TITLE
Use `zip` method instead of standalone function

### DIFF
--- a/rten-imageproc/src/contours.rs
+++ b/rten-imageproc/src/contours.rs
@@ -233,8 +233,6 @@ pub fn find_contours(mask: NdTensorView<bool, 2>, mode: RetrievalMode) -> Polygo
 
 #[cfg(test)]
 mod tests {
-    use std::iter::zip;
-
     use rten_tensor::prelude::*;
     use rten_tensor::NdTensor;
 
@@ -369,8 +367,8 @@ mod tests {
         let contours = find_contours(mask.view(), RetrievalMode::List);
         assert_eq!(contours.len(), rects.len());
 
-        for (border, rect) in zip(contours.iter(), rects.iter()) {
-            assert_eq!(border, border_points(*rect, false /* omit_corners */));
+        for (border, rect) in contours.iter().zip(rects) {
+            assert_eq!(border, border_points(rect, false /* omit_corners */));
         }
     }
 
@@ -386,8 +384,8 @@ mod tests {
         let contours = find_contours(mask.view(), RetrievalMode::List);
         assert_eq!(contours.len(), rects.len());
 
-        for (border, rect) in zip(contours.iter(), rects.iter()) {
-            assert_eq!(border, border_points(*rect, false /* omit_corners */));
+        for (border, rect) in contours.iter().zip(rects) {
+            assert_eq!(border, border_points(rect, false /* omit_corners */));
         }
     }
 

--- a/rten-imageproc/src/poly_algos.rs
+++ b/rten-imageproc/src/poly_algos.rs
@@ -1,5 +1,3 @@
-use std::iter::zip;
-
 use crate::{BoundingRect, Line, PointF, Polygon, RotatedRect, Vec2};
 
 /// Return the sorted subset of points from `poly` that form a convex hull
@@ -175,7 +173,7 @@ pub fn min_area_rect(points: &[PointF]) -> Option<RotatedRect> {
     // Iterate over each edge of the polygon and find the smallest bounding
     // rect where one of the rect's edges aligns with the polygon edge. Keep
     // the rect that has the smallest area over all edges.
-    for (&edge_start, &edge_end) in zip(hull.iter(), hull.iter().cycle().skip(1)) {
+    for (&edge_start, &edge_end) in hull.iter().zip(hull.iter().cycle().skip(1)) {
         debug_assert!(
             edge_start != edge_end,
             "hull edges should have non-zero length"

--- a/rten-imageproc/src/shapes.rs
+++ b/rten-imageproc/src/shapes.rs
@@ -1,5 +1,4 @@
 use std::fmt;
-use std::iter::zip;
 use std::marker::PhantomData;
 use std::ops::Range;
 use std::slice::Iter;
@@ -940,11 +939,11 @@ impl<T: Coord, S: AsRef<[Point<T>]>> Polygon<T, S> {
 
     /// Return an iterator over the edges of this polygon.
     pub fn edges(&self) -> impl Iterator<Item = Line<T>> + '_ {
-        zip(
-            self.points.as_ref().iter(),
-            self.points.as_ref().iter().cycle().skip(1),
-        )
-        .map(|(p0, p1)| Line::from_endpoints(*p0, *p1))
+        self.points
+            .as_ref()
+            .iter()
+            .zip(self.points.as_ref().iter().cycle().skip(1))
+            .map(|(p0, p1)| Line::from_endpoints(*p0, *p1))
     }
 
     /// Return a slice of the endpoints of the polygon's edges.

--- a/rten-tensor/src/overlap.rs
+++ b/rten-tensor/src/overlap.rs
@@ -1,5 +1,3 @@
-use std::iter::zip;
-
 use smallvec::SmallVec;
 
 /// Return true if a given shape and strides describe a contiguous layout in
@@ -56,7 +54,7 @@ pub fn may_have_internal_overlap(shape: &[usize], strides: &[usize]) -> bool {
 
     // Sort dimensions in order of increasing stride.
     let mut stride_shape: SmallVec<[(usize, usize); 8]> =
-        zip(strides.iter().copied(), shape.iter().copied()).collect();
+        strides.iter().copied().zip(shape.iter().copied()).collect();
     stride_shape.sort_unstable();
 
     // Verify that the stride for each dimension fully "steps over" the

--- a/rten-tensor/src/test_util.rs
+++ b/rten-tensor/src/test_util.rs
@@ -1,6 +1,5 @@
 use std::error::Error;
 use std::fmt::{Debug, Display, Formatter};
-use std::iter::zip;
 
 use crate::{AsView, Layout, TensorView};
 
@@ -152,7 +151,9 @@ where
         )));
     }
 
-    let mismatches: Vec<_> = zip(x.iter(), y.iter())
+    let mismatches: Vec<_> = x
+        .iter()
+        .zip(y.iter())
         .enumerate()
         .filter_map(|(i, (xi, yi))| {
             if !xi.approx_eq_with_atol_rtol(yi, atol.clone(), rtol.clone()) {
@@ -187,7 +188,9 @@ pub fn eq_with_nans(a: TensorView, b: TensorView) -> bool {
     if a.shape() != b.shape() {
         false
     } else {
-        zip(a.iter(), b.iter()).all(|(a, b)| (a.is_nan() && b.is_nan()) || a == b)
+        a.iter()
+            .zip(b.iter())
+            .all(|(a, b)| (a.is_nan() && b.is_nan()) || a == b)
     }
 }
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 use std::error::Error;
 use std::fmt;
-use std::iter::zip;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -1192,7 +1191,7 @@ impl Graph {
             op_node.operator.name(),
             op_node.name.as_ref().unwrap_or(&String::new())
         );
-        for (index, (id, shape)) in zip(op_node.inputs.iter(), input_shapes.iter()).enumerate() {
+        for (index, (id, shape)) in op_node.inputs.iter().zip(input_shapes).enumerate() {
             if let (Some(id), Some(shape)) = (id, shape) {
                 let name = self.node_name(*id);
                 println!("  input {}: {} ({:?})", index, name, shape);
@@ -1200,7 +1199,7 @@ impl Graph {
         }
 
         if let Ok(outputs) = op_result.as_ref() {
-            for (index, (id, output)) in zip(op_node.outputs.iter(), outputs.iter()).enumerate() {
+            for (index, (id, output)) in op_node.outputs.iter().zip(outputs).enumerate() {
                 let name = id.map(|id| self.node_name(id)).unwrap_or(String::new());
                 println!("  output {}: {} ({:?})", index, name, output.shape());
             }

--- a/src/ops/binary_elementwise.rs
+++ b/src/ops/binary_elementwise.rs
@@ -1,6 +1,6 @@
 use smallvec::SmallVec;
 use std::fmt::Debug;
-use std::iter::{repeat, zip};
+use std::iter::repeat;
 
 use rten_tensor::prelude::*;
 use rten_tensor::{Tensor, TensorView, TensorViewMut};
@@ -28,7 +28,7 @@ pub fn broadcast_shapes(a: &[usize], b: &[usize]) -> Option<SmallVec<[usize; 4]>
     let b_iter = b.iter().copied().rev().chain(repeat(1).take(b_pad));
 
     let mut result = SmallVec::with_capacity(a.len().max(b.len()));
-    for (a, b) in zip(a_iter, b_iter) {
+    for (a, b) in a_iter.zip(b_iter) {
         if a == b {
             result.push(a);
         } else if a == 1 {

--- a/src/ops/conv.rs
+++ b/src/ops/conv.rs
@@ -1,4 +1,3 @@
-use std::iter::zip;
 use std::mem::MaybeUninit;
 
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -254,7 +253,9 @@ where
         };
         let prepacked_kernel = prepacked_kernel.as_deref();
 
-        zip(out_group.axis_iter_mut(0), in_group.axis_iter(0))
+        out_group
+            .axis_iter_mut(0)
+            .zip(in_group.axis_iter(0))
             .par_bridge()
             .for_each(|(mut out_item, in_item)| {
                 let mut out_mat = out_item.reshaped_mut([out_channels_per_group, out_h * out_w]);

--- a/src/ops/gather.rs
+++ b/src/ops/gather.rs
@@ -1,5 +1,3 @@
-use std::iter::zip;
-
 use rten_tensor::prelude::*;
 use rten_tensor::{to_slice_items, NdTensorView, SliceItem, Tensor, TensorView, TensorViewMut};
 use smallvec::SmallVec;
@@ -60,7 +58,7 @@ pub fn gather<T: Copy + Default>(
     let mut in_range = full_range(input.ndim());
     let mut out_range = full_range(output.ndim());
 
-    for (index_idx, index) in zip(indices.indices(), indices.iter()) {
+    for (index_idx, index) in indices.indices().zip(indices.iter()) {
         in_range[axis] = SliceItem::Index(*index as isize);
         for (i, index_val) in index_idx.into_iter().enumerate() {
             out_range[axis + i] = SliceItem::Index(index_val as isize);
@@ -406,7 +404,7 @@ pub fn scatter_elements<
     let axis = resolve_axis(data.ndim(), axis)?;
 
     let mut output = data.to_tensor_in(pool);
-    for (index, update) in zip(updates.indices(), updates.iter()) {
+    for (index, update) in updates.indices().zip(updates.iter()) {
         let target_index: SmallVec<[usize; 5]> = index
             .iter()
             .enumerate()

--- a/src/ops/generate.rs
+++ b/src/ops/generate.rs
@@ -1,4 +1,3 @@
-use std::iter::zip;
 use std::ops;
 
 use rten_tensor::prelude::*;
@@ -60,7 +59,7 @@ pub fn onehot<T: Copy + Default + PartialEq>(
     data.resize(len, off_value);
     let mut output = Tensor::from_data(&out_shape, data);
 
-    for (mut index, class) in zip(indices.indices(), indices.iter()) {
+    for (mut index, class) in indices.indices().zip(indices.iter()) {
         if let Some(class) = resolve_index(depth, *class as isize) {
             index.insert(onehot_axis, class);
             output[&index] = on_value;

--- a/src/ops/layout.rs
+++ b/src/ops/layout.rs
@@ -1,6 +1,5 @@
 //! Operators which query or change the shape of a tensor, or copy/move/reorder
 //! elements.
-use std::iter::zip;
 
 use rten_tensor::prelude::*;
 use rten_tensor::{is_valid_permutation, NdTensorView, Tensor, TensorView};
@@ -537,7 +536,10 @@ pub fn unsqueeze_in_place<T: Clone>(
         let mut sorted_axes = resolve_axes(input.ndim() + axes.len(), axes.iter())?;
         sorted_axes.sort_unstable();
 
-        let axes_unique = zip(sorted_axes.iter().skip(1), sorted_axes.iter())
+        let axes_unique = sorted_axes
+            .iter()
+            .skip(1)
+            .zip(sorted_axes.iter())
             .all(|(prev, current)| prev != current);
         if !axes_unique {
             return Err(OpError::InvalidValue("Axes must be unique"));

--- a/src/ops/resize.rs
+++ b/src/ops/resize.rs
@@ -1,4 +1,3 @@
-use std::iter::zip;
 use std::mem::MaybeUninit;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -249,7 +248,10 @@ pub fn resize(
     nearest_mode: NearestMode,
 ) -> Result<Tensor, OpError> {
     let sizes: NdTensor<i32, 1> = match target {
-        ResizeTarget::Scales(scales) => zip(input.shape().iter(), scales.iter())
+        ResizeTarget::Scales(scales) => input
+            .shape()
+            .iter()
+            .zip(scales.iter())
             .map(|(&in_size, scale)| ((in_size as f32) * scale).floor() as i32)
             .collect(),
         ResizeTarget::Sizes(sizes) => sizes.to_tensor(),
@@ -278,7 +280,7 @@ pub fn resize(
     // other than 1.0 for the H and W dims.
     let input = static_dims!(input, 4, "NCHW")?;
     let [batch, _chans, _height, _width] = input.shape();
-    let sizes_valid = zip(0..input.ndim(), input.shape().iter()).all(|(dim, &in_size)| {
+    let sizes_valid = (0..input.ndim()).zip(input.shape()).all(|(dim, in_size)| {
         dim == input.ndim() - 1 || dim == input.ndim() - 2 || sizes[[dim]] == in_size as i32
     });
     if !sizes_valid {

--- a/src/ops/rnn.rs
+++ b/src/ops/rnn.rs
@@ -1,4 +1,4 @@
-use std::iter::{zip, Rev};
+use std::iter::Rev;
 use std::ops::Range;
 
 use rten_tensor::prelude::*;
@@ -63,23 +63,23 @@ fn sequence_for_dir(op_dirs: Direction, dir: usize, seq_len: usize) -> Sequence 
     }
 }
 
-/// Like [std::iter::zip], but combines 3 iterators.
+/// Like [`std::iter::zip`], but combines 3 iterators.
 fn zip3<T1, T2, T3>(
     a: impl Iterator<Item = T1>,
     b: impl Iterator<Item = T2>,
     c: impl Iterator<Item = T3>,
 ) -> impl Iterator<Item = (T1, T2, T3)> {
-    zip(a, zip(b, c)).map(|(a, (b, c))| (a, b, c))
+    a.zip(b.zip(c)).map(|(a, (b, c))| (a, b, c))
 }
 
-/// Like [std::iter::zip], but combines 4 iterators.
+/// Like [`std::iter::zip`], but combines 4 iterators.
 fn zip4<T1, T2, T3, T4>(
     a: impl Iterator<Item = T1>,
     b: impl Iterator<Item = T2>,
     c: impl Iterator<Item = T3>,
     d: impl Iterator<Item = T4>,
 ) -> impl Iterator<Item = (T1, T2, T3, T4)> {
-    zip3(a, b, zip(c, d)).map(|(a, b, (c, d))| (a, b, c, d))
+    zip3(a, b, c.zip(d)).map(|(a, b, (c, d))| (a, b, c, d))
 }
 
 /// Sequence length threshold for prepacking weights.

--- a/src/ops/slice.rs
+++ b/src/ops/slice.rs
@@ -1,5 +1,3 @@
-use std::iter::zip;
-
 use rten_tensor::prelude::*;
 use rten_tensor::{NdTensorView, SliceItem, SliceRange, Tensor, TensorView};
 
@@ -37,7 +35,7 @@ fn slice_ranges(
         .iter()
         .map(|dim_size| SliceRange::new(0, Some(*dim_size as isize), 1))
         .collect();
-    for (i, (start, end)) in zip(starts.iter(), ends.iter()).enumerate() {
+    for (i, (start, end)) in starts.iter().zip(ends.iter()).enumerate() {
         let axis = if let Some(axes) = axes {
             resolve_axis(input_shape.len(), axes[[i]] as isize)?
         } else {

--- a/src/wasm_api.rs
+++ b/src/wasm_api.rs
@@ -1,5 +1,4 @@
 use std::borrow::Borrow;
-use std::iter::zip;
 use std::rc::Rc;
 
 use rten_tensor::prelude::*;
@@ -67,11 +66,11 @@ impl Model {
         input: Vec<Tensor>,
         output_ids: &[usize],
     ) -> Result<Vec<Tensor>, String> {
-        let inputs: Vec<(usize, InputOrOutput)> = zip(
-            input_ids.iter().copied(),
-            input.iter().map(|tensor| tensor.data.as_input().into()),
-        )
-        .collect();
+        let inputs: Vec<(usize, InputOrOutput)> = input_ids
+            .iter()
+            .copied()
+            .zip(input.iter().map(|tensor| tensor.data.as_input().into()))
+            .collect();
         let result = self.model.run(inputs, output_ids, None);
         match result {
             Ok(outputs) => {


### PR DESCRIPTION
For stylistic consistency, use the `Iterator::zip` method instead of the standalone `zip` function everywhere.