### PR TITLE
Apply clippy fixes suggested in Rust v1.83

### DIFF
--- a/rten-generate/src/generator.rs
+++ b/rten-generate/src/generator.rs
@@ -245,7 +245,7 @@ pub struct GeneratorConfig<'a> {
     pub model_inputs: ModelInputsConfig<'a>,
 }
 
-impl<'a> Default for ModelInputsConfig<'a> {
+impl Default for ModelInputsConfig<'_> {
     /// Return default model input names.
     ///
     /// These are based on [Hugging Face's
@@ -863,7 +863,7 @@ impl<'a> Generator<'a> {
 /// Output items from a [`Generator`].
 pub type GeneratorItem = Result<TokenId, GeneratorError>;
 
-impl<'a> Iterator for Generator<'a> {
+impl Iterator for Generator<'_> {
     type Item = Result<TokenId, GeneratorError>;
 
     /// Run the model and generate the next output token.
@@ -912,7 +912,7 @@ impl<'a, G: Iterator> Profiler<'a, G> {
     }
 }
 
-impl<'a, G: Iterator> Iterator for Profiler<'a, G> {
+impl<G: Iterator> Iterator for Profiler<'_, G> {
     type Item = G::Item;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/rten-generate/src/text_decoder.rs
+++ b/rten-generate/src/text_decoder.rs
@@ -27,7 +27,7 @@ where
     }
 }
 
-impl<'a, G: Iterator<Item = GeneratorItem>> Iterator for TextDecoder<'a, G> {
+impl<G: Iterator<Item = GeneratorItem>> Iterator for TextDecoder<'_, G> {
     /// The decoded string, or the error that occurred during generation.
     type Item = Result<String, GeneratorError>;
 

--- a/rten-imageproc/src/shapes.rs
+++ b/rten-imageproc/src/shapes.rs
@@ -1148,7 +1148,7 @@ impl<'a> Iterator for PolygonsIter<'a> {
     }
 }
 
-impl<'a> ExactSizeIterator for PolygonsIter<'a> {}
+impl ExactSizeIterator for PolygonsIter<'_> {}
 
 #[cfg(test)]
 mod tests {

--- a/rten-tensor/src/impl_debug.rs
+++ b/rten-tensor/src/impl_debug.rs
@@ -102,7 +102,7 @@ impl<'a, S: Storage, L: MutLayout> FormatTensor<'a, S, L> {
     }
 }
 
-impl<'a, S: Storage, L: MutLayout> Debug for FormatTensor<'a, S, L>
+impl<S: Storage, L: MutLayout> Debug for FormatTensor<'_, S, L>
 where
     S::Elem: Debug,
 {

--- a/rten-tensor/src/impl_serialize.rs
+++ b/rten-tensor/src/impl_serialize.rs
@@ -10,7 +10,7 @@ struct TensorData<'a, T> {
     iter: Iter<'a, T>,
 }
 
-impl<'a, T> Serialize for TensorData<'a, T>
+impl<T> Serialize for TensorData<'_, T>
 where
     T: Serialize,
 {

--- a/rten-tensor/src/iterators.rs
+++ b/rten-tensor/src/iterators.rs
@@ -193,7 +193,7 @@ enum IterKind<'a, T> {
     Indexing(IndexingIter<'a, T>),
 }
 
-impl<'a, T> Clone for IterKind<'a, T> {
+impl<T> Clone for IterKind<'_, T> {
     fn clone(&self) -> Self {
         match self {
             IterKind::Direct(slice_iter) => IterKind::Direct(slice_iter.clone()),
@@ -221,7 +221,7 @@ impl<'a, T> Iter<'a, T> {
     }
 }
 
-impl<'a, T> Clone for Iter<'a, T> {
+impl<T> Clone for Iter<'_, T> {
     fn clone(&self) -> Self {
         Iter {
             iter: self.iter.clone(),
@@ -258,9 +258,9 @@ impl<'a, T> Iterator for Iter<'a, T> {
     }
 }
 
-impl<'a, T> ExactSizeIterator for Iter<'a, T> {}
+impl<T> ExactSizeIterator for Iter<'_, T> {}
 
-impl<'a, T> FusedIterator for Iter<'a, T> {}
+impl<T> FusedIterator for Iter<'_, T> {}
 
 struct IndexingIter<'a, T> {
     base: IndexingIterBase,
@@ -278,7 +278,7 @@ impl<'a, T> IndexingIter<'a, T> {
     }
 }
 
-impl<'a, T> Clone for IndexingIter<'a, T> {
+impl<T> Clone for IndexingIter<'_, T> {
     fn clone(&self) -> Self {
         IndexingIter {
             base: self.base.clone(),
@@ -308,9 +308,9 @@ impl<'a, T> Iterator for IndexingIter<'a, T> {
     }
 }
 
-impl<'a, T> ExactSizeIterator for IndexingIter<'a, T> {}
+impl<T> ExactSizeIterator for IndexingIter<'_, T> {}
 
-impl<'a, T> FusedIterator for IndexingIter<'a, T> {}
+impl<T> FusedIterator for IndexingIter<'_, T> {}
 
 /// Mutable iterator over elements of a tensor.
 pub struct IterMut<'a, T> {
@@ -372,9 +372,9 @@ impl<'a, T> Iterator for IterMut<'a, T> {
     }
 }
 
-impl<'a, T> ExactSizeIterator for IterMut<'a, T> {}
+impl<T> ExactSizeIterator for IterMut<'_, T> {}
 
-impl<'a, T> FusedIterator for IterMut<'a, T> {}
+impl<T> FusedIterator for IterMut<'_, T> {}
 
 struct IndexingIterMut<'a, T> {
     base: IndexingIterBase,
@@ -422,9 +422,9 @@ impl<'a, T> Iterator for IndexingIterMut<'a, T> {
     }
 }
 
-impl<'a, T> ExactSizeIterator for IndexingIterMut<'a, T> {}
+impl<T> ExactSizeIterator for IndexingIterMut<'_, T> {}
 
-impl<'a, T> FusedIterator for IndexingIterMut<'a, T> {}
+impl<T> FusedIterator for IndexingIterMut<'_, T> {}
 
 /// Iterator over element offsets of a tensor.
 ///
@@ -578,9 +578,9 @@ impl<'a, T> Iterator for Lane<'a, T> {
     }
 }
 
-impl<'a, T> ExactSizeIterator for Lane<'a, T> {}
+impl<T> ExactSizeIterator for Lane<'_, T> {}
 
-impl<'a, T> FusedIterator for Lane<'a, T> {}
+impl<T> FusedIterator for Lane<'_, T> {}
 
 impl<'a, T> Lanes<'a, T> {
     /// Create an iterator which yields all possible slices over the `dim`
@@ -613,9 +613,9 @@ impl<'a, T> Iterator for Lanes<'a, T> {
     }
 }
 
-impl<'a, T> ExactSizeIterator for Lanes<'a, T> {}
+impl<T> ExactSizeIterator for Lanes<'_, T> {}
 
-impl<'a, T> FusedIterator for Lanes<'a, T> {}
+impl<T> FusedIterator for Lanes<'_, T> {}
 
 /// Mutable version of [`Lanes`].
 ///
@@ -681,7 +681,7 @@ impl<'a, T> Iterator for LaneMut<'a, T> {
     }
 }
 
-impl<'a, T> ExactSizeIterator for LaneMut<'a, T> {}
+impl<T> ExactSizeIterator for LaneMut<'_, T> {}
 
 impl<'a, T> Iterator for LanesMut<'a, T> {
     type Item = LaneMut<'a, T>;
@@ -789,7 +789,7 @@ impl<'a, T, const N: usize> Iterator for InnerIter<'a, T, N> {
     }
 }
 
-impl<'a, T, const N: usize> ExactSizeIterator for InnerIter<'a, T, N> {}
+impl<T, const N: usize> ExactSizeIterator for InnerIter<'_, T, N> {}
 
 /// Iterator over views of the N innermost dimensions of a tensor with element
 /// type `T` and layout `L`, where `N` is determined at runtime.
@@ -825,7 +825,7 @@ impl<'a, T, L: MutLayout> Iterator for InnerIterDyn<'a, T, L> {
     }
 }
 
-impl<'a, T, L: MutLayout> ExactSizeIterator for InnerIterDyn<'a, T, L> {}
+impl<T, L: MutLayout> ExactSizeIterator for InnerIterDyn<'_, T, L> {}
 
 /// Iterator over mutable views of the N innermost dimensions of a tensor.
 pub struct InnerIterMut<'a, T, const N: usize> {
@@ -865,7 +865,7 @@ impl<'a, T, const N: usize> Iterator for InnerIterMut<'a, T, N> {
     }
 }
 
-impl<'a, T, const N: usize> ExactSizeIterator for InnerIterMut<'a, T, N> {}
+impl<T, const N: usize> ExactSizeIterator for InnerIterMut<'_, T, N> {}
 
 /// Iterator over mutable views of the N innermost dimensions of a tensor,
 /// where N is determined at runtime.
@@ -906,7 +906,7 @@ impl<'a, T, L: MutLayout> Iterator for InnerIterDynMut<'a, T, L> {
     }
 }
 
