### PR TITLE
Optimize LayerNormalization for better cache efficiency + SIMD

### DIFF
--- a/rten-vecmath/src/lib.rs
+++ b/rten-vecmath/src/lib.rs
@@ -19,6 +19,7 @@
 
 mod erf;
 mod exp;
+mod shift_scale;
 mod softmax;
 mod sum;
 mod tanh;
@@ -34,6 +35,7 @@ pub use exp::{
     exp, sigmoid, silu, vec_exp, vec_exp_in_place, vec_sigmoid, vec_sigmoid_in_place, vec_silu,
     vec_silu_in_place,
 };
+pub use shift_scale::vec_shift_scale_in_place;
 pub use softmax::{vec_softmax, vec_softmax_in_place};
 pub use sum::{vec_sum, vec_sum_square};
 pub use tanh::{tanh, vec_tanh, vec_tanh_in_place};

--- a/rten-vecmath/src/shift_scale.rs
+++ b/rten-vecmath/src/shift_scale.rs
@@ -1,0 +1,114 @@
+use rten_simd::dispatch::{dispatch, SimdOp};
+use rten_simd::SimdFloat;
+
+struct SimdShiftScale<'a> {
+    data: &'a mut [f32],
+    bias: Option<&'a [f32]>,
+    scale: &'a [f32],
+    const_scale: f32,
+}
+
+impl<'a> SimdOp for SimdShiftScale<'a> {
+    type Output = &'a mut [f32];
+
+    #[inline(always)]
+    unsafe fn eval<S: SimdFloat>(self) -> Self::Output {
+        let Self {
+            data,
+            bias,
+            scale,
+            const_scale,
+        } = self;
+
+        let mut out_ptr = data.as_mut_ptr();
+        let mut scale_ptr = scale.as_ptr();
+        let mut bias_ptr = bias.map(|b| b.as_ptr());
+        let mut n = data.len();
+
+        let zero = S::zero();
+        let const_scale_vec = S::splat(const_scale);
+
+        while n >= S::LEN {
+            let scale_vec = S::load(scale_ptr).mul(const_scale_vec);
+            let bias_vec = bias_ptr.map(|b| S::load(b)).unwrap_or(zero);
+            let y = S::load(out_ptr).mul_add(scale_vec, bias_vec);
+            y.store(out_ptr);
+
+            out_ptr = out_ptr.add(S::LEN);
+            scale_ptr = scale_ptr.add(S::LEN);
+            bias_ptr = bias_ptr.map(|b| b.add(S::LEN));
+
+            n -= S::LEN;
+        }
+
+        if n > 0 {
+            let scale_vec = S::load_partial(scale_ptr, n, 0.).mul(const_scale_vec);
+            let bias_vec = bias_ptr.map(|b| S::load_partial(b, n, 0.)).unwrap_or(zero);
+            let y = S::load_partial(out_ptr, n, 0.).mul_add(scale_vec, bias_vec);
+            y.store_partial(out_ptr, n);
+        }
+
+        data
+    }
+}
+
+/// Shift and scale each element in the input.
+///
+/// This scales and shifts each element using `y[i] = y[i] * const_scale *
+/// scale[i] + bias[i]`.
+pub fn vec_shift_scale_in_place(
+    data: &mut [f32],
+    const_scale: f32,
+    scale: &[f32],
+    bias: Option<&[f32]>,
+) {
+    let simd_op = SimdShiftScale {
+        data,
+        bias,
+        scale,
+        const_scale,
+    };
+    dispatch(simd_op);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::vec_shift_scale_in_place;
+
+    fn reference_shift_scale(
+        data: &mut [f32],
+        const_scale: f32,
+        scale: &[f32],
+        bias: Option<&[f32]>,
+    ) {
+        for i in 0..data.len() {
+            data[i] = data[i].mul_add(const_scale * scale[i], bias.map(|b| b[i]).unwrap_or(0.));
+        }
+    }
+
+    #[test]
+    fn test_vec_shift_scale() {
+        let data: Vec<_> = (0..10).map(|i| i as f32 * 0.1).collect();
+        let const_scale = 0.123;
+        let scale: Vec<_> = (0..data.len()).map(|i| 1.0 + i as f32 * 0.1).collect();
+        let bias: Vec<_> = (0..data.len()).map(|i| -0.5 + i as f32 * 0.2).collect();
+
+        // With bias
+        let mut expected = data.clone();
+        reference_shift_scale(&mut expected[..], const_scale, &scale, Some(&bias));
+
+        let mut actual = data.clone();
+        vec_shift_scale_in_place(&mut actual[..], const_scale, &scale, Some(&bias));
+
+        assert_eq!(actual, expected);
+
+        // Without bias
+        let mut expected = data.clone();
+        reference_shift_scale(&mut expected[..], const_scale, &scale, None);
+
+        let mut actual = data.clone();
+        vec_shift_scale_in_place(&mut actual[..], const_scale, &scale, None);
+
+        assert_eq!(actual, expected);
+    }
+}

