### PR TITLE
Use packing buffer when reducing non-contiguous tensors

### DIFF
--- a/rten-tensor/src/copy.rs
+++ b/rten-tensor/src/copy.rs
@@ -171,14 +171,13 @@ fn copy_blocked<T: Clone>(src: Matrix<T>, mut dest: MatrixMut<MaybeUninit<T>>) {
 ///
 /// Returns `dest` as an initialized slice.
 pub fn copy_into_slice<'a, T: Clone>(
-    src: TensorView<T>,
+    mut src: TensorView<T>,
     dest: &'a mut [MaybeUninit<T>],
 ) -> &'a [T] {
     assert!(dest.len() == src.len());
 
     // Merge axes to increase the chance that we can use the fast path and
     // also maximize the iteration count of the innermost loops.
-    let mut src = src.clone();
     src.merge_axes();
 
     if src.ndim() > 4 {

--- a/src/ops/reduce.rs
+++ b/src/ops/reduce.rs
@@ -366,8 +366,9 @@ fn reduce<T: Copy>(
                         reducer.reduce_slice(data)
                     } else {
                         tmp_buf.clear();
-                        tmp_buf.extend(slice.iter().copied());
-                        reducer.reduce_slice(&tmp_buf)
+                        let tmp_uninit = &mut tmp_buf.spare_capacity_mut()[..slice.len()];
+                        let tmp = slice.copy_into_slice(tmp_uninit);
+                        reducer.reduce_slice(tmp)
                     };
                     reduced_data.push(reduced);
                 }

--- a/src/slice_reductions.rs
+++ b/src/slice_reductions.rs
@@ -64,36 +64,6 @@ pub fn slice_map_sum<T: Copy + Default + std::ops::Add<Output = T>, M: Fn(T) -> 
         .fold(T::default(), |acc, x| acc + x)
 }
 
-/// Return the sum of an iterator of numbers.
-pub fn iter_sum<T: Copy + Default + std::ops::Add<Output = T>, I: ExactSizeIterator<Item = T>>(
-    mut iter: I,
-) -> T {
-    let zero = T::default();
-    let len = iter.len();
-    let mut sum = zero;
-    let mut n = len;
-
-    while n > 4 {
-        n -= 4;
-
-        let a = iter.next().unwrap_or(zero);
-        let b = iter.next().unwrap_or(zero);
-        let c = iter.next().unwrap_or(zero);
-        let d = iter.next().unwrap_or(zero);
-
-        let ab = a + b;
-        let cd = c + d;
-        let abcd = ab + cd;
-        sum = sum + abcd;
-    }
-
-    for x in iter {
-        sum = sum + x;
-    }
-
-    sum
-}
-
 #[cfg(test)]
 mod tests {
     use rten_tensor::rng::XorShiftRng;


### PR DESCRIPTION
Each `Reduce*` op has two implementations of the main reduction loop: one optimized for contiguous inputs and one for non-contiguous inputs. This means that each reduction had to be implemented twice and the fallback's efficiency was worse by a varying amount.

Simplify this by making reductions of non-contiguous inputs pack slices of the input into a contiguous buffer before reducing. This means that only one implementation of the inner reduction loop is needed per `(operation, data type)` combination. It also means the cost of the fallback is more predictable. Also dynamic dispatch can now be used to dispatch the inner reduction loop. This trades off reduced code size at the cost of some overhead per call. The overhead of that depends on the size of reduced slices.