### PR TITLE
Move `to_array` method from `SimdInt` to `Simd` trait

### DIFF
--- a/rten-simd/src/arch/aarch64.rs
+++ b/rten-simd/src/arch/aarch64.rs
@@ -55,6 +55,13 @@ impl Simd for int32x4_t {
     unsafe fn store(self, ptr: *mut i32) {
         vst1q_s32(ptr, self)
     }
+
+    #[inline]
+    unsafe fn to_array(self) -> Self::Array {
+        let mut array = [0; Self::LEN];
+        self.store(array.as_mut_ptr());
+        array
+    }
 }
 
 impl SimdInt for int32x4_t {
@@ -104,13 +111,6 @@ impl SimdInt for int32x4_t {
     unsafe fn reinterpret_as_float(self) -> Self::Float {
         vreinterpretq_f32_s32(self)
     }
-
-    #[inline]
-    unsafe fn to_array(self) -> Self::Array {
-        let mut array = [0; Self::LEN];
-        self.store(array.as_mut_ptr());
-        array
-    }
 }
 
 impl Simd for float32x4_t {
@@ -138,6 +138,13 @@ impl Simd for float32x4_t {
     #[inline]
     unsafe fn store(self, ptr: *mut f32) {
         vst1q_f32(ptr, self)
+    }
+
+    #[inline]
+    unsafe fn to_array(self) -> Self::Array {
+        let mut array = [0.; Self::LEN];
+        self.store(array.as_mut_ptr());
+        array
     }
 }
 

--- a/rten-simd/src/arch/scalar.rs
+++ b/rten-simd/src/arch/scalar.rs
@@ -46,6 +46,11 @@ macro_rules! impl_simd {
             unsafe fn store(self, ptr: *mut $type) {
                 *ptr = self;
             }
+
+            #[inline]
+            unsafe fn to_array(self) -> Self::Array {
+                [self]
+            }
         }
     };
 }
@@ -100,11 +105,6 @@ impl SimdInt for i32 {
     #[inline]
     unsafe fn reinterpret_as_float(self) -> Self::Float {
         f32::from_bits(self as u32)
-    }
-
-    #[inline]
-    unsafe fn to_array(self) -> Self::Array {
-        [self]
     }
 }
 

--- a/rten-simd/src/arch/wasm.rs
+++ b/rten-simd/src/arch/wasm.rs
@@ -59,6 +59,13 @@ impl Simd for v128i {
     unsafe fn store(self, ptr: *mut i32) {
         v128_store(ptr as *mut v128, self.0)
     }
+
+    #[inline]
+    unsafe fn to_array(self) -> Self::Array {
+        let mut array = [0; Self::LEN];
+        self.store(array.as_mut_ptr());
+        array
+    }
 }
 
 impl SimdInt for v128i {
@@ -108,13 +115,6 @@ impl SimdInt for v128i {
     unsafe fn reinterpret_as_float(self) -> Self::Float {
         v128f(self.0)
     }
-
-    #[inline]
-    unsafe fn to_array(self) -> Self::Array {
-        let mut array = [0; Self::LEN];
-        self.store(array.as_mut_ptr());
-        array
-    }
 }
 
 impl Simd for v128f {
@@ -142,6 +142,13 @@ impl Simd for v128f {
     #[inline]
     unsafe fn store(self, ptr: *mut f32) {
         v128_store(ptr as *mut v128, self.0)
+    }
+
+    #[inline]
+    unsafe fn to_array(self) -> Self::Array {
+        let mut array = [0.; Self::LEN];
+        self.store(array.as_mut_ptr());
+        array
     }
 }
 

--- a/rten-simd/src/arch/x86_64.rs
+++ b/rten-simd/src/arch/x86_64.rs
@@ -71,6 +71,13 @@ impl Simd for __m256i {
         // Cast is OK because instruction does not require alignment.
         _mm256_storeu_si256(ptr as *mut __m256i, self)
     }
+
+    #[inline]
+    unsafe fn to_array(self) -> Self::Array {
+        let mut array = [0; Self::LEN];
+        self.store(array.as_mut_ptr());
+        array
+    }
 }
 
 impl SimdInt for __m256i {
@@ -129,13 +136,6 @@ impl SimdInt for __m256i {
     unsafe fn reinterpret_as_float(self) -> Self::Float {
         _mm256_castsi256_ps(self)
     }
-
-    #[inline]
-    unsafe fn to_array(self) -> Self::Array {
-        let mut array = [0; Self::LEN];
-        self.store(array.as_mut_ptr());
-        array
-    }
 }
 
 impl Simd for __m256 {
@@ -177,6 +177,13 @@ impl Simd for __m256 {
     #[target_feature(enable = "avx2")]
     unsafe fn store(self, ptr: *mut f32) {
         _mm256_storeu_ps(ptr, self)
+    }
+
+    #[inline]
+    unsafe fn to_array(self) -> Self::Array {
+        let mut array = [0.; Self::LEN];
+        self.store(array.as_mut_ptr());
+        array
     }
 }
 
@@ -347,6 +354,14 @@ impl Simd for __m512i {
     unsafe fn store(self, ptr: *mut i32) {
         _mm512_storeu_si512(ptr, self)
     }
+
+    #[inline]
+    #[target_feature(enable = "avx512f")]
+    unsafe fn to_array(self) -> Self::Array {
+        let mut array = [0; Self::LEN];
+        self.store(array.as_mut_ptr());
+        array
+    }
 }
 
 #[cfg(feature = "avx512")]
@@ -407,14 +422,6 @@ impl SimdInt for __m512i {
     unsafe fn reinterpret_as_float(self) -> Self::Float {
         _mm512_castsi512_ps(self)
     }
-
-    #[inline]
-    #[target_feature(enable = "avx512f")]
-    unsafe fn to_array(self) -> Self::Array {
-        let mut array = [0; Self::LEN];
-        self.store(array.as_mut_ptr());
-        array
-    }
 }
 
 #[cfg(feature = "avx512")]
@@ -457,6 +464,14 @@ impl Simd for __m512 {
     #[inline]
     unsafe fn prefetch_write(data: *mut f32) {
         _mm_prefetch(data as *const i8, _MM_HINT_ET0);
+    }
+
+    #[inline]
+    #[target_feature(enable = "avx512f")]
+    unsafe fn to_array(self) -> Self::Array {
+        let mut array = [0.; Self::LEN];
+        self.store(array.as_mut_ptr());
+        array
     }
 }
 

--- a/rten-simd/src/vec.rs
+++ b/rten-simd/src/vec.rs
@@ -133,6 +133,9 @@ pub trait Simd: Copy + Sized {
         }
     }
 
+    /// Return the contents of this vector as an array.
+    unsafe fn to_array(self) -> Self::Array;
+
     /// Return a new vector with all elements set to zero.
     #[inline]
     unsafe fn zero() -> Self
@@ -194,9 +197,6 @@ pub trait SimdInt: Simd<Elem = i32> {
 
     /// Reinterpret the bits of each element as a float.
     unsafe fn reinterpret_as_float(self) -> Self::Float;
-
-    /// Return the contents of this vector as an array.
-    unsafe fn to_array(self) -> Self::Array;
 }
 
 /// Trait for SIMD vectors containing single-precision floats.


### PR DESCRIPTION
This makes it available for float vectors as well. Not currently used, but may be useful for some upcoming work on MatMul with unpacked LHS inputs.