### PR TITLE
Remove self-dependency of crates in development

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,7 +365,6 @@ dependencies = [
  "memmap2",
  "num_cpus",
  "rayon",
- "rten",
  "rten-bench",
  "rten-simd",
  "rten-tensor",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,7 +414,6 @@ version = "0.13.1"
 dependencies = [
  "fastrand",
  "rten",
- "rten-generate",
  "rten-tensor",
  "rten-text",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,6 @@ num_cpus = "1.16.0"
 
 [dev-dependencies]
 libm = "0.2.6"
-rten = { path = ".", features = ["mmap", "random"] }
 rten-bench = { path = "./rten-bench" }
 serde_json = { workspace = true }
 

--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,11 @@ miri:
 	#   require changes to prevent tests taking too long to run.
 	cargo +nightly miri test -p rten-tensor
 
+# Run tests for all crates with all features enabled that do not require
+# nightly Rust.
 .PHONY: test
 test:
-	cargo test --workspace
+	cargo test --workspace --features mmap,random
 
 .PHONY: wasm
 wasm:

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ miri:
 # nightly Rust.
 .PHONY: test
 test:
-	cargo test --workspace --features mmap,random
+	cargo test --workspace --features mmap,random,text-decoder
 
 .PHONY: wasm
 wasm:

--- a/rten-generate/Cargo.toml
+++ b/rten-generate/Cargo.toml
@@ -15,9 +15,6 @@ rten = { path = "../", version = "0.13.1" }
 rten-text = { path = "../rten-text", version = "0.13.0", optional = true }
 rten-tensor = { path = "../rten-tensor", version = "0.13.1" }
 
-[dev-dependencies]
-rten-generate = { path = ".", features = ["text-decoder"] }
-
 [features]
 # Enable text decoding using tokenizers from rten-text
 text-decoder = ["rten-text"]

--- a/src/model.rs
+++ b/src/model.rs
@@ -1421,28 +1421,31 @@ mod tests {
         add_operator!(Pad, [input_node, pads]);
         add_operator!(Pow, [input_node, input_node]);
 
-        add_operator!(RandomNormal, [], {
-            shape: vec![50, 50],
-            mean: 0.,
-            scale: 1.,
-            seed: None,
-        });
-        add_operator!(RandomNormalLike, [input_node], {
-            mean: 0.,
-            scale: 1.,
-            seed: None,
-        });
-        add_operator!(RandomUniform, [], {
-            shape: vec![50, 50],
-            low: 0.,
-            high: 1.,
-            seed: None,
-        });
-        add_operator!(RandomUniformLike, [input_node], {
-            low: 0.,
-            high: 1.,
-            seed: None,
-        });
+        #[cfg(feature = "random")]
+        {
+            add_operator!(RandomNormal, [], {
+                shape: vec![50, 50],
+                mean: 0.,
+                scale: 1.,
+                seed: None,
+            });
+            add_operator!(RandomNormalLike, [input_node], {
+                mean: 0.,
+                scale: 1.,
+                seed: None,
+            });
+            add_operator!(RandomUniform, [], {
+                shape: vec![50, 50],
+                low: 0.,
+                high: 1.,
+                seed: None,
+            });
+            add_operator!(RandomUniformLike, [input_node], {
+                low: 0.,
+                high: 1.,
+                seed: None,
+            });
+        }
 
         let range_start_node = graph_builder.add_value("range_start", None);
         let range_limit_node = graph_builder.add_value("range_limit", None);


### PR DESCRIPTION
The rten and rten-generate crates had a self-dependency used to enable features when running tests. This caused rust-analyzer to complain about cyclic dependencies when running `rust-analyzer diagnostics` and it seems that there might be some issues in Cargo (see https://github.com/rust-lang/cargo/issues/2911) but I haven't read the whole thread yet.

See also https://github.com/rust-lang/rust-analyzer/issues/14167.