### PR TITLE
Fuse Swish operations

### DIFF
--- a/rten-vecmath/src/exp.rs
+++ b/rten-vecmath/src/exp.rs
@@ -214,12 +214,6 @@ unsafe fn simd_silu<S: SimdFloat>(x: S) -> S {
     x.mul(simd_sigmoid(x))
 }
 
-/// Sigmoid Linear Unit (SiLU) function. This computes `x * sigmoid(x)`.
-pub fn silu(x: f32) -> f32 {
-    // Safety: f32 is available on all systems
-    unsafe { simd_silu(x) }
-}
-
 struct SimdSilu {}
 impl SimdUnaryOp for SimdSilu {
     #[inline(always)]
@@ -242,6 +236,45 @@ pub fn vec_silu_in_place(xs: &mut [f32]) {
     dispatch_map_op_in_place(xs, SimdSilu {});
 }
 
+/// Sigmoid Linear Unit (SiLU) function. This computes `x * sigmoid(x)`.
+pub fn silu(x: f32) -> f32 {
+    // Safety: f32 is available on all systems
+    unsafe { simd_silu(x) }
+}
+
+struct SimdSwish {
+    beta: f32,
+}
+
+impl SimdUnaryOp for SimdSwish {
+    #[inline(always)]
+    unsafe fn eval<S: SimdFloat>(&self, x: S) -> S {
+        let beta = S::splat(self.beta);
+        x.mul(simd_sigmoid(x.mul(beta)))
+    }
+}
+
+/// Vectorized Swish function.
+///
+/// This computes `x * sigmoid(beta * x)` for each element.
+pub fn vec_swish(xs: &[f32], out: &mut [MaybeUninit<f32>], beta: f32) {
+    dispatch_map_op(xs, out, SimdSwish { beta });
+}
+
+/// Vectorized Swish function.
+///
+/// This computes `x * sigmoid(beta * x)` for each element.
+pub fn vec_swish_in_place(xs: &mut [f32], beta: f32) {
+    dispatch_map_op_in_place(xs, SimdSwish { beta });
+}
+
+/// Swish function. This computes `x * sigmoid(beta * x)`.
+pub fn swish(x: f32, beta: f32) -> f32 {
+    // Safety: f32 is available on all systems
+    let op = SimdSwish { beta };
+    unsafe { op.eval(x) }
+}
+
 #[cfg(test)]
 mod tests {
     use std::mem::MaybeUninit;
@@ -249,7 +282,7 @@ mod tests {
     use crate::testing::{
         arange, benchmark_op, check_f32s_are_equal_ulps, check_with_all_f32s, AsUninit,
     };
-    use crate::{exp, vec_exp, vec_sigmoid, vec_silu};
+    use crate::{exp, vec_exp, vec_sigmoid, vec_silu, vec_swish};
 
     // Maximum error of `vec_expf` compared to Rust standard library
     // implementation.
@@ -265,6 +298,10 @@ mod tests {
 
     fn reference_silu(x: f32) -> f32 {
         x * reference_sigmoid(x)
+    }
+
+    fn reference_swish(x: f32, beta: f32) -> f32 {
+        x * reference_sigmoid(beta * x)
     }
 
     /// Check the results of a SIMD implementation of a unary operator against
@@ -370,6 +407,17 @@ mod tests {
             MAX_SIGMOID_ERROR_ULPS,
             arange(-6., 6., 0.001f32),
         );
+    }
+
+    #[test]
+    fn test_swish() {
+        let beta = 1.7;
+        check_simd_vs_reference(
+            |src, dest| vec_swish(src, dest, beta),
+            |x| reference_swish(x, beta),
+            MAX_SIGMOID_ERROR_ULPS,
+            arange(-6., 6., 0.001f32),
+        )
     }
 
     #[test]

--- a/rten-vecmath/src/exp.rs
+++ b/rten-vecmath/src/exp.rs
@@ -132,6 +132,30 @@ pub(crate) unsafe fn simd_exp<S: SimdFloat>(x: S) -> S {
     r.blend(S::zero(), underflow_mask)
 }
 
+struct SimdExp {}
+impl SimdUnaryOp for SimdExp {
+    #[inline(always)]
+    unsafe fn eval<S: SimdFloat>(&self, x: S) -> S {
+        simd_exp(x)
+    }
+}
+
+/// Vectorized exponential function.
+///
+/// This is a vectorized version of [`exp`] that computes the function for each
+/// element in `xs` and writes the result to `out`. `xs` and `out` must be equal
+/// in length.
+///
+/// `out` will be fully initialized after this function returns.
+pub fn vec_exp(xs: &[f32], out: &mut [MaybeUninit<f32>]) {
+    dispatch_map_op(xs, out, SimdExp {});
+}
+
+/// Variant of [`vec_exp`] that modifies elements in-place.
+pub fn vec_exp_in_place(xs: &mut [f32]) {
+    dispatch_map_op_in_place(xs, SimdExp {});
+}
+
 /// Compute sigmoid of each element in a SIMD vector.
 ///
 /// ie. This computes `1. / (1. + exp(-x))`.
@@ -216,30 +240,6 @@ pub fn vec_silu(xs: &[f32], out: &mut [MaybeUninit<f32>]) {
 /// This computes `x * sigmoid(x)` for each element.
 pub fn vec_silu_in_place(xs: &mut [f32]) {
     dispatch_map_op_in_place(xs, SimdSilu {});
-}
-
-struct SimdExp {}
-impl SimdUnaryOp for SimdExp {
-    #[inline(always)]
-    unsafe fn eval<S: SimdFloat>(&self, x: S) -> S {
-        simd_exp(x)
-    }
-}
-
-/// Vectorized exponential function.
-///
-/// This is a vectorized version of [`exp`] that computes the function for each
-/// element in `xs` and writes the result to `out`. `xs` and `out` must be equal
-/// in length.
-///
-/// `out` will be fully initialized after this function returns.
-pub fn vec_exp(xs: &[f32], out: &mut [MaybeUninit<f32>]) {
-    dispatch_map_op(xs, out, SimdExp {});
-}
-
-/// Variant of [`vec_exp`] that modifies elements in-place.
-pub fn vec_exp_in_place(xs: &mut [f32]) {
-    dispatch_map_op_in_place(xs, SimdExp {});
 }
 
 #[cfg(test)]

--- a/rten-vecmath/src/lib.rs
+++ b/rten-vecmath/src/lib.rs
@@ -32,8 +32,8 @@ mod testing;
 
 pub use erf::{erf, gelu, vec_erf, vec_erf_in_place, vec_gelu, vec_gelu_in_place};
 pub use exp::{
-    exp, sigmoid, silu, vec_exp, vec_exp_in_place, vec_sigmoid, vec_sigmoid_in_place, vec_silu,
-    vec_silu_in_place,
+    exp, sigmoid, silu, swish, vec_exp, vec_exp_in_place, vec_sigmoid, vec_sigmoid_in_place,
+    vec_silu, vec_silu_in_place, vec_swish, vec_swish_in_place,
 };
 pub use normalize::{vec_normalize, vec_normalize_in_place};
 pub use softmax::{vec_softmax, vec_softmax_in_place};

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -121,10 +121,10 @@ pub use unary_elementwise::{
     hard_sigmoid_in_place, hard_swish, hard_swish_in_place, leaky_relu, leaky_relu_in_place, log,
     log_in_place, neg, neg_in_place, not, not_in_place, reciprocal, reciprocal_in_place, relu,
     relu_in_place, round, round_in_place, sigmoid, sigmoid_in_place, sign, sign_in_place, silu,
-    silu_in_place, sin, sin_in_place, softplus, softplus_in_place, sqrt, sqrt_in_place, tan,
-    tan_in_place, tanh, tanh_in_place, Abs, Acos, Asin, Atan, Ceil, Clip, Cos, Elu, Erf, Exp,
-    Floor, Gelu, HardSigmoid, HardSwish, LeakyRelu, Log, Neg, Not, Reciprocal, Relu, Round,
-    Sigmoid, Sign, Silu, Sin, Softplus, Sqrt, Tan, Tanh,
+    silu_in_place, sin, sin_in_place, softplus, softplus_in_place, sqrt, sqrt_in_place, swish,
+    swish_in_place, tan, tan_in_place, tanh, tanh_in_place, Abs, Acos, Asin, Atan, Ceil, Clip, Cos,
+    Elu, Erf, Exp, Floor, Gelu, HardSigmoid, HardSwish, LeakyRelu, Log, Neg, Not, Reciprocal, Relu,
+    Round, Sigmoid, Sign, Silu, Sin, Softplus, Sqrt, Swish, Tan, Tanh,
 };
 pub use variadic_elementwise::{max, mean, min, sum, Max, Mean, Min, Sum};
 

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -176,6 +176,15 @@ impl GraphMutator {
         })
     }
 
+    /// Get the scalar value of a constant node, or `None` if the node is
+    /// not a constant or the value is not a scalar.
+    fn get_scalar(&self, node_id: NodeId) -> Option<f32> {
+        self.graph.get_node(node_id).and_then(|node| match node {
+            Node::Constant(const_node) => const_node.as_scalar(),
+            _ => None,
+        })
+    }
+
     fn set_captures(&mut self, captures: &[NodeId]) {
         self.graph.set_captures(captures)
     }
@@ -457,18 +466,11 @@ impl GraphOptimizer {
         let beta = const_symbol("beta");
         let swish_pattern = x.clone() * unary_op("Sigmoid", beta * x.clone());
 
-        let get_const_scalar = |graph: &Graph, node_id: NodeId| -> Option<f32> {
-            graph.get_node(node_id).and_then(|node| match node {
-                Node::Constant(const_node) => const_node.as_scalar(),
-                _ => None,
-            })
-        };
-
         graph.apply_fusion(|graph, op_node_id, op_node| {
             let swish_match = swish_pattern.test(op_node_id, graph.graph())?;
             let swish_input = swish_match.resolved_symbol("x").expect("missing symbol");
             let beta_input = swish_match.resolved_symbol("beta").expect("missing symbol");
-            let beta = get_const_scalar(graph.graph(), beta_input)?;
+            let beta = graph.get_scalar(beta_input)?;
             let op_output = op_node.output_id()?;
 
             Some(Fusion::from_op(
@@ -535,40 +537,34 @@ impl GraphOptimizer {
             }
         };
 
-        let get_const_scalar = |graph: &Graph, node_id: NodeId| -> Option<f32> {
-            graph.get_node(node_id).and_then(|node| match node {
-                Node::Constant(const_node) => const_node.as_scalar(),
-                _ => None,
-            })
-        };
-
         // Test if `op_node` is a Mul or Div node with one constant scalar
         // input and one non-constant input. If so, returns the constant scalar
         // which the node multiplies the other input by and the ID of the other
         // input.
-        let get_scale_factor = |graph: &Graph, op_node: &OperatorNode| -> Option<(f32, NodeId)> {
-            let op_type = op_node.operator().name();
-            if !["Mul", "Div"].contains(&op_type) {
-                return None;
-            }
+        let get_scale_factor =
+            |graph: &GraphMutator, op_node: &OperatorNode| -> Option<(f32, NodeId)> {
+                let op_type = op_node.operator().name();
+                if !["Mul", "Div"].contains(&op_type) {
+                    return None;
+                }
 
-            let [lhs, rhs] = binary_op_input_ids(op_node)?;
-            let lhs_scalar = get_const_scalar(graph, lhs);
-            let rhs_scalar = get_const_scalar(graph, rhs);
+                let [lhs, rhs] = binary_op_input_ids(op_node)?;
+                let lhs_scalar = graph.get_scalar(lhs);
+                let rhs_scalar = graph.get_scalar(rhs);
 
-            match op_type {
-                "Mul" => match (lhs_scalar, rhs_scalar) {
-                    (Some(lhs_scale), None) => Some((lhs_scale, rhs)),
-                    (None, Some(rhs_scale)) => Some((rhs_scale, lhs)),
+                match op_type {
+                    "Mul" => match (lhs_scalar, rhs_scalar) {
+                        (Some(lhs_scale), None) => Some((lhs_scale, rhs)),
+                        (None, Some(rhs_scale)) => Some((rhs_scale, lhs)),
+                        _ => None,
+                    },
+                    "Div" => match (lhs_scalar, rhs_scalar) {
+                        (None, Some(rhs_scale)) => Some((1. / rhs_scale, lhs)),
+                        _ => None,
+                    },
                     _ => None,
-                },
-                "Div" => match (lhs_scalar, rhs_scalar) {
-                    (None, Some(rhs_scale)) => Some((1. / rhs_scale, lhs)),
-                    _ => None,
-                },
-                _ => None,
-            }
-        };
+                }
+            };
 
         graph.apply_fusion(|graph, _op_node_id, op_node| {
             // Accumulated scale factor from scalings applied to MatMul inputs
@@ -576,13 +572,12 @@ impl GraphOptimizer {
             let mut alpha = 1.0;
 
             let op_output = op_node.output_id()?;
-            let graph = graph.graph();
 
             // Check if this is a Mul/Div node scaling the output of a MatMul.
             let matmul_node = if ["Mul", "Div"].contains(&op_node.operator().name()) {
                 let (output_scale, scale_input) = get_scale_factor(graph, op_node)?;
                 alpha *= output_scale;
-                let (_, scale_input_op) = graph.get_source_node(scale_input)?;
+                let (_, scale_input_op) = graph.graph().get_source_node(scale_input)?;
                 scale_input_op
             } else {
                 op_node
@@ -593,25 +588,27 @@ impl GraphOptimizer {
             }
 
             let [matmul_lhs, matmul_rhs] = binary_op_input_ids(matmul_node)?;
-            let lhs_input = if let Some((_, lhs_source_op)) = graph.get_source_node(matmul_lhs) {
-                let (lhs_scale, lhs_input) =
-                    get_scale_factor(graph, lhs_source_op).unwrap_or((1.0, matmul_lhs));
-                alpha *= lhs_scale;
-                lhs_input
-            } else {
-                // MatMul LHS is not computed by an upstream operator.
-                matmul_lhs
-            };
+            let lhs_input =
+                if let Some((_, lhs_source_op)) = graph.graph().get_source_node(matmul_lhs) {
+                    let (lhs_scale, lhs_input) =
+                        get_scale_factor(graph, lhs_source_op).unwrap_or((1.0, matmul_lhs));
+                    alpha *= lhs_scale;
+                    lhs_input
+                } else {
+                    // MatMul LHS is not computed by an upstream operator.
+                    matmul_lhs
+                };
 
-            let rhs_input = if let Some((_, rhs_source_op)) = graph.get_source_node(matmul_rhs) {
-                let (rhs_scale, rhs_input) =
-                    get_scale_factor(graph, rhs_source_op).unwrap_or((1.0, matmul_rhs));
-                alpha *= rhs_scale;
-                rhs_input
-            } else {
-                // MatMul RHS is not computed by an upstream operator.
-                matmul_rhs
-            };
+            let rhs_input =
+                if let Some((_, rhs_source_op)) = graph.graph().get_source_node(matmul_rhs) {
+                    let (rhs_scale, rhs_input) =
+                        get_scale_factor(graph, rhs_source_op).unwrap_or((1.0, matmul_rhs));
+                    alpha *= rhs_scale;
+                    rhs_input
+                } else {
+                    // MatMul RHS is not computed by an upstream operator.
+                    matmul_rhs
+                };
 
             if alpha == 1.0 {
                 // Scale factor of 1 has no effect.


### PR DESCRIPTION
Add a vectorized implementation of the Swish activation function that computes `x * sigmoid(beta * x)` and a graph fusion. Swish is used by [CLIP](https://huggingface.co/openai/clip-vit-base-patch32). This function is a generalization of the existing SiLU operator, which is similar except there is no `beta` parameter. The `Silu` operator could potentially be replaced with `Swish { beta: 1 }` in future, with a fast path in the kernel to handle the `beta = 1` case.

A few aspects of the implementation are slightly different than other parallel, vectorized unary operators because this is the first such case where are parameters in addition to the input.

Related spec issue: https://github.com/onnx/onnx/issues/5853