### PR TITLE
Move common SIMD vector functionality to base trait

### DIFF
--- a/rten-simd/src/arch.rs
+++ b/rten-simd/src/arch.rs
@@ -13,7 +13,7 @@ mod aarch64;
 #[cfg(target_feature = "simd128")]
 pub mod wasm;
 
-use crate::{SimdFloat, SimdInt};
+use crate::{Simd, SimdMask};
 
 /// Fallback implementation for [`SimdFloat::gather_mask`], for CPUs where
 /// a native gather implementation is unavailable or unusable.
@@ -25,18 +25,23 @@ use crate::{SimdFloat, SimdInt};
 /// See notes in [`SimdFloat::gather_mask`]. In particular, `src` must point
 /// to a non-empty buffer, so that `src[0]` is valid.
 #[inline]
-unsafe fn simd_gather_mask<S: SimdFloat, const LEN: usize>(
-    src: *const f32,
-    offsets: S::Int,
-    mask: S::Mask,
+unsafe fn simd_gather_mask<
+    M: SimdMask,
+    S: Simd<Mask = M>,
+    SI: Simd<Elem = i32, Mask = M>,
+    const LEN: usize,
+>(
+    src: *const S::Elem,
+    offsets: SI,
+    mask: M,
 ) -> S {
     // Set offset to zero where masked out. `src` is required to point to
     // a non-empty buffer, so index zero can be loaded as a dummy. This avoids
     // an unpredictable branch.
-    let offsets = S::Int::splat(0).blend(offsets, mask);
+    let offsets = SI::zero().blend(offsets, mask);
     let mut offset_array = [0; LEN];
     offsets.store(offset_array.as_mut_ptr());
 
-    let values: [f32; LEN] = std::array::from_fn(|i| *src.add(offset_array[i] as usize));
-    S::splat(0.).blend(S::load(values.as_ptr()), mask)
+    let values: [S::Elem; LEN] = std::array::from_fn(|i| *src.add(offset_array[i] as usize));
+    S::zero().blend(S::load(values.as_ptr()), mask)
 }

--- a/rten-simd/src/lib.rs
+++ b/rten-simd/src/lib.rs
@@ -35,7 +35,7 @@ pub mod isa_detection;
 pub mod span;
 mod vec;
 
-pub use vec::{vec_count, SimdFloat, SimdInt, SimdMask, SimdVal};
+pub use vec::{vec_count, Simd, SimdFloat, SimdInt, SimdMask};
 
 #[cfg(feature = "avx512")]
 #[cfg(target_arch = "x86_64")]

--- a/rten-vecmath/src/exp.rs
+++ b/rten-vecmath/src/exp.rs
@@ -5,7 +5,7 @@
 use std::mem::MaybeUninit;
 
 use rten_simd::dispatch::{dispatch_map_op, dispatch_map_op_in_place, SimdUnaryOp};
-use rten_simd::{SimdFloat, SimdInt};
+use rten_simd::{Simd, SimdFloat, SimdInt};
 
 const INV_LOG2: f32 = std::f32::consts::LOG2_E; // aka. 1 / ln2
 const ROUNDING_MAGIC: f32 = 12582912.; // 0x3 << 22


### PR DESCRIPTION
Rename the base trait from `SimdVal` to `Simd` and move methods for functionality common to all element types (load, store, splat, blend etc.) there. This allows making some SIMD code generic over the element type, such as the `simd_map`, `simd_gather_mask` and `simd_fold` helpers.