### PR TITLE
Output transcription speed as a multiple of real-time in Whisper example

### DIFF
--- a/rten-examples/src/whisper.rs
+++ b/rten-examples/src/whisper.rs
@@ -563,7 +563,13 @@ fn main() -> Result<(), Box<dyn Error>> {
         }
     }
 
-    println!("Decoding took {:.3}s", start.elapsed().as_secs_f64());
+    let decode_duration = start.elapsed().as_secs_f64();
+    let audio_duration: f64 = audio.len() as f64 / sample_rate as f64;
+    let real_time_factor = audio_duration / decode_duration;
+    println!(
+        "Transcribed {:.0}s of audio in {:.2}s, {:.1}x real-time",
+        audio_duration, decode_duration, real_time_factor
+    );
 
     Ok(())
 }


### PR DESCRIPTION
This allows comparing performance across different audio clip lengths. Also this is a number that is often reported for other inference engines.

As a data point, on my Intel i5 laptop I get:

- whisper-base: ~18x realtime
- whisper-small: ~5x realtime
- whisper-medium: ~2x realtime