-impl<'a, T, L: MutLayout> ExactSizeIterator for InnerIterDynMut<'a, T, L> {}
+impl<T, L: MutLayout> ExactSizeIterator for InnerIterDynMut<'_, T, L> {}
 
 /// Iterator over slices of a tensor along an axis. See [`TensorView::axis_iter`].
 pub struct AxisIter<'a, T, L: MutLayout + RemoveDim> {

--- a/rten-tensor/src/layout.rs
+++ b/rten-tensor/src/layout.rs
@@ -1203,7 +1203,7 @@ impl<const N: usize> IntoLayout for [usize; N] {
     }
 }
 
-impl<'a> IntoLayout for &'a [usize] {
+impl IntoLayout for &[usize] {
     type Layout = DynLayout;
 
     #[inline]

--- a/rten-tensor/src/storage.rs
+++ b/rten-tensor/src/storage.rs
@@ -265,15 +265,15 @@ pub struct ViewData<'a, T> {
 
 // Safety: `ViewData` does not provide mutable access to its elements, so it
 // is `Send` and `Sync`.
-unsafe impl<'a, T> Send for ViewData<'a, T> {}
-unsafe impl<'a, T> Sync for ViewData<'a, T> {}
+unsafe impl<T> Send for ViewData<'_, T> {}
+unsafe impl<T> Sync for ViewData<'_, T> {}
 
-impl<'a, T> Clone for ViewData<'a, T> {
+impl<T> Clone for ViewData<'_, T> {
     fn clone(&self) -> Self {
         *self
     }
 }
-impl<'a, T> Copy for ViewData<'a, T> {}
+impl<T> Copy for ViewData<'_, T> {}
 
 impl<'a, T> ViewData<'a, T> {
     /// Variant of [`Storage::get`] which preserves lifetimes.
@@ -327,7 +327,7 @@ impl<'a, T> ViewData<'a, T> {
     }
 }
 
-unsafe impl<'a, T> Storage for ViewData<'a, T> {
+unsafe impl<T> Storage for ViewData<'_, T> {
     type Elem = T;
 
     const MUTABLE: bool = false;
@@ -353,7 +353,7 @@ pub struct ViewMutData<'a, T> {
     len: usize,
     _marker: PhantomData<&'a mut T>,
 }
-unsafe impl<'a, T> Send for ViewMutData<'a, T> {}
+unsafe impl<T> Send for ViewMutData<'_, T> {}
 
 impl<'a, T> ViewMutData<'a, T> {
     /// Variant of [`StorageMut::as_slice_mut`] which preserves the underlying
@@ -392,7 +392,7 @@ impl<'a, T> ViewMutData<'a, T> {
     }
 }
 
-unsafe impl<'a, T> Storage for ViewMutData<'a, T> {
+unsafe impl<T> Storage for ViewMutData<'_, T> {
     type Elem = T;
 
     const MUTABLE: bool = true;
@@ -406,7 +406,7 @@ unsafe impl<'a, T> Storage for ViewMutData<'a, T> {
     }
 }
 
-unsafe impl<'a, T> StorageMut for ViewMutData<'a, T> {
+unsafe impl<T> StorageMut for ViewMutData<'_, T> {
     fn as_mut_ptr(&mut self) -> *mut T {
         self.ptr
     }
@@ -423,7 +423,7 @@ pub enum CowData<'a, T> {
     Borrowed(ViewData<'a, T>),
 }
 
-unsafe impl<'a, T> Storage for CowData<'a, T> {
+unsafe impl<T> Storage for CowData<'_, T> {
     type Elem = T;
 
     const MUTABLE: bool = false;

--- a/rten-tensor/src/tensor.rs
+++ b/rten-tensor/src/tensor.rs
@@ -1159,7 +1159,7 @@ impl<T, L: Clone + MutLayout> TensorBase<Vec<T>, L> {
     }
 }
 
-impl<'a, T, L: MutLayout> TensorBase<CowData<'a, T>, L> {
+impl<T, L: MutLayout> TensorBase<CowData<'_, T>, L> {
     /// Consume self and return the underlying data in whatever order the
     /// elements are currently stored, if the storage is owned, or `None` if
     /// it is borrowed.
@@ -1855,7 +1855,7 @@ impl<T> TensorBase<Vec<T>, DynLayout> {
     }
 }
 
-impl<'a, T> TensorBase<ViewData<'a, T>, DynLayout> {
+impl<T> TensorBase<ViewData<'_, T>, DynLayout> {
     /// Reshape this view.
     ///
     /// Panics if the view is not contiguous.
@@ -1906,7 +1906,7 @@ impl<'a, T, L: MutLayout> TensorBase<ViewMutData<'a, T>, L> {
     }
 }
 
-impl<'a, T> TensorBase<ViewMutData<'a, T>, DynLayout> {
+impl<T> TensorBase<ViewMutData<'_, T>, DynLayout> {
     /// Reshape this view.
     ///
     /// Panics if the view is not contiguous.

--- a/rten-tensor/src/type_num.rs
+++ b/rten-tensor/src/type_num.rs
@@ -236,7 +236,7 @@ where
     type Count = <[T::IsIndex; N] as Add>::Result;
 }
 
-impl<'a, T> IndexCount for &'a [T] {
+impl<T> IndexCount for &[T] {
     type Count = Unknown;
 }
 

--- a/src/gemm.rs
+++ b/src/gemm.rs
@@ -104,7 +104,7 @@ pub enum GemmInputA<'a, T> {
     // TODO - Support virtual "A" inputs, like `GemmInputB::Virtual`.
 }
 
-impl<'a, T> GemmInputA<'a, T> {
+impl<T> GemmInputA<'_, T> {
     pub fn rows(&self) -> usize {
         match self {
             Self::Unpacked(m) => m.rows(),
@@ -194,7 +194,7 @@ pub enum GemmInputB<'a, T> {
     Virtual(&'a dyn VirtualMatrix<T>),
 }
 
-impl<'a, T> GemmInputB<'a, T> {
+impl<T> GemmInputB<'_, T> {
     pub fn rows(&self) -> usize {
         match self {
             Self::Unpacked(m) => m.rows(),

--- a/src/model.rs
+++ b/src/model.rs
@@ -109,7 +109,7 @@ pub struct NodeInfo<'a> {
     node: &'a Node,
 }
 
-impl<'a> NodeInfo<'a> {
+impl NodeInfo<'_> {
     /// Return the unique name associated with the node, if present.
     pub fn name(&self) -> Option<&str> {
         self.node.name()
@@ -446,7 +446,7 @@ impl Model {
             load_graph: &'a dyn Fn(sg::Graph) -> Result<Graph, ModelLoadError>,
         }
 
-        impl<'a> OpLoadContext for LoadContext<'a> {
+        impl OpLoadContext for LoadContext<'_> {
             fn load_graph(&self, graph: sg::Graph) -> Result<Graph, ReadOpError> {
                 (self.load_graph)(graph).map_err(|err| ReadOpError::SubgraphError(err.into()))
             }

--- a/src/model_builder.rs
+++ b/src/model_builder.rs
@@ -989,7 +989,7 @@ impl<'a> ModelBuilder<'a> {
     }
 }
 
-impl<'a> Default for ModelBuilder<'a> {
+impl Default for ModelBuilder<'_> {
     fn default() -> Self {
         Self::new(ModelFormat::V2)
     }

--- a/src/ops/conv/im2col.rs
+++ b/src/ops/conv/im2col.rs
@@ -276,7 +276,7 @@ impl<'a, T: Copy + Default> VirtualIm2Col<'a, T> {
     }
 }
 
-impl<'a> VirtualIm2Col<'a, f32> {
+impl VirtualIm2Col<'_, f32> {
     #[cfg(target_arch = "x86_64")]
     #[target_feature(enable = "avx2")]
     #[target_feature(enable = "fma")]
@@ -328,7 +328,7 @@ const KERNEL_FMA_NR: usize = 16;
 const KERNEL_WASM_NR: usize = 8;
 
 // Safety: `pack_b` initializes the entire buffer passed to it.
-unsafe impl<'a> VirtualMatrix<f32> for VirtualIm2Col<'a, f32> {
+unsafe impl VirtualMatrix<f32> for VirtualIm2Col<'_, f32> {
     fn rows(&self) -> usize {
         self.row_offsets.chan.len()
     }

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -233,7 +233,7 @@ pub enum Input<'a> {
     UInt8Tensor(TensorView<'a, u8>),
 }
 
-impl<'a> Input<'a> {
+impl Input<'_> {
     pub fn to_output(&self) -> Output {
         match self {
             Input::FloatTensor(t) => t.to_tensor().into(),
@@ -253,7 +253,7 @@ impl<'a> Input<'a> {
     }
 }
 
-impl<'a> Layout for Input<'a> {
+impl Layout for Input<'_> {
     impl_proxy_layout!();
 }
 
@@ -462,7 +462,7 @@ pub enum InputOrOutput<'a> {
     Output(Output),
 }
 
-impl<'a> InputOrOutput<'a> {
+impl InputOrOutput<'_> {
     /// Convert this value to a tensor view.
     pub fn as_input(&self) -> Input {
         match self {
@@ -535,7 +535,7 @@ impl<'a> From<&'a Output> for InputOrOutput<'a> {
     }
 }
 
-impl<'a> Layout for InputOrOutput<'a> {
+impl Layout for InputOrOutput<'_> {
     impl_proxy_layout!();
 }
 
@@ -920,7 +920,7 @@ impl<'a> InputList<'a> {
     }
 }
 
-impl<'a> Default for InputList<'a> {
+impl Default for InputList<'_> {
     fn default() -> Self {
         Self::new()
     }

--- a/src/tensor_pool.rs
+++ b/src/tensor_pool.rs
@@ -224,7 +224,7 @@ impl<T, L: MutLayout> ExtractBuffer for TensorBase<Vec<T>, L> {
     }
 }
 
-impl<'a, T, L: MutLayout> ExtractBuffer for TensorBase<CowData<'a, T>, L> {
+impl<T, L: MutLayout> ExtractBuffer for TensorBase<CowData<'_, T>, L> {
     type Elem = T;
 
     fn extract_buffer(self) -> Option<Vec<Self::Elem>> {
@@ -277,7 +277,7 @@ impl<'a, T: ExtractBuffer> PoolRef<'a, T> {
     }
 }
 
-impl<'a, T: ExtractBuffer> Deref for PoolRef<'a, T> {
+impl<T: ExtractBuffer> Deref for PoolRef<'_, T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
@@ -285,13 +285,13 @@ impl<'a, T: ExtractBuffer> Deref for PoolRef<'a, T> {
     }
 }
 
-impl<'a, T: ExtractBuffer> DerefMut for PoolRef<'a, T> {
+impl<T: ExtractBuffer> DerefMut for PoolRef<'_, T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.container.as_mut().unwrap()
     }
 }
 
-impl<'a, T: ExtractBuffer> Drop for PoolRef<'a, T> {
+impl<T: ExtractBuffer> Drop for PoolRef<'_, T> {
     fn drop(&mut self) {
         if let Some(container) = self.container.take() {
             if let Some(buffer) = container.extract_buffer() {

--- a/src/timing.rs
+++ b/src/timing.rs
@@ -91,7 +91,7 @@ struct DisplayTable<'a, T: Table> {
     indent: usize,
 }
 
-impl<'a, T: Table> fmt::Display for DisplayTable<'a, T> {
+impl<T: Table> fmt::Display for DisplayTable<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
         let col_widths: Vec<_> = self
             .table
@@ -151,7 +151,7 @@ pub struct RunTiming<'a> {
     pub total_time: Duration,
 }
 
-impl<'a> RunTiming<'a> {
+impl RunTiming<'_> {
     /// Return a struct that formats output with the given options.
     pub fn display(&self, sort: TimingSort, include_shapes: bool) -> impl fmt::Display + '_ {
         FormattedRunTiming {
@@ -162,7 +162,7 @@ impl<'a> RunTiming<'a> {
     }
 }
 
-impl<'a> fmt::Display for RunTiming<'a> {
+impl fmt::Display for RunTiming<'_> {
     /// Format timings with the default sort order (see [`TimingSort`]).
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
         self.display(TimingSort::ByTime, false /* include_shapes */)
@@ -271,7 +271,7 @@ struct FormattedRunTiming<'a> {
     include_shapes: bool,
 }
 
-impl<'a> FormattedRunTiming<'a> {
+impl FormattedRunTiming<'_> {
     /// Create a table that breaks down execution times for all runs of `op_name`
     /// by input shape.
     fn timing_by_shape_table(&self, op_name: &str) -> impl Table {
@@ -322,7 +322,7 @@ impl<'a> FormattedRunTiming<'a> {
     }
 }
 
-impl<'a> fmt::Display for FormattedRunTiming<'a> {
+impl fmt::Display for FormattedRunTiming<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> std::fmt::Result {
         let mut op_timings: Vec<_> = self
             .timing


### PR DESCRIPTION
Remove various lifetimes in impl headers that were not necessary, as the body of the impl did not reference them.