### PR TITLE
Extract pre-tokenization out of tokenization models

### DIFF
--- a/rten-generate/src/text_decoder.rs
+++ b/rten-generate/src/text_decoder.rs
@@ -73,7 +73,7 @@ mod tests {
     use std::collections::HashMap;
 
     use rten_text::models::{Bpe, WordPiece};
-    use rten_text::pretokenizers::ByteLevelPreTokenizer;
+    use rten_text::pre_tokenizers::ByteLevelPreTokenizer;
     use rten_text::tokenizers::{TokenId, Tokenizer};
 
     use crate::{GeneratorError, GeneratorUtils};

--- a/rten-generate/src/text_decoder.rs
+++ b/rten-generate/src/text_decoder.rs
@@ -72,8 +72,8 @@ impl<G: Iterator<Item = GeneratorItem>> Iterator for TextDecoder<'_, G> {
 mod tests {
     use std::collections::HashMap;
 
-    use rten_text::models::patterns::GPT2;
     use rten_text::models::{Bpe, WordPiece};
+    use rten_text::pretokenizers::ByteLevelPreTokenizer;
     use rten_text::tokenizers::{TokenId, Tokenizer};
 
     use crate::{GeneratorError, GeneratorUtils};
@@ -92,8 +92,9 @@ mod tests {
     /// Create a BPE tokenizer with an empty vocab. This can encode and decode
     /// arbitrary Unicode characters, by using one token per UTF-8 byte.
     fn create_bpe_tokenizer() -> Tokenizer {
-        let model = Bpe::new(&[], GPT2, None, Default::default(), None).unwrap();
+        let model = Bpe::new(&[], None, Default::default(), None).unwrap();
         Tokenizer::new(model, Default::default())
+            .with_pre_tokenizer(Box::new(ByteLevelPreTokenizer::gpt2()))
     }
 
     #[test]

--- a/rten-text/src/lib.rs
+++ b/rten-text/src/lib.rs
@@ -10,6 +10,7 @@
 
 pub mod models;
 pub mod normalizer;
+pub mod pretokenizers;
 pub mod tokenizers;
 
 mod split;

--- a/rten-text/src/lib.rs
+++ b/rten-text/src/lib.rs
@@ -10,7 +10,7 @@
 
 pub mod models;
 pub mod normalizer;
-pub mod pretokenizers;
+pub mod pre_tokenizers;
 pub mod tokenizers;
 
 mod split;

--- a/rten-text/src/models/bpe.rs
+++ b/rten-text/src/models/bpe.rs
@@ -547,7 +547,7 @@ mod tests {
     use std::collections::HashMap;
 
     use super::{merge_pairs_from_lines, Bpe, EncodedBytes};
-    use crate::pretokenizers::ByteLevelPreTokenizer;
+    use crate::pre_tokenizers::ByteLevelPreTokenizer;
     use crate::tokenizers::{TokenId, Tokenizer};
 
     // The first ~25 lines of the merge list from GPT 2.

--- a/rten-text/src/models/wordpiece.rs
+++ b/rten-text/src/models/wordpiece.rs
@@ -136,7 +136,7 @@ mod tests {
 
     use crate::models::{WordPiece, WordPieceOptions};
     use crate::normalizer::{BertNormalizer, BertNormalizerOptions, Normalizer};
-    use crate::pretokenizers::BertPreTokenizer;
+    use crate::pre_tokenizers::BertPreTokenizer;
     use crate::tokenizers::{Tokenizer, TokenizerOptions};
 
     fn create_tokenizer(

--- a/rten-text/src/pre_tokenizers.rs
+++ b/rten-text/src/pre_tokenizers.rs
@@ -26,7 +26,7 @@ impl fmt::Display for PreTokenizeError {
 /// tokenized by a [`Model`](crate::tokenizers::Model) individually.
 pub trait PreTokenizer {
     /// Split `text` into chunks and return a vector of sub-slices.
-    fn pretokenize<'a>(&self, text: &'a str) -> Result<Vec<&'a str>, PreTokenizeError>;
+    fn pre_tokenize<'a>(&self, text: &'a str) -> Result<Vec<&'a str>, PreTokenizeError>;
 }
 
 /// Tokenization regex used by GPT-2.
@@ -59,7 +59,7 @@ impl ByteLevelPreTokenizer {
 }
 
 impl PreTokenizer for ByteLevelPreTokenizer {
-    fn pretokenize<'a>(&self, text: &'a str) -> Result<Vec<&'a str>, PreTokenizeError> {
+    fn pre_tokenize<'a>(&self, text: &'a str) -> Result<Vec<&'a str>, PreTokenizeError> {
         self.splitter
             .find_iter(text)
             .filter_map(|piece| match piece {
@@ -91,7 +91,7 @@ impl Default for BertPreTokenizer {
 }
 
 impl PreTokenizer for BertPreTokenizer {
-    fn pretokenize<'a>(&self, text: &'a str) -> Result<Vec<&'a str>, PreTokenizeError> {
+    fn pre_tokenize<'a>(&self, text: &'a str) -> Result<Vec<&'a str>, PreTokenizeError> {
         let is_punc_or_space =
             |ch: char| ch.is_ascii_punctuation() || ch.is_punctuation() || ch.is_whitespace();
         let words = text.split_keep_delimeters(is_punc_or_space).collect();

--- a/rten-text/src/pretokenizers.rs
+++ b/rten-text/src/pretokenizers.rs
@@ -1,6 +1,9 @@
 use std::fmt;
 
 use fancy_regex::Regex;
+use unicode_categories::UnicodeCategories;
+
+use crate::split::SplitExt;
 
 /// Errors occuring while constructing a [`PreTokenizer`] or splitting input
 /// using one.
@@ -70,5 +73,28 @@ impl PreTokenizer for ByteLevelPreTokenizer {
                 Err(err) => Some(Err(PreTokenizeError::RegexError(Box::new(err)))),
             })
             .collect()
+    }
+}
+
+pub struct BertPreTokenizer {}
+
+impl BertPreTokenizer {
+    pub fn new() -> Self {
+        BertPreTokenizer {}
+    }
+}
+
+impl Default for BertPreTokenizer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PreTokenizer for BertPreTokenizer {
+    fn pretokenize<'a>(&self, text: &'a str) -> Result<Vec<&'a str>, PreTokenizeError> {
+        let is_punc_or_space =
+            |ch: char| ch.is_ascii_punctuation() || ch.is_punctuation() || ch.is_whitespace();
+        let words = text.split_keep_delimeters(is_punc_or_space).collect();
+        Ok(words)
     }
 }

