### PR TITLE
Better track output buffer lifetime and initialized state via types in GEMM internals

### DIFF
--- a/src/gemm/kernels.rs
+++ b/src/gemm/kernels.rs
@@ -45,8 +45,9 @@ pub enum Lhs<'a, T> {
 ///
 /// # Safety
 ///
-/// It must only be possible to construct the kernel using `new` if the
-/// instructions it uses are supported on the current system.
+/// - It must only be possible to construct the kernel using `new` if the
+///   instructions it uses are supported on the current system.
+/// - Kernels must initialize all output elements when `beta` is zero.
 ///
 /// [^1]: https://dl.acm.org/doi/pdf/10.1145/2925987
 pub unsafe trait Kernel<LhsT, RhsT, OutT>: Sync {
@@ -130,6 +131,14 @@ pub unsafe trait Kernel<LhsT, RhsT, OutT>: Sync {
     /// # Safety
     ///
     /// If `beta` is zero then the output may be uninitialized and must not be
-    /// read by the implementation.
-    fn gemv_kernel(&self, out: &mut [OutT], a: &[LhsT], b: Matrix<RhsT>, alpha: f32, beta: OutT);
+    /// read by the implementation. After the kernel has run, all elements will
+    /// be initialized.
+    fn gemv_kernel(
+        &self,
+        out: &mut [MaybeUninit<OutT>],
+        a: &[LhsT],
+        b: Matrix<RhsT>,
+        alpha: f32,
+        beta: OutT,
+    );
 }

--- a/src/gemm/kernels/aarch64.rs
+++ b/src/gemm/kernels/aarch64.rs
@@ -84,7 +84,14 @@ unsafe impl Kernel<f32, f32, f32> for ArmNeonKernel {
         );
     }
 
-    fn gemv_kernel(&self, out: &mut [f32], a: &[f32], b: Matrix, alpha: f32, beta: f32) {
+    fn gemv_kernel(
+        &self,
+        out: &mut [MaybeUninit<f32>],
+        a: &[f32],
+        b: Matrix,
+        alpha: f32,
+        beta: f32,
+    ) {
         // Safety - float32x4_t is supported if this kernel was constructed.
         unsafe {
             simd_gemv::<float32x4_t, 4>(out, a, b, alpha, beta);

--- a/src/gemm/kernels/generic.rs
+++ b/src/gemm/kernels/generic.rs
@@ -88,7 +88,14 @@ unsafe impl Kernel<f32, f32, f32> for GenericKernel {
         );
     }
 
-    fn gemv_kernel(&self, out: &mut [f32], a: &[f32], b: Matrix, alpha: f32, beta: f32) {
+    fn gemv_kernel(
+        &self,
+        out: &mut [MaybeUninit<f32>],
+        a: &[f32],
+        b: Matrix,
+        alpha: f32,
+        beta: f32,
+    ) {
         // Safety - f32 "SIMD" type is always supported
         unsafe {
             simd_gemv::<f32, 4>(out, a, b, alpha, beta);

--- a/src/gemm/kernels/wasm.rs
+++ b/src/gemm/kernels/wasm.rs
@@ -88,7 +88,14 @@ unsafe impl Kernel<f32, f32, f32> for WasmKernel {
         );
     }
 
-    fn gemv_kernel(&self, out: &mut [f32], a: &[f32], b: Matrix, alpha: f32, beta: f32) {
+    fn gemv_kernel(
+        &self,
+        out: &mut [MaybeUninit<f32>],
+        a: &[f32],
+        b: Matrix,
+        alpha: f32,
+        beta: f32,
+    ) {
         // Safety - WASM SIMD types are supported if this kernel was constructed.
         unsafe {
             simd_gemv::<v128f, 4>(out, a, b, alpha, beta);

--- a/src/gemm/kernels/x86_64.rs
+++ b/src/gemm/kernels/x86_64.rs
@@ -126,10 +126,23 @@ unsafe impl Kernel<f32, f32, f32> for FmaKernel {
         );
     }
 
-    fn gemv_kernel(&self, out: &mut [f32], a: &[f32], b: Matrix, alpha: f32, beta: f32) {
+    fn gemv_kernel(
+        &self,
+        out: &mut [MaybeUninit<f32>],
+        a: &[f32],
+        b: Matrix,
+        alpha: f32,
+        beta: f32,
+    ) {
         #[target_feature(enable = "avx2")]
         #[target_feature(enable = "fma")]
-        unsafe fn gemv_kernel_impl(out: &mut [f32], a: &[f32], b: Matrix, alpha: f32, beta: f32) {
+        unsafe fn gemv_kernel_impl(
+            out: &mut [MaybeUninit<f32>],
+            a: &[f32],
+            b: Matrix,
+            alpha: f32,
+            beta: f32,
+        ) {
             simd_gemv::<__m256, 4>(out, a, b, alpha, beta);
         }
         // Safety: Kernel can only be constructed if supported.
@@ -232,10 +245,23 @@ unsafe impl Kernel<f32, f32, f32> for Avx512Kernel {
         )
     }
 
-    fn gemv_kernel(&self, out: &mut [f32], a: &[f32], b: Matrix, alpha: f32, beta: f32) {
+    fn gemv_kernel(
+        &self,
+        out: &mut [MaybeUninit<f32>],
+        a: &[f32],
+        b: Matrix,
+        alpha: f32,
+        beta: f32,
+    ) {
         #[target_feature(enable = "avx512f")]
         #[target_feature(enable = "avx512vl")]
-        unsafe fn gemv_kernel_impl(out: &mut [f32], a: &[f32], b: Matrix, alpha: f32, beta: f32) {
+        unsafe fn gemv_kernel_impl(
+            out: &mut [MaybeUninit<f32>],
+            a: &[f32],
+            b: Matrix,
+            alpha: f32,
+            beta: f32,
+        ) {
             simd_gemv::<__m512, 2>(out, a, b, alpha, beta);
         }
         // Safety: Kernel can only be constructed if supported.


### PR DESCRIPTION
For performance the GEMM internals use raw pointers for output tiles, which may be uninitialized if `beta` is zero. Add lifetimes to `OutputTiles` and make more use of `MaybeUninit<OutT>` to track the initialization status of each output tile through the implementation.