### PR TITLE
Fix AVX-512 build of im2col.rs

### DIFF
--- a/src/ops/conv/im2col.rs
+++ b/src/ops/conv/im2col.rs
@@ -304,7 +304,7 @@ impl<'a> VirtualIm2Col<'a, f32> {
         cols: Range<usize>,
     ) {
         use std::arch::x86_64::__m512i;
-        const NR_REGS: usize = vec_count::<__m512>(KERNEL_AVX512_NR);
+        const NR_REGS: usize = vec_count::<__m512i>(KERNEL_AVX512_NR);
         self.pack_b_impl::<__m512i, NR_REGS>(out, panel_width, rows.clone(), cols.clone());
     }
 }


### PR DESCRIPTION
Fix reference to unimported identifier. The AVX-512 case now matches the AVX-2 case just above.