### PR TITLE
Support indexing 1D tensors using scalars instead of arrays

### DIFF
--- a/rten-tensor/src/layout.rs
+++ b/rten-tensor/src/layout.rs
@@ -1301,6 +1301,12 @@ impl<const N: usize> AsIndex<NdLayout<N>> for [usize; N] {
     }
 }
 
+impl AsIndex<NdLayout<1>> for usize {
+    fn as_index(&self) -> [usize; 1] {
+        [*self]
+    }
+}
+
 /// Trait that removes one dimension from a layout.
 pub trait RemoveDim {
     type Output: MutLayout;

--- a/src/ops/conv/depthwise.rs
+++ b/src/ops/conv/depthwise.rs
@@ -98,7 +98,7 @@ fn conv_2d_depthwise_block<X, W, Y>(
         let in_chan_data = in_chan.data().unwrap();
 
         let init_value = if let Some(bias) = bias {
-            bias[[c]]
+            bias[c]
         } else {
             Y::default()
         };

--- a/src/ops/generate.rs
+++ b/src/ops/generate.rs
@@ -70,7 +70,7 @@ pub fn onehot<T: Copy + Default + PartialEq>(
 
 fn extract_on_off_values<T: Copy>(values: NdTensorView<T, 1>) -> Result<(T, T), OpError> {
     if values.len() == 2 {
-        Ok((values[[0]], values[[1]]))
+        Ok((values[0], values[1]))
     } else {
         Err(OpError::InvalidValue("Expected size-2 vector"))
     }

--- a/src/ops/layout.rs
+++ b/src/ops/layout.rs
@@ -619,7 +619,7 @@ pub fn unsqueeze_in_place<T: Clone>(
     axes: &NdTensorView<i32, 1>,
 ) -> Result<Tensor<T>, OpError> {
     let sorted_axes = if axes.len() == 1 {
-        let axis = resolve_axis(input.ndim() + 1, axes[[0]] as isize)?;
+        let axis = resolve_axis(input.ndim() + 1, axes[0] as isize)?;
         SmallVec::from_slice(&[axis])
     } else {
         let mut sorted_axes = resolve_axes(input.ndim() + axes.len(), axes.iter())?;

--- a/src/ops/norm.rs
+++ b/src/ops/norm.rs
@@ -160,10 +160,10 @@ pub fn batch_norm_in_place(
 
     for n in 0..batch {
         for c in 0..chans {
-            let chan_mean = mean[[c]];
-            let chan_var = var[[c]];
-            let chan_scale = scale[[c]];
-            let chan_bias = bias[[c]];
+            let chan_mean = mean[c];
+            let chan_var = var[c];
+            let chan_scale = scale[c];
+            let chan_bias = bias[c];
             let mut chan = input.slice_mut([n, c]);
             let chan_data = chan.data_mut().unwrap();
 
@@ -309,8 +309,8 @@ pub fn instance_normalization_in_place(
                 chan_data.into(),
                 NormalizeOptions {
                     epsilon,
-                    scale: scale[[c]],
-                    bias: bias[[c]],
+                    scale: scale[c],
+                    bias: bias[c],
                     ..Default::default()
                 },
             );
@@ -674,8 +674,8 @@ mod tests {
 
             let flattened = input.reshaped([input.len()]);
 
-            let y1 = (flattened[[0]] - mean[0]) / (var[0] + epsilon).sqrt() * scale[0] + bias[0];
-            let y2 = (flattened[[1]] - mean[1]) / (var[1] + epsilon).sqrt() * scale[1] + bias[1];
+            let y1 = (flattened[0] - mean[0]) / (var[0] + epsilon).sqrt() * scale[0] + bias[0];
+            let y2 = (flattened[1] - mean[1]) / (var[1] + epsilon).sqrt() * scale[1] + bias[1];
             let expected = Tensor::from_data(input.shape(), vec![y1, y2]);
             let result = batch_norm(
                 &pool,

--- a/src/ops/pad.rs
+++ b/src/ops/pad.rs
@@ -31,7 +31,7 @@ pub fn pad<T: Copy>(
         .iter()
         .enumerate()
         .map(|(i, size)| {
-            let start_pad = padding[[i]] as usize;
+            let start_pad = padding[i] as usize;
             let end_pad = padding[[input.ndim() + i]] as usize;
             start_pad + size + end_pad
         })
@@ -49,7 +49,7 @@ pub fn pad<T: Copy>(
                 .iter()
                 .enumerate()
                 .map(|(i, size)| {
-                    let start_pad = padding[[i]] as usize;
+                    let start_pad = padding[i] as usize;
                     (start_pad..start_pad + size).into()
                 })
                 .collect();

--- a/src/ops/pooling.rs
+++ b/src/ops/pooling.rs
@@ -321,14 +321,14 @@ pub fn global_average_pool(pool: &TensorPool, input: TensorView) -> Result<Tenso
                 }
 
                 for i in 0..N {
-                    out_group[[i]].write(sums[i] / (in_h * in_w) as f32);
+                    out_group[i].write(sums[i] / (in_h * in_w) as f32);
                 }
                 n_init += N;
             } else {
                 // Compute average over remaining channels.
                 for i in 0..chan_group.size(0) {
                     let sum: f32 = chan_group.slice([i]).iter().sum();
-                    out_group[[i]].write(sum / (in_h * in_w) as f32);
+                    out_group[i].write(sum / (in_h * in_w) as f32);
                     n_init += 1;
                 }
             }

--- a/src/ops/slice.rs
+++ b/src/ops/slice.rs
@@ -37,12 +37,12 @@ fn slice_ranges(
         .collect();
     for (i, (start, end)) in starts.iter().zip(ends.iter()).enumerate() {
         let axis = if let Some(axes) = axes {
-            resolve_axis(input_shape.len(), axes[[i]] as isize)?
+            resolve_axis(input_shape.len(), axes[i] as isize)?
         } else {
             i
         };
 
-        let step = steps.map(|s| s[[i]]).unwrap_or(1);
+        let step = steps.map(|s| s[i]).unwrap_or(1);
         ranges[axis] = SliceRange::new(*start as isize, Some(*end as isize), step as isize);
     }
     Ok(ranges)


### PR DESCRIPTION
Make indexing 1D tensors more ergonomic by supporting `tensor[index]` instead of `tensor[[index]]` where `index` is a usize.