### PR TITLE
Support pre-packing weights after model optimization

### DIFF
--- a/src/gemm.rs
+++ b/src/gemm.rs
@@ -108,6 +108,16 @@ impl<T> PackedBMatrix<T> {
     fn panel_len(&self) -> usize {
         self.panel_width * self.rows
     }
+
+    /// Number of rows in the unpacked matrix.
+    pub fn rows(&self) -> usize {
+        self.rows
+    }
+
+    /// Number of columns in the unpacked matrix.
+    pub fn cols(&self) -> usize {
+        self.cols
+    }
 }
 
 impl<T> ExtractBuffer for PackedBMatrix<T> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,6 +109,7 @@ mod slice_reductions;
 mod tensor_pool;
 mod threading;
 mod timing;
+mod weight_cache;
 
 #[cfg(feature = "wasm_api")]
 mod wasm_api;

--- a/src/ops/control_flow.rs
+++ b/src/ops/control_flow.rs
@@ -4,6 +4,7 @@ use smallvec::SmallVec;
 use crate::graph::{CaptureEnv, Graph, RunError, RunOptions};
 use crate::ops::{InputList, OpError, Operator, Output, OutputList};
 use crate::tensor_pool::TensorPool;
+use crate::weight_cache::WeightCache;
 
 fn output_list_from_vec(xs: Vec<Output>) -> OutputList {
     xs.into_iter().collect()
@@ -47,6 +48,7 @@ impl Operator for If {
         pool: &TensorPool,
         inputs: InputList,
         captures: CaptureEnv,
+        weight_caches: Option<&[WeightCache]>,
         run_opts: Option<RunOptions>,
     ) -> Result<OutputList, RunError> {
         let cond: TensorView<i32> = inputs.require_as(0).map_err(run_error_from_op_error)?;
@@ -63,6 +65,7 @@ impl Operator for If {
                     self.then_branch.output_ids(),
                     captures,
                     Some(pool),
+                    weight_caches.map(|wcs| &wcs[0]),
                     run_opts,
                 )
                 .map(output_list_from_vec)
@@ -73,6 +76,7 @@ impl Operator for If {
                     self.else_branch.output_ids(),
                     captures,
                     Some(pool),
+                    weight_caches.map(|wcs| &wcs[1]),
                     run_opts,
                 )
                 .map(output_list_from_vec)

--- a/src/ops/einsum.rs
+++ b/src/ops/einsum.rs
@@ -497,7 +497,7 @@ fn einsum_matmul(
 
     let xp = permute_and_insert_axes(x, term1, &x_order);
     let yp = permute_and_insert_axes(y, term2, &y_order);
-    let mut out = matmul(pool, xp, yp)?;
+    let mut out = matmul(pool, xp, yp, None)?;
 
     if !matmul_m.is_ascii_lowercase() {
         out.remove_axis(out.ndim() - 2);
@@ -720,7 +720,7 @@ mod tests {
 
         let mat_a = Tensor::from([[1., 2., 3.], [4., 5., 6.]]);
         let mat_b = Tensor::from([[1., 2., 3., 4.], [5., 6., 7., 8.], [9., 10., 11., 12.]]);
-        let matmul_ab = matmul(&pool, mat_a.view(), mat_b.view()).unwrap();
+        let matmul_ab = matmul(&pool, mat_a.view(), mat_b.view(), None).unwrap();
         let matmul_ba = matmul_ab.transposed().to_tensor();
         let outer_mat_ab = mul(
             &pool,
@@ -867,7 +867,7 @@ mod tests {
             Case {
                 equation: "ij,j->i",
                 inputs: vec![mat_a.view(), mat_b.slice((.., 0))],
-                expected: Ok(matmul(&pool, mat_a.view(), mat_b.slice((.., ..1)))
+                expected: Ok(matmul(&pool, mat_a.view(), mat_b.slice((.., ..1)), None)
                     .unwrap()
                     .into_shape([mat_a.size(0)].as_slice())),
             },
@@ -875,7 +875,7 @@ mod tests {
             Case {
                 equation: "j,jk->k",
                 inputs: vec![mat_a.slice(0), mat_b.view()],
-                expected: Ok(matmul(&pool, mat_a.slice((..1, ..)), mat_b.view())
+                expected: Ok(matmul(&pool, mat_a.slice((..1, ..)), mat_b.view(), None)
                     .unwrap()
                     .into_shape([mat_b.size(1)].as_slice())),
             },

--- a/src/ops/fused.rs
+++ b/src/ops/fused.rs
@@ -1,8 +1,9 @@
 use std::sync::Arc;
 
 use rten_tensor::prelude::*;
+use smallvec::SmallVec;
 
-use crate::ops::{Input, InputList, OpError, Operator, OutputList};
+use crate::ops::{Input, InputList, OpError, Operator, OutputList, PrepackedInput};
 use crate::tensor_pool::TensorPool;
 
 /// Specifies a permutation to an operator input.
@@ -75,6 +76,14 @@ impl Operator for FusedTranspose {
     fn run(&self, pool: &TensorPool, mut inputs: InputList) -> Result<OutputList, OpError> {
         self.perm.apply(&mut inputs)?;
         self.inner.run(pool, inputs)
+    }
+
+    fn prepack_inputs(&self) -> SmallVec<[usize; 1]> {
+        self.inner.prepack_inputs()
+    }
+
+    fn prepack(&self, index: usize, input: Input) -> Option<PrepackedInput> {
+        self.inner.prepack(index, input)
     }
 }
 

--- a/src/ops/operators.rs
+++ b/src/ops/operators.rs
@@ -194,7 +194,7 @@ impl<T: Send, S: Storage<Elem = T>, L: MutLayout> Operators for TensorBase<S, L>
 impl<S: Storage<Elem = f32>, L: MutLayout> FloatOperators for TensorBase<S, L> {
     fn matmul(&self, other: TensorView) -> Result<Tensor, OpError> {
         let view = self.as_dyn();
-        use_thread_pool(|| matmul(&TensorPool::new(), view, other))
+        use_thread_pool(|| matmul(&TensorPool::new(), view, other, None))
     }
 
     fn reduce_l2(&self, axes: Option<&[i32]>, keep_dims: bool) -> Result<Tensor, OpError> {

--- a/src/wasm_api.rs
+++ b/src/wasm_api.rs
@@ -214,7 +214,7 @@ impl Tensor {
         let a = self.as_float()?;
         let b = other.as_float()?;
         let pool = TensorPool::new();
-        let out = matmul(&pool, a, b).map_err(|e| e.to_string())?;
+        let out = matmul(&pool, a, b, None).map_err(|e| e.to_string())?;
         Ok(Tensor::from_output(out.into()))
     }
 }

--- a/src/weight_cache.rs
+++ b/src/weight_cache.rs
@@ -1,0 +1,71 @@
+use rustc_hash::FxHashMap;
+
+use crate::graph::NodeId;
+use crate::ops::PrepackedInput;
+
+/// A cache of prepacked weights for graph operators.
+///
+/// The weight cache has a hierarchical structure which mirrors the model
+/// graph. At the top level is the root graph. For each operator with a
+/// subgraph (eg. control flow operators) there are separate sub-caches.
+pub struct WeightCache {
+    /// Map of constant node ID to prepacked weights.
+    cache: FxHashMap<NodeId, PrepackedInput>,
+
+    /// Map of operator ID to caches for the operator's subgraphs.
+    subgraph_caches: FxHashMap<NodeId, Vec<WeightCache>>,
+}
+
+impl WeightCache {
+    /// Create an empty cache.
+    pub fn new() -> WeightCache {
+        WeightCache {
+            cache: FxHashMap::default(),
+            subgraph_caches: FxHashMap::default(),
+        }
+    }
+
+    /// Check if a pre-packed weight exists for a given constant node ID.
+    pub fn contains(&self, node: NodeId) -> bool {
+        self.cache.contains_key(&node)
+    }
+
+    /// Add a prepacked weight to the cache.
+    pub fn insert(&mut self, node: NodeId, packed: PrepackedInput) {
+        self.cache.insert(node, packed);
+    }
+
+    /// Look up weight in the cache.
+    pub fn get(&self, node: NodeId) -> Option<&PrepackedInput> {
+        self.cache.get(&node)
+    }
+
+    /// Add caches for subgraphs belonging to an operator.
+    pub fn insert_subgraph_caches(&mut self, operator_id: NodeId, caches: Vec<WeightCache>) {
+        self.subgraph_caches.insert(operator_id, caches);
+    }
+
+    /// Look up caches for an operator's subgraphs.
+    pub fn get_subgraph_caches(&self, operator_id: NodeId) -> Option<&[WeightCache]> {
+        self.subgraph_caches
+            .get(&operator_id)
+            .map(|wcs| wcs.as_slice())
+    }
+
+    /// Return the total number of cached weights, including in subgraphs.
+    pub fn len(&self) -> usize {
+        self.cache.len()
+            + self
+                .subgraph_caches
+                .values()
+                .flat_map(|caches| caches.iter())
+                .map(|cache| cache.len())
+                .sum::<usize>()
+    }
+}
+
+impl Default for WeightCache {
+    fn default() -> Self {
+        WeightCache::new()
+    }
+}


### PR DESCRIPTION
This reduces inference time for matmul operations at the cost of higher memory usage. Prepacking is initially disabled by default as there are common situations (single inference run, large transformer decoder models) where it isn't worthwhile. It is enabled via `ModelOptions::prepack_weights`:

```rs
let mut model_options = ModelOptions::with_all_ops();
model_options.prepack_weights(true);
let model = model_options.load_file(path)
```

To facilitate a quick comparison of the performance impact of prepacking, the rten CLI now has a `--prepacked` option to enable prepacking.

There are some caveats:

 - Non-MatMul operations which use matmuls internally (Conv, ConvTranspose, LSTM, GRU etc.) currently don't prepack their weights.
 - MatMul operations which turn out to be matrix-vector (gemv) products don't use the prepacked weights. This affects transformer decoders doing non-batched generation after the initial prompt encoding step.

Fixes https://github.com/robertknight/rten/issues/214.

**TODO:**

- [x] Tests
- [x] Make it configurable whether prepacking is used
- [x] Support subgraphs
