### PR TITLE
Remove `pad` argument from `Simd::load_partial`, `simd_fold`, `simd_map`

### DIFF
--- a/rten-simd/src/arch/aarch64.rs
+++ b/rten-simd/src/arch/aarch64.rs
@@ -2,8 +2,8 @@ use std::arch::aarch64::{
     float32x4_t, int32x4_t, uint32x4_t, vabsq_f32, vaddq_f32, vaddq_s32, vaddvq_f32, vandq_u32,
     vbslq_f32, vbslq_s32, vceqq_s32, vcgeq_f32, vcgeq_s32, vcgtq_s32, vcleq_f32, vcleq_s32,
     vcltq_f32, vcltq_s32, vcvtq_s32_f32, vdivq_f32, vdupq_n_f32, vdupq_n_s32, vfmaq_f32, vld1q_f32,
-    vld1q_s32, vmaxq_f32, vmulq_f32, vreinterpretq_f32_s32, vshlq_n_s32, vst1q_f32, vst1q_s32,
-    vst1q_u32, vsubq_f32, vsubq_s32,
+    vld1q_s32, vld1q_u32, vmaxq_f32, vmulq_f32, vreinterpretq_f32_s32, vshlq_n_s32, vst1q_f32,
+    vst1q_s32, vst1q_u32, vsubq_f32, vsubq_s32,
 };
 
 use crate::{Simd, SimdFloat, SimdInt, SimdMask};
