### PR TITLE
Avoid packing LHS input to GEMM kernel if column stride is 1

### DIFF
--- a/src/gemm/kernels/generic.rs
+++ b/src/gemm/kernels/generic.rs
@@ -5,7 +5,7 @@ use rten_simd::vec_count;
 use rten_tensor::Matrix;
 
 use super::simd_generic::{simd_gemm, simd_gemv};
-use super::Kernel;
+use super::{Kernel, Lhs};
 use crate::gemm::packing::{pack_a_block, pack_b_block};
 
 /// This is the base kernel that does not use architecture-specific intrinsics
@@ -66,7 +66,8 @@ unsafe impl Kernel<f32, f32, f32> for GenericKernel {
         &self,
         tile_ptr: *mut f32,
         tile_row_stride: usize,
-        a: &[f32],
+        a: Lhs<f32>,
+        used_rows: usize,
         b: &[f32],
         depth: usize,
         alpha: f32,
@@ -75,7 +76,16 @@ unsafe impl Kernel<f32, f32, f32> for GenericKernel {
         const MR: usize = GenericKernel::MR;
         const NR: usize = GenericKernel::NR;
         const NR_REGS: usize = vec_count::<f32>(NR);
-        simd_gemm::<f32, MR, NR_REGS>(tile_ptr, tile_row_stride, a, b, depth, alpha, beta);
+        simd_gemm::<f32, MR, NR_REGS>(
+            tile_ptr,
+            tile_row_stride,
+            a,
+            used_rows,
+            b,
+            depth,
+            alpha,
+            beta,
+        );
     }
 
     fn gemv_kernel(&self, out: &mut [f32], a: &[f32], b: Matrix, alpha: f32, beta: f32) {

--- a/src/gemm/kernels/wasm.rs
+++ b/src/gemm/kernels/wasm.rs
@@ -6,7 +6,7 @@ use rten_simd::vec_count;
 use rten_tensor::Matrix;
 
 use super::simd_generic::{simd_gemm, simd_gemv};
-use super::Kernel;
+use super::{Kernel, Lhs};
 use crate::gemm::packing::{pack_a_block, pack_b_block};
 
 pub struct WasmKernel {
@@ -65,7 +65,8 @@ unsafe impl Kernel<f32, f32, f32> for WasmKernel {
         &self,
         tile_ptr: *mut f32,
         tile_row_stride: usize,
-        a: &[f32],
+        a: Lhs<f32>,
+        used_rows: usize,
         b: &[f32],
         depth: usize,
         alpha: f32,
@@ -75,7 +76,16 @@ unsafe impl Kernel<f32, f32, f32> for WasmKernel {
         const NR: usize = WasmKernel::NR;
         const NR_REGS: usize = vec_count::<v128f>(NR);
 
-        simd_gemm::<v128f, MR, NR_REGS>(tile_ptr, tile_row_stride, a, b, depth, alpha, beta);
+        simd_gemm::<v128f, MR, NR_REGS>(
+            tile_ptr,
+            tile_row_stride,
+            a,
+            used_rows,
+            b,
+            depth,
+            alpha,
+            beta,
+        );
     }
 
     fn gemv_kernel(&self, out: &mut [f32], a: &[f32], b: Matrix, alpha: f32, beta: f32) {


### PR DESCRIPTION
This avoids the overhead of packing, at the cost of potentially more expensive loads from the LHS in the kernel as rows are spaced further apart in memory.

Some [initial GEMM benchmarks](https://docs.google.com/spreadsheets/d/1d1pGSILVqGDwj9g5Lh2R4XuYXDrKI3c7SVC9wxXO2mc/edit?gid=1760158567#gid=1760158567) on my i5 laptop suggest that performance is unchanged for large matrices and very slightly better for small matrices. On real models I see a very slight win, but not statistically significant. What stands out much more are spikes for friendly and unfriendly sizes (M and N being multiples of MR and NR respectively).

See https://github.com/robertknight/rten/issues/415.