### PR TITLE
Check that prepacked matmul inputs are using matching configuration

### DIFF
--- a/src/gemm/kernels.rs
+++ b/src/gemm/kernels.rs
@@ -44,7 +44,7 @@ pub unsafe trait Kernel<LhsT, RhsT, OutT>: Sync {
     fn nr(&self) -> usize;
 
     /// Return a name for this kernel for use in logging etc.
-    fn name(&self) -> &str;
+    fn name(&self) -> &'static str;
 
     /// Pack a block of the LHS / "A" input for use by this kernel.
     fn pack_a_block(


### PR DESCRIPTION
When a matmul is performed using a prepacked input, verify that the input was prepacked with the same configuration that is later used during computation. This includes the block sizes and kernel ID.

Adding early checks avoids a harder-to-debug error later if the prepacked buffer doesn't have the expected length or worse, incorrect results.