### PR TITLE
Add fallible variants of `TensorBase::slice_with`

### DIFF
--- a/rten-tensor/src/errors.rs
+++ b/rten-tensor/src/errors.rs
@@ -60,6 +60,10 @@ pub enum SliceError {
     /// The step in a slice range is negative, in a context where this is not
     /// supported.
     InvalidStep,
+
+    /// There is a mismatch between the actual and expected number of axes
+    /// in the output slice.
+    OutputDimsMismatch,
 }
 
 impl Display for SliceError {
@@ -69,6 +73,9 @@ impl Display for SliceError {
             SliceError::InvalidIndex => write!(f, "slice index is invalid"),
             SliceError::InvalidRange => write!(f, "slice range is invalid"),
             SliceError::InvalidStep => write!(f, "slice step is invalid"),
+            SliceError::OutputDimsMismatch => {
+                write!(f, "slice output dims does not match expected dims")
+            }
         }
     }
 }

--- a/rten-tensor/src/iterators.rs
+++ b/rten-tensor/src/iterators.rs
@@ -470,7 +470,7 @@ impl LaneRanges {
                 (0..end).into()
             })
             .collect();
-        let (_range, sliced) = layout.slice_dyn(&slice_starts);
+        let (_range, sliced) = layout.slice_dyn(&slice_starts).unwrap();
         let offsets = Offsets::new(&sliced);
         LaneRanges {
             offsets,

--- a/rten-tensor/src/layout.rs
+++ b/rten-tensor/src/layout.rs
@@ -472,22 +472,26 @@ impl<const N: usize> NdLayout<N> {
     /// an existing tensor view.
     ///
     /// Returns a tuple of (offset_range, layout) for the sliced view.
-    pub fn slice<const M: usize>(&self, range: &[SliceItem]) -> (Range<usize>, NdLayout<M>) {
-        assert!(
-            self.ndim() >= range.len(),
-            "Slice dims must be <= current dims"
-        );
+    pub fn slice<const M: usize>(
+        &self,
+        range: &[SliceItem],
+    ) -> Result<(Range<usize>, NdLayout<M>), SliceError> {
+        if self.ndim() < range.len() {
+            return Err(SliceError::TooManyDims);
+        }
 
         let mut shape: [usize; M] = [0; M];
         let mut strides: [usize; M] = [0; M];
 
         let (ndim, offset) =
-            slice_layout(&self.shape, &self.strides, &mut shape, &mut strides, range).unwrap();
+            slice_layout(&self.shape, &self.strides, &mut shape, &mut strides, range)?;
 
-        assert!(ndim == M, "sliced dims != {}", M);
+        if ndim != M {
+            return Err(SliceError::OutputDimsMismatch);
+        }
 
         let layout = NdLayout { shape, strides };
-        (offset..offset + layout.min_data_len(), layout)
+        Ok((offset..offset + layout.min_data_len(), layout))
     }
 
     pub fn resize_dim(&mut self, dim: usize, new_size: usize) {
@@ -687,28 +691,9 @@ impl DynLayout {
     /// Compute the new layout and offset of the first element for a slice into
     /// an existing tensor view.
     ///
-    /// Returns a tuple of (offset_range, layout) for the sliced view.
-    ///
-    /// Panics if the range is invalid for the current layout.
-    pub fn slice(&self, range: &[SliceItem]) -> (Range<usize>, DynLayout) {
-        match self.try_slice(range) {
-            Ok(result) => result,
-
-            // These error conversions preserve existing error messages in
-            // various tests.
-            Err(SliceError::InvalidRange) => panic!("Slice range is invalid for tensor shape"),
-            Err(SliceError::InvalidIndex) => panic!("Slice index is invalid for tensor shape"),
-            Err(SliceError::InvalidStep) => panic!("Cannot slice with negative step"),
-            Err(err) => panic!("{:?}", err),
-        }
-    }
-
-    /// Compute the new layout and offset of the first element for a slice into
-    /// an existing tensor view.
-    ///
     /// Returns a tuple of (offset_range, layout) for the sliced view, or an
     /// error if the range is invalid.
-    pub fn try_slice(&self, range: &[SliceItem]) -> Result<(Range<usize>, DynLayout), SliceError> {
+    pub fn slice(&self, range: &[SliceItem]) -> Result<(Range<usize>, DynLayout), SliceError> {
         if self.ndim() < range.len() {
             return Err(SliceError::TooManyDims);
         }
@@ -930,10 +915,18 @@ pub trait MutLayout: Layout + Clone {
     /// `self.permuted([N-1, N-2, ... 0])`.
     fn transposed(&self) -> Self;
 
-    /// Slice the layout.
+    /// Slice the layout and return a static-rank layout.
     ///
     /// Returns a tuple of `(offset_range, sliced_layout)`.
-    fn slice<const M: usize>(&self, range: &[SliceItem]) -> (Range<usize>, NdLayout<M>);
+    fn slice<const M: usize>(
+        &self,
+        range: &[SliceItem],
+    ) -> Result<(Range<usize>, NdLayout<M>), SliceError>;
+
+    /// Slice the layout and return a dynamic rank layout.
+    ///
+    /// Returns a tuple of `(offset_range, sliced_layout)`.
+    fn slice_dyn(&self, range: &[SliceItem]) -> Result<(Range<usize>, DynLayout), SliceError>;
 
     /// Slice the layout along a given axis.
     ///
@@ -953,11 +946,6 @@ pub trait MutLayout: Layout + Clone {
         (range, sliced_layout)
     }
 
-    /// Slice the layout and return a dynamic rank layout.
-    ///
-    /// Returns a tuple of `(offset_range, sliced_layout)`.
-    fn slice_dyn(&self, range: &[SliceItem]) -> (Range<usize>, DynLayout);
-
     /// Return a layout with all size-one dimensions removed.
     fn squeezed(&self) -> DynLayout;
 
@@ -966,13 +954,6 @@ pub trait MutLayout: Layout + Clone {
     /// Returns a tuple of `(left, right)` where each item is an `(offset_range,
     /// layout)` tuple.
     fn split(&self, axis: usize, mid: usize) -> ((Range<usize>, Self), (Range<usize>, Self));
-
-    /// Attempt to slice the layout or return an error if the range is invalid
-    /// for the layout's shape.
-    fn try_slice<R: IntoSliceItems>(
-        &self,
-        range: R,
-    ) -> Result<(Range<usize>, DynLayout), SliceError>;
 }
 
 /// Trait for broadcasting a layout from one shape to another.
@@ -1040,11 +1021,14 @@ impl<const N: usize> MutLayout for NdLayout<N> {
         self.transposed()
     }
 
-    fn slice<const M: usize>(&self, range: &[SliceItem]) -> (Range<usize>, NdLayout<M>) {
+    fn slice<const M: usize>(
+        &self,
+        range: &[SliceItem],
+    ) -> Result<(Range<usize>, NdLayout<M>), SliceError> {
         self.slice(range)
     }
 
-    fn slice_dyn(&self, range: &[SliceItem]) -> (Range<usize>, DynLayout) {
+    fn slice_dyn(&self, range: &[SliceItem]) -> Result<(Range<usize>, DynLayout), SliceError> {
         self.as_dyn().slice(range)
     }
 
@@ -1086,14 +1070,6 @@ impl<const N: usize> MutLayout for NdLayout<N> {
 
         ((left_offsets, left), (right_offsets, right))
     }
-
-    fn try_slice<R: IntoSliceItems>(
-        &self,
-        range: R,
-    ) -> Result<(Range<usize>, DynLayout), SliceError> {
-        let items = range.into_slice_items();
-        self.as_dyn().try_slice(items.as_ref())
-    }
 }
 
 impl MutLayout for DynLayout {
@@ -1125,19 +1101,17 @@ impl MutLayout for DynLayout {
         self.transposed()
     }
 
-    fn slice<const M: usize>(&self, range: &[SliceItem]) -> (Range<usize>, NdLayout<M>) {
-        let (offset_range, dyn_layout) = self.slice(range);
-        let nd_layout = NdLayout::try_from(&dyn_layout).unwrap_or_else(|_| {
-            panic!(
-                "expected sliced tensor to have {} dims but it has {}",
-                M,
-                dyn_layout.ndim()
-            );
-        });
-        (offset_range, nd_layout)
+    fn slice<const M: usize>(
+        &self,
+        range: &[SliceItem],
+    ) -> Result<(Range<usize>, NdLayout<M>), SliceError> {
+        let (offset_range, dyn_layout) = self.slice(range)?;
+        let nd_layout =
+            NdLayout::try_from(&dyn_layout).map_err(|_| SliceError::OutputDimsMismatch)?;
+        Ok((offset_range, nd_layout))
     }
 
-    fn slice_dyn(&self, range: &[SliceItem]) -> (Range<usize>, DynLayout) {
+    fn slice_dyn(&self, range: &[SliceItem]) -> Result<(Range<usize>, DynLayout), SliceError> {
         self.slice(range)
     }
 
@@ -1183,14 +1157,6 @@ impl MutLayout for DynLayout {
         };
 
         ((left_offsets, left), (right_offsets, right))
-    }
-
-    fn try_slice<R: IntoSliceItems>(
-        &self,
-        range: R,
-    ) -> Result<(Range<usize>, DynLayout), SliceError> {
-        let items = range.into_slice_items();
-        self.try_slice(items.as_ref())
     }
 }
 
@@ -1393,13 +1359,13 @@ pub trait SliceWith<R: IntoSliceItems, IdxCount: OptionalUInt> {
     /// Returns a tuple of `(offset_range, sliced_layout)` where `offset_range`
     /// is the range of data from the original view that is used by the slice
     /// and `sliced_layout` is the layout of the sliced view.
-    fn slice_with(&self, range: R) -> (Range<usize>, Self::Layout);
+    fn slice_with(&self, range: R) -> Result<(Range<usize>, Self::Layout), SliceError>;
 }
 
 impl<R: IntoSliceItems, L: MutLayout> SliceWith<R, Unknown> for L {
     type Layout = DynLayout;
 
-    fn slice_with(&self, range: R) -> (Range<usize>, Self::Layout) {
+    fn slice_with(&self, range: R) -> Result<(Range<usize>, Self::Layout), SliceError> {
         self.slice_dyn(range.into_slice_items().as_ref())
     }
 }
@@ -1407,7 +1373,7 @@ impl<R: IntoSliceItems, L: MutLayout> SliceWith<R, Unknown> for L {
 impl<R: IntoSliceItems, const N: usize> SliceWith<R, U0> for NdLayout<N> {
     type Layout = NdLayout<N>;
 
-    fn slice_with(&self, range: R) -> (Range<usize>, Self::Layout) {
+    fn slice_with(&self, range: R) -> Result<(Range<usize>, Self::Layout), SliceError> {
         self.slice(range.into_slice_items().as_ref())
     }
 }
@@ -1417,7 +1383,7 @@ macro_rules! impl_slice_with_dynlayout {
         impl<R: IntoSliceItems> SliceWith<R, $range_ndim> for DynLayout {
             type Layout = DynLayout;
 
-            fn slice_with(&self, range: R) -> (Range<usize>, Self::Layout) {
+            fn slice_with(&self, range: R) -> Result<(Range<usize>, Self::Layout), SliceError> {
                 self.slice_dyn(range.into_slice_items().as_ref())
             }
         }
@@ -1436,7 +1402,7 @@ macro_rules! impl_slice_with {
         impl<R: IntoSliceItems> SliceWith<R, $range_ndim> for NdLayout<$ndim> {
             type Layout = NdLayout<$out_ndim>;
 
-            fn slice_with(&self, range: R) -> (Range<usize>, Self::Layout) {
+            fn slice_with(&self, range: R) -> Result<(Range<usize>, Self::Layout), SliceError> {
                 self.slice(range.into_slice_items().as_ref())
             }
         }
@@ -1464,7 +1430,7 @@ mod tests {
     use std::ops::Range;
 
     use super::OverlapPolicy;
-    use crate::errors::ReshapeError;
+    use crate::errors::{ReshapeError, SliceError};
     use crate::layout::{DynLayout, Layout, MutLayout, NdLayout, ResizeLayout};
     use crate::SliceItem;
 
@@ -1736,38 +1702,50 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Slice index is invalid for tensor shape")]
-    fn test_slice_invalid_index() {
-        let layout = DynLayout::from_shape(&[3, 5]);
-        layout.slice(&[SliceItem::Index(4), SliceItem::Index(0)]);
-    }
+    fn test_slice_invalid() {
+        struct Case<'a> {
+            layout: DynLayout,
+            ranges: &'a [SliceItem],
+            expected: SliceError,
+        }
 
-    #[test]
-    #[should_panic(expected = "Slice index is invalid for tensor shape")]
-    fn test_slice_invalid_negative_index() {
-        let layout = DynLayout::from_shape(&[3, 5]);
-        layout.slice(&[SliceItem::Index(-4)]);
-    }
+        let cases = [
+            Case {
+                layout: DynLayout::from_shape(&[3, 5]),
+                ranges: &[SliceItem::Index(4), SliceItem::Index(0)],
+                expected: SliceError::InvalidIndex,
+            },
+            Case {
+                layout: DynLayout::from_shape(&[3, 5]),
+                ranges: &[SliceItem::Range((1..4).into()), SliceItem::Index(0)],
+                expected: SliceError::InvalidRange,
+            },
+            Case {
+                layout: DynLayout::from_shape(&[3, 5]),
+                ranges: &[SliceItem::Index(-4)],
+                expected: SliceError::InvalidIndex,
+            },
+            Case {
+                layout: DynLayout::from_shape(&[3, 5]),
+                ranges: &[SliceItem::Range((4..).into()), SliceItem::Index(0)],
+                expected: SliceError::InvalidRange,
+            },
+            Case {
+                layout: DynLayout::from_shape(&[3, 5]),
+                ranges: &[SliceItem::full_range(), SliceItem::range(0, None, -1)],
+                expected: SliceError::InvalidStep,
+            },
+        ];
 
-    #[test]
-    #[should_panic(expected = "Slice range is invalid for tensor shape")]
-    fn test_slice_invalid_range() {
-        let layout = DynLayout::from_shape(&[3, 5]);
-        layout.slice(&[SliceItem::Range((1..4).into()), SliceItem::Index(0)]);
-    }
-
-    #[test]
-    #[should_panic(expected = "Slice range is invalid for tensor shape")]
-    fn test_slice_invalid_from_range() {
-        let layout = DynLayout::from_shape(&[3, 5]);
-        layout.slice(&[SliceItem::Range((4..).into()), SliceItem::Index(0)]);
-    }
-
-    #[test]
-    #[should_panic(expected = "Cannot slice with negative step")]
-    fn test_slice_negative_step() {
-        let layout = DynLayout::from_shape(&[3, 5]);
-        layout.slice(&[SliceItem::full_range(), SliceItem::range(0, None, -1)]);
+        for Case {
+            layout,
+            ranges,
+            expected,
+        } in cases
+        {
+            let result = layout.slice(ranges);
+            assert_eq!(result, Err(expected));
+        }
     }
 
     #[test]

--- a/rten-tensor/src/layout.rs
+++ b/rten-tensor/src/layout.rs
@@ -1374,7 +1374,7 @@ impl_remove_dim!(5, 4);
 /// the number of items in `R` that are indices, as opposed to ranges.
 pub trait SliceWith<R: IntoSliceItems, IdxCount: OptionalUInt> {
     /// The layout produced after slicing.
-    type Layout: Layout;
+    type Layout: MutLayout;
 
     /// Slice the layout with a range.
     ///

--- a/rten-tensor/src/tensor.rs
+++ b/rten-tensor/src/tensor.rs
@@ -319,6 +319,22 @@ pub trait AsView: Layout {
         self.view().slice_with(range)
     }
 
+    /// A variant of [`slice_with`](Self::slice_with) that returns a result
+    /// instead of panicking.
+    #[allow(clippy::type_complexity)]
+    fn try_slice_with<R: IntoSliceItems + IndexCount>(
+        &self,
+        range: R,
+    ) -> Result<
+        TensorBase<ViewData<Self::Elem>, <Self::Layout as SliceWith<R, R::Count>>::Layout>,
+        SliceError,
+    >
+    where
+        Self::Layout: SliceWith<R, R::Count, Layout: MutLayout>,
+    {
+        self.view().try_slice_with(range)
+    }
+
     /// Return a slice of this tensor as an owned tensor.
     ///
     /// This is more expensive than [`slice`](AsView::slice) as it copies the
@@ -811,11 +827,7 @@ impl<S: StorageMut, L: MutLayout> TensorBase<S, L> {
     where
         L: SliceWith<R, R::Count, Layout: MutLayout>,
     {
-        let (offset_range, sliced_layout) = self.layout.slice_with(range).expect("slice failed");
-        TensorBase {
-            data: self.data.slice_mut(offset_range),
-            layout: sliced_layout,
-        }
+        self.try_slice_with_mut(range).expect("slice failed")
     }
 
     /// Slice this tensor and return a dynamic-rank view.
@@ -830,6 +842,23 @@ impl<S: StorageMut, L: MutLayout> TensorBase<S, L> {
         Ok(TensorBase {
             data: self.data.slice_mut(offset_range),
             layout,
+        })
+    }
+
+    /// A variant of [`slice_with_mut`](Self::slice_with_mut) that returns a
+    /// result instead of panicking.
+    #[allow(clippy::type_complexity)]
+    pub fn try_slice_with_mut<R: IntoSliceItems + IndexCount>(
+        &mut self,
+        range: R,
+    ) -> Result<TensorBase<ViewMutData<S::Elem>, <L as SliceWith<R, R::Count>>::Layout>, SliceError>
+    where
+        L: SliceWith<R, R::Count, Layout: MutLayout>,
+    {
+        let (offset_range, sliced_layout) = self.layout.slice_with(range)?;
+        Ok(TensorBase {
+            data: self.data.slice_mut(offset_range),
+            layout: sliced_layout,
         })
     }
 
@@ -1514,11 +1543,24 @@ impl<'a, T, L: Clone + MutLayout> TensorBase<ViewData<'a, T>, L> {
     where
         L: SliceWith<R, R::Count, Layout: MutLayout>,
     {
-        let (offset_range, sliced_layout) = self.layout.slice_with(range).expect("slice failed");
-        TensorBase {
+        self.try_slice_with(range).expect("slice failed")
+    }
+
+    /// A variant of [`slice_with`](Self::slice_with) that returns a result
+    /// instead of panicking.
+    #[allow(clippy::type_complexity)]
+    pub fn try_slice_with<R: IntoSliceItems + IndexCount>(
+        &self,
+        range: R,
+    ) -> Result<TensorBase<ViewData<'a, T>, <L as SliceWith<R, R::Count>>::Layout>, SliceError>
+    where
+        L: SliceWith<R, R::Count, Layout: MutLayout>,
+    {
+        let (offset_range, sliced_layout) = self.layout.slice_with(range)?;
+        Ok(TensorBase {
             data: self.data.slice(offset_range),
             layout: sliced_layout,
-        }
+        })
     }
 
     /// Remove all size-one dimensions from this tensor.
@@ -3809,6 +3851,22 @@ mod tests {
     }
 
     #[test]
+    fn test_try_slice_with() {
+        let data = vec![1., 2., 3., 4.];
+        let tensor = Tensor::from_data(&[2, 2], data);
+
+        let row = tensor.try_slice_with(0);
+        assert!(row.is_ok());
+        assert_eq!(row.unwrap().data(), Some([1., 2.].as_slice()));
+
+        let row = tensor.try_slice_with(1);
+        assert!(row.is_ok());
+
+        let row = tensor.try_slice_with(2);
+        assert!(row.is_err());
+    }
+
+    #[test]
     fn test_try_slice_mut() {
         let data = vec![1., 2., 3., 4.];
         let mut tensor = Tensor::from_data(&[2, 2], data);
@@ -3822,6 +3880,23 @@ mod tests {
         assert!(row.is_ok());
 
         let row = tensor.try_slice_dyn(2);
+        assert!(row.is_err());
+    }
+
+    #[test]
+    fn test_try_slice_with_mut() {
+        let data = vec![1., 2., 3., 4.];
+        let mut tensor = Tensor::from_data(&[2, 2], data);
+
+        let mut row = tensor.try_slice_with_mut(0).unwrap();
+        row[[0]] += 1.;
+        row[[1]] += 1.;
+        assert_eq!(row.data(), Some([2., 3.].as_slice()));
+
+        let row = tensor.try_slice_with_mut(1);
+        assert!(row.is_ok());
+
+        let row = tensor.try_slice_with(2);
         assert!(row.is_err());
     }
 

--- a/rten-tensor/src/tensor.rs
+++ b/rten-tensor/src/tensor.rs
@@ -314,7 +314,7 @@ pub trait AsView: Layout {
         range: R,
     ) -> TensorBase<ViewData<Self::Elem>, <Self::Layout as SliceWith<R, R::Count>>::Layout>
     where
-        Self::Layout: SliceWith<R, R::Count, Layout: MutLayout>,
+        Self::Layout: SliceWith<R, R::Count>,
     {
         self.view().slice_with(range)
     }
@@ -330,7 +330,7 @@ pub trait AsView: Layout {
         SliceError,
     >
     where
-        Self::Layout: SliceWith<R, R::Count, Layout: MutLayout>,
+        Self::Layout: SliceWith<R, R::Count>,
     {
         self.view().try_slice_with(range)
     }
@@ -825,7 +825,7 @@ impl<S: StorageMut, L: MutLayout> TensorBase<S, L> {
         range: R,
     ) -> TensorBase<ViewMutData<S::Elem>, <L as SliceWith<R, R::Count>>::Layout>
     where
-        L: SliceWith<R, R::Count, Layout: MutLayout>,
+        L: SliceWith<R, R::Count>,
     {
         self.try_slice_with_mut(range).expect("slice failed")
     }
@@ -853,7 +853,7 @@ impl<S: StorageMut, L: MutLayout> TensorBase<S, L> {
         range: R,
     ) -> Result<TensorBase<ViewMutData<S::Elem>, <L as SliceWith<R, R::Count>>::Layout>, SliceError>
     where
-        L: SliceWith<R, R::Count, Layout: MutLayout>,
+        L: SliceWith<R, R::Count>,
     {
         let (offset_range, sliced_layout) = self.layout.slice_with(range)?;
         Ok(TensorBase {
@@ -1541,7 +1541,7 @@ impl<'a, T, L: Clone + MutLayout> TensorBase<ViewData<'a, T>, L> {
         range: R,
     ) -> TensorBase<ViewData<'a, T>, <L as SliceWith<R, R::Count>>::Layout>
     where
-        L: SliceWith<R, R::Count, Layout: MutLayout>,
+        L: SliceWith<R, R::Count>,
     {
         self.try_slice_with(range).expect("slice failed")
     }
@@ -1554,7 +1554,7 @@ impl<'a, T, L: Clone + MutLayout> TensorBase<ViewData<'a, T>, L> {
         range: R,
     ) -> Result<TensorBase<ViewData<'a, T>, <L as SliceWith<R, R::Count>>::Layout>, SliceError>
     where
-        L: SliceWith<R, R::Count, Layout: MutLayout>,
+        L: SliceWith<R, R::Count>,
     {
         let (offset_range, sliced_layout) = self.layout.slice_with(range)?;
         Ok(TensorBase {

--- a/rten-tensor/src/tensor.rs
+++ b/rten-tensor/src/tensor.rs
@@ -781,7 +781,8 @@ impl<S: StorageMut, L: MutLayout> TensorBase<S, L> {
         range: R,
     ) -> NdTensorViewMut<S::Elem, M> {
         let range = range.into_slice_items();
-        let (offset_range, sliced_layout) = self.layout.slice(range.as_ref());
+        let (offset_range, sliced_layout) =
+            self.layout.slice(range.as_ref()).expect("slice failed");
         NdTensorViewMut {
             data: self.data.slice_mut(offset_range),
             layout: sliced_layout,
@@ -791,7 +792,8 @@ impl<S: StorageMut, L: MutLayout> TensorBase<S, L> {
     /// Slice this tensor and return a dynamic-rank view.
     pub fn slice_mut_dyn<R: IntoSliceItems>(&mut self, range: R) -> TensorViewMut<S::Elem> {
         let range = range.into_slice_items();
-        let (offset_range, sliced_layout) = self.layout.slice_dyn(range.as_ref());
+        let (offset_range, sliced_layout) =
+            self.layout.slice_dyn(range.as_ref()).expect("slice failed");
         TensorViewMut {
             data: self.data.slice_mut(offset_range),
             layout: sliced_layout,
@@ -809,7 +811,7 @@ impl<S: StorageMut, L: MutLayout> TensorBase<S, L> {
     where
         L: SliceWith<R, R::Count, Layout: MutLayout>,
     {
-        let (offset_range, sliced_layout) = self.layout.slice_with(range);
+        let (offset_range, sliced_layout) = self.layout.slice_with(range).expect("slice failed");
         TensorBase {
             data: self.data.slice_mut(offset_range),
             layout: sliced_layout,
@@ -824,7 +826,7 @@ impl<S: StorageMut, L: MutLayout> TensorBase<S, L> {
         &mut self,
         range: R,
     ) -> Result<TensorViewMut<S::Elem>, SliceError> {
-        let (offset_range, layout) = self.layout.try_slice(range)?;
+        let (offset_range, layout) = self.layout.slice_dyn(range.into_slice_items().as_ref())?;
         Ok(TensorBase {
             data: self.data.slice_mut(offset_range),
             layout,
@@ -1487,7 +1489,7 @@ impl<'a, T, L: Clone + MutLayout> TensorBase<ViewData<'a, T>, L> {
     /// Slice this tensor and return a static-rank view. See [AsView::slice].
     pub fn slice<const M: usize, R: IntoSliceItems>(&self, range: R) -> NdTensorView<'a, T, M> {
         let range = range.into_slice_items();
-        let (offset_range, sliced_layout) = self.layout.slice(range.as_ref());
+        let (offset_range, sliced_layout) = self.layout.slice(range.as_ref()).unwrap();
         NdTensorView {
             data: self.data.slice(offset_range),
             layout: sliced_layout,
@@ -1497,7 +1499,7 @@ impl<'a, T, L: Clone + MutLayout> TensorBase<ViewData<'a, T>, L> {
     /// Slice this tensor and return a dynamic-rank view. See [AsView::slice_dyn].
     pub fn slice_dyn<R: IntoSliceItems>(&self, range: R) -> TensorView<'a, T> {
         let range = range.into_slice_items();
-        let (offset_range, sliced_layout) = self.layout.slice_dyn(range.as_ref());
+        let (offset_range, sliced_layout) = self.layout.slice_dyn(range.as_ref()).unwrap();
         TensorView {
             data: self.data.slice(offset_range),
             layout: sliced_layout,
@@ -1512,7 +1514,7 @@ impl<'a, T, L: Clone + MutLayout> TensorBase<ViewData<'a, T>, L> {
     where
         L: SliceWith<R, R::Count, Layout: MutLayout>,
     {
-        let (offset_range, sliced_layout) = self.layout.slice_with(range);
+        let (offset_range, sliced_layout) = self.layout.slice_with(range).expect("slice failed");
         TensorBase {
             data: self.data.slice(offset_range),
             layout: sliced_layout,
@@ -1620,7 +1622,7 @@ impl<'a, T, L: Clone + MutLayout> TensorBase<ViewData<'a, T>, L> {
         &self,
         range: R,
     ) -> Result<TensorView<'a, T>, SliceError> {
-        let (offset_range, layout) = self.layout.try_slice(range)?;
+        let (offset_range, layout) = self.layout.slice_dyn(range.into_slice_items().as_ref())?;
         Ok(TensorBase {
             data: self.data.slice(offset_range),
             layout,

--- a/src/ops/gather.rs
+++ b/src/ops/gather.rs
@@ -40,7 +40,7 @@ pub fn gather<T: Copy + Default>(
             let mut slice_range = full_range(input.ndim());
             slice_range[axis] = SliceItem::Index(*index as isize);
             let slice = input
-                .try_slice_dyn(slice_range.as_slice())
+                .try_slice_with(slice_range.as_slice())
                 .map_err(|_| INVALID_INDEX_ERR)?;
             slice.to_tensor_in(pool)
         };
@@ -64,7 +64,7 @@ pub fn gather<T: Copy + Default>(
             out_range[axis + i] = SliceItem::Index(index_val as isize);
         }
         let in_slice = input
-            .try_slice_dyn(in_range.as_slice())
+            .try_slice_with(in_range.as_slice())
             .map_err(|_| INVALID_INDEX_ERR)?;
         let mut out_slice = output.slice_mut_dyn(out_range.as_slice());
         out_slice.copy_from(&in_slice);
@@ -304,7 +304,7 @@ pub fn gather_nd<T: Clone + Default>(
         for (out_slice, idx) in out_slices.zip(idx_slices) {
             let slice_items = to_slice_items(idx);
             let in_slice = input
-                .try_slice_dyn(slice_items.as_slice())
+                .try_slice_with(slice_items.as_slice())
                 .map_err(|_| OpError::InvalidValue("Invalid index"))?;
 
             for (out, x) in out_slice.iter_mut().zip(in_slice.iter()) {


### PR DESCRIPTION
Add fallible variants of the new `slice_with` method and use it to replace usage of the old `try_slice_*` methods in rten operators.

In the process the errors reported by fallible slicing methods have been improved to include more details about the problem.

These are now breaking changes since existing low-level layout methods exported by rten-tensor have been modified and so has `SliceError`.