### PR TITLE
Convert `Normalizer` into a trait

### DIFF
--- a/rten-text/src/tokenizers/wordpiece.rs
+++ b/rten-text/src/tokenizers/wordpiece.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::rc::Rc;
 
 use super::{Encoder, TokenId, TokenizerError};
 use crate::normalizer::Normalizer;
@@ -18,7 +19,7 @@ use unicode_categories::UnicodeCategories;
 ///       (2018). <https://arxiv.org/abs/1810.04805>
 #[derive(Clone)]
 pub struct WordPiece {
-    normalizer: Option<Normalizer>,
+    normalizer: Option<Rc<dyn Normalizer>>,
     token_to_id: HashMap<String, TokenId>,
     id_to_token: HashMap<TokenId, String>,
     subword_prefix: String,
@@ -30,7 +31,7 @@ pub struct WordPiece {
 pub struct WordPieceOptions {
     /// The normalizer that handles Unicode normalization, lower-casing the
     /// input etc.
-    pub normalizer: Option<Normalizer>,
+    pub normalizer: Option<Rc<dyn Normalizer>>,
 
     /// The maximum length of words that can be tokenized. Any words longer than
     /// this are tokenized as `[UNK]`.
@@ -172,8 +173,9 @@ impl Encoder for WordPiece {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+    use std::rc::Rc;
 
-    use crate::normalizer::{Normalizer, NormalizerOptions};
+    use crate::normalizer::{BertNormalizer, BertNormalizerOptions};
     use crate::tokenizers::{
         EncodeOptions, Tokenizer, TokenizerOptions, WordPiece, WordPieceOptions,
     };
@@ -298,10 +300,10 @@ mod tests {
         let tokenizer = create_tokenizer(
             vocab,
             WordPieceOptions {
-                normalizer: Some(Normalizer::new(NormalizerOptions {
+                normalizer: Some(Rc::new(BertNormalizer::new(BertNormalizerOptions {
                     lowercase: true,
                     ..Default::default()
-                })),
+                }))),
                 ..Default::default()
             },
         );
@@ -358,10 +360,10 @@ mod tests {
         let tokenizer = create_tokenizer(
             vocab,
             WordPieceOptions {
-                normalizer: Some(Normalizer::new(NormalizerOptions {
+                normalizer: Some(Rc::new(BertNormalizer::new(BertNormalizerOptions {
                     lowercase: true,
                     ..Default::default()
-                })),
+                }))),
                 ..Default::default()
             },
         );

--- a/rten-text/tests/reftest.rs
+++ b/rten-text/tests/reftest.rs
@@ -3,8 +3,9 @@ use std::error::Error;
 use std::fs::read_to_string;
 use std::io;
 use std::path::PathBuf;
+use std::rc::Rc;
 
-use rten_text::normalizer::{Normalizer, NormalizerOptions};
+use rten_text::normalizer::{BertNormalizer, BertNormalizerOptions};
 use rten_text::tokenizers::patterns::GPT2 as GPT2_SPLIT_PATTERN;
 use rten_text::tokenizers::{
     merge_pairs_from_lines, Bpe, TokenId, Tokenizer, TokenizerOptions, WordPiece, WordPieceOptions,
@@ -120,7 +121,7 @@ fn test_wordpiece_bert_uncased() -> Result<(), Box<dyn Error>> {
 
     let vocab = read_vocab_text_file("models/bert-base-uncased/vocab.txt")?;
 
-    let normalizer = Normalizer::new(NormalizerOptions {
+    let normalizer = BertNormalizer::new(BertNormalizerOptions {
         lowercase: true,
         strip_accents: true,
         ..Default::default()
@@ -128,7 +129,7 @@ fn test_wordpiece_bert_uncased() -> Result<(), Box<dyn Error>> {
     let encoder = WordPiece::from_vocab(
         vocab,
         WordPieceOptions {
-            normalizer: Some(normalizer),
+            normalizer: Some(Rc::new(normalizer)),
             ..Default::default()
         },
     );


### PR DESCRIPTION
Add a `Normalizer` trait which provides the common interface for normalizers and rename the previous `Normalizer` struct to `BertNormalizer`, to align with the name in tokenizer.json files. Change other parts of the tokenization process to use the normalizer via a trait object.

Part of https://github.com/robertknight/rten/issues/427