### PR TITLE
Use "dep:" prefix to prevent implicit creation of features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,11 +65,11 @@ crate-type = ["lib", "cdylib"]
 # Use AVX-512 instructions if available. Requires nightly Rust for AVX-512 intrinsics.
 avx512 = ["rten-simd/avx512", "rten-vecmath/avx512"]
 # Enable loading models using memory mapping
-mmap = ["memmap2"]
+mmap = ["dep:memmap2"]
 # Generate WebAssembly API using wasm-bindgen.
 wasm_api = []
 # Enable operators that generate random numbers.
-random = ["fastrand", "fastrand-contrib"]
+random = ["dep:fastrand", "dep:fastrand-contrib"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2.83"

--- a/rten-generate/Cargo.toml
+++ b/rten-generate/Cargo.toml
@@ -17,7 +17,7 @@ rten-tensor = { path = "../rten-tensor", version = "0.13.1" }
 
 [features]
 # Enable text decoding using tokenizers from rten-text
-text-decoder = ["rten-text"]
+text-decoder = ["dep:rten-text"]
 
 [package.metadata.docs.rs]
 features = ["text-decoder"]


### PR DESCRIPTION
Avoid creating implicit features named after dependencies, as these implicit features are not used.

See https://doc.rust-lang.org/cargo/reference/features.html#optional-dependencies.

This should remove the fastrand, fastrand-contrib and memmap2 "features" shown on https://docs.rs/crate/rten/0.13.1/features.