### PR TITLE
Support setting `RunOptions` for model inference when using `Generator`

### DIFF
--- a/rten-generate/src/model.rs
+++ b/rten-generate/src/model.rs
@@ -2,7 +2,7 @@
 
 use std::error::Error;
 
-use rten::{Dimension, InputOrOutput, NodeId, Output};
+use rten::{Dimension, InputOrOutput, NodeId, Output, RunOptions};
 
 /// Describes the name and shape of a model input or output.
 ///
@@ -53,6 +53,7 @@ pub trait Model {
         &self,
         inputs: Vec<(NodeId, InputOrOutput)>,
         outputs: &[NodeId],
+        opts: Option<RunOptions>,
     ) -> Result<Vec<Output>, Box<dyn Error>>;
 
     /// Run as much of the model as possible given the provided inputs and
@@ -61,6 +62,7 @@ pub trait Model {
         &self,
         inputs: Vec<(NodeId, InputOrOutput)>,
         outputs: &[NodeId],
+        opts: Option<RunOptions>,
     ) -> Result<Vec<(NodeId, Output)>, Box<dyn Error>>;
 }
 
@@ -89,16 +91,18 @@ impl Model for rten::Model {
         &self,
         inputs: Vec<(NodeId, InputOrOutput)>,
         outputs: &[NodeId],
+        opts: Option<RunOptions>,
     ) -> Result<Vec<Output>, Box<dyn Error>> {
-        self.run(inputs, outputs, None).map_err(|e| e.into())
+        self.run(inputs, outputs, opts).map_err(|e| e.into())
     }
 
     fn partial_run(
         &self,
         inputs: Vec<(NodeId, InputOrOutput)>,
         outputs: &[NodeId],
+        opts: Option<RunOptions>,
     ) -> Result<Vec<(NodeId, Output)>, Box<dyn Error>> {
-        self.partial_run(inputs, outputs, None)
+        self.partial_run(inputs, outputs, opts)
             .map_err(|e| e.into())
     }
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -534,7 +534,7 @@ impl<'a> CaptureEnv<'a> {
 
 /// Options that control logging and other behaviors when executing a
 /// [Model](crate::Model).
-#[derive(Clone, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct RunOptions {
     /// Whether to log times spent in different operators when run completes.
     pub timing: bool,

--- a/src/timing.rs
+++ b/src/timing.rs
@@ -399,7 +399,7 @@ pub struct TimingRecord<'a> {
 }
 
 /// Specifies sort order for graph run timings.
-#[derive(Clone, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub enum TimingSort {
     /// Sort timings by operator name
     ByName,


### PR DESCRIPTION
Add a `Generator::with_run_options` API that sets the execution options passed to `Model::run`. This makes it possible to enable verbose logging for example.
