### PR TITLE
Refactor GEMM prepacking to depend on fewer blocking parameters

### DIFF
--- a/src/gemm/kernels.rs
+++ b/src/gemm/kernels.rs
@@ -57,10 +57,10 @@ pub unsafe trait Kernel<LhsT, RhsT, OutT>: Sync {
     where
         Self: Sized;
 
-    /// Return the width of this kernel's tiles.
+    /// Return the number of rows in each tile.
     fn mr(&self) -> usize;
 
-    /// Return the height of this kernel's tiles.
+    /// Return the number of columns in each tile.
     fn nr(&self) -> usize;
 
     /// Return a name for this kernel for use in logging etc.
@@ -75,8 +75,7 @@ pub unsafe trait Kernel<LhsT, RhsT, OutT>: Sync {
         cols: Range<usize>,
     );
 
-    /// Pack a block of the RHS / "B" input for use
-    /// by this kernel.
+    /// Pack a block of the RHS / "B" input for use by this kernel.
     fn pack_b_block(
         &self,
         out: &mut [MaybeUninit<RhsT>],


### PR DESCRIPTION
In preparation for longer-lived pre-packed matrices, reduce the number of parameters that affect the packed layout and have to be kept the same at the time of pre-packing and later usage.

Previously the packed layout depended on the NC, KC, MC, MR and NR blocking parameters, plus the size of the input matrix. Change it so that it only depends on the MR and NR parameters for packed A and B matrices respectively. The NC parameter varied depending on the thread pool size, so prepacked buffers would become unusable if the thread pool size changed.

This is achieved by revising the packed layout so that packed A matrices with shape `M*K` are laid out as row panels of height MR and width K.  Packed B matrices with shape `K*N` are laid out as column panels of width NR and height K. Compared to the previous layout this means there may be a gap between each of the `MR*KC` and `NR*KC`-shaped panels used by each call to the kernel. This is handled by adding a `panel_stride` field to the packed block which is used when setting up the kernel inputs in `gemm_block`.

A downside of this change is that panels accessed by consecutive invocations of the kernel are no longer guaranteed to be contiguous in memory and are therefore less likely to have been prefetched by hardware prefetchers. Initial tests suggest the effect is small, and I plan to work around this if necessary by adding explicit prefetches in software if necessary.