### PR TITLE
Update crate READMEs

### DIFF
--- a/rten-bench/README.md
+++ b/rten-bench/README.md
@@ -1,0 +1,1 @@
+Internal benchmarking utilities used in RTen development.

--- a/rten-generate/README.md
+++ b/rten-generate/README.md
@@ -1,0 +1,4 @@
+rten-generate is a layer on top of RTen which handles the generation loop for
+auto-regressive transformer models (aka. "transformer decoders" or "generative
+AI"). This includes managing the KV cache, sampling and post-processing logits
+etc.

--- a/rten-imageio/README.md
+++ b/rten-imageio/README.md
@@ -1,4 +1,4 @@
 # rten-imageio
 
-Library for loading images and converting them to [NdTensor]s that can be
-used as inputs for RTen models.
+Crate for loading images and converting them to tensors that can be used as
+inputs for RTen models.

--- a/rten-simd/src/README.md
+++ b/rten-simd/src/README.md
@@ -1,0 +1,2 @@
+This crate contains RTen's portable SIMD library. It is used to implement
+vectorized kernels for neural network operators.

--- a/rten-vecmath/README.md
+++ b/rten-vecmath/README.md
@@ -1,11 +1,12 @@
 # rten-vecmath
 
-This crate provides portable SIMD types that abstract over SIMD intrinsics on
-different architectures. Unlike
-[`std::simd`](https://doc.rust-lang.org/std/simd/index.html) this works on
-stable Rust. There is also functionality to detect the available instructions
-at runtime and dispatch to the optimal implementation.
+This crate contains SIMD-vectorized kernels ("vectorized math") for various
+operations used in machine learning models. This includes:
 
-This crate also contains SIMD-vectorized versions of math functions such as exp,
-erf, tanh, softmax etc. that are performance-critical in machine-learning
-models.
+ - Math functions such as exp, erf, tanh
+ - Activation function such as gelu
+ - Normalization functions such as softmax and mean-variance normalization
+ - Reduction functions such as sums and sum-of-square
+
+SIMD operations are implemented using portable SIMD types from the rten-simd
+crate.


### PR DESCRIPTION
Each crate directory root contains a short README summarizing what it is for. Update the rten-vecmath README that was out of date and add these files to other crates that were missing them.