### PR TITLE
Add data type information to value nodes

### DIFF
--- a/rten-convert/rten_convert/schema_generated.py
+++ b/rten-convert/rten_convert/schema_generated.py
@@ -5921,14 +5921,24 @@ class ValueNode(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
         return o == 0
 
+    # ValueNode
+    def Dtype(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(6))
+        if o != 0:
+            return self._tab.Get(flatbuffers.number_types.Uint8Flags, o + self._tab.Pos)
+        return None
+
 def ValueNodeStart(builder):
-    builder.StartObject(1)
+    builder.StartObject(2)
 
 def ValueNodeAddShape(builder, shape):
     builder.PrependUOffsetTRelativeSlot(0, flatbuffers.number_types.UOffsetTFlags.py_type(shape), 0)
 
 def ValueNodeStartShapeVector(builder, numElems):
     return builder.StartVector(4, numElems, 4)
+
+def ValueNodeAddDtype(builder, dtype):
+    builder.PrependUint8Slot(1, dtype, None)
 
 def ValueNodeEnd(builder):
     return builder.EndObject()
@@ -5944,6 +5954,7 @@ class ValueNodeT(object):
     # ValueNodeT
     def __init__(self):
         self.shape = None  # type: List[DimT]
+        self.dtype = None  # type: Optional[int]
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -5974,6 +5985,7 @@ class ValueNodeT(object):
                 else:
                     dim_ = DimT.InitFromObj(valueNode.Shape(i))
                     self.shape.append(dim_)
+        self.dtype = valueNode.Dtype()
 
     # ValueNodeT
     def Pack(self, builder):
@@ -5988,6 +6000,7 @@ class ValueNodeT(object):
         ValueNodeStart(builder)
         if self.shape is not None:
             ValueNodeAddShape(builder, shape)
+        ValueNodeAddDtype(builder, self.dtype)
         valueNode = ValueNodeEnd(builder)
         return valueNode
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -199,6 +199,15 @@ impl Constant {
             Constant::UInt8(i) => Input::UInt8Tensor(i.view()),
         }
     }