--- a/rten-text/src/pretokenizers.rs
+++ b/rten-text/src/pretokenizers.rs
@@ -1,0 +1,74 @@
+use std::fmt;
+
+use fancy_regex::Regex;
+
+/// Errors occuring while constructing a [`PreTokenizer`] or splitting input
+/// using one.
+#[derive(Clone, Debug)]
+pub enum PreTokenizeError {
+    /// An error occurred while constructing a regex from a pattern or
+    /// splitting a string using a regex.
+    RegexError(Box<fancy_regex::Error>),
+}
+
+impl fmt::Display for PreTokenizeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::RegexError(err) => write!(f, "regex failed {}", err),
+        }
+    }
+}
+
+/// A pre-tokenizer splits input text into chunks ("words") which are then
+/// tokenized by a [`Model`](crate::tokenizers::Model) individually.
+pub trait PreTokenizer {
+    /// Split `text` into chunks and return a vector of sub-slices.
+    fn pretokenize<'a>(&self, text: &'a str) -> Result<Vec<&'a str>, PreTokenizeError>;
+}
+
+/// Tokenization regex used by GPT-2.
+///
+/// See <https://github.com/openai/tiktoken/blob/main/tiktoken_ext/openai_public.py>.
+pub const GPT2_REGEX: &str =
+    r"'s|'t|'re|'ve|'m|'ll|'d| ?\p{L}+| ?\p{N}+| ?[^\s\p{L}\p{N}]+|\s+(?!\S)|\s+";
+
+pub struct ByteLevelPreTokenizer {
+    /// Pattern used to split the text into pieces.
+    splitter: Regex,
+}
+
+impl ByteLevelPreTokenizer {
+    /// Construct a pre-tokenizer which splits input using a given regex
+    /// pattern.
+    pub fn new(regex_pattern: &str) -> Result<Self, PreTokenizeError> {
+        let splitter =
+            Regex::new(regex_pattern).map_err(|err| PreTokenizeError::RegexError(err.into()))?;
+        Ok(ByteLevelPreTokenizer { splitter })
+    }
+
+    /// Return a `ByteLevelPreTokenizer` configured using the standard regex
+    /// originating from GPT-2.
+    ///
+    /// Use [`new`](Self::new) to specify a custom pattern.
+    pub fn gpt2() -> Self {
+        Self::new(GPT2_REGEX).expect("should be a valid pattern")
+    }
+}
+
+impl PreTokenizer for ByteLevelPreTokenizer {
+    fn pretokenize<'a>(&self, text: &'a str) -> Result<Vec<&'a str>, PreTokenizeError> {
+        self.splitter
+            .find_iter(text)
+            .filter_map(|piece| match piece {
+                Ok(piece) => {
+                    if piece.range().is_empty() {
+                        None
+                    } else {
+                        Some(Ok(piece.as_str()))
+                    }
+                }
+                Err(err) => Some(Err(PreTokenizeError::RegexError(Box::new(err)))),
+            })
+            .collect()
+    }
+}

