### PR TITLE
Normalize and chunk audio inputs in wav2vec2 example

### DIFF
--- a/src/ops/norm.rs
+++ b/src/ops/norm.rs
@@ -272,7 +272,7 @@ pub fn layer_normalization(
         .map(|axis| axis as i32)
         .collect();
 
-    // First step: standardize input elements to have unit mean and variance.
+    // First step: standardize input elements to have zero mean and unit variance.
     let mean = reduce_mean(
         pool,
         input.view(),


### PR DESCRIPTION
Improve the wav2vec2 example by:

 - Normalizing audio samples to unit mean and variance, as described in the
   wav2vec2 paper and linked issues. In the original fairseq source the
   PyTorch `layer_norm` function is used, which does the same thing.

 - Chunking the audio to improve performance when transcribing long audio
   inputs (see also https://huggingface.co/blog/asr-chunking)

 - Improving the readability of the output by lower-casing the raw char
   predictions and replacing "|" with spaces.