+
+    fn dtype(&self) -> DataType {
+        match self {
+            Constant::Float(_) => DataType::Float,
+            Constant::Int32(_) => DataType::Int32,
+            Constant::Int8(_) => DataType::Int8,
+            Constant::UInt8(_) => DataType::UInt8,
+        }
+    }
 }
 
 macro_rules! impl_constant_node {
@@ -281,6 +290,20 @@ impl Node {
             Node::Operator(_) => None,
             Node::Constant(node) => Some(dims_from_fixed_shape(node.layout().shape())),
             Node::Value(node) => node.shape.clone(),
+        }
+    }
+
+    /// Return the data type associated with this node.
+    ///
+    /// - For constants this returns the element type of the tensor
+    /// - For values this returns the expected element type of the tensor at
+    ///   runtime, if known
+    /// - For operators this always returns `None`.
+    pub fn dtype(&self) -> Option<DataType> {
+        match self {
+            Node::Value(node) => node.dtype,
+            Node::Constant(constant) => Some(constant.dtype()),
+            Node::Operator(_) => None,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,7 +123,7 @@ pub use graph::{Dimension, NodeId, RunError, RunOptions};
 pub use model::{Model, ModelLoadError, ModelOptions, NodeInfo};
 pub use model_metadata::ModelMetadata;
 pub use op_registry::{OpRegistry, ReadOp, ReadOpError};
-pub use ops::{FloatOperators, Input, InputOrOutput, Operators, Output};
+pub use ops::{DataType, FloatOperators, Input, InputOrOutput, Operators, Output};
 pub use tensor_pool::{ExtractBuffer, PoolRef, TensorPool};
 pub use threading::{thread_pool, ThreadPool};
 pub use timing::TimingSort;

--- a/src/op_registry.rs
+++ b/src/op_registry.rs
@@ -226,7 +226,7 @@ impl Display for ReadOpError {
 
 impl Error for ReadOpError {}
 
-fn convert_dtype(dtype: sg::DataType) -> Result<DataType, ReadOpError> {
+pub fn convert_dtype(dtype: sg::DataType) -> Result<DataType, ReadOpError> {
     match dtype {
         sg::DataType::Int32 => Ok(DataType::Int32),
         sg::DataType::Float => Ok(DataType::Float),

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -170,12 +170,30 @@ impl<S: AsRef<[usize]>> From<S> for Padding {
     }
 }
 
-#[derive(Copy, Clone, Debug)]
+/// Enum specifying the data type of a tensor.
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub enum DataType {
     Int32,
     Float,
     Int8,
     UInt8,
+}
+
+impl std::fmt::Display for DataType {
+    /// Format this enum value in the style of the corresponding Rust type (eg.
+    /// "i32" for `DataType::Int32`).
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                DataType::Float => "f32",
+                DataType::Int32 => "i32",
+                DataType::Int8 => "i8",
+                DataType::UInt8 => "u8",
+            }
+        )
+    }
 }
 
 /// Generate the body of a [`Layout`] impl for a type which wraps an

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -96,7 +96,7 @@ impl GraphMutator {
         inputs: &[Option<NodeId>],
         op_output_id: Option<NodeId>,
     ) -> NodeId {
-        let op_output_id = op_output_id.unwrap_or(self.graph.add_value(None, None));
+        let op_output_id = op_output_id.unwrap_or(self.graph.add_value(None, None, None));
         let op_id = self.graph.add_op(name, op, inputs, &[Some(op_output_id)]);
 
         for input_id in inputs.iter().filter_map(|id| *id) {
@@ -622,7 +622,7 @@ mod tests {
 
         // Capture the constant in the subgraph as a value.
         let mut subgraph = Graph::new();
-        let sg_val = subgraph.add_value(Some("const_a"), None);
+        let sg_val = subgraph.add_value(Some("const_a"), None, None);
         subgraph.set_captures(&[sg_val]);
         subgraph.set_output_ids(&[sg_val]);
 
@@ -652,7 +652,7 @@ mod tests {
         let (_, add_out) = graph.add_simple_op("add_1", Add {}, &[const_a, const_b]);
 
         // Add an operator with a dynamic input and the output of the previous operator.
-        let input = graph.add_value(Some("input"), None);
+        let input = graph.add_value(Some("input"), None, None);
         let (add_op_2, add_2_out) = graph.add_simple_op("add_2", Add {}, &[add_out, input]);
         graph.set_input_ids(&[input]);
         graph.set_output_ids(&[add_out, add_2_out]);
@@ -703,8 +703,8 @@ mod tests {
     fn test_fuse_transpose() {
         let mut graph = Graph::new();
 
-        let input_1 = graph.add_value(None, None);
-        let input_2 = graph.add_value(None, None);
+        let input_1 = graph.add_value(None, None, None);
+        let input_2 = graph.add_value(None, None, None);
 
         let (_, transpose_out) =
             graph.add_simple_op("transpose", Transpose { perm: None }, &[input_1]);
@@ -723,7 +723,7 @@ mod tests {
     fn test_fuse_silu() {
         let mut graph = Graph::new();
 
-        let input = graph.add_value(None, None);
+        let input = graph.add_value(None, None, None);
         let (_, sigmoid_out) = graph.add_simple_op("sigmoid", Sigmoid {}, &[input]);
         let (_, mul_out) = graph.add_simple_op("mul", Mul {}, &[input, sigmoid_out]);
         graph.set_input_ids(&[input]);
@@ -741,7 +741,7 @@ mod tests {
         let mut graph = Graph::new();
 
         // Add two consecutive decomposed Silu operations
-        let input = graph.add_value(None, None);
+        let input = graph.add_value(None, None, None);
         let (_, sigmoid_out) = graph.add_simple_op("sigmoid", Sigmoid {}, &[input]);
         let (_, mul_out) = graph.add_simple_op("mul", Mul {}, &[input, sigmoid_out]);
         let (_, sigmoid_2_out) = graph.add_simple_op("sigmoid", Sigmoid {}, &[mul_out]);
@@ -769,7 +769,7 @@ mod tests {
         let one = graph.add_constant(None, Tensor::from(1.0));
         let half = graph.add_constant(None, Tensor::from(0.5));
 
-        let input = graph.add_value(None, None);
+        let input = graph.add_value(None, None, None);
         let (_, div_out) = graph.add_simple_op("div", Div {}, &[input, sqrt_2]);
         let (_, erf_out) = graph.add_simple_op("erf", Erf {}, &[div_out]);
         let (_, add_out) = graph.add_simple_op("add", Add {}, &[erf_out, one]);
@@ -786,7 +786,7 @@ mod tests {
 
     fn layer_norm_graph() -> Graph {
         let mut graph = Graph::new();
-        let input = graph.add_value(None, None);
+        let input = graph.add_value(None, None, None);
 
         // Center values
         let (_, mean_out) = graph.add_simple_op(
@@ -843,8 +843,8 @@ mod tests {
     fn test_optimize_preserves_input_output_nodes() {
         let mut graph = Graph::new();
 
-        let input_1 = graph.add_value(None, None);
-        let input_2 = graph.add_value(None, None);
+        let input_1 = graph.add_value(None, None, None);
+        let input_2 = graph.add_value(None, None, None);
 
         // Add fuse-able Transpose + MatMul
         let (_, transpose_out) =

--- a/src/optimize/pattern_matcher.rs
+++ b/src/optimize/pattern_matcher.rs
@@ -350,7 +350,7 @@ mod tests {
     /// Create a graph that implements the softsign function `x / 1 + |x|`.
     fn softsign_graph() -> (Graph, NodeId, NodeId) {
         let mut graph = Graph::new();
-        let input_id = graph.add_value(Some("x"), None);
+        let input_id = graph.add_value(Some("x"), None, None);
 
         let (_, abs_out) = graph.add_simple_op("abs", Abs {}, &[input_id]);
         let one = graph.add_constant(None, Tensor::from(1.0));

--- a/src/schema.fbs
+++ b/src/schema.fbs
@@ -550,6 +550,8 @@ table Dim {
 table ValueNode {
   // Expected shape of the tensor at runtime.
   shape:[Dim];
+  // Expected data type of the tensor at runtime.
+  dtype:DataType = null;
 }
 
 table Node {


### PR DESCRIPTION
Support storing and querying the expected runtime dtype of a value node in models, and convert the corresponding information from ONNX models in the rten-convert tool. In the RTen CLI, use this information to generate random data of the appropriate type for model inputs.

The dtype is not enforced at runtime, so you can still pass an f32 tensor for an input expecting i32. In that case you will probably get an inference operator from somewhere in the model.

As a test case, with this branch you can convert and run the [magika models](https://github.com/google/magika/tree/main/assets/models/standard_v2_1) using the rten CLI. Previously running the model with the CLI would fail because it always generated randomized inputs with `f32` elements, but this particular model has a `bytes` input of type `i32`.