### PR TITLE
Support `end_of_word_suffix` in BPE tokenizers

### DIFF
--- a/rten-generate/src/text_decoder.rs
+++ b/rten-generate/src/text_decoder.rs
@@ -91,7 +91,7 @@ mod tests {
     /// Create a BPE tokenizer with an empty vocab. This can encode and decode
     /// arbitrary Unicode characters, by using one token per UTF-8 byte.
     fn create_bpe_tokenizer() -> Tokenizer {
-        let encoder = Bpe::new(&[], GPT2, None, Default::default()).unwrap();
+        let encoder = Bpe::new(&[], GPT2, None, Default::default(), None).unwrap();
         Tokenizer::new(encoder, Default::default())
     }
 

--- a/rten-text/src/tokenizers.rs
+++ b/rten-text/src/tokenizers.rs
@@ -329,6 +329,7 @@ impl Tokenizer {
                     bpe::patterns::GPT2,
                     Some(model.vocab),
                     added_tokens,
+                    model.end_of_word_suffix,
                 )
                 .map_err(FromJsonError::BpeError)?;
 

--- a/rten-text/src/tokenizers/json.rs
+++ b/rten-text/src/tokenizers/json.rs
@@ -49,6 +49,13 @@ pub(crate) struct BpeModel {
 
     /// List of pairs of tokens to merge.
     pub merges: MergeList,
+
+    /// A string which is implicitly appended to each substring after
+    /// pre-tokenization before it is tokenized using BPE.
+    ///
+    /// This originated from CLIP's tokenizer.
+    /// See https://github.com/openai/CLIP/blob/main/clip/simple_tokenizer.py.
+    pub end_of_word_suffix: Option<String>,
 }
 
 #[derive(Deserialize)]

--- a/rten-text/tests/reftest.rs
+++ b/rten-text/tests/reftest.rs
@@ -161,7 +161,13 @@ fn test_bpe_gpt2() -> Result<(), Box<dyn Error>> {
     let merges = read_test_file("models/gpt2/merges.txt")?;
     let merge_lines: Vec<_> = merges.lines().collect();
     let merge_pairs = merge_pairs_from_lines(&merge_lines);
-    let encoder = Bpe::new(&merge_pairs, GPT2_SPLIT_PATTERN, None, Default::default())?;
+    let encoder = Bpe::new(
+        &merge_pairs,
+        GPT2_SPLIT_PATTERN,
+        None,
+        Default::default(),
+        None,
+    )?;
     let tokenizer = Tokenizer::new(encoder, Default::default());
 
     // Create tokenizer from a `tokenizers.json` file.

--- a/src/ops/resize.rs
+++ b/src/ops/resize.rs
@@ -307,7 +307,7 @@ fn resize_impl(
         ));
     }
 
-    let mut output = Tensor::uninit_in(pool, &output_size);
+    let mut output = Tensor::uninit_in(pool, output_size);
 
     if output.is_empty() {
         // Safety: Empty output is already initialized.


### PR DESCRIPTION
Support a behavior in the CLIP tokenizer [1] where a suffix (`</w>`) is implicitly appended to each substring produced after regex splitting, before BPE tokenization is applied.

Extracted from https://github.com/robertknight/rten/pull/421.

[1] https://github.com/openai/CLIP/blob/main/clip/simple_tokenizer.py