### PR TITLE
Test running all operators in-place

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -1628,12 +1628,33 @@ mod tests {
                 continue;
             }
 
+            // Run with inputs as views.
+            //
+            // This will run the non-in-place implementation of the operator
+            // (`Operator::run`).
             let output_id = model.find_node(&output).unwrap();
             let result = model
                 .run(
                     vec![
                         (input_node, input.view().into()),
                         (input_bool, input_bool_data.view().into()),
+                    ],
+                    &[output_id],
+                    None,
+                )
+                .unwrap();
+            assert_eq!(result.len(), 1);
+
+            // Run with inputs as owned tensors.
+            //
+            // This will run the in-place implementation of the operator if
+            // supported (`Operator::run_in_place`).
+            let output_id = model.find_node(&output).unwrap();
+            let result = model
+                .run(
+                    vec![
+                        (input_node, input.clone().into()),
+                        (input_bool, input_bool_data.clone().into()),
                     ],
                     &[output_id],
                     None,


### PR DESCRIPTION
In the existing test that runs all operators, run the model twice. The first time the operator's main input is passed as a view, the second time as an owned tensor. This enables running the operator in-place if supported. This is an easy way to gain some additional coverage of `Operator::run_in_place` implementations.