### PR TITLE
Use a single value for the maximum temporary GEMM tile size

### DIFF
--- a/src/gemm.rs
+++ b/src/gemm.rs
@@ -840,7 +840,8 @@ fn gemm_impl<LhsT: GemmInT, RhsT: GemmInT, OutT: GemmOutT>(
     // Buffers for packed blocks of the matrix.
     //
     // These use `u64` rather than LhsT / RhsT because statics cannot be generic.
-    // `u64` is used to ensure alignment is a m
+    // `u64` is assumed to have an alignment that is greater or equal to the
+    // alignment of any LhsT / RhsT.
     thread_local!(static PACKED_A: RefCell<Vec<u64>> = const { RefCell::new(Vec::new()) });
     thread_local!(static PACKED_B: RefCell<Vec<u64>> = const { RefCell::new(Vec::new()) });
     assert!(align_of::<LhsT>() <= align_of::<u64>());
@@ -993,7 +994,7 @@ fn gemm_impl<LhsT: GemmInT, RhsT: GemmInT, OutT: GemmOutT>(
 /// `packed_a` and `packed_b` are the corresponding packed inputs. `panel_length`
 /// is the size of panels along the depth/K dimension.
 ///
-/// `is_first` indicates whether this is the first write to the output tiles
+/// `first_update` indicates whether this is the first write to the output tiles
 /// in this block during the current GEMM operation.
 fn gemm_block<LhsT, RhsT, OutT: GemmOutT>(
     kernel: &dyn Kernel<LhsT, RhsT, OutT>,

--- a/src/ops/conv/im2col.rs
+++ b/src/ops/conv/im2col.rs
@@ -80,7 +80,7 @@ impl<'a, T: Copy + Default> VirtualIm2Col<'a, T> {
         strides: [usize; 2],
         dilations: [usize; 2],
         panel_width: usize,
-    ) -> VirtualIm2Col<T> {
+    ) -> VirtualIm2Col<'a, T> {
         // Ensure image has at least one cell.
         assert!(image.len() > 0);
 

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -283,19 +283,19 @@ macro_rules! impl_input_conversions {
         }
 
         impl<'a> From<&'a Tensor<$element_type>> for Input<'a> {
-            fn from(t: &'a Tensor<$element_type>) -> Input {
+            fn from(t: &'a Tensor<$element_type>) -> Input<'a> {
                 Input::$variant(t.view())
             }
         }
 
         impl<'a> From<TensorView<'a, $element_type>> for Input<'a> {
-            fn from(t: TensorView<'a, $element_type>) -> Input {
+            fn from(t: TensorView<'a, $element_type>) -> Input<'a> {
                 Input::$variant(t)
             }
         }
 
         impl<'a, const N: usize> From<NdTensorView<'a, $element_type, N>> for Input<'a> {
-            fn from(t: NdTensorView<'a, $element_type, N>) -> Input {
+            fn from(t: NdTensorView<'a, $element_type, N>) -> Input<'a> {
                 Input::$variant(t.as_dyn())
             }
         }
@@ -308,7 +308,7 @@ impl_input_conversions!(Int8Tensor, i8);
 impl_input_conversions!(UInt8Tensor, u8);
 
 impl<'a> From<&'a Output> for Input<'a> {
-    fn from(output: &'a Output) -> Input {
+    fn from(output: &'a Output) -> Input<'a> {
         match output {
             Output::FloatTensor(t) => Input::FloatTensor(t.view()),
             Output::Int32Tensor(t) => Input::Int32Tensor(t.view()),


### PR DESCRIPTION
This allows for a wider range of kernel tile sizes, as long as the total number of elements is less than the maximum.