--- a/rten-text/src/tokenizers.rs
+++ b/rten-text/src/tokenizers.rs
@@ -751,6 +751,7 @@ mod tests {
 
     use super::{EncodeOptions, EncoderInput, TokenId, Tokenizer, TokenizerOptions, WordPiece};
     use crate::normalizer::{BertNormalizer, BertNormalizerOptions, Normalizer};
+    use crate::pretokenizers::BertPreTokenizer;
     use serde::Deserialize;
 
     fn make_wordpiece(vocab: &[&str]) -> WordPiece {
@@ -784,7 +785,8 @@ mod tests {
                 cls_token: Some("[CLS]"),
                 sep_token: Some("[SEP]"),
             },
-        );
+        )
+        .with_pre_tokenizer(Box::new(BertPreTokenizer::new()));
 
         // Two sequences, no subwords.
         let encoded = tokenizer
@@ -882,7 +884,8 @@ mod tests {
                 cls_token: Some("[CLS]"),
                 sep_token: Some("[SEP]"),
             },
-        );
+        )
+        .with_pre_tokenizer(Box::new(BertPreTokenizer::new()));
 
         for Case {
             input,
@@ -1010,7 +1013,8 @@ mod tests {
                     cls_token: use_cls_sep.then_some("[CLS]"),
                     sep_token: use_cls_sep.then_some("[SEP]"),
                 },
-            );
+            )
+            .with_pre_tokenizer(Box::new(BertPreTokenizer::new()));
 
             if lowercase {
                 tokenizer = tokenizer.with_normalizer(lowercase_normalizer());
@@ -1203,7 +1207,8 @@ mod tests {
                     cls_token: use_sep_cls.then_some("[CLS]"),
                     sep_token: use_sep_cls.then_some("[SEP]"),
                 },
-            );
+            )
+            .with_pre_tokenizer(Box::new(BertPreTokenizer::new()));
 
             if lowercase {
                 tokenizer = tokenizer.with_normalizer(lowercase_normalizer());

--- a/rten-text/src/tokenizers.rs
+++ b/rten-text/src/tokenizers.rs
@@ -725,9 +725,6 @@ pub enum TokenizerError {
     /// An error occurred while performing pre-tokenization to split the input.
     PreTokenizeError(PreTokenizeError),
 
-    /// Splitting the input with a regex failed.
-    RegexSplitFailed(Box<fancy_regex::Error>),
-
     /// There was an error parsing a byte sequence as a UTF-8 string.
     ///
     /// This can arise when working with tokenizers like [`Bpe`] where
@@ -740,7 +737,6 @@ impl fmt::Display for TokenizerError {
         match self {
             Self::MissingToken(ref token) => write!(f, "missing vocab token {}", token),
             Self::InvalidTokenId(id) => write!(f, "unknown token id {}", id),
-            Self::RegexSplitFailed(err) => write!(f, "regex failed {}", err),
             Self::PreTokenizeError(err) => write!(f, "pretokenization error: {}", err),
             Self::InvalidUtf8 => write!(f, "UTF-8 decode failed"),
         }

--- a/rten-text/src/tokenizers/json.rs
+++ b/rten-text/src/tokenizers/json.rs
@@ -28,6 +28,15 @@ pub(crate) enum Normalizer {
 }
 
 #[derive(Deserialize)]
+#[serde(tag = "type")]
+pub(crate) enum PreTokenizer {
+    #[serde(rename = "BertPreTokenizer")]
+    Bert,
+    #[serde(rename = "ByteLevel")]
+    ByteLevel,
+}
+
+#[derive(Deserialize)]
 pub(crate) struct WordPieceModel {
     /// Mapping from token text to token ID.
     pub vocab: HashMap<String, TokenId>,
@@ -74,6 +83,7 @@ pub(crate) enum Model {
 pub(crate) struct TokenizerJson {
     pub added_tokens: Option<Vec<AddedToken>>,
     pub normalizer: Option<Normalizer>,
+    pub pre_tokenizer: Option<PreTokenizer>,
     pub model: Model,
 }
 

--- a/rten-text/tests/reftest.rs
+++ b/rten-text/tests/reftest.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 
 use rten_text::models::{merge_pairs_from_lines, Bpe, WordPiece};
 use rten_text::normalizer::{BertNormalizer, BertNormalizerOptions};
-use rten_text::pretokenizers::ByteLevelPreTokenizer;
+use rten_text::pretokenizers::{BertPreTokenizer, ByteLevelPreTokenizer};
 use rten_text::tokenizers::{TokenId, Tokenizer, TokenizerOptions};
 use serde::Deserialize;
 
@@ -84,7 +84,8 @@ fn test_wordpiece_bert_cased() -> Result<(), Box<dyn Error>> {
         ReferenceTokenization::from_file("Rust_(programming_language)-bert-base-cased.json")?;
 
     let model = WordPiece::from_vocab(vocab, Default::default());
-    let tokenizer = Tokenizer::new(model, wordpiece_tokenizer_opts());
+    let tokenizer = Tokenizer::new(model, wordpiece_tokenizer_opts())
+        .with_pre_tokenizer(Box::new(BertPreTokenizer::new()));
     let encoded = tokenizer.encode(text.as_str(), None)?;
 
     compare_tokens(encoded.token_ids(), &expected.token_ids)?;
@@ -125,8 +126,9 @@ fn test_wordpiece_bert_uncased() -> Result<(), Box<dyn Error>> {
         ..Default::default()
     });
     let model = WordPiece::from_vocab(vocab, Default::default());
-    let tokenizer =
-        Tokenizer::new(model, wordpiece_tokenizer_opts()).with_normalizer(Box::new(normalizer));
+    let tokenizer = Tokenizer::new(model, wordpiece_tokenizer_opts())
+        .with_normalizer(Box::new(normalizer))
+        .with_pre_tokenizer(Box::new(BertPreTokenizer::new()));
 
     for Case { text, reference } in cases {
         let text = read_test_file(text)?;

--- a/rten-text/tests/reftest.rs
+++ b/rten-text/tests/reftest.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 
 use rten_text::models::{merge_pairs_from_lines, Bpe, WordPiece};
 use rten_text::normalizer::{BertNormalizer, BertNormalizerOptions};
-use rten_text::pretokenizers::{BertPreTokenizer, ByteLevelPreTokenizer};
+use rten_text::pre_tokenizers::{BertPreTokenizer, ByteLevelPreTokenizer};
 use rten_text::tokenizers::{TokenId, Tokenizer, TokenizerOptions};
 use serde::Deserialize;
 

--- a/rten-text/tests/reftest.rs
+++ b/rten-text/tests/reftest.rs
@@ -4,10 +4,9 @@ use std::fs::read_to_string;
 use std::io;
 use std::path::PathBuf;
 
-use rten_text::models::{
-    merge_pairs_from_lines, patterns::GPT2 as GPT2_SPLIT_PATTERN, Bpe, WordPiece,
-};
+use rten_text::models::{merge_pairs_from_lines, Bpe, WordPiece};
 use rten_text::normalizer::{BertNormalizer, BertNormalizerOptions};
+use rten_text::pretokenizers::ByteLevelPreTokenizer;
 use rten_text::tokenizers::{TokenId, Tokenizer, TokenizerOptions};
 use serde::Deserialize;
 
@@ -156,14 +155,9 @@ fn test_bpe_gpt2() -> Result<(), Box<dyn Error>> {
     let merges = read_test_file("models/gpt2/merges.txt")?;
     let merge_lines: Vec<_> = merges.lines().collect();
     let merge_pairs = merge_pairs_from_lines(&merge_lines);
-    let model = Bpe::new(
-        &merge_pairs,
-        GPT2_SPLIT_PATTERN,
-        None,
-        Default::default(),
-        None,
-    )?;
-    let tokenizer = Tokenizer::new(model, Default::default());
+    let model = Bpe::new(&merge_pairs, None, Default::default(), None)?;
+    let tokenizer = Tokenizer::new(model, Default::default())
+        .with_pre_tokenizer(Box::new(ByteLevelPreTokenizer::gpt2()));
 
     // Create tokenizer from a `tokenizers.json` file.
     let tokenizer_json = read_test_file("models/gpt2/tokenizer.json")?;


### PR DESCRIPTION
As part of https://github.com/robertknight/rten/issues/427, extract the input splitting logic out of the `WordPiece` and `Bpe` tokenization models and make it a separate pre-tokenization step in the pipeline executed by `Tokenizer`.

**TODO:**

- [x] Decide on `pre_tokenizer` vs `pretokenizer` in naming
- [x] Parse `pretokenizer` field from `tokenizer.json` files, for already-supported pre-tokenizers
- [x] Refactor away duplication in tokenization pipeline for the first and second sequences in a pair