### PR TITLE
Use a Python virtualenv in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,12 +44,12 @@ jobs:
         make docs
     - name: Setup Python
       run: |
-        pip install --upgrade pip
-      if: ${{ matrix.os == 'ubuntu-latest' }}
+        python -m venv .venv
+        .venv/bin/pip install --upgrade pip
     - name: Python Lint
       run: |
+        source .venv/bin/activate
         cd rten-convert
         pip install -e .
         pip install -r requirements.dev.txt
         make check
-      if: ${{ matrix.os == 'ubuntu-latest' }}


### PR DESCRIPTION
Fix `externally-managed-environment` error from pip in Linux CI by creating a virtualenv and installing packages there, as advised by the error messages.

