### PR TITLE
Add API to rten-generate for filtering/processing logits

### DIFF
--- a/rten-generate/src/filter.rs
+++ b/rten-generate/src/filter.rs
@@ -1,0 +1,16 @@
+//! Filters for processing model outputs prior to sampling.
+
+use rten_tensor::{NdTensor, NdTensorView};
+
+/// Filter which modifies the output logits from a model.
+///
+/// The filter is applied to the model outputs before a token is sampled.
+pub trait LogitsFilter {
+    /// Filter the model's output and return the modified logits.
+    ///
+    /// If this method returns `None`, the input logits are passed unmodified
+    /// to the sampler. `prev_tokens` contains the previously sampled tokens,
+    /// including the prompt.
+    fn filter(&self, logits: NdTensorView<f32, 1>, prev_tokens: &[u32])
+        -> Option<NdTensor<f32, 1>>;
+}

--- a/rten-generate/src/lib.rs
+++ b/rten-generate/src/lib.rs
@@ -7,6 +7,7 @@
 //! [rten]: https://github.com/robertknight/rten
 //! [rten-examples]: https://github.com/robertknight/rten/tree/main/rten-examples
 
+pub mod filter;
 pub mod generator;
 pub mod metrics;
 pub mod model;


### PR DESCRIPTION
Add support for modifying the raw model outputs before applying the sampler to select the next token. This can be used to adjust the probability that specific tokens are sampled.