### PR TITLE
(rten-text) Re-organize `Model` trait and associated error types

### DIFF
--- a/rten-examples/src/qwen2_chat.rs
+++ b/rten-examples/src/qwen2_chat.rs
@@ -129,9 +129,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     let tokenizer_config = fs::read_to_string(&args.tokenizer_config)?;
     let tokenizer = Tokenizer::from_json(&tokenizer_config)?;
 
-    let im_start_token = tokenizer.model().get_token_id("<|im_start|>")?;
-    let im_end_token = tokenizer.model().get_token_id("<|im_end|>")?;
-    let end_of_text_token = tokenizer.model().get_token_id("<|endoftext|>")?;
+    let im_start_token = tokenizer.get_token_id("<|im_start|>")?;
+    let im_end_token = tokenizer.get_token_id("<|im_end|>")?;
+    let end_of_text_token = tokenizer.get_token_id("<|endoftext|>")?;
 
     // From `chat_template` in tokenizer_config.json.
     let prompt_tokens = encode_message(

--- a/rten-generate/src/text_decoder.rs
+++ b/rten-generate/src/text_decoder.rs
@@ -1,5 +1,6 @@
 //! Iterator adapters to decode token IDs into text using `rten-text`.
 
+use rten_text::models::DecodeError;
 use rten_text::tokenizers::{Tokenizer, TokenizerError};
 
 use crate::generator::{GeneratorError, GeneratorItem};
@@ -53,7 +54,7 @@ impl<G: Iterator<Item = GeneratorItem>> Iterator for TextDecoder<'_, G> {
             let text = self.tokenizer.decode(&token_buf);
             match text {
                 Ok(text) => return Some(Ok(text)),
-                Err(TokenizerError::InvalidUtf8) => {
+                Err(TokenizerError::DecodeError(DecodeError::InvalidUtf8)) => {
                     // If the current token sequence doesn't correspond to a
                     // complete UTF-8 sequence, add more tokens until it does.
                     continue;
@@ -166,7 +167,7 @@ mod tests {
             tokens,
             [
                 Ok("one".to_string()),
-                Err("decode error: unknown token id 5".to_string()),
+                Err("decode error: decoding failed: cannot decode unknown token ID 5".to_string()),
                 Ok("three".to_string())
             ]
         );

--- a/rten-text/src/models.rs
+++ b/rten-text/src/models.rs
@@ -8,3 +8,75 @@ mod wordpiece;
 
 pub use bpe::{merge_pairs_from_lines, patterns, Bpe, BpeError};
 pub use wordpiece::{WordPiece, WordPieceOptions};
+
+use crate::tokenizers::{TokenId, TokenizerError};
+
+/// Trait for tokenization models which convert words (or other string pieces)
+/// into tokens with numeric IDs.
+///
+/// Models are not generally used directly but instead via a wrapping
+/// [`Tokenizer`](crate::tokenizers::Tokenizer).
+pub trait Model {
+    /// Look up the numeric ID for a token given its canonical string
+    /// representation. This is used eg. for looking up the IDs of special
+    /// tokens.
+    fn get_token_id(&self, token: &str) -> Result<TokenId, TokenizerError>;
+
+    /// Convert a token ID to its canonical string representation.
+    ///
+    /// This is the representation of the token used in text-based
+    /// representations of the vocabulary, such as the `tokenizer.json` file
+    /// for Hugging Face tokenizers.
+    ///
+    /// For tokenizers such as [`Bpe`] where tokens correspond to sequences of
+    /// bytes rather than strings, the canonical string representation is an
+    /// encoding of the _bytes_, not the text string that the token logically
+    /// corresponds to. To get text strings, pass a sequence of token IDs to
+    /// [`decode`](Self::decode) instead.
+    fn get_token_str(&self, id: TokenId) -> Result<String, TokenizerError>;
+
+    /// Return the canonical strings that correspond to a sequence of token IDs.
+    ///
+    /// See [`get_token_str`](Self::get_token_str) for notes on what the
+    /// "canonical string" is.
+    fn get_tokens(&self, ids: &[TokenId]) -> Result<Vec<String>, TokenizerError> {
+        let mut tokens = Vec::with_capacity(ids.len());
+        for &id in ids {
+            let token = self.get_token_str(id)?;
+            tokens.push(token);
+        }
+        Ok(tokens)
+    }
+
+    /// Encode a string into a sequence of token IDs with source offsets.
+    ///
+    /// `on_token` is a callback with `(offset, token_id)` arguments that should
+    /// be invoked for each token produced.
+    fn encode_with_offsets(
+        &self,
+        text: &str,
+        on_token: &mut dyn FnMut(usize, TokenId),
+    ) -> Result<(), TokenizerError>;
+
+    /// Encode a string into a sequence of token IDs.
+    ///
+    /// This is a convenience wrapper around
+    /// [`encode_with_offsets`](Self::encode_with_offsets) for cases when the
+    /// source offsets are not needed.
+    fn encode(&self, text: &str) -> Result<Vec<TokenId>, TokenizerError> {
+        let mut token_ids = Vec::new();
+        self.encode_with_offsets(text, &mut |_offset, token_id| token_ids.push(token_id))?;
+        Ok(token_ids)
+    }
+
+    /// Decode a sequence of token IDs to a text string.
+    ///
+    /// For tokenizers which operate on byte sequences (eg. [`Bpe`]) this can
+    /// fail if the token IDs don't correspond to a complete UTF-8 sequence.
+    /// In that case the solution is to accumulate more token IDs and then
+    /// retry decoding.
+    ///
+    /// Special tokens are decoded into their canonical string representations
+    /// as returned by [`get_token_str`](Self::get_token_str).
+    fn decode(&self, ids: &[TokenId]) -> Result<String, TokenizerError>;
+}

--- a/rten-text/src/models.rs
+++ b/rten-text/src/models.rs
@@ -89,14 +89,12 @@ pub trait Model {
     /// See [`get_token_str`](Self::get_token_str) for notes on what the
     /// "canonical string" is.
     fn get_tokens(&self, ids: &[TokenId]) -> Result<Vec<String>, DecodeError> {
-        let mut tokens = Vec::with_capacity(ids.len());
-        for &id in ids {
-            let token = self
-                .get_token_str(id)
-                .ok_or(DecodeError::InvalidTokenId(id))?;
-            tokens.push(token);
-        }
-        Ok(tokens)
+        ids.iter()
+            .map(|&id| {
+                self.get_token_str(id)
+                    .ok_or(DecodeError::InvalidTokenId(id))
+            })
+            .collect()
     }
 
     /// Encode a string into a sequence of token IDs with source offsets.

--- a/rten-text/src/models/bpe.rs
+++ b/rten-text/src/models/bpe.rs
@@ -3,7 +3,8 @@ use std::error::Error;
 use std::fmt;
 use std::fmt::{Debug, Display};
 
-use crate::tokenizers::{Model, TokenId, TokenizerError};
+use super::Model;
+use crate::tokenizers::{TokenId, TokenizerError};
 
 /// Errors that can occur when building a [`Bpe`] tokenizer or encoding or
 /// decoding text using it.

--- a/rten-text/src/models/wordpiece.rs
+++ b/rten-text/src/models/wordpiece.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
-use super::Model;
-use crate::tokenizers::{TokenId, TokenizerError};
+use super::{DecodeError, EncodeError, Model};
+use crate::tokenizers::TokenId;
 
 /// WordPiece tokenizer [^1] used by BERT [^2] models.
 ///
@@ -55,14 +55,17 @@ impl Model for WordPiece {
         &self,
         word: &str,
         on_token: &mut dyn FnMut(usize, TokenId),
-    ) -> Result<(), TokenizerError> {
+    ) -> Result<(), EncodeError> {
         let mut tmp_buf = String::with_capacity(self.max_word_len);
         let mut offset = 0;
 
         macro_rules! add_unknown_token {
             () => {
-                let unknown_token = self.get_token_id("[UNK]")?;
-                on_token(offset, unknown_token);
+                let unknown_token = "[UNK]";
+                let unknown_token_id = self
+                    .get_token_id(unknown_token)
+                    .ok_or_else(|| EncodeError::TokenIdNotFound(unknown_token.to_string()))?;
+                on_token(offset, unknown_token_id);
             };
         }
 
@@ -111,21 +114,15 @@ impl Model for WordPiece {
         Ok(())
     }
 
-    fn get_token_str(&self, id: TokenId) -> Result<String, TokenizerError> {
-        self.id_to_token
-            .get(&id)
-            .cloned()
-            .ok_or(TokenizerError::InvalidTokenId(id))
+    fn get_token_str(&self, id: TokenId) -> Option<String> {
+        self.id_to_token.get(&id).cloned()
     }
 
-    fn get_token_id(&self, tok: &str) -> Result<TokenId, TokenizerError> {
-        self.token_to_id
-            .get(tok)
-            .copied()
-            .ok_or(TokenizerError::MissingToken(tok.to_string()))
+    fn get_token_id(&self, tok: &str) -> Option<TokenId> {
+        self.token_to_id.get(tok).copied()
     }
 
-    fn decode(&self, ids: &[TokenId]) -> Result<String, TokenizerError> {
+    fn decode(&self, ids: &[TokenId]) -> Result<String, DecodeError> {
         let token_strings = self.get_tokens(ids)?;
         Ok(token_strings.join(" "))
     }

--- a/rten-text/src/models/wordpiece.rs
+++ b/rten-text/src/models/wordpiece.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
-use crate::tokenizers::{Model, TokenId, TokenizerError};
+use super::Model;
+use crate::tokenizers::{TokenId, TokenizerError};
 
 /// WordPiece tokenizer [^1] used by BERT [^2] models.
 ///

--- a/rten-text/src/pre_tokenizers.rs
+++ b/rten-text/src/pre_tokenizers.rs
@@ -23,7 +23,7 @@ impl fmt::Display for PreTokenizeError {
 }
 
 /// A pre-tokenizer splits input text into chunks ("words") which are then
-/// tokenized by a [`Model`](crate::tokenizers::Model) individually.
+/// tokenized by a [`Model`](crate::models::Model) individually.
 pub trait PreTokenizer {
     /// Split `text` into chunks and return a vector of sub-slices.
     fn pre_tokenize<'a>(&self, text: &'a str) -> Result<Vec<&'a str>, PreTokenizeError>;

--- a/rten-text/src/pre_tokenizers.rs
+++ b/rten-text/src/pre_tokenizers.rs
@@ -1,3 +1,4 @@
+use std::error::Error;
 use std::fmt;
 
 use fancy_regex::Regex;
@@ -21,6 +22,8 @@ impl fmt::Display for PreTokenizeError {
         }
     }
 }
+
+impl Error for PreTokenizeError {}
 
 /// A pre-tokenizer splits input text into chunks ("words") which are then
 /// tokenized by a [`Model`](crate::models::Model) individually.

--- a/rten-text/src/tokenizers.rs
+++ b/rten-text/src/tokenizers.rs
@@ -16,7 +16,7 @@ use std::fmt;
 use std::iter::repeat;
 use std::ops::Range;
 
-use crate::models::{merge_pairs_from_lines, Bpe, BpeError, WordPiece};
+use crate::models::{merge_pairs_from_lines, Bpe, BpeError, Model, WordPiece};
 use crate::normalizer::{BertNormalizer, BertNormalizerOptions, Normalizer};
 use crate::pre_tokenizers::{
     BertPreTokenizer, ByteLevelPreTokenizer, PreTokenizeError, PreTokenizer,
@@ -158,76 +158,6 @@ pub struct EncodeOptions {
 
     /// The number of tokens that a chunk will overlap with the previous chunk.
     pub overlap: usize,
-}
-
-/// Trait for tokenization models which convert words (or other string pieces)
-/// into tokens with numeric IDs.
-///
-/// Models are not generally used directly but instead via a wrapping
-/// [`Tokenizer`].
-pub trait Model {
-    /// Look up the numeric ID for a token given its canonical string
-    /// representation. This is used eg. for looking up the IDs of special
-    /// tokens.
-    fn get_token_id(&self, token: &str) -> Result<TokenId, TokenizerError>;
-
-    /// Convert a token ID to its canonical string representation.
-    ///
-    /// This is the representation of the token used in text-based
-    /// representations of the vocabulary, such as the `tokenizer.json` file
-    /// for Hugging Face tokenizers.
-    ///
-    /// For tokenizers such as [`Bpe`] where tokens correspond to sequences of
-    /// bytes rather than strings, the canonical string representation is an
-    /// encoding of the _bytes_, not the text string that the token logically
-    /// corresponds to. To get text strings, pass a sequence of token IDs to
-    /// [`decode`](Self::decode) instead.
-    fn get_token_str(&self, id: TokenId) -> Result<String, TokenizerError>;
-
-    /// Return the canonical strings that correspond to a sequence of token IDs.
-    ///
-    /// See [`get_token_str`](Self::get_token_str) for notes on what the
-    /// "canonical string" is.
-    fn get_tokens(&self, ids: &[TokenId]) -> Result<Vec<String>, TokenizerError> {
-        let mut tokens = Vec::with_capacity(ids.len());
-        for &id in ids {
-            let token = self.get_token_str(id)?;
-            tokens.push(token);
-        }
-        Ok(tokens)
-    }
-
-    /// Encode a string into a sequence of token IDs with source offsets.
-    ///
-    /// `on_token` is a callback with `(offset, token_id)` arguments that should
-    /// be invoked for each token produced.
-    fn encode_with_offsets(
-        &self,
-        text: &str,
-        on_token: &mut dyn FnMut(usize, TokenId),
-    ) -> Result<(), TokenizerError>;
-
-    /// Encode a string into a sequence of token IDs.
-    ///
-    /// This is a convenience wrapper around
-    /// [`encode_with_offsets`](Self::encode_with_offsets) for cases when the
-    /// source offsets are not needed.
-    fn encode(&self, text: &str) -> Result<Vec<TokenId>, TokenizerError> {
-        let mut token_ids = Vec::new();
-        self.encode_with_offsets(text, &mut |_offset, token_id| token_ids.push(token_id))?;
-        Ok(token_ids)
-    }
-
-    /// Decode a sequence of token IDs to a text string.
-    ///
-    /// For tokenizers which operate on byte sequences (eg. [`Bpe`]) this can
-    /// fail if the token IDs don't correspond to a complete UTF-8 sequence.
-    /// In that case the solution is to accumulate more token IDs and then
-    /// retry decoding.
-    ///
-    /// Special tokens are decoded into their canonical string representations
-    /// as returned by [`get_token_str`](Self::get_token_str).
-    fn decode(&self, ids: &[TokenId]) -> Result<String, TokenizerError>;
 }
 
 /// Errors returned by [`Tokenizer::from_json`].


### PR DESCRIPTION
Re-organize the `Model` trait and associated error types in rten-text to align with the structure of traits and error types for other phases of tokenization. In the process add a dummy error type for normalization errors. None of the current normalizers are fallible, but additional ones added soon will be.

For consumers, there are breaking changes for pattern-matching errors and also `Model::get_token_id` now returns an `Option` rather than `Result`. Consumers can use `Tokenizer::get_token_id` instead which does return a result.