### PR TITLE
Replace old tensor slicing methods with new API

### DIFF
--- a/rten-examples/src/bert_qa.rs
+++ b/rten-examples/src/bert_qa.rs
@@ -159,13 +159,13 @@ fn extract_nbest_answers<'a>(
     let min_start = 1; // Ignore [CLS] token at start.
     let max_end = end_probs.size(1) - 1; // Ignore [SEP] token at end.
     let mut span_scores: Vec<(usize, usize, f32)> = start_probs
-        .slice::<1, _>((0, min_start..max_end))
+        .slice((0, min_start..max_end))
         .iter()
         .enumerate()
         .map(|(start_pos, start_score)| {
             let start_pos = start_pos + min_start;
             let (relative_end_pos, end_score) = end_probs
-                .slice::<1, _>((0, start_pos..(start_pos + max_answer_len).min(max_end)))
+                .slice((0, start_pos..(start_pos + max_answer_len).min(max_end)))
                 .iter()
                 .enumerate()
                 .max_by(|(_pos_a, score_a), (_pos_b, score_b)| score_a.total_cmp(score_b))

--- a/rten-examples/src/deeplab.rs
+++ b/rten-examples/src/deeplab.rs
@@ -131,7 +131,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     output.permute(&[0, 2, 3, 1]); // (N,class,H,W) => (N,H,W,class)
 
     let seg_classes: NdTensor<i32, 2> = output
-        .slice_dyn(0)
+        .slice(0)
         .arg_max(-1, false /* keep_dims */)?
         .try_into()?;
     let [out_height, out_width] = seg_classes.shape();

--- a/rten-examples/src/depth_anything.rs
+++ b/rten-examples/src/depth_anything.rs
@@ -105,7 +105,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // Resize output map back to original input size and write to file.
     let resized = output.resize_image([orig_height, orig_width])?;
-    let resized = resized.slice::<3, _>(0);
+    let resized = resized.nd_view::<4>().slice(0);
     write_image(&args.output, resized)?;
 
     Ok(())

--- a/rten-examples/src/piper.rs
+++ b/rten-examples/src/piper.rs
@@ -223,7 +223,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // Convert audio samples from float to 16-bit ints and write to output .wav
     // file.
-    let int_samples = audio_float_to_int16(samples.slice::<1, _>((0, 0, 0)), None);
+    let int_samples = audio_float_to_int16(samples.slice((0, 0, 0)), None);
     let wav_file = BufWriter::new(File::create("output.wav")?);
 
     let mut wav_writer = WavWriter::new(

--- a/rten-examples/src/rmbg.rs
+++ b/rten-examples/src/rmbg.rs
@@ -119,7 +119,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let bg_color = [0., 1., 0.]; // RGB
     fill_mask(
         image.view_mut(),
-        background_mask.slice::<2, _>([0, 0]), // Extract first mask and channel
+        background_mask.slice([0, 0]), // Extract first mask and channel
         bg_color,
     );
 

--- a/rten-examples/src/segment_anything.rs
+++ b/rten-examples/src/segment_anything.rs
@@ -207,11 +207,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     // Resize the output mask to match the original image and save to disk.
     let pred_masks: NdTensor<f32, 5> = pred_masks.try_into()?;
     let [_batch, _point_batch, _mask, mask_h, mask_w] = pred_masks.shape();
-    let best_mask = pred_masks
-        .slice::<2, _>((0, 0, 0))
-        .reshaped([1, 1, mask_h, mask_w]);
+    let best_mask = pred_masks.slice((0, 0, 0)).reshaped([1, 1, mask_h, mask_w]);
     let resized_mask = best_mask.resize_image([image_h, image_w])?;
-    write_image("segmented.png", resized_mask.slice::<3, _>(0).nd_view())?;
+    write_image("segmented.png", resized_mask.nd_view::<4>().slice(0))?;
 
     Ok(())
 }

--- a/rten-examples/src/trocr.rs
+++ b/rten-examples/src/trocr.rs
@@ -97,7 +97,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     image.insert_axis(0); // Add batch dim
 
     // From `image_size` in config.json.
-    let mut image = image.resize_image([384, 384])?;
+    let mut image: NdTensor<_, 4> = image.resize_image([384, 384])?.try_into()?;
 
     // Values taken from `preprocessor_config.json`.
     let mean = [0.5, 0.5, 0.5];

--- a/rten-examples/src/yolo.rs
+++ b/rten-examples/src/yolo.rs
@@ -146,11 +146,11 @@ fn main() -> Result<(), Box<dyn Error>> {
     let scale_x = image_width as f32 / model_in_w as f32;
 
     // [batch, n_boxes, coord]
-    let boxes = output.slice::<3, _>((.., ..4, ..)).permuted([0, 2, 1]);
+    let boxes = output.slice((.., ..4, ..)).permuted([0, 2, 1]);
 
     // [batch, n_classes, n_boxes]. The `n_boxes` coord is last because that
     // is what `non_max_suppression` requires.
-    let scores = output.slice::<3, _>((.., 4.., ..));
+    let scores = output.slice((.., 4.., ..));
 
     let iou_threshold = 0.3;
     let score_threshold = 0.25;

--- a/rten-generate/src/generator.rs
+++ b/rten-generate/src/generator.rs
@@ -602,7 +602,7 @@ impl<'a> Generator<'a> {
 
         // Sample output token.
         let logits: NdTensor<f32, 3> = outputs.remove(0).try_into().map_err(wrap_error)?;
-        let next_id = self.sampler.sample(logits.slice_with((0, -1)));
+        let next_id = self.sampler.sample(logits.slice((0, -1)));
 
         // Update the self-attention key-value cache.
         //

--- a/rten-generate/src/sampler.rs
+++ b/rten-generate/src/sampler.rs
@@ -97,7 +97,7 @@ impl Sampler for TopKSampler {
         let topk_index = multinomial(&mut self.rng.borrow_mut(), probs.nd_view())
             .expect("probs should be non-empty and sum to 1");
 
-        let token_id = topk_indices.slice_with(topk_index).item().copied().unwrap();
+        let token_id = topk_indices.slice(topk_index).item().copied().unwrap();
         token_id as TokenId
     }
 }

--- a/rten-imageproc/src/drawing.rs
+++ b/rten-imageproc/src/drawing.rs
@@ -465,7 +465,7 @@ impl<'a, T: Copy + Default> Painter<'a, T> {
     pub fn draw_polygon(&mut self, points: &[Point]) {
         for i in 0..3 {
             draw_polygon(
-                self.surface.slice_with_mut([i]),
+                self.surface.slice_mut([i]),
                 points,
                 self.state.stroke[i],
                 self.state.stroke_width,
@@ -600,9 +600,9 @@ mod tests {
         let expected_g = expected_r.map(|&x| if x == r { g } else { 0 });
         let expected_b = expected_r.map(|&x| if x == r { b } else { 0 });
 
-        compare_images(img.slice_with([0]), expected_r.view());
-        compare_images(img.slice_with([1]), expected_g.view());
-        compare_images(img.slice_with([2]), expected_b.view());
+        compare_images(img.slice([0]), expected_r.view());
+        compare_images(img.slice([1]), expected_g.view());
+        compare_images(img.slice([2]), expected_b.view());
     }
 
     #[test]

--- a/rten-imageproc/src/normalize.rs
+++ b/rten-imageproc/src/normalize.rs
@@ -32,7 +32,7 @@ pub fn normalize_image<const C: usize>(
 
     for chan in 0..n_chans {
         let inv_std_dev = 1. / std_dev[chan];
-        img.slice_with_mut(chan)
+        img.slice_mut(chan)
             .apply(|x| (x - mean[chan]) * inv_std_dev);
     }
 }

--- a/rten-tensor/src/copy.rs
+++ b/rten-tensor/src/copy.rs
@@ -205,8 +205,8 @@ pub fn copy_into_slice<'a, T: Clone>(
         let mut dest = NdTensorViewMut::from_data(src.shape(), dest);
         for i0 in 0..src.size(0) {
             for i1 in 0..src.size(1) {
-                let src = src.slice_with([i0, i1]);
-                let dest = dest.slice_with_mut([i0, i1]);
+                let src = src.slice([i0, i1]);
+                let dest = dest.slice_mut([i0, i1]);
                 copy_blocked(src, dest);
             }
         }
@@ -437,7 +437,7 @@ fn copy_range_into_slice_inner<T: Clone>(
     } else {
         // Iterate over views of outermost dimension and recurse.
         for i0 in ranges[0] {
-            let src_slice = src.slice_dyn(i0);
+            let src_slice = src.slice(i0);
             let (dest_slice, dest_tail) = dest.split_at_mut(src_slice.len());
 
             copy_range_into_slice_inner(src_slice, dest_slice, &ranges[1..]);

--- a/rten-tensor/src/iterators.rs
+++ b/rten-tensor/src/iterators.rs
@@ -779,7 +779,7 @@ impl<'a, T, L: MutLayout> Iterator for InnerIterDyn<'a, T, L> {
     fn next(&mut self) -> Option<Self::Item> {
         self.outer_indices.next().map(|idx| {
             let slice_items = to_slice_items(&idx);
-            self.view.slice_with(slice_items.as_slice())
+            self.view.slice(slice_items.as_slice())
         })
     }
 
@@ -855,7 +855,7 @@ impl<'a, T, L: MutLayout> Iterator for InnerIterDynMut<'a, T, L> {
     fn next(&mut self) -> Option<Self::Item> {
         self.outer_indices.next().map(|idx| {
             let slice_items = to_slice_items(&idx);
-            let view: TensorViewMut<'_, T> = self.view.slice_mut_dyn(slice_items.as_slice());
+            let view: TensorViewMut<'_, T> = self.view.slice_mut(slice_items.as_slice());
             unsafe {
                 // Safety: Outer view is non-broadcasting, and we increment the
                 // outer index each time, so returned views will not overlap.

--- a/rten-tensor/src/type_num.rs
+++ b/rten-tensor/src/type_num.rs
@@ -1,8 +1,8 @@
 //! Traits and types for compile-time arithmetic.
 //!
 //! These types are used in various tensor methods, such as
-//! [`slice_with`](crate::TensorBase::slice_with), as part of computing the
-//! layout of the result at compile time.
+//! [`slice`](crate::TensorBase::slice), as part of computing the layout of the
+//! result at compile time.
 
 use std::ops::{Range, RangeFrom, RangeFull, RangeTo};
 

--- a/src/gemm.rs
+++ b/src/gemm.rs
@@ -722,7 +722,7 @@ fn gemv<LhsT: GemmInT, RhsT: GemmInT, OutT: GemmOutT>(
             for (k_block, a_block) in
                 range_chunks(0..a_cols, k_block_size).zip(a_data.chunks(k_block_size))
             {
-                let b_block = b.slice_with((k_block, col_block.clone()));
+                let b_block = b.slice((k_block, col_block.clone()));
                 kernel.gemv_kernel(out_chunk, a_block, b_block, alpha, effective_beta);
 
                 // Reset `beta` so that subsequent updates for each column
@@ -815,7 +815,7 @@ fn gemm_impl<LhsT: GemmInT, RhsT: GemmInT, OutT: GemmOutT>(
     if let (1, GemmInputA::Unpacked(a), GemmInputB::Unpacked(b)) = (a.rows(), a, b) {
         gemv(
             kernel,
-            a.slice_with(0),
+            a.slice(0),
             b,
             output_mat.view_mut(),
             alpha,

--- a/src/gemm/kernels/simd_generic.rs
+++ b/src/gemm/kernels/simd_generic.rs
@@ -148,7 +148,7 @@ unsafe fn simd_gemv_transposed<S: SimdFloat>(
         simd_gemv_fallback(
             &mut out[last_col_tile.clone()],
             a,
-            b.slice_with((.., last_col_tile)),
+            b.slice((.., last_col_tile)),
             alpha,
             beta,
         );

--- a/src/ops/conv/depthwise.rs
+++ b/src/ops/conv/depthwise.rs
@@ -83,16 +83,16 @@ fn conv_2d_depthwise_block<X, W, Y>(
     let [dilation_y, _dilation_x] = dilations;
 
     for c in chan_range.clone() {
-        let kernel_view = kernel.slice_with([c, 0]).weakly_checked_view();
+        let kernel_view = kernel.slice([c, 0]).weakly_checked_view();
 
         // For efficiency, use manual slicing in the inner loops to extract
         // input/output rows.
-        let mut out_chan = output.slice_with_mut([c - chan_range.start]);
+        let mut out_chan = output.slice_mut([c - chan_range.start]);
         let out_row_stride = out_chan.stride(0);
         let out_row_len = out_chan.size(1);
         let out_chan_data = out_chan.data_mut().unwrap();
 
-        let in_chan = input.slice_with([c]);
+        let in_chan = input.slice([c]);
         let in_row_stride = in_chan.stride(0);
         let in_row_len = in_chan.size(1);
         let in_chan_data = in_chan.data().unwrap();
@@ -204,8 +204,8 @@ where
 
     let n_init = AtomicUsize::new(0);
     for n in 0..batch {
-        let mut out_chans = output.slice_with_mut(n);
-        let input = input.slice_with(n);
+        let mut out_chans = output.slice_mut(n);
+        let input = input.slice(n);
 
         out_chans
             .axis_chunks_mut(0, channel_chunk_size)

--- a/src/ops/einsum.rs
+++ b/src/ops/einsum.rs
@@ -866,16 +866,16 @@ mod tests {
             // Matrix-vector product
             Case {
                 equation: "ij,j->i",
-                inputs: vec![mat_a.view(), mat_b.slice_dyn((.., 0))],
-                expected: Ok(matmul(&pool, mat_a.view(), mat_b.slice_dyn((.., ..1)))
+                inputs: vec![mat_a.view(), mat_b.slice((.., 0))],
+                expected: Ok(matmul(&pool, mat_a.view(), mat_b.slice((.., ..1)))
                     .unwrap()
                     .into_shape([mat_a.size(0)].as_slice())),
             },
             // Vector-matrix product
             Case {
                 equation: "j,jk->k",
-                inputs: vec![mat_a.slice_dyn(0), mat_b.view()],
-                expected: Ok(matmul(&pool, mat_a.slice_dyn((..1, ..)), mat_b.view())
+                inputs: vec![mat_a.slice(0), mat_b.view()],
+                expected: Ok(matmul(&pool, mat_a.slice((..1, ..)), mat_b.view())
                     .unwrap()
                     .into_shape([mat_b.size(1)].as_slice())),
             },
@@ -895,11 +895,11 @@ mod tests {
             // are not present in all tensors.
             Case {
                 equation: "ij,j->",
-                inputs: vec![mat_a.view(), mat_b.slice_dyn((.., 0))],
+                inputs: vec![mat_a.view(), mat_b.slice((.., 0))],
                 expected: Ok(Tensor::from(
                     mat_a
                         .iter()
-                        .zip(mat_b.slice_dyn((.., 0)).broadcast(mat_a.shape()).iter())
+                        .zip(mat_b.slice((.., 0)).broadcast(mat_a.shape()).iter())
                         .map(|(x, y)| x * y)
                         .sum::<f32>(),
                 )),

--- a/src/ops/gather.rs
+++ b/src/ops/gather.rs
@@ -40,7 +40,7 @@ pub fn gather<T: Copy + Default>(
             let mut slice_range = full_range(input.ndim());
             slice_range[axis] = SliceItem::Index(*index as isize);
             let slice = input
-                .try_slice_with(slice_range.as_slice())
+                .try_slice(slice_range.as_slice())
                 .map_err(|_| INVALID_INDEX_ERR)?;
             slice.to_tensor_in(pool)
         };
@@ -64,9 +64,9 @@ pub fn gather<T: Copy + Default>(
             out_range[axis + i] = SliceItem::Index(index_val as isize);
         }
         let in_slice = input
-            .try_slice_with(in_range.as_slice())
+            .try_slice(in_range.as_slice())
             .map_err(|_| INVALID_INDEX_ERR)?;
-        let mut out_slice = output.slice_mut_dyn(out_range.as_slice());
+        let mut out_slice = output.slice_mut(out_range.as_slice());
         out_slice.copy_from(&in_slice);
     }
 
@@ -304,7 +304,7 @@ pub fn gather_nd<T: Clone + Default>(
         for (out_slice, idx) in out_slices.zip(idx_slices) {
             let slice_items = to_slice_items(idx);
             let in_slice = input
-                .try_slice_with(slice_items.as_slice())
+                .try_slice(slice_items.as_slice())
                 .map_err(|_| OpError::InvalidValue("Invalid index"))?;
 
             for (out, x) in out_slice.iter_mut().zip(in_slice.iter()) {

--- a/src/ops/non_max_suppression.rs
+++ b/src/ops/non_max_suppression.rs
@@ -93,7 +93,7 @@ pub fn non_max_suppression(
     for n in 0..batch {
         for b in 0..n_boxes {
             let (max_score_cls, max_score) = scores
-                .slice_with((n, .., b))
+                .slice((n, .., b))
                 .iter()
                 .copied()
                 .enumerate()
@@ -104,7 +104,7 @@ pub fn non_max_suppression(
                 continue;
             }
 
-            let [c0, c1, c2, c3] = boxes.slice_with((n, b)).to_array();
+            let [c0, c1, c2, c3] = boxes.slice((n, b)).to_array();
             let [top, left, bottom, right] = match box_order {
                 BoxOrder::TopLeftBottomRight => [c0, c1, c2, c3],
                 BoxOrder::CenterWidthHeight => {
@@ -172,7 +172,7 @@ pub fn non_max_suppression(
 
     let mut selected_indices = NdTensor::zeros_in(pool, [selected.len(), 3]);
     for (i, nms_box) in selected.into_iter().enumerate() {
-        selected_indices.slice_with_mut(i).assign_array([
+        selected_indices.slice_mut(i).assign_array([
             nms_box.batch_index as i32,
             nms_box.class as i32,
             nms_box.box_index as i32,
@@ -255,7 +255,7 @@ mod tests {
                     [cx, cy, w, h]
                 }
             };
-            out_boxes.slice_with_mut((0, i)).assign_array(coords);
+            out_boxes.slice_mut((0, i)).assign_array(coords);
             out_scores[[0, nms_box.class, i]] = nms_box.score;
         }
 
@@ -309,10 +309,10 @@ mod tests {
 
         assert_eq!(selected.size(0), 2);
 
-        let [batch, class, box_idx] = selected.slice_with(0).to_array();
+        let [batch, class, box_idx] = selected.slice(0).to_array();
         assert_eq!([batch, class, box_idx], [0, 0, 0]);
 
-        let [batch, class, box_idx] = selected.slice_with(1).to_array();
+        let [batch, class, box_idx] = selected.slice(1).to_array();
         assert_eq!([batch, class, box_idx], [0, 1, 2]);
     }
 
@@ -371,10 +371,10 @@ mod tests {
         // returned.
         assert_eq!(selected.size(0), 3);
 
-        let [batch, class, box_idx] = selected.slice_with(0).to_array();
+        let [batch, class, box_idx] = selected.slice(0).to_array();
         assert_eq!([batch, class, box_idx], [0, 0, 0]);
 
-        let [batch, class, box_idx] = selected.slice_with(1).to_array();
+        let [batch, class, box_idx] = selected.slice(1).to_array();
         assert_eq!([batch, class, box_idx], [0, 0, 1]);
     }
 
@@ -400,10 +400,10 @@ mod tests {
         // be returned from each class.
         assert!(selected.size(0) == 2);
 
-        let [batch, class, box_idx] = selected.slice_with(0).to_array();
+        let [batch, class, box_idx] = selected.slice(0).to_array();
         assert_eq!([batch, class, box_idx], [0, 0, 0]);
 
-        let [batch, class, box_idx] = selected.slice_with(1).to_array();
+        let [batch, class, box_idx] = selected.slice(1).to_array();
         assert_eq!([batch, class, box_idx], [0, 1, 2]);
     }
 
@@ -428,7 +428,7 @@ mod tests {
         // Only the box with score exceeding `score_threshold` will be returned.
         assert!(selected.size(0) == 1);
 
-        let [batch, class, box_idx] = selected.slice_with(0).to_array();
+        let [batch, class, box_idx] = selected.slice(0).to_array();
         assert_eq!([batch, class, box_idx], [0, 0, 0]);
     }
 

--- a/src/ops/norm.rs
+++ b/src/ops/norm.rs
@@ -45,7 +45,7 @@ pub fn batch_norm_in_place(
             let scaled_std_dev_reciprocal = chan_scale / (chan_var + epsilon).sqrt();
 
             input
-                .slice_mut_dyn([n, c])
+                .slice_mut([n, c])
                 .apply(|el| (*el - chan_mean) * scaled_std_dev_reciprocal + chan_bias);
         }
     }
@@ -169,7 +169,7 @@ pub fn instance_normalization_in_place(
 
     for n in 0..batch {
         for c in 0..chans {
-            let mut slice = input.slice_mut_dyn([n, c]);
+            let mut slice = input.slice_mut([n, c]);
             let chan_scale = scale[[c]];
             let chan_bias = bias[[c]];
             let chan_mean = slice_sum(slice.data().unwrap()) / slice.len() as f32;

--- a/src/ops/pad.rs
+++ b/src/ops/pad.rs
@@ -57,7 +57,7 @@ pub fn pad<T: Copy>(
 
             let mut output = Tensor::full_in(pool, &out_shape, const_val);
             output
-                .slice_mut_dyn(non_pad_region.as_slice())
+                .slice_mut(non_pad_region.as_slice())
                 .copy_from(&input);
             output
         }

--- a/src/ops/pooling.rs
+++ b/src/ops/pooling.rs
@@ -303,9 +303,9 @@ pub fn global_average_pool(pool: &TensorPool, input: TensorView) -> Result<Tenso
         const N: usize = 4;
 
         for (chan_group, mut out_group) in input
-            .slice_with(n)
+            .slice(n)
             .axis_chunks(0, N)
-            .zip(output.slice_with_mut((n, .., 0, 0)).axis_chunks_mut(0, N))
+            .zip(output.slice_mut((n, .., 0, 0)).axis_chunks_mut(0, N))
         {
             if chan_group.size(0) == N {
                 // Compute average over batch of N channels in parallel.
@@ -328,7 +328,7 @@ pub fn global_average_pool(pool: &TensorPool, input: TensorView) -> Result<Tenso
             } else {
                 // Compute average over remaining channels.
                 for i in 0..chan_group.size(0) {
-                    let sum: f32 = chan_group.slice_with([i]).iter().sum();
+                    let sum: f32 = chan_group.slice([i]).iter().sum();
                     out_group[[i]].write(sum / (in_h * in_w) as f32);
                     n_init += 1;
                 }

--- a/src/ops/reduce.rs
+++ b/src/ops/reduce.rs
@@ -354,7 +354,7 @@ fn reduce<T: Copy, R: Reducer<T>>(
                             SliceItem::Index(idx as isize)
                         }
                     }));
-                    let slice = input.slice_with(inner_range.as_slice());
+                    let slice = input.slice(inner_range.as_slice());
                     let reduced = reducer.reduce(slice.iter().copied());
                     reduced_data.push(reduced);
                 }

--- a/src/ops/resize.rs
+++ b/src/ops/resize.rs
@@ -300,9 +300,9 @@ pub fn resize(
 
     let n_init = AtomicUsize::new(0);
     for n in 0..batch {
-        let in_image = input.slice_with([n]);
+        let in_image = input.slice([n]);
         let mut out_batch = output.nd_view_mut::<4>();
-        let mut out_image = out_batch.slice_with_mut([n]);
+        let mut out_image = out_batch.slice_mut([n]);
 
         out_image
             .axis_chunks_mut(0, CHAN_GROUP_SIZE)

--- a/src/ops/split.rs
+++ b/src/ops/split.rs
@@ -40,7 +40,7 @@ pub fn split<T: Copy>(
 
             split_start += split_size;
 
-            input.slice_with(slice_range.as_slice()).to_tensor_in(pool)
+            input.slice(slice_range.as_slice()).to_tensor_in(pool)
         })
         .collect();
 


### PR DESCRIPTION
Remove the old `TensorBase::{slice, slice_mut, slice_dyn, slice_mut_dyn}` implementations and replace them with the `slice_with` APIs that infer the result layout type based on the input layout and slice range.

This now leaves the API with a smaller and easier to use set of methods for slicing, which automatically infer the output view's layout:

```rs
// Slice static or dynamic rank tensor, return a view that is
// static or dynamic rank respectively.
tensor.slice((.., 1, 2))

// Same, but returns a result
tensor.try_slice((.., 1, 2))

// Same, but returns a mutable view
tensor.slice_mut((.., 1, 2))

// Same, but returns a mutable view in a result
tensor.try_slice_mut((.., 1, 2))
```