### PR TITLE
Support passing captures by-value to subgraphs

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -431,7 +431,7 @@ impl Model {
                 optimize,
                 capture_env,
             } = &subgraph_opts;
-            let capture_env = CaptureEnv::new(*capture_env, graph, None, None);
+            let capture_env = CaptureEnv::new(*capture_env, graph, None, None, None);
             Self::load_graph(
                 g,
                 registry,

--- a/src/ops/control_flow.rs
+++ b/src/ops/control_flow.rs
@@ -46,7 +46,7 @@ impl Operator for If {
         &self,
         pool: &TensorPool,
         inputs: InputList,
-        captures: &CaptureEnv,
+        captures: CaptureEnv,
         run_opts: Option<RunOptions>,
     ) -> Result<OutputList, RunError> {
         let cond: TensorView<i32> = inputs.require_as(0).map_err(run_error_from_op_error)?;

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -788,7 +788,7 @@ pub trait Operator: Any + Debug {
         &self,
         pool: &TensorPool,
         input: InputList,
-        #[allow(unused)] captures: &CaptureEnv,
+        #[allow(unused)] captures: CaptureEnv,
         #[allow(unused)] run_opts: Option<RunOptions>,
     ) -> Result<OutputList, RunError> {
         self.run(pool, input)

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -629,7 +629,7 @@ mod tests {
         // Run optimizations on the subgraph. This should replace the captured
         // value with a local constant that references the same data.
         let optimizer = GraphOptimizer::new();
-        let capture_env = CaptureEnv::new(None, &graph, None, None);
+        let capture_env = CaptureEnv::new(None, &graph, None, None, None);
         let optimized_subgraph = optimizer.optimize(subgraph, Some(&capture_env))?;
 
         let outputs = optimized_subgraph.output_ids();


### PR DESCRIPTION
When preparing the capture environment to pass to an operator with subgraphs, if a captured value is not going to be needed by subsequent operators in the current graph then it can be passed by value rather than by reference. In the subgraph, this allows the value to be (potentially) used as an in-place input.

 - Pass `CaptureEnv` to `Graph::run_subgraph` by value rather than by reference

 - Add map of by-value captures to `CaptureEnv`

 - Add `CaptureEnv::child` method which creates a child environment with no captures of its own. This is not currently used but will be needed by loop operators which run a subgraph more than once and need to obtain a fresh capture environment for each iteration.

Part of https://github.com/robertknight/rten/issues/399.