### PR TITLE
Make `TensorBase::reshaped` copy instead of panic if input is not contiguous

### DIFF
--- a/rten-tensor/src/tensor.rs
+++ b/rten-tensor/src/tensor.rs
@@ -1923,19 +1923,6 @@ impl<T> TensorBase<Vec<T>, DynLayout> {
     }
 }
 
-impl<T> TensorBase<ViewData<'_, T>, DynLayout> {
-    /// Reshape this view.
-    ///
-    /// Panics if the view is not contiguous.
-    pub fn reshape(&mut self, shape: &[usize])
-    where
-        T: Clone,
-    {
-        assert!(self.is_contiguous(), "can only reshape contiguous views");
-        self.layout = DynLayout::from_shape(shape);
-    }
-}
-
 impl<'a, T, L: MutLayout> TensorBase<ViewMutData<'a, T>, L> {
     /// Divide this tensor into two mutable views along a given axis.
     ///
@@ -1971,19 +1958,6 @@ impl<'a, T, L: MutLayout> TensorBase<ViewMutData<'a, T>, L> {
         };
 
         (left_view, right_view)
-    }
-}
-
-impl<T> TensorBase<ViewMutData<'_, T>, DynLayout> {
-    /// Reshape this view.
-    ///
-    /// Panics if the view is not contiguous.
-    pub fn reshape(&mut self, shape: &[usize])
-    where
-        T: Clone,
-    {
-        assert!(self.is_contiguous(), "can only reshape contiguous views");
-        self.layout = DynLayout::from_shape(shape);
     }
 }
 
@@ -3358,22 +3332,11 @@ mod tests {
 
     #[test]
     fn test_reshape() {
-        // Owned tensor
         let mut tensor = Tensor::<f32>::from_data(&[2, 2], vec![1., 2., 3., 4.]);
         tensor.transpose();
         tensor.reshape(&[4]);
         assert_eq!(tensor.shape(), &[4]);
         assert_eq!(tensor.to_vec(), &[1., 3., 2., 4.]);
-
-        // View
-        let mut view = tensor.view();
-        view.reshape(&[2, 2]);
-        assert_eq!(view.shape(), &[2, 2]);
-
-        // Mut view
-        let mut view_mut = tensor.view_mut();
-        view_mut.reshape(&[2, 2]);
-        assert_eq!(view_mut.shape(), &[2, 2]);
     }
 
     #[test]

--- a/src/ops/conv.rs
+++ b/src/ops/conv.rs
@@ -259,7 +259,9 @@ where
             .zip(in_group.axis_iter(0))
             .par_bridge()
             .for_each(|(mut out_item, in_item)| {
-                let mut out_mat = out_item.reshaped_mut([out_channels_per_group, out_h * out_w]);
+                let mut out_mat = out_item
+                    .reshaped_mut([out_channels_per_group, out_h * out_w])
+                    .unwrap();
                 let out_row_stride = out_mat.stride(0);
 
                 let im2col = VirtualIm2Col::new(

--- a/src/ops/einsum.rs
+++ b/src/ops/einsum.rs
@@ -379,8 +379,8 @@ fn einsum_step(
             .collect();
         einsum_matmul(
             pool,
-            &x,
-            &y,
+            &x.view(),
+            &y.view(),
             &term_simplified,
             &term_simplified,
             &step.output,

--- a/src/ops/layout.rs
+++ b/src/ops/layout.rs
@@ -1372,7 +1372,10 @@ mod tests {
 
             let reference_transpose_stats = run_bench(100, None, || {
                 let transposed = tensor.permuted(perm);
-                reference_transpose_into(transposed.view(), dest.reshaped_mut(transposed.shape()));
+                reference_transpose_into(
+                    transposed.view(),
+                    dest.reshaped_mut(transposed.shape()).unwrap(),
+                );
             });
 
             let transpose_stats = run_bench(100, None, || {

--- a/src/ops/layout.rs
+++ b/src/ops/layout.rs
@@ -45,12 +45,12 @@ pub fn depth_to_space<T: Clone>(
     // See https://onnx.ai/onnx/operators/onnx__DepthToSpace.html#summary
     let tmp = input.to_contiguous_in(pool);
     let tmp = match mode {
-        DepthToSpaceMode::DepthColumnRow => tmp
-            .reshaped([n, block_size, block_size, new_c, h, w])
-            .permuted([0, 3, 4, 1, 5, 2]),
-        DepthToSpaceMode::ColumnRowDepth => tmp
-            .reshaped([n, new_c, block_size, block_size, h, w])
-            .permuted([0, 1, 4, 2, 5, 3]),
+        DepthToSpaceMode::DepthColumnRow => tmp.reshaped([n, block_size, block_size, new_c, h, w]),
+        DepthToSpaceMode::ColumnRowDepth => tmp.reshaped([n, new_c, block_size, block_size, h, w]),
+    };
+    let tmp = match mode {
+        DepthToSpaceMode::DepthColumnRow => tmp.permuted([0, 3, 4, 1, 5, 2]),
+        DepthToSpaceMode::ColumnRowDepth => tmp.permuted([0, 1, 4, 2, 5, 3]),
     };
     let mut tmp = tmp.to_tensor_in(pool).into_dyn();
     tmp.reshape(&new_shape);

--- a/src/ops/matmul.rs
+++ b/src/ops/matmul.rs
@@ -188,7 +188,7 @@ where
         // nb. We assume `a` is likely already contiguous, so this will be cheap.
         let a_contig = a.to_contiguous_in(pool).auto_return(pool);
         let a_matrix = a_contig.reshaped([num_a_matrices * a_rows, a_cols].as_slice());
-        let mut output = matmul_impl(pool, a_matrix, b.clone(), strategy, bias)?;
+        let mut output = matmul_impl(pool, a_matrix.view(), b.clone(), strategy, bias)?;
         output.reshape(out_shape);
         return Ok(output);
     }


### PR DESCRIPTION
Remove a long-standing footgun where `TensorBase::reshaped` would panic if the caller failed to ensure that it was contiguous first. Instead it will now copy if needed. A variant `reshaped_in` has been added so an allocator can be provided as necessary. The related `reshaped_mut` method now returns an error instead of panicking if the result is not contiguous. It cannot copy since it is used in contexts where writing to a copy would be useless. This change at least makes the caller aware of the need to handle this case.

A downside of this change is that the lifetime of the result is shorter since it may be owned. That turned out not to be too inconvenient to deal with.