### PR TITLE
Vectorize sum and sum-of-square reductions in ReduceMean, ReduceL2, InstanceNormalization, LayerNormalization ops

### DIFF
--- a/rten-simd/src/dispatch.rs
+++ b/rten-simd/src/dispatch.rs
@@ -17,36 +17,34 @@ impl SimdDispatcher {
     /// system.
     #[allow(unused_imports)]
     #[allow(unreachable_code)] // Ignore fallback, if unused
-    pub fn dispatch<Op: SimdOp>(&self, op: Op) {
+    pub fn dispatch<Op: SimdOp>(&self, op: Op) -> Op::Output {
         #[cfg(feature = "avx512")]
         #[cfg(target_arch = "x86_64")]
         #[target_feature(enable = "avx512f")]
         #[target_feature(enable = "avx512vl")]
-        unsafe fn simd_op_avx512<Op: SimdOp>(op: Op) {
+        unsafe fn simd_op_avx512<Op: SimdOp>(op: Op) -> Op::Output {
             use std::arch::x86_64::__m512;
-            op.eval::<__m512>();
+            op.eval::<__m512>()
         }
 
         #[cfg(target_arch = "x86_64")]
         #[target_feature(enable = "avx2")]
         #[target_feature(enable = "fma")]
-        unsafe fn simd_op_avx<Op: SimdOp>(op: Op) {
+        unsafe fn simd_op_avx<Op: SimdOp>(op: Op) -> Op::Output {
             use std::arch::x86_64::__m256;
-            op.eval::<__m256>();
+            op.eval::<__m256>()
         }
 
         #[cfg(target_arch = "x86_64")]
         {
             #[cfg(feature = "avx512")]
             if crate::is_avx512_supported() {
-                unsafe { simd_op_avx512(op) };
-                return;
+                return unsafe { simd_op_avx512(op) };
             }
 
             if is_x86_feature_detected!("fma") && is_x86_feature_detected!("avx2") {
                 // Safety: We've checked that AVX2 + FMA are available.
-                unsafe { simd_op_avx(op) };
-                return;
+                return unsafe { simd_op_avx(op) };
             }
         }
 
@@ -57,19 +55,17 @@ impl SimdDispatcher {
 
             // Safety: The WASM runtime will have verified SIMD instructions
             // are accepted when loading the binary.
-            unsafe { op.eval::<v128f>() };
-            return;
+            return unsafe { op.eval::<v128f>() };
         }
 
         #[cfg(target_arch = "aarch64")]
         {
             use std::arch::aarch64::float32x4_t;
-            unsafe { op.eval::<float32x4_t>() };
-            return;
+            return unsafe { op.eval::<float32x4_t>() };
         }
 
         // Generic fallback.
-        unsafe { op.eval::<f32>() };
+        unsafe { op.eval::<f32>() }
     }
 }
 
@@ -79,13 +75,16 @@ impl SimdDispatcher {
 /// To dispatch the operation, create a [`SimdDispatcher`] and call
 /// [`dispatch(op)`](SimdDispatcher::dispatch).
 pub trait SimdOp {
+    /// Output type returned by `eval`.
+    type Output;
+
     /// Evaluate the operator using a given SIMD vector type.
     ///
     /// # Safety
     ///
     /// The caller must ensure that the `S` is a supported SIMD vector type
     /// on the current system.
-    unsafe fn eval<S: SimdFloat>(&self);
+    unsafe fn eval<S: SimdFloat>(&self) -> Self::Output;
 }
 
 /// Trait for evaluating a unary function on a SIMD vector.
@@ -140,6 +139,8 @@ impl<Op: SimdUnaryOp> SimdMapOp<Op> {
 }
 
 impl<Op: SimdUnaryOp> SimdOp for SimdMapOp<Op> {
+    type Output = ();
+
     #[inline(always)]
     unsafe fn eval<S: SimdFloat>(&self) {
         simd_map(

--- a/rten-simd/src/dispatch.rs
+++ b/rten-simd/src/dispatch.rs
@@ -69,6 +69,11 @@ impl SimdDispatcher {
     }
 }
 
+/// Run `op` using the default SIMD dispatch configuration.
+pub fn dispatch<Op: SimdOp>(op: Op) -> Op::Output {
+    SimdDispatcher::default().dispatch(op)
+}
+
 /// Trait for SIMD operations which can be evaluated using different SIMD
 /// vector types.
 ///
@@ -101,16 +106,14 @@ pub trait SimdUnaryOp {
 /// Apply a vectorized unary function to elements of `input` using [`simd_map`].
 pub fn dispatch_map_op<Op: SimdUnaryOp>(input: &[f32], out: &mut [MaybeUninit<f32>], op: Op) {
     let wrapped_op = SimdMapOp::wrap(input.into(), out.into(), op, 0. /* pad */);
-    let dispatcher = SimdDispatcher::default();
-    dispatcher.dispatch(wrapped_op);
+    dispatch(wrapped_op)
 }
 
 /// Apply a vectorized unary function in-place to elements of `input`.
 pub fn dispatch_map_op_in_place<Op: SimdUnaryOp>(input: &mut [f32], op: Op) {
     let out: MutPtrLen<f32> = input.into();
     let wrapped_op = SimdMapOp::wrap(input.into(), out.as_uninit(), op, 0. /* pad */);
-    let dispatcher = SimdDispatcher::default();
-    dispatcher.dispatch(wrapped_op);
+    dispatch(wrapped_op)
 }
 
 /// SIMD operation which applies a unary operator `Op` to all elements in

--- a/rten-vecmath/src/lib.rs
+++ b/rten-vecmath/src/lib.rs
@@ -20,6 +20,7 @@
 mod erf;
 mod exp;
 mod softmax;
+mod sum;
 mod tanh;
 
 #[cfg(test)]
@@ -34,4 +35,5 @@ pub use exp::{
     vec_silu_in_place,
 };
 pub use softmax::{vec_softmax, vec_softmax_in_place};
+pub use sum::{vec_sum, vec_sum_square};
 pub use tanh::{tanh, vec_tanh, vec_tanh_in_place};

--- a/rten-vecmath/src/softmax.rs
+++ b/rten-vecmath/src/softmax.rs
@@ -56,8 +56,10 @@ struct SimdSoftmax {
 }
 
 impl SimdOp for SimdSoftmax {
+    type Output = ();
+
     #[inline(always)]
-    unsafe fn eval<S: SimdFloat>(&self) {
+    unsafe fn eval<S: SimdFloat>(&self) -> Self::Output {
         simd_softmax::<S>(self.input, self.output)
     }
 }

--- a/rten-vecmath/src/softmax.rs
+++ b/rten-vecmath/src/softmax.rs
@@ -1,6 +1,6 @@
 use std::mem::MaybeUninit;
 
-use rten_simd::dispatch::{SimdDispatcher, SimdOp};
+use rten_simd::dispatch::{dispatch, SimdOp};
 use rten_simd::functional::{simd_fold, simd_map};
 use rten_simd::span::{MutPtrLen, PtrLen};
 use rten_simd::SimdFloat;
@@ -74,8 +74,7 @@ pub fn vec_softmax(xs: &[f32], out: &mut [MaybeUninit<f32>]) {
         input: xs.into(),
         output: out.into(),
     };
-    let dispatcher = SimdDispatcher::default();
-    dispatcher.dispatch(op);
+    dispatch(op)
 }
 
 /// Computes the [softmax][softmax] function over a slice of floats.
@@ -87,8 +86,7 @@ pub fn vec_softmax_in_place(xs: &mut [f32]) {
         input: xs.into(),
         output: out.as_uninit(),
     };
-    let dispatcher = SimdDispatcher::default();
-    dispatcher.dispatch(op);
+    dispatch(op)
 }
 
 #[cfg(test)]

--- a/rten-vecmath/src/sum.rs
+++ b/rten-vecmath/src/sum.rs
@@ -1,0 +1,76 @@
+use rten_simd::dispatch::{dispatch, SimdOp};
+use rten_simd::functional::simd_fold;
+use rten_simd::SimdFloat;
+
+struct SimdSum<'a> {
+    input: &'a [f32],
+}
+
+impl SimdOp for SimdSum<'_> {
+    type Output = f32;
+
+    #[inline(always)]
+    unsafe fn eval<S: SimdFloat>(&self) -> Self::Output {
+        let vec_sum = simd_fold(
+            self.input.into(),
+            S::zero(),
+            #[inline(always)]
+            |sum, x| sum.add(x),
+            0., /* pad */
+        );
+        vec_sum.sum()
+    }
+}
+
+/// Return the sum of a slice of floats.
+pub fn vec_sum(xs: &[f32]) -> f32 {
+    let op = SimdSum { input: xs };
+    dispatch(op)
+}
+
+struct SimdSumSquare<'a> {
+    input: &'a [f32],
+}
+
+impl SimdOp for SimdSumSquare<'_> {
+    type Output = f32;
+
+    #[inline(always)]
+    unsafe fn eval<S: SimdFloat>(&self) -> Self::Output {
+        let vec_sum = simd_fold(
+            self.input.into(),
+            S::zero(),
+            #[inline(always)]
+            |sum, x| x.mul_add(x, sum),
+            0., /* pad */
+        );
+        vec_sum.sum()
+    }
+}
+
+/// Return the sum of the squares of elements in `xs`.
+pub fn vec_sum_square(xs: &[f32]) -> f32 {
+    let op = SimdSumSquare { input: xs };
+    dispatch(op)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{vec_sum, vec_sum_square};
+
+    #[test]
+    fn test_vec_sum() {
+        let xs: Vec<f32> = (0..100).map(|i| i as f32 * 0.1).collect();
+        let expected_sum: f32 = xs.iter().sum();
+        let sum = vec_sum(&xs);
+        assert_eq!(sum, expected_sum);
+    }
+
+    #[test]
+    fn test_vec_sum_square() {
+        let xs: Vec<f32> = (0..100).map(|i| i as f32 * 0.1).collect();
+        let expected_sum: f32 = xs.iter().copied().map(|x| x * x).sum();
+        let sum = vec_sum_square(&xs);
+        assert_eq!(sum, expected_sum);
+    }
+}

--- a/src/ops/norm.rs
+++ b/src/ops/norm.rs
@@ -2,13 +2,13 @@ use rayon::prelude::*;
 
 use rten_tensor::prelude::*;
 use rten_tensor::{NdTensorView, Tensor, TensorView};
-use rten_vecmath::vec_softmax_in_place;
+use rten_vecmath::{vec_softmax_in_place, vec_sum};
 use smallvec::SmallVec;
 
 use crate::ops::reduce::reduce_inverse_rms;
 use crate::ops::{add_in_place, mul_in_place, reduce_mean, static_dims, sub};
 use crate::ops::{resolve_axis, InputList, IntoOpResult, OpError, Operator, Output, OutputList};
-use crate::slice_reductions::{slice_max, slice_sum};
+use crate::slice_reductions::slice_max;
 use crate::tensor_pool::{AutoReturn, TensorPool};
 
 /// Perform in-place batch normalization on the `NC*` tensor `out`.
@@ -173,7 +173,7 @@ pub fn instance_normalization_in_place(
             let mut slice = input.slice_mut([n, c]);
             let chan_scale = scale[[c]];
             let chan_bias = bias[[c]];
-            let chan_mean = slice_sum(slice.data().unwrap()) / slice.len() as f32;
+            let chan_mean = vec_sum(slice.data().unwrap()) / slice.len() as f32;
             let chan_variance = slice
                 .iter()
                 .map(|x| {

--- a/src/ops/reduce.rs
+++ b/src/ops/reduce.rs
@@ -4,13 +4,14 @@ use std::cmp::Ordering;
 use rten_tensor;
 use rten_tensor::prelude::*;
 use rten_tensor::{DynIndices, NdTensor, NdTensorView, SliceItem, Tensor, TensorView};
+use rten_vecmath::{vec_sum, vec_sum_square};
 
 use crate::number::{Identities, IsNaN};
 use crate::ops::layout::squeeze_in_place;
 use crate::ops::{
     resolve_axes, resolve_axis, Input, InputList, IntoOpResult, OpError, Operator, OutputList,
 };
-use crate::slice_reductions::{iter_sum, slice_map_sum, slice_sum};
+use crate::slice_reductions::iter_sum;
 use crate::tensor_pool::TensorPool;
 
 /// Compute the indices of the max elements along an axis, according to a
@@ -400,7 +401,7 @@ pub fn reduce_mean(
         }
 
         fn reduce_slice(&self, slice: &[f32]) -> f32 {
-            slice_sum(slice) / slice.len() as f32
+            vec_sum(slice) / slice.len() as f32
         }
     }
 
@@ -434,7 +435,7 @@ pub fn reduce_inverse_rms(
         }
 
         fn reduce_slice(&self, slice: &[f32]) -> f32 {
-            let mean_square = slice_map_sum(slice, |x| x * x) / slice.len() as f32;
+            let mean_square = vec_sum_square(slice) / slice.len() as f32;
             1. / (mean_square + self.epsilon).sqrt()
         }
     }
@@ -477,6 +478,10 @@ pub fn reduce_l2(
         fn reduce<I: ExactSizeIterator<Item = f32>>(&self, iter: I) -> f32 {
             let sum_of_squares: f32 = iter.map(|val| val * val).sum();
             sum_of_squares.sqrt()
+        }
+
+        fn reduce_slice(&self, slice: &[f32]) -> f32 {
+            vec_sum_square(slice).sqrt()
         }
     }
 

--- a/src/ops/reduce.rs
+++ b/src/ops/reduce.rs
@@ -11,7 +11,7 @@ use crate::ops::layout::squeeze_in_place;
 use crate::ops::{
     resolve_axes, resolve_axis, Input, InputList, IntoOpResult, OpError, Operator, OutputList,
 };
-use crate::slice_reductions::iter_sum;
+use crate::slice_reductions::{iter_sum, slice_sum};
 use crate::tensor_pool::TensorPool;
 
 /// Compute the indices of the max elements along an axis, according to a
@@ -675,6 +675,10 @@ pub fn reduce_sum<T: Copy + Default + std::ops::Add<T, Output = T>>(
     impl<T: Copy + Default + std::ops::Add<T, Output = T>> Reducer<T> for SumReducer {
         fn reduce<I: ExactSizeIterator<Item = T>>(&self, iter: I) -> T {
             iter_sum(iter)
+        }
+
+        fn reduce_slice(&self, slice: &[T]) -> T {
+            slice_sum(slice)
         }
     }
     reduce(pool, input, axes, keep_dims, SumReducer {})


### PR DESCRIPTION
Vectorize these reductions for f32 inputs. For LayerNormalization under AVX2 this gives a modest speedup of ~13%. The ReduceSum and ReduceSumOfSquares ops don't benefit yet. Those ops are generic to support int tensors, so some additional work is required to support having both a generic and a specialized path.

A non-vectorized fast path for contiguous slices was added in ReduceSum though, since this is a trivial change.