### PR TITLE
Return input to pool if we can't append in Concat operator

### DIFF
--- a/src/ops/concat.rs
+++ b/src/ops/concat.rs
@@ -85,6 +85,7 @@ pub fn concat_in_place<T: Copy>(
     let axis = resolve_axis(output.ndim(), axis)?;
     let out_shape = concatenated_shape(output.shape(), inputs, axis)?;
     if !output.has_capacity(axis, out_shape[axis]) {
+        let output = output.auto_return(pool);
         return concat_impl(pool, &out_shape, axis, &output.view(), inputs);
     }
 


### PR DESCRIPTION
If in-place Concat is not possible because the buffer doesn't have enough spare capacity, return it to the pool so it can be re-used for subsequent operations. This avoids the overhead of freeing it immediately using the system allocator.