### PR TITLE
Replace remaining uses of `check_dims` with `static_dims`

### DIFF
--- a/src/ops/concat.rs
+++ b/src/ops/concat.rs
@@ -5,10 +5,10 @@ use rten_tensor::{NdTensorView, Tensor, TensorView};
 
 use smallvec::SmallVec;
 
+use crate::ops::static_dims;
 use crate::ops::{
     resolve_axis, Input, InputList, IntoOpResult, OpError, Operator, Output, OutputList,
 };
-use crate::static_dims;
 use crate::tensor_pool::{AutoReturn, TensorPool};
 
 /// Return the shape formed by concatenating all tensors along a given axis.

--- a/src/ops/generate.rs
+++ b/src/ops/generate.rs
@@ -4,10 +4,9 @@ use rten_tensor::prelude::*;
 use rten_tensor::{NdTensorView, Tensor, TensorView};
 
 use crate::ops::{
-    resolve_axis, resolve_index, Input, InputList, IntoOpResult, OpError, Operator, OutputList,
-    Scalar,
+    resolve_axis, resolve_index, static_dims, Input, InputList, IntoOpResult, OpError, Operator,
+    OutputList, Scalar,
 };
-use crate::static_dims;
 use crate::tensor_pool::TensorPool;
 
 pub fn constant_of_shape<T: Copy>(

--- a/src/ops/layout.rs
+++ b/src/ops/layout.rs
@@ -7,10 +7,9 @@ use smallvec::SmallVec;
 
 use crate::ops::binary_elementwise::{broadcast_shapes, fast_broadcast_cycles_repeats};
 use crate::ops::{
-    resolve_axes, resolve_axis, Input, InputList, IntoOpResult, OpError, Operator, Output,
-    OutputList,
+    resolve_axes, resolve_axis, static_dims, Input, InputList, IntoOpResult, OpError, Operator,
+    Output, OutputList,
 };
-use crate::static_dims;
 use crate::tensor_pool::TensorPool;
 
 /// Return the tensor shape resulting from broadcasting `input_shape` with `shape`.

--- a/src/ops/matmul.rs
+++ b/src/ops/matmul.rs
@@ -3,12 +3,11 @@ use rayon::prelude::*;
 use rten_tensor::prelude::*;
 use rten_tensor::{Tensor, TensorView};
 
-use crate::check_dims;
 use crate::gemm::{GemmExecutor, GemmInT, GemmInputA, GemmInputB, GemmOutT};
 use crate::iter_util::range_chunks;
 use crate::ops::binary_elementwise::broadcast_shapes;
 use crate::ops::layout::expand_to;
-use crate::ops::{InputList, IntoOpResult, OpError, Operator, OutputList};
+use crate::ops::{static_dims, InputList, IntoOpResult, OpError, Operator, OutputList};
 use crate::tensor_pool::{AutoReturn, TensorPool};
 
 /// Compute the General Matrix Multiplication (GEMM) `c = alpha * (ab) + beta * c`.
@@ -30,8 +29,8 @@ pub fn gemm_op<LhsT: GemmInT, RhsT: GemmInT, OutT: GemmOutT>(
 where
     GemmExecutor<LhsT, RhsT, OutT>: Default,
 {
-    check_dims!(a, 2);
-    check_dims!(b, 2);
+    let a = static_dims!(a, 2)?;
+    let b = static_dims!(b, 2)?;
 
     let a = if transpose_a { a.transposed() } else { a };
     let b = if transpose_b { b.transposed() } else { b };

--- a/src/ops/non_max_suppression.rs
+++ b/src/ops/non_max_suppression.rs
@@ -1,8 +1,7 @@
 use rten_tensor::prelude::*;
 use rten_tensor::{NdTensor, NdTensorView};
 
-use crate::ops::{InputList, IntoOpResult, OpError, Operator, OutputList};
-use crate::static_dims;
+use crate::ops::{static_dims, InputList, IntoOpResult, OpError, Operator, OutputList};
 use crate::tensor_pool::TensorPool;
 
 #[derive(Copy, Clone, Debug, PartialEq)]

--- a/src/ops/norm.rs
+++ b/src/ops/norm.rs
@@ -6,10 +6,9 @@ use rten_vecmath::vec_softmax_in_place;
 use smallvec::SmallVec;
 
 use crate::ops::reduce::reduce_inverse_rms;
-use crate::ops::{add_in_place, mul_in_place, reduce_mean, sub};
+use crate::ops::{add_in_place, mul_in_place, reduce_mean, static_dims, sub};
 use crate::ops::{resolve_axis, InputList, IntoOpResult, OpError, Operator, Output, OutputList};
 use crate::slice_reductions::{slice_max, slice_sum};
-use crate::static_dims;
 use crate::tensor_pool::{AutoReturn, TensorPool};
 
 /// Perform in-place batch normalization on the `NC*` tensor `out`.

--- a/src/ops/pad.rs
+++ b/src/ops/pad.rs
@@ -1,8 +1,7 @@
 use rten_tensor::prelude::*;
 use rten_tensor::{NdTensorView, SliceItem, Tensor, TensorView};
 
-use crate::ops::{Input, InputList, IntoOpResult, OpError, Operator, OutputList};
-use crate::static_dims;
+use crate::ops::{static_dims, Input, InputList, IntoOpResult, OpError, Operator, OutputList};
 use crate::tensor_pool::TensorPool;
 
 #[derive(Copy, Clone, Debug, PartialEq)]

--- a/src/ops/pooling.rs
+++ b/src/ops/pooling.rs
@@ -5,8 +5,7 @@ use rayon::prelude::*;
 use rten_tensor::prelude::*;
 use rten_tensor::{NdTensor, NdTensorView, NdTensorViewMut, Tensor, TensorView, TensorViewMut};
 
-use crate::ops::{InputList, IntoOpResult, OpError, Operator, OutputList, Padding};
-use crate::static_dims;
+use crate::ops::{static_dims, InputList, IntoOpResult, OpError, Operator, OutputList, Padding};
 use crate::tensor_pool::TensorPool;
 
 /// Calculate the output size and padding for a convolution or pooling operation.

--- a/src/ops/resize.rs
+++ b/src/ops/resize.rs
@@ -6,9 +6,8 @@ use rten_tensor::prelude::*;
 use rten_tensor::{NdTensor, NdTensorView, NdTensorViewMut, Tensor, TensorView};
 
 use crate::iter_util::range_chunks;
-use crate::ops::{Input, InputList, IntoOpResult, OpError, Operator, OutputList};
+use crate::ops::{static_dims, Input, InputList, IntoOpResult, OpError, Operator, OutputList};
 use crate::tensor_pool::TensorPool;
-use crate::{check_dims, static_dims};
 
 /// Specifies an output size for a resize operation.
 pub enum ResizeTarget<'a> {
@@ -226,7 +225,7 @@ fn bilinear_resize(
 ///
 /// This is a simplified API for [resize].
 pub fn resize_image(input: TensorView, size: [usize; 2]) -> Result<Tensor, OpError> {
-    let [batch, chans, _height, _width] = check_dims!(input, 4);
+    let [batch, chans, _height, _width] = static_dims!(input, 4)?.shape();
     let [out_height, out_width] = size;
     let out_shape = [batch, chans, out_height, out_width].map(|x| x as i32);
     resize(

--- a/src/ops/rnn.rs
+++ b/src/ops/rnn.rs
@@ -6,10 +6,9 @@ use rten_tensor::{NdTensor, Tensor, TensorView};
 
 use crate::gemm::{GemmExecutor, GemmInputA, GemmInputB};
 use crate::ops::{
-    add_in_place, mul_in_place, sigmoid, tanh, InputList, IntoOpResult, OpError, Operator,
-    OutputList,
+    add_in_place, mul_in_place, sigmoid, static_dims, tanh, InputList, IntoOpResult, OpError,
+    Operator, OutputList,
 };
-use crate::static_dims;
 use crate::tensor_pool::{AutoReturn, TensorPool};
 
 /// Direction that an RNN operator will traverse the input sequence in.

--- a/src/ops/slice.rs
+++ b/src/ops/slice.rs
@@ -4,9 +4,9 @@ use rten_tensor::{NdTensorView, SliceItem, SliceRange, Tensor, TensorView};
 use smallvec::SmallVec;
 
 use crate::ops::{
-    resolve_axis, Input, InputList, IntoOpResult, OpError, Operator, Output, OutputList,
+    resolve_axis, static_dims, Input, InputList, IntoOpResult, OpError, Operator, Output,
+    OutputList,
 };
-use crate::static_dims;
 use crate::tensor_pool::TensorPool;
 
 /// Compute the effective starts, ends and steps for each input dimension in

--- a/src/ops/split.rs
+++ b/src/ops/split.rs
@@ -1,8 +1,7 @@
 use rten_tensor::prelude::*;
 use rten_tensor::{NdTensorView, SliceItem, Tensor, TensorView};
 
-use crate::ops::{resolve_axis, InputList, OpError, Operator, OutputList};
-use crate::static_dims;
+use crate::ops::{resolve_axis, static_dims, InputList, OpError, Operator, OutputList};
 use crate::tensor_pool::TensorPool;
 
 pub fn split<T: Copy>(


### PR DESCRIPTION
Avoid having two different ways for an operator to check that an input has the expected number of dimensions.

In the process convert `static_dims` to a true crate-internal macro instead of a public-but-undocumented one.