### PR TITLE
Add `SimdFloat::{load_partial, store_partial}`, make `SimdOp::eval` take self by value

### DIFF
--- a/rten-simd/src/dispatch.rs
+++ b/rten-simd/src/dispatch.rs
@@ -89,7 +89,7 @@ pub trait SimdOp {
     ///
     /// The caller must ensure that the `S` is a supported SIMD vector type
     /// on the current system.
-    unsafe fn eval<S: SimdFloat>(&self) -> Self::Output;
+    unsafe fn eval<S: SimdFloat>(self) -> Self::Output;
 }
 
 /// Trait for evaluating a unary function on a SIMD vector.
@@ -145,7 +145,7 @@ impl<Op: SimdUnaryOp> SimdOp for SimdMapOp<Op> {
     type Output = ();
 
     #[inline(always)]
-    unsafe fn eval<S: SimdFloat>(&self) {
+    unsafe fn eval<S: SimdFloat>(self) {
         simd_map(
             self.input,
             self.output,

--- a/rten-vecmath/src/softmax.rs
+++ b/rten-vecmath/src/softmax.rs
@@ -59,7 +59,7 @@ impl SimdOp for SimdSoftmax {
     type Output = ();
 
     #[inline(always)]
-    unsafe fn eval<S: SimdFloat>(&self) -> Self::Output {
+    unsafe fn eval<S: SimdFloat>(self) -> Self::Output {
         simd_softmax::<S>(self.input, self.output)
     }
 }

--- a/rten-vecmath/src/sum.rs
+++ b/rten-vecmath/src/sum.rs
@@ -10,7 +10,7 @@ impl SimdOp for SimdSum<'_> {
     type Output = f32;
 
     #[inline(always)]
-    unsafe fn eval<S: SimdFloat>(&self) -> Self::Output {
+    unsafe fn eval<S: SimdFloat>(self) -> Self::Output {
         let vec_sum = simd_fold(
             self.input.into(),
             S::zero(),
@@ -36,7 +36,7 @@ impl SimdOp for SimdSumSquare<'_> {
     type Output = f32;
 
     #[inline(always)]
-    unsafe fn eval<S: SimdFloat>(&self) -> Self::Output {
+    unsafe fn eval<S: SimdFloat>(self) -> Self::Output {
         let vec_sum = simd_fold(
             self.input.into(),
             S::zero(),


### PR DESCRIPTION
- Add methods to simplify implementing tail handling in SIMD ops
- Make `SimdOp::eval` take `self` by value rather than immutable reference. This allows for ops which store a mutable slice in their fields which they write to