### PR TITLE
Improve ergonomics of encoding and decoding text with `Tokenizer`

### DIFF
--- a/rten-examples/src/gpt2.rs
+++ b/rten-examples/src/gpt2.rs
@@ -102,7 +102,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let tokenizer = Tokenizer::from_json(&tokenizer_config)?;
 
     let prompt = args.prompt.as_str();
-    let encoded_prompt = tokenizer.encode(prompt.into(), Default::default())?;
+    let encoded_prompt = tokenizer.encode(prompt, None)?;
 
     // The output starts with the user's prompt.
     print!("{}", prompt);

--- a/rten-examples/src/jina_similarity.rs
+++ b/rten-examples/src/jina_similarity.rs
@@ -82,11 +82,11 @@ fn embed_sentence_batch(
     let mut encoded = Vec::new();
     for &sentence in sentences {
         encoded.push(tokenizer.encode(
-            sentence.into(),
-            EncodeOptions {
+            sentence,
+            Some(EncodeOptions {
                 max_chunk_len: Some(max_seq_len),
                 ..Default::default()
-            },
+            }),
         )?);
     }
 

--- a/rten-examples/src/qwen2_chat.rs
+++ b/rten-examples/src/qwen2_chat.rs
@@ -90,7 +90,7 @@ fn encode_message(
         match chunk {
             MessageChunk::Token(tok_id) => token_ids.push(*tok_id),
             MessageChunk::Text(text) => {
-                let encoded = tokenizer.encode((*text).into(), Default::default())?;
+                let encoded = tokenizer.encode(*text, None)?;
                 token_ids.extend(encoded.token_ids());
             }
         }

--- a/rten-examples/src/whisper.rs
+++ b/rten-examples/src/whisper.rs
@@ -526,7 +526,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                     transcript_chunks.push(TranscriptChunk {
                         start_ms: start_timestamp,
                         end_ms: timestamp_token_id_to_ms(token),
-                        caption: tokenizer.encoder().decode(&curr_chunk_tokens)?,
+                        caption: tokenizer.decode(&curr_chunk_tokens)?,
                     });
                     curr_chunk_start = None;
                     curr_chunk_tokens.clear();

--- a/rten-generate/src/text_decoder.rs
+++ b/rten-generate/src/text_decoder.rs
@@ -50,7 +50,7 @@ impl<G: Iterator<Item = GeneratorItem>> Iterator for TextDecoder<'_, G> {
 
             token_buf.push(token);
 
-            let text = self.tokenizer.encoder().decode(&token_buf);
+            let text = self.tokenizer.decode(&token_buf);
             match text {
                 Ok(text) => return Some(Ok(text)),
                 Err(TokenizerError::InvalidUtf8) => {
@@ -113,7 +113,7 @@ mod tests {
         // Encode a character which will require multiple token IDs. This means
         // the text decoder will need to loop until accumulated tokens decode
         // to a valid UTF-8 sequence.
-        let token_ids = tokenizer.encoder().encode("😊").unwrap();
+        let token_ids = tokenizer.encode("😊", None).unwrap().into_token_ids();
         assert!(token_ids.len() > 1);
         let generator = token_ids.into_iter().map(|tok_id| Ok(tok_id as u32));
 

--- a/rten-text/src/tokenizers/bpe.rs
+++ b/rten-text/src/tokenizers/bpe.rs
@@ -709,7 +709,7 @@ ba r",
             )
             .unwrap();
             let tokenizer = Tokenizer::new(encoder, Default::default());
-            let encoded = tokenizer.encode(text.into(), Default::default()).unwrap();
+            let encoded = tokenizer.encode(text, None).unwrap();
             assert_eq!(
                 tokenizer.encoder().get_tokens(encoded.token_ids()).unwrap(),
                 tokens
@@ -813,13 +813,13 @@ ba r",
             .unwrap();
             let tokenizer = Tokenizer::new(encoder, Default::default());
 
-            let encoded = tokenizer.encode(text.into(), Default::default()).unwrap();
+            let encoded = tokenizer.encode(text, None).unwrap();
             let mut token_ids = encoded.token_ids().to_vec();
             if add_eos {
                 // The `<|endoftext|>` token ID from GPT-2.
                 token_ids.push(50256);
             }
-            let decoded = tokenizer.encoder().decode(&token_ids).unwrap();
+            let decoded = tokenizer.decode(&token_ids).unwrap();
             assert_eq!(decoded, expected);
         }
     }

--- a/rten-text/src/tokenizers/wordpiece.rs
+++ b/rten-text/src/tokenizers/wordpiece.rs
@@ -176,9 +176,7 @@ mod tests {
     use std::rc::Rc;
 
     use crate::normalizer::{BertNormalizer, BertNormalizerOptions};
-    use crate::tokenizers::{
-        EncodeOptions, Tokenizer, TokenizerOptions, WordPiece, WordPieceOptions,
-    };
+    use crate::tokenizers::{Tokenizer, TokenizerOptions, WordPiece, WordPieceOptions};
 
     fn create_tokenizer(vocab: &[&str], options: WordPieceOptions) -> Tokenizer {
         let vocab: HashMap<_, _> = vocab
@@ -254,9 +252,7 @@ mod tests {
         ];
 
         for Case { text, tokens } in cases {
-            let encoded = tokenizer
-                .encode(text.into(), EncodeOptions::default())
-                .unwrap();
+            let encoded = tokenizer.encode(text, None).unwrap();
             assert_eq!(
                 tokenizer.encoder().get_tokens(encoded.token_ids()).unwrap(),
                 tokens
@@ -277,9 +273,7 @@ mod tests {
         // The third word should be tokenized to `[UNK]` because it exceeds
         // `max_word_len`.
         let text = "foobar foofoo foobarfoo";
-        let encoded = tokenizer
-            .encode(text.into(), EncodeOptions::default())
-            .unwrap();
+        let encoded = tokenizer.encode(text, None).unwrap();
 
         assert_eq!(
             tokenizer.encoder().get_tokens(encoded.token_ids()).unwrap(),
@@ -321,9 +315,7 @@ mod tests {
         ];
 
         for Case { text, tokens } in cases {
-            let encoded = tokenizer
-                .encode(text.into(), EncodeOptions::default())
-                .unwrap();
+            let encoded = tokenizer.encode(text, None).unwrap();
             assert_eq!(
                 tokenizer.encoder().get_tokens(encoded.token_ids()).unwrap(),
                 tokens
@@ -369,8 +361,8 @@ mod tests {
         );
 
         for Case { input, expected } in cases {
-            let encoded = tokenizer.encode(input.into(), Default::default()).unwrap();
-            let decoded = tokenizer.encoder().decode(encoded.token_ids()).unwrap();
+            let encoded = tokenizer.encode(input, None).unwrap();
+            let decoded = tokenizer.decode(encoded.token_ids()).unwrap();
             assert_eq!(decoded, expected);
         }
     }

--- a/rten-text/tests/reftest.rs
+++ b/rten-text/tests/reftest.rs
@@ -87,7 +87,7 @@ fn test_wordpiece_bert_cased() -> Result<(), Box<dyn Error>> {
 
     let encoder = WordPiece::from_vocab(vocab, Default::default());
     let tokenizer = Tokenizer::new(encoder, wordpiece_tokenizer_opts());
-    let encoded = tokenizer.encode(text.as_str().into(), Default::default())?;
+    let encoded = tokenizer.encode(text.as_str(), None)?;
 
     compare_tokens(encoded.token_ids(), &expected.token_ids)?;
 
@@ -138,7 +138,7 @@ fn test_wordpiece_bert_uncased() -> Result<(), Box<dyn Error>> {
     for Case { text, reference } in cases {
         let text = read_test_file(text)?;
         let expected = ReferenceTokenization::from_file(reference)?;
-        let encoded = tokenizer.encode(text.as_str().into(), Default::default())?;
+        let encoded = tokenizer.encode(text.as_str(), None)?;
 
         compare_tokens(encoded.token_ids(), &expected.token_ids)?;
     }
@@ -179,10 +179,10 @@ fn test_bpe_gpt2() -> Result<(), Box<dyn Error>> {
         let text = read_test_file(text)?;
         let expected = ReferenceTokenization::from_file(reference)?;
 
-        let encoded = tokenizer.encode(text.as_str().into(), Default::default())?;
+        let encoded = tokenizer.encode(text.as_str(), None)?;
         compare_tokens(encoded.token_ids(), &expected.token_ids)?;
 
-        let encoded = tokenizer_from_json.encode(text.as_str().into(), Default::default())?;
+        let encoded = tokenizer_from_json.encode(text.as_str(), None)?;
         compare_tokens(encoded.token_ids(), &expected.token_ids)?;
     }
 


### PR DESCRIPTION
 - Allow an `&str` to be passed to `Tokenizer::encode` directly, instead of requiring the caller to use `str.into()` to construct an `EncoderInput`
 - Make the options argument an `Option`. This makes it more obvious how to pass nothing, and easier.
 - Add a `Tokenizer::decode` method which wraps `Encoder::decode` for symmetry with `Tokenizer::encode`
 - Add `Encoded::into_token_ids` to make it easier to get the encoded token IDs as an owned vector and discard offset information