### PR TITLE
Reuse existing output node when replacing operator with a fusion

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -711,7 +711,11 @@ impl Graph {
         captures
     }
 
-    pub fn add_node(&mut self, node: Node) -> NodeId {
+    /// Add a node to the graph and return its ID.
+    ///
+    /// This contains the common logic for adding different types of node to
+    /// the graph.
+    fn add_node(&mut self, node: Node) -> NodeId {
         let node_id = NodeId::from_u32(self.nodes.len() as u32);
         self.nodes.push(node);
 
@@ -790,7 +794,7 @@ impl Graph {
         (op_node_id, op_out_id)
     }
 
-    /// Add a constant node to the graph.
+    /// Convert `value` to a constant node and add it to the graph.
     ///
     /// `name` is an identifier for this node that is used in debug messages etc.
     ///
@@ -800,12 +804,20 @@ impl Graph {
         V: Into<ConstantNodeData<T>>,
         ConstantNode<T>: Into<Constant>,
     {
-        let node = ConstantNode {
-            name: name.map(|s| s.to_owned()),
-            data: value.into(),
-        };
+        self.add_constant_node(
+            ConstantNode {
+                name: name.map(|s| s.to_owned()),
+                data: value.into(),
+            }
+            .into(),
+        )
+    }
 
-        self.add_node(Node::Constant(node.into()))
+    /// Add a constant node to the graph.
+    ///
+    /// Returns the ID of the added node.
+    pub fn add_constant_node(&mut self, node: Constant) -> NodeId {
+        self.add_node(Node::Constant(node))
     }
 
     /// Add a value node to the graph.

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -277,12 +277,11 @@ impl GraphOptimizer {
 
     /// Apply optimizations to a graph.
     ///
-    /// The input and output nodes specified by `input_ids` and `output_ids`
-    /// will be preserved, but their IDs may change. Other nodes in the graph
-    /// may be modified, removed or replaced by optimization.
+    /// The graph's input and output nodes, identified by
+    /// [`input_ids`](Graph::input_ids) and [`output_ids`](Graph::output_ids)
+    /// will be preserved. Other nodes may be modified, removed or replaced.
     ///
-    /// This method returns the new graph along with the node IDs in the new
-    /// graph that correspond to `input_ids` and `output_ids`.
+    /// Returns the optimized graph.
     pub fn optimize(
         &self,
         graph: Graph,

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -78,6 +78,11 @@ impl GraphMutator {
         self.graph.add_constant(name, value)
     }
 
+    /// Add a new constant value to the graph.
+    fn add_constant_node(&mut self, const_node: Constant) -> NodeId {
+        self.graph.add_constant_node(const_node)
+    }
+
     /// Add a new operator to the graph with a single output node.
     ///
     /// `op_output_id` specifies the ID of the output node. If not specified,
@@ -103,11 +108,6 @@ impl GraphMutator {
         }
 
         op_output_id
-    }
-
-    /// Add a new node to the graph.
-    fn add_node(&mut self, node: Node) -> NodeId {
-        self.graph.add_node(node)
     }
 
     /// Return a reference to the graph.
@@ -330,7 +330,7 @@ impl GraphOptimizer {
         let mut new_captures: FxHashSet<_> = graph.graph().captures().iter().copied().collect();
 
         for (capture_id, local_const) in captured_constants {
-            let const_id = graph.add_node(Node::Constant(local_const));
+            let const_id = graph.add_constant_node(local_const);
             new_captures.remove(&capture_id);
             graph.replace_value(capture_id, const_id);
         }


### PR DESCRIPTION
When replacing a subgraph with a fused operator, reuse the output value node
from the subgraph instead of creating a new one. This preserves metadata such as
the name and shape associated with that value node. Also it simplifies the code
by removing the need to replace all references to the previous output node with
the new one.

This improves the runtime of the Whisper example using the whisper-base model by
~25% by fixing an issue where fused Transpose + MatMul operations did not get
used.