@@ -14,6 +14,12 @@ impl SimdMask for uint32x4_t {
     #[inline]
     unsafe fn and(self, other: Self) -> Self {
         vandq_u32(self, other)
+    }
+
+    #[inline]
+    unsafe fn from_array(array: [bool; 4]) -> Self {
+        let u32_array = array.map(|b| if b { u32::MAX } else { 0 });
+        vld1q_u32(u32_array.as_ptr())
     }
 
     #[inline]

--- a/rten-simd/src/arch/scalar.rs
+++ b/rten-simd/src/arch/scalar.rs
@@ -12,6 +12,11 @@ impl SimdMask for bool {
     unsafe fn to_array(self) -> Self::Array {
         [self]
     }
+
+    #[inline]
+    unsafe fn from_array(mask: Self::Array) -> Self {
+        mask[0]
+    }
 }
 
 macro_rules! impl_simd {

--- a/rten-simd/src/arch/wasm.rs
+++ b/rten-simd/src/arch/wasm.rs
@@ -1,8 +1,8 @@
 use std::arch::wasm32::{
     f32x4_abs, f32x4_add, f32x4_div, f32x4_extract_lane, f32x4_ge, f32x4_le, f32x4_lt, f32x4_max,
-    f32x4_mul, f32x4_splat, f32x4_sub, i32x4_add, i32x4_eq, i32x4_ge, i32x4_gt, i32x4_le, i32x4_lt,
-    i32x4_shl, i32x4_shuffle, i32x4_splat, i32x4_sub, i32x4_trunc_sat_f32x4, v128, v128_and,
-    v128_bitselect, v128_load, v128_store,
+    f32x4_mul, f32x4_splat, f32x4_sub, i32x4, i32x4_add, i32x4_eq, i32x4_ge, i32x4_gt, i32x4_le,
+    i32x4_lt, i32x4_shl, i32x4_shuffle, i32x4_splat, i32x4_sub, i32x4_trunc_sat_f32x4, v128,
+    v128_and, v128_bitselect, v128_load, v128_store,
 };
 
 use crate::{Simd, SimdFloat, SimdInt, SimdMask};
@@ -23,6 +23,16 @@ impl SimdMask for v128i {
     #[inline]
     unsafe fn and(self, other: Self) -> Self {
         Self(v128_and(self.0, other.0))
+    }
+
+    #[inline]
+    unsafe fn from_array(array: [bool; 4]) -> Self {
+        Self(i32x4(
+            if array[0] { -1 } else { 0 },
+            if array[1] { -1 } else { 0 },
+            if array[2] { -1 } else { 0 },
+            if array[3] { -1 } else { 0 },
+        ))
     }
 
     #[inline]

--- a/rten-simd/src/arch/x86_64.rs
+++ b/rten-simd/src/arch/x86_64.rs
@@ -3,10 +3,10 @@ use std::arch::x86_64::{
     _mm256_blendv_epi8, _mm256_blendv_ps, _mm256_castps256_ps128, _mm256_castsi256_ps,
     _mm256_cmp_ps, _mm256_cmpeq_epi32, _mm256_cmpgt_epi32, _mm256_cvttps_epi32, _mm256_div_ps,
     _mm256_extractf128_ps, _mm256_fmadd_ps, _mm256_loadu_ps, _mm256_loadu_si256, _mm256_max_ps,
-    _mm256_mul_ps, _mm256_or_si256, _mm256_set1_epi32, _mm256_set1_ps, _mm256_slli_epi32,
-    _mm256_storeu_ps, _mm256_storeu_si256, _mm256_sub_epi32, _mm256_sub_ps, _mm_add_ps,
-    _mm_cvtss_f32, _mm_movehl_ps, _mm_prefetch, _mm_shuffle_ps, _CMP_GE_OQ, _CMP_LE_OQ, _CMP_LT_OQ,
-    _MM_HINT_ET0, _MM_HINT_T0,
+    _mm256_mul_ps, _mm256_or_si256, _mm256_set1_epi32, _mm256_set1_ps, _mm256_setr_epi32,
+    _mm256_slli_epi32, _mm256_storeu_ps, _mm256_storeu_si256, _mm256_sub_epi32, _mm256_sub_ps,
+    _mm_add_ps, _mm_cvtss_f32, _mm_movehl_ps, _mm_prefetch, _mm_shuffle_ps, _CMP_GE_OQ, _CMP_LE_OQ,
+    _CMP_LT_OQ, _MM_HINT_ET0, _MM_HINT_T0,
 };
 use std::mem::transmute;
 
@@ -19,6 +19,21 @@ impl SimdMask for __m256i {
     #[target_feature(enable = "avx2")]
     unsafe fn and(self, other: Self) -> Self {
         _mm256_and_si256(self, other)
+    }
+
+    #[inline]
+    #[target_feature(enable = "avx2")]
+    unsafe fn from_array(array: [bool; 8]) -> Self {
+        _mm256_setr_epi32(
+            if array[0] { -1 } else { 0 },
+            if array[1] { -1 } else { 0 },
+            if array[2] { -1 } else { 0 },
+            if array[3] { -1 } else { 0 },
+            if array[4] { -1 } else { 0 },
+            if array[5] { -1 } else { 0 },
+            if array[6] { -1 } else { 0 },
+            if array[7] { -1 } else { 0 },
+        )
     }
 
     #[inline]
@@ -308,6 +323,18 @@ impl SimdMask for __mmask16 {
     #[target_feature(enable = "avx512f")]
     unsafe fn and(self, other: Self) -> Self {
         self & other
+    }
+
+    #[inline]
+    #[target_feature(enable = "avx512f")]
+    unsafe fn from_array(array: [bool; 16]) -> Self {
+        let mut mask = 0;
+        for i in 0..16 {
+            if array[i] {
+                mask |= 1 << i;
+            }
+        }
+        mask
     }
 
     #[inline]

--- a/rten-simd/src/vec.rs
+++ b/rten-simd/src/vec.rs
@@ -90,14 +90,13 @@ pub trait Simd: Copy + Sized {
     /// values.
     unsafe fn load(ptr: *const Self::Elem) -> Self;
 
-    /// Load `len` values from `ptr` into a vector and pad the remainder with
-    /// `pad`.
+    /// Load `len` values from `ptr` into a vector and zero the unused lanes.
     ///
     /// Panics if `len > Self::LEN`.
     #[inline]
-    unsafe fn load_partial(ptr: *const Self::Elem, len: usize, pad: Self::Elem) -> Self {
+    unsafe fn load_partial(ptr: *const Self::Elem, len: usize) -> Self {
         assert!(len <= Self::LEN);
-        let mut remainder = [pad; MAX_LEN];
+        let mut remainder = [Self::Elem::default(); MAX_LEN];
         for i in 0..len {
             remainder[i] = *ptr.add(i);
         }

--- a/rten-simd/src/vec.rs
+++ b/rten-simd/src/vec.rs
@@ -159,13 +159,25 @@ pub const fn vec_count<S: Simd>(count: usize) -> usize {
 #[allow(clippy::missing_safety_doc)]
 pub trait SimdMask: Copy {
     /// A representation of this mask as a bool array.
-    type Array: std::ops::Index<usize, Output = bool>;
+    type Array: Copy + Default + std::ops::Index<usize, Output = bool> + std::ops::IndexMut<usize>;
 
     /// Return a bitwise AND of self and `rhs`.
     unsafe fn and(self, rhs: Self) -> Self;
 
+    /// Return a mask with the first `n` lanes set.
+    unsafe fn first_n(n: usize) -> Self {
+        let mut array = Self::Array::default();
+        for i in 0..n {
+            array[i] = true;
+        }
+        Self::from_array(array)
+    }
+
     /// Convert this SIMD mask to a boolean array.
     unsafe fn to_array(self) -> Self::Array;
+
+    /// Create a SIMD mask from a boolean array.
+    unsafe fn from_array(mask: Self::Array) -> Self;
 }
 
 /// Trait for SIMD vectors containing 32-bit integers.

--- a/rten-vecmath/src/normalize.rs
+++ b/rten-vecmath/src/normalize.rs
@@ -81,14 +81,14 @@ impl SimdOp for SimdNormalize<'_> {
 
         if n > 0 {
             let scale_vec = scale_ptr
-                .map(|s| S::load_partial(s, n, 0.))
+                .map(|s| S::load_partial(s, n))
                 .unwrap_or(one)
                 .mul(const_scale_vec);
             let bias_vec = bias_ptr
-                .map(|b| S::load_partial(b, n, 0.))
+                .map(|b| S::load_partial(b, n))
                 .unwrap_or(zero)
                 .add(const_bias_vec);
-            let y = S::load_partial(in_ptr, n, 0.)
+            let y = S::load_partial(in_ptr, n)
                 .sub(pre_scale_bias_vec)
                 .mul_add(scale_vec, bias_vec);
             y.store_partial(out_ptr as *mut f32, n);

--- a/rten-vecmath/src/softmax.rs
+++ b/rten-vecmath/src/softmax.rs
@@ -3,7 +3,7 @@ use std::mem::MaybeUninit;
 use rten_simd::dispatch::{dispatch, SimdOp};
 use rten_simd::functional::{simd_fold, simd_map};
 use rten_simd::span::{MutPtrLen, PtrLen};
-use rten_simd::SimdFloat;
+use rten_simd::{SimdFloat, SimdMask};
 
 use crate::exp::simd_exp;
 
@@ -20,24 +20,30 @@ unsafe fn simd_softmax<S: SimdFloat>(input: PtrLen<f32>, out: MutPtrLen<MaybeUni
         S::splat(f32::MIN),
         #[inline(always)]
         |max, x| max.max(x),
-        f32::MIN, /* pad */
     );
     let max_val = max_val.fold_splat(f32::MIN, |max: f32, x: f32| max.max(x));
 
     // *x = (*x - max_val).exp()
+    let mut prev_exp_sum = S::zero();
     let mut exp_sum = S::zero();
-    let exp_pad = f32::NEG_INFINITY; // exp(-inf) = 0, so won't affect `exp_sum`
     simd_map(
         input,
         out,
         #[inline(always)]
         |x: S| {
             let y = simd_exp(x.sub(max_val));
+            prev_exp_sum = exp_sum;
             exp_sum = exp_sum.add(y);
             y
         },
-        exp_pad,
     );
+
+    // Undo the last update to `exp_sum` for unused lanes.
+    let remainder = input.len() % S::LEN;
+    if remainder != 0 {
+        let remainder_mask = S::Mask::first_n(remainder);
+        exp_sum = prev_exp_sum.blend(exp_sum, remainder_mask);
+    }
 
     // *x /= exp_sum
     let exp_sum = exp_sum.fold_splat(0., |sum, x| sum + x);
@@ -46,7 +52,6 @@ unsafe fn simd_softmax<S: SimdFloat>(input: PtrLen<f32>, out: MutPtrLen<MaybeUni
         out,
         #[inline(always)]
         |x: S| x.div(exp_sum),
-        1., /* pad */
     );
 }
 

--- a/rten-vecmath/src/softmax.rs
+++ b/rten-vecmath/src/softmax.rs
@@ -116,6 +116,7 @@ mod tests {
 
     #[test]
     fn test_vec_softmax() {
+        // Test against reference values.
         let input = vec![0.1634, 0.8647, 0.6401, 0.8265, 0.0560, 0.2304];
         let expected = &([
             0.11715934, 0.23623686, 0.18871443, 0.2273828, 0.10522857, 0.12527795,
@@ -123,8 +124,18 @@ mod tests {
         let mut actual = vec![0.; input.len()];
 
         vec_softmax(&input, actual.as_mut_slice().as_uninit());
-
         check_f32s_are_equal_ulps(triples(&input, &actual, expected), 0. /* max ULPs */);
+
+        // Test against reference implementation for various lengths.
+        for len in 1..20 {
+            let input: Vec<f32> = (0..len).map(|x| x as f32 + 0.1).collect();
+            let mut expected = vec![0.; input.len()];
+            reference_softmax(&input, &mut expected);
+
+            let mut actual = vec![0.; input.len()];
+            vec_softmax(&input, actual.as_mut_slice().as_uninit());
+            check_f32s_are_equal_ulps(triples(&input, &actual, &expected), 2. /* max ULPs */);
+        }
     }
 
     #[test]

--- a/rten-vecmath/src/sum.rs
+++ b/rten-vecmath/src/sum.rs
@@ -16,7 +16,6 @@ impl SimdOp for SimdSum<'_> {
             S::zero(),
             #[inline(always)]
             |sum, x| sum.add(x),
-            0., /* pad */
         );
         vec_sum.sum()
     }
@@ -47,7 +46,6 @@ impl SimdOp for SimdSumSquare<'_> {
             S::zero(),
             #[inline(always)]
             |sum, x| x.mul_add(x, sum),
-            0., /* pad */
         );
         vec_sum.sum()
     }
@@ -83,10 +81,6 @@ impl SimdOp for SimdSumSquareSub<'_> {
                 let x_offset = x.sub(offset_vec);
                 x_offset.mul_add(x_offset, sum)
             },
-            // Padding value chosen so that `x - offset` is zero for unused
-            // positions in the final update, and thus the accumulator is not
-            // modified in those positions.
-            self.offset,
         );
         vec_sum.sum()
     }


### PR DESCRIPTION
Simplify usage of these functions by removing the `pad` argument and always setting unused lanes to zero. This was already the case in most places, with a few exceptions for reductions where using zero as a padding value affected the
final result. Handle this instead by using the accumulator for the one-before-last update for the lanes that are unused in the final update.

As well as simplifying usage, this also allows for translating partial loads into masked loads.
