### PR TITLE
Optimize GatherND by avoiding redundant zeroing of output and adding fast path for contiguous inputs

### DIFF
--- a/src/ops/gather.rs
+++ b/src/ops/gather.rs
@@ -307,16 +307,36 @@ pub fn gather_nd<T: Clone + Default>(
         let out_slices = output.data_mut().unwrap().chunks_mut(out_slice_len);
         let idx_slices = indices.data().unwrap().chunks(idx_tuple_size);
 
-        for (out_slice, idx) in out_slices.zip(idx_slices) {
-            let slice_items = to_slice_items(idx);
-            let in_slice = input
-                .try_slice(slice_items.as_slice())
-                .map_err(|_| OpError::InvalidValue("Invalid index"))?;
-
-            for (out, x) in out_slice.iter_mut().zip(in_slice.iter()) {
-                out.write(x.clone());
+        if let Some(input_data) = input.data() {
+            // Fast path for when the gathered data is contiguous. In that case
+            // the gather just amounts to copying chunks of the input to the
+            // output.
+            for (out_slice, idx) in out_slices.zip(idx_slices) {
+                let offset = idx
+                    .iter()
+                    .zip(input.strides())
+                    .map(|(idx, stride)| *idx as usize * stride)
+                    .sum();
+                let in_slice = input_data
+                    .get(offset..offset + out_slice.len())
+                    .ok_or(OpError::InvalidValue("Invalid index"))?;
+                for (out, x) in out_slice.iter_mut().zip(in_slice) {
+                    out.write(x.clone());
+                }
+                n_init += out_slice.len();
             }
-            n_init += out_slice.len();
+        } else {
+            for (out_slice, idx) in out_slices.zip(idx_slices) {
+                let slice_items = to_slice_items(idx);
+                let in_slice = input
+                    .try_slice(slice_items.as_slice())
+                    .map_err(|_| OpError::InvalidValue("Invalid index"))?;
+
+                for (out, x) in out_slice.iter_mut().zip(in_slice.iter()) {
+                    out.write(x.clone());
+                }
+                n_init += out_slice.len();
+            }
         }
     }
 
@@ -788,6 +808,7 @@ mod tests {
         struct Case {
             batch_dims: usize,
             data: Tensor<i32>,
+            transpose: bool,
             indices: Tensor<i32>,
             expected: Result<Tensor<i32>, OpError>,
         }
@@ -797,43 +818,75 @@ mod tests {
             Case {
                 batch_dims: 0,
                 data: [[0, 1], [2, 3]].into(),
+                transpose: false,
                 indices: [[0, 0], [1, 1]].into(),
                 expected: Ok([0, 3].into()),
             },
             Case {
                 batch_dims: 0,
                 data: [[0, 1], [2, 3]].into(),
+                transpose: false,
                 indices: [[1], [0]].into(),
                 expected: Ok([[2, 3], [0, 1]].into()),
             },
             Case {
                 batch_dims: 0,
                 data: [[[0, 1], [2, 3]], [[4, 5], [6, 7]]].into(),
+                transpose: false,
                 indices: [[0, 1], [1, 0]].into(),
                 expected: Ok([[2, 3], [4, 5]].into()),
             },
             Case {
                 batch_dims: 0,
                 data: [[[0, 1], [2, 3]], [[4, 5], [6, 7]]].into(),
+                transpose: false,
                 indices: [[[0, 1]], [[1, 0]]].into(),
                 expected: Ok([[[2, 3]], [[4, 5]]].into()),
             },
             Case {
                 batch_dims: 1,
                 data: [[[0, 1], [2, 3]], [[4, 5], [6, 7]]].into(),
+                transpose: false,
                 indices: [[1], [0]].into(),
                 expected: Ok([[2, 3], [4, 5]].into()),
+            },
+            // Invalid indexes
+            Case {
+                batch_dims: 0,
+                data: [[0, 1], [2, 3]].into(),
+                transpose: false,
+                indices: [[0, 0], [1, 2]].into(),
+                expected: Err(OpError::InvalidValue("Invalid index")),
+            },
+            // Transposed input
+            Case {
+                batch_dims: 0,
+                data: [[0, 1], [2, 3]].into(),
+                transpose: true,
+                indices: [[0, 1], [1, 0]].into(),
+                expected: Ok([2, 1].into()),
+            },
+            Case {
+                batch_dims: 0,
+                data: [[0, 1], [2, 3]].into(),
+                transpose: true,
+                indices: [[0, 1], [1, 2]].into(),
+                expected: Err(OpError::InvalidValue("Invalid index")),
             },
         ];
 
         let pool = new_pool();
         for Case {
             batch_dims,
-            data,
+            mut data,
+            transpose,
             indices,
             expected,
         } in cases
         {
+            if transpose {
+                data.transpose();
+            }
             let result = gather_nd(&pool, data.view(), indices.view(), batch_dims);
             assert_eq!(result, expected);
         }


### PR DESCRIPTION
Optimize GatherND by:

- Avoiding redundant zeroing of the output buffer
- Adding a fast path for contiguous inputs. This allows skipping of expensive slicing of the input for each element. Instead we just compute the offset of the start of the gathered chunk for each index and copy to the output.

The fallback path for non contiguous inputs could be further optimized by creating the slice view once and just shifting the base offset on each iteration.

**TODO:**

- [x] Ensure there are test cases for both contiguous and non-contiguous inputs

