### PR TITLE
Fuse `Add(MatMul(a, b), bias)` subgraphs

### DIFF
--- a/src/gemm.rs
+++ b/src/gemm.rs
@@ -212,9 +212,15 @@ impl<T> GemmInputB<'_, T> {
     }
 }
 
+/// A bias to add to the output of a matrix multiplication.
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub enum BiasVector<'a, T> {
+    /// Slice of values treated as a column vector. The length must match the
+    /// number of rows in the LHS / A input.
     Column(&'a [T]),
+
+    /// Slice of values treated as a column vector. The length must match the
+    /// number of columns in the RHS / B input.
     Row(&'a [T]),
 }
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -170,6 +170,10 @@ impl Constant {
         }
     }
 
+    pub fn shape(&self) -> &[usize] {
+        self.layout().shape()
+    }
+
     /// Clone this constant, but only if it can be done so cheaply by
     /// incrementing a ref count on the underlying data.
     pub fn clone_ref(&self) -> Option<Constant> {

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -82,7 +82,7 @@ pub use layout::{
     expand, flatten, reshape, squeeze, squeeze_in_place, Expand, Flatten, Reshape, Shape, Size,
     Squeeze, Transpose, Unsqueeze,
 };
-pub use matmul::{gemm_op, matmul, Gemm, MatMul, MatMulInteger};
+pub use matmul::{gemm_op, matmul, Gemm, MatMul, MatMulAdd, MatMulInteger};
 pub use non_max_suppression::{non_max_suppression, BoxOrder, NonMaxSuppression};
 pub use norm::{
     batch_norm, batch_norm_in_place, instance_normalization, layer_normalization, log_softmax,


### PR DESCRIPTION
Fuse MatMul -> Add subgraphs where the second input to `Add` is a constant bias vector. Unlike earlier matmul + bias fusions, the bias is treated as a row rather than column vector in this case, so this also adds support for that in the GEMM implementation.

In the process I spotted an existing bug in the handling of matmul operations with k=0. In that case the bias was not added to the output.