### PR TITLE
Generalize `Output` => `Tensor`/`TensorView` convenience methods

### DIFF
--- a/rten-examples/src/jina_similarity.rs
+++ b/rten-examples/src/jina_similarity.rs
@@ -135,7 +135,9 @@ fn embed_sentence_batch(
 
     let output_id = model.node_id("last_hidden_state")?;
     let [last_hidden_state] = model.run_n(inputs, [output_id], None)?;
-    let last_hidden_state = last_hidden_state.into_float().ok_or("wrong output type")?;
+    let last_hidden_state = last_hidden_state
+        .into_tensor::<f32>()
+        .ok_or("wrong output type")?;
 
     // Mean pool each item in the batch. We process each batch item separately
     // since they can have different lengths.

--- a/src/model.rs
+++ b/src/model.rs
@@ -897,7 +897,7 @@ mod tests {
     fn check_output(mut result: Vec<Output>) -> Tensor<f32> {
         assert_eq!(result.len(), 1);
 
-        let tensor: Tensor<f32> = result.remove(0).into_float().unwrap();
+        let tensor: Tensor<f32> = result.remove(0).into_tensor::<f32>().unwrap();
         assert_eq!(tensor.shape(), &[2, 2, 2]);
         assert_eq!(tensor.to_vec(), &[0.5, 0., 0.1, 0., 1., 2., 0., 0.]);
 

--- a/src/ops/binary_elementwise.rs
+++ b/src/ops/binary_elementwise.rs
@@ -795,7 +795,9 @@ impl Operator for Pow {
         input: Output,
         other: InputList,
     ) -> Result<Output, OpError> {
-        let mut a = input.into_float().ok_or(OpError::IncorrectInputType)?;
+        let mut a = input
+            .into_tensor::<f32>()
+            .ok_or(OpError::IncorrectInputType)?;
         let b = other.require_as(0)?;
 
         if can_run_binary_op_in_place(&a, &b) {
@@ -1151,7 +1153,7 @@ mod tests {
         let result = op
             .run_in_place(&pool, Output::FloatTensor(a_copy), (&b).into())
             .unwrap();
-        expect_equal(result.as_float_ref().unwrap(), &expected)?;
+        expect_equal(&result.as_tensor_view().unwrap(), &expected.view())?;
 
         // Run `Add` operator in-place with inputs that don't support in-place
         // addition. The operator should fall back to creating a new output tensor.
@@ -1160,7 +1162,7 @@ mod tests {
         let result = op
             .run_in_place(&pool, Output::FloatTensor(scalar), (&b).into())
             .unwrap();
-        expect_equal(result.as_float_ref().unwrap(), &expected)?;
+        expect_equal(&result.as_tensor_view().unwrap(), &expected.view())?;
 
         // In-place addition where the second input must be broadcast to the
         // shape of the first.

--- a/src/ops/conv.rs
+++ b/src/ops/conv.rs
@@ -842,7 +842,7 @@ mod tests {
             .run(&pool, (&input, &kernel).into())
             .unwrap()
             .remove(0)
-            .into_float()
+            .into_tensor::<f32>()
             .unwrap();
         let reference_result = reference_conv(
             input.view(),

--- a/src/ops/convert.rs
+++ b/src/ops/convert.rs
@@ -80,7 +80,7 @@ mod tests {
             .run(&pool, (&int_input).into())
             .unwrap()
             .remove(0)
-            .into_int()
+            .into_tensor::<i32>()
             .unwrap();
 
         // Flooring cast from float => int32
@@ -89,7 +89,7 @@ mod tests {
             .run(&pool, (&float_input).into())
             .unwrap()
             .remove(0)
-            .into_int()
+            .into_tensor::<i32>()
             .unwrap();
         assert_eq!(&result, &int_input);
 
@@ -101,7 +101,7 @@ mod tests {
             .run(&pool, (&float_input).into())
             .unwrap()
             .remove(0)
-            .into_float()
+            .into_tensor::<f32>()
             .unwrap();
         expect_equal(&result, &float_input)?;
 
@@ -110,7 +110,7 @@ mod tests {
             .run(&pool, (&int_input).into())
             .unwrap()
             .remove(0)
-            .into_float()
+            .into_tensor::<f32>()
             .unwrap();
         expect_equal(&result, &float_input)?;
 
@@ -131,7 +131,7 @@ mod tests {
             .run(&pool, (&int_input).into())
             .unwrap()
             .remove(0)
-            .into_float()
+            .into_tensor::<f32>()
             .unwrap();
         expect_equal(&result, &Tensor::from([-2147483600.0, 2147483600.0]))?;
 
@@ -144,7 +144,7 @@ mod tests {
             .run(&pool, (&float_input).into())
             .unwrap()
             .remove(0)
-            .into_int()
+            .into_tensor::<i32>()
             .unwrap();
         assert_eq!(&result, &Tensor::from([i32::MIN, i32::MAX]));
 

--- a/src/ops/generate.rs
+++ b/src/ops/generate.rs
@@ -184,7 +184,7 @@ mod tests {
             .run(&pool, (&shape).into())
             .unwrap()
             .remove(0)
-            .into_int()
+            .into_tensor::<i32>()
             .unwrap();
 
         assert_eq!(result.shape(), &[1, 5, 10]);

--- a/src/ops/identity.rs
+++ b/src/ops/identity.rs
@@ -60,7 +60,7 @@ mod tests {
             .run(&pool, (&int_input).into())
             .unwrap()
             .remove(0)
-            .into_int()
+            .into_tensor::<i32>()
             .unwrap();
         assert_eq!(result, int_input);
 
@@ -69,7 +69,7 @@ mod tests {
             .run(&pool, (&float_input).into())
             .unwrap()
             .remove(0)
-            .into_float()
+            .into_tensor::<f32>()
             .unwrap();
         expect_equal(&result, &float_input)?;
 

--- a/src/ops/layout.rs
+++ b/src/ops/layout.rs
@@ -870,7 +870,7 @@ mod tests {
             .run(&pool, (&input, &shape).into())
             .unwrap()
             .remove(0)
-            .into_float()
+            .into_tensor::<f32>()
             .unwrap();
 
         expect_equal(&result, &expected)?;
@@ -889,7 +889,7 @@ mod tests {
             .run(&pool, (&input).into())
             .unwrap()
             .remove(0)
-            .into_int()
+            .into_tensor::<i32>()
             .unwrap();
         assert_eq!(result.shape(), &[4]);
         assert_eq!(result.to_vec(), &[1, 1, 2, 2]);
@@ -900,7 +900,7 @@ mod tests {
             .run(&pool, (&input).into())
             .unwrap()
             .remove(0)
-            .into_int()
+            .into_tensor::<i32>()
             .unwrap();
         assert_eq!(result.shape(), &[4]);
         assert_eq!(result.to_vec(), &[1, 1, 2, 2]);
@@ -915,7 +915,7 @@ mod tests {
             .run(&pool, (&input).into())
             .unwrap()
             .remove(0)
-            .into_int()
+            .into_tensor::<i32>()
             .unwrap();
         assert_eq!(result.ndim(), 0);
         assert_eq!(result.item(), Some(&4));

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -340,36 +340,25 @@ impl Output {
         };
     }
 
-    pub fn into_int(self) -> Option<Tensor<i32>> {
-        if let Output::Int32Tensor(t) = self {
-            Some(t)
-        } else {
-            None
-        }
+    /// Convert this output into a tensor with a given element type.
+    ///
+    /// Returns `None` if the element type does not match `T`.
+    pub fn into_tensor<T>(self) -> Option<Tensor<T>>
+    where
+        Tensor<T>: TryFrom<Self>,
+    {
+        self.try_into().ok()
     }
 
-    pub fn as_int_ref(&self) -> Option<&Tensor<i32>> {
-        if let Output::Int32Tensor(t) = self {
-            Some(t)
-        } else {
-            None
-        }
-    }
-
-    pub fn into_float(self) -> Option<Tensor<f32>> {
-        if let Output::FloatTensor(t) = self {
-            Some(t)
-        } else {
-            None
-        }
-    }
-
-    pub fn as_float_ref(&self) -> Option<&Tensor<f32>> {
-        if let Output::FloatTensor(t) = self {
-            Some(t)
-        } else {
-            None
-        }
+    /// Convert a reference to this output into a tensor view with a given
+    /// element type.
+    ///
+    /// Returns `None` if the element type does not match `T`.
+    pub fn as_tensor_view<'a, T>(&'a self) -> Option<TensorView<'a, T>>
+    where
+        TensorView<'a, T>: TryFrom<&'a Self>,
+    {
+        self.try_into().ok()
     }
 
     fn layout(&self) -> &DynLayout {

--- a/src/ops/norm.rs
+++ b/src/ops/norm.rs
@@ -108,7 +108,9 @@ impl Operator for BatchNormalization {
         input: Output,
         other: InputList,
     ) -> Result<Output, OpError> {
-        let mut output = input.into_float().ok_or(OpError::IncorrectInputType)?;
+        let mut output = input
+            .into_tensor::<f32>()
+            .ok_or(OpError::IncorrectInputType)?;
         let scale = other.require_as(0)?;
         let scale = static_dims!(scale, 1)?;
 
@@ -228,7 +230,9 @@ impl Operator for InstanceNormalization {
         output: Output,
         inputs: InputList,
     ) -> Result<Output, OpError> {
-        let mut output = output.into_float().ok_or(OpError::IncorrectInputType)?;
+        let mut output = output
+            .into_tensor::<f32>()
+            .ok_or(OpError::IncorrectInputType)?;
 
         let scale = inputs.require_as(0)?;
         let scale = static_dims!(scale, 1)?;
@@ -433,7 +437,9 @@ impl Operator for LogSoftmax {
         input: Output,
         _other: InputList,
     ) -> Result<Output, OpError> {
-        let mut output = input.into_float().ok_or(OpError::IncorrectInputType)?;
+        let mut output = input
+            .into_tensor::<f32>()
+            .ok_or(OpError::IncorrectInputType)?;
         log_softmax_in_place(&mut output, self.axis)?;
         Ok(output.into())
     }
@@ -475,7 +481,9 @@ impl Operator for Softmax {
         input: Output,
         _other: InputList,
     ) -> Result<Output, OpError> {
-        let mut output = input.into_float().ok_or(OpError::IncorrectInputType)?;
+        let mut output = input
+            .into_tensor::<f32>()
+            .ok_or(OpError::IncorrectInputType)?;
         softmax_in_place(&mut output, self.axis)?;
         Ok(output.into())
     }

--- a/src/ops/pad.rs
+++ b/src/ops/pad.rs
@@ -417,7 +417,7 @@ mod tests {
             .run(&pool, (&input, &pads).into())
             .unwrap()
             .remove(0)
-            .into_float()
+            .into_tensor::<f32>()
             .unwrap();
         expect_equal(&result, &expected)?;
 

--- a/src/ops/resize.rs
+++ b/src/ops/resize.rs
@@ -818,8 +818,7 @@ mod tests {
             let result = op.run(&pool, InputList::from_optional(&inputs));
             match (case.expected, result) {
                 (CaseOutput::Shape(shape), Ok(out)) => {
-                    let tensor = out[0].as_float_ref().unwrap();
-                    assert_eq!(tensor.shape(), &shape);
+                    assert_eq!(out[0].shape(), &shape);
                 }
                 (CaseOutput::Error(expected_err), Err(err)) => {
                     assert_eq!(err, expected_err);

--- a/src/ops/unary_elementwise.rs
+++ b/src/ops/unary_elementwise.rs
@@ -56,7 +56,9 @@ impl<Op: Any + Debug + UnaryFloatOp> Operator for Op {
         input: Output,
         _: InputList,
     ) -> Result<Output, OpError> {
-        let mut output = input.into_float().ok_or(OpError::IncorrectInputType)?;
+        let mut output = input
+            .into_tensor::<f32>()
+            .ok_or(OpError::IncorrectInputType)?;
         self.apply(output.view_mut());
         Ok(output.into())
     }
@@ -214,7 +216,9 @@ macro_rules! parallel_unary_float_op {
                 input: Output,
                 _: InputList,
             ) -> Result<Output, OpError> {
-                let mut tensor = input.into_float().ok_or(OpError::IncorrectInputType)?;
+                let mut tensor = input
+                    .into_tensor::<f32>()
+                    .ok_or(OpError::IncorrectInputType)?;
                 $in_place_func_name(tensor.view_mut());
                 Ok(tensor.into())
             }
@@ -564,7 +568,9 @@ impl Operator for Not {
         input: Output,
         _: InputList,
     ) -> Result<Output, OpError> {
-        let mut output = input.into_int().ok_or(OpError::IncorrectInputType)?;
+        let mut output = input
+            .into_tensor::<i32>()
+            .ok_or(OpError::IncorrectInputType)?;
         not_in_place(output.view_mut());
         Ok(output.into())
     }


### PR DESCRIPTION
Replace `Output::{into_int, into_float}` with generic `into_tensor` and `Output::{as_float_ref, as_int_ref}` with generic `as_tensor_view`.

This adds support for u8/i8 tensors and other types as they are added in future.