--- a/src/model.rs
+++ b/src/model.rs
@@ -1387,9 +1387,9 @@ mod tests {
             input_node, instance_norm_scale, instance_norm_bias
         ], { epsilon: Some(1e-5) });
 
-        let layer_norm_scale_val = Tensor::from([1.0]);
+        let layer_norm_scale_val = Tensor::full(&[input_shape[input_shape.len() - 1]], 1.);
         let layer_norm_scale = graph_builder.add_constant(layer_norm_scale_val.view());
-        let layer_norm_bias_val = Tensor::from([1.0]);
+        let layer_norm_bias_val = layer_norm_scale_val.clone();
         let layer_norm_bias = graph_builder.add_constant(layer_norm_bias_val.view());
         add_operator!(LayerNormalization, [
             input_node, layer_norm_scale, layer_norm_bias

--- a/src/ops/norm.rs
+++ b/src/ops/norm.rs
@@ -705,6 +705,27 @@ mod tests {
                     [1.0744, 0.0683],
                 ]])),
             },
+            // Normalize multiple axes
+            Case {
+                // Sample values generated using `torch.rand`.
+                input: Tensor::from([[
+                    [0.9562, 0.0572],
+                    [0.4366, 0.5655],
+                    [0.2017, 0.0230],
+                    [0.7941, 0.1554],
+                    [0.3226, 0.120],
+                ]]),
+                scale: Tensor::full(&[5, 2], 1.1),
+                bias: Some(Tensor::full(&[5, 2], 0.1)),
+                axis: -2,
+                expected: Ok(Tensor::from([[
+                    [2.2467697, -1.0079411],
+                    [0.36562642, 0.83229196],
+                    [-0.48479798, -1.1317577],
+                    [1.6599079, -0.65242106],
+                    [-0.04709549, -0.7805821],
+                ]])),
+            },
             // Unsupported scale shape
             Case {
                 input: Tensor::from([[1., 2., 3.], [4., 5., 6.]]),
@@ -745,7 +766,9 @@ mod tests {
             );
 
             match (result, expected) {
-                (Ok(result), Ok(expected)) => expect_eq_1e4(&result, &expected)?,
+                (Ok(result), Ok(expected)) => {
+                    expect_eq_1e4(&result, &expected)?;
+                }
                 (result, expected) => assert_eq!(result, expected),
             }
         }

--- a/src/ops/reduce.rs
+++ b/src/ops/reduce.rs
@@ -408,35 +408,6 @@ pub fn reduce_mean(
     reduce(pool, input, axes, keep_dims, &MeanKernel {})
 }
 
-/// Reduces axes of a tensor using an inverse Root Mean Squared (RMS)
-/// operation.
-///
-/// This reduces axes according to the formula:
-///
-/// ```text
-/// 1. / (mean(x^2) + epsilon).sqrt()
-/// ```
-pub fn reduce_inverse_rms(
-    pool: &TensorPool,
-    input: TensorView,
-    axes: Option<&[i32]>,
-    keep_dims: bool,
-    epsilon: f32,
-) -> Result<Tensor, OpError> {
-    struct InverseRmsKernel {
-        epsilon: f32,
-    }
-
-    impl ReduceKernel<f32> for InverseRmsKernel {
-        fn reduce_slice(&self, slice: &[f32]) -> f32 {
-            let mean_square = vec_sum_square(slice) / slice.len() as f32;
-            1. / (mean_square + self.epsilon).sqrt()
-        }
-    }
-
-    reduce(pool, input, axes, keep_dims, &InverseRmsKernel { epsilon })
-}
-
 #[derive(Debug)]
 pub struct ReduceMean {
     pub axes: Option<Vec<i32>>,


### PR DESCRIPTION
Optimize the LayerNormalization implementation by:

1. Re-organizing the process to be more cache efficient. Instead of applying each step in the process to the whole input before moving on to the next, apply the whole normalization process to each normalized slice individually. This means we only load each slice into cache once (assuming each slice fits in L1)
2. Fusing the steps that normalize the variance and apply the `bias` and `scale` into one vectorized pass

Tested on [docvqa](https://huggingface.co/naver-clova-ix/donut-base-finetuned-docvqa) this speeds up `LayerNormalization` in the encoder by 2.5-3x.