### PR TITLE
Fuse MatMul + Mul/Div by constant

### DIFF
--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -84,7 +84,7 @@ pub use layout::{
     depth_to_space, expand, flatten, reshape, squeeze, squeeze_in_place, DepthToSpace,
     DepthToSpaceMode, Expand, Flatten, Reshape, Shape, Size, Squeeze, Transpose, Unsqueeze,
 };
-pub use matmul::{gemm_op, matmul, Gemm, MatMul, MatMulAdd, MatMulInteger};
+pub use matmul::{gemm_op, matmul, FusedMatMul, Gemm, MatMul, MatMulInteger};
 pub use non_max_suppression::{non_max_suppression, BoxOrder, NonMaxSuppression};
 pub use norm::{
     batch_norm, batch_norm_in_place, instance_normalization, layer_normalization, log_softmax,


### PR DESCRIPTION
A subgraph of the form `Mul(MatMul(Mul(A, c), Mul(B, d)), e)` where all of the `Mul`s are optional and c, d and e are constants can be rewritten as `MatMul(A, B, alpha = c * d * e)` where `alpha` is the scaling already handled by the `C = alpha * AB + beta * C` result that GEMM already computes. Such scaling is common in transformers as part of attention operations (SDPA).

The initial implementation only handles two specific cases of this form which have been seen in real models. This should be generalized to all possible cases.