### PR TITLE
Vectorize InstanceNormalization and BatchNormalization

### DIFF
--- a/rten-simd/src/vec.rs
+++ b/rten-simd/src/vec.rs
@@ -64,7 +64,11 @@ pub trait Simd: Copy + Sized {
     type Mask: SimdMask;
 
     /// The contents of a vector as an array.
-    type Array: std::ops::Index<usize, Output = Self::Elem>;
+    ///
+    /// This type should always be `[Self::ELEM; Self::LEN]`. The `to_array`
+    /// method returns this associated type rather than a concrete array due to
+    /// const generics limitations.
+    type Array: Copy + std::fmt::Debug + std::ops::Index<usize, Output = Self::Elem>;
 
     /// Combine elements of `self` and `rhs` according to a mask.
     ///

--- a/rten-vecmath/src/lib.rs
+++ b/rten-vecmath/src/lib.rs
@@ -35,7 +35,7 @@ pub use exp::{
     exp, sigmoid, silu, vec_exp, vec_exp_in_place, vec_sigmoid, vec_sigmoid_in_place, vec_silu,
     vec_silu_in_place,
 };
-pub use shift_scale::vec_shift_scale_in_place;
+pub use shift_scale::{vec_shift_scale_bias, vec_shift_scale_in_place};
 pub use softmax::{vec_softmax, vec_softmax_in_place};
-pub use sum::{vec_sum, vec_sum_square};
+pub use sum::{vec_sum, vec_sum_square, vec_sum_square_sub};
 pub use tanh::{tanh, vec_tanh, vec_tanh_in_place};


### PR DESCRIPTION
InstanceNormalization has two steps:

 1. Compute channel mean and variance
 2. Shift and scale result to normalize the mean and variance, and then apply a per-channel scale and bias

BatchNormalization is similar but uses precomputed values for step 1. Previously part of step 1 was vectorized, but not the variance calculation. Add a vectorized kernel for step 2 and use it for BatchNormalization and InstanceNormalization.

This can be further improved in future by:

- Computing both the mean and variance in one pass over the input
- Unifying LayerNormalization and BatchNormalization / InstanceNormalization

Tested using the wav2vec example on x64, this made InstanceNormalization ~3x faster (~26ms -> ~8ms per run).
