### PR TITLE
Optimize Gather with fast path for axis=0 case and avoiding slicing in general case

### DIFF
--- a/rten-tensor/src/lib.rs
+++ b/rten-tensor/src/lib.rs
@@ -120,7 +120,7 @@ pub use iterators::{
 };
 pub use layout::{
     is_valid_permutation, DynLayout, IntoLayout, Layout, MatrixLayout, MutLayout, NdLayout,
-    OverlapPolicy,
+    OverlapPolicy, ResizeLayout,
 };
 pub use slice_range::{to_slice_items, DynSliceItems, IntoSliceItems, SliceItem, SliceRange};
 

--- a/rten-tensor/src/tensor.rs
+++ b/rten-tensor/src/tensor.rs
@@ -1257,7 +1257,7 @@ where
     /// initialized before calling `assume_init`.
     pub unsafe fn assume_init(self) -> TensorBase<<S as AssumeInit>::Output, L> {
         TensorBase {
-            layout: self.layout.clone(),
+            layout: self.layout,
             data: self.data.assume_init(),
         }
     }


### PR DESCRIPTION
Optimize the Gather operator by:

- Adding a fast path for the case where `axis=0` and the input is contiguous. The output is then constructed by just copying contiguous chunks of the input to the output. This occurs when a transformer gathers embedding vectors from a `[token_id, d_embed]` matrix for example.
- Improving the general case by taking advantage of the fact that the layout of the gathered input slice and output slice is the same for each index, so we can construct the layout once and re-use them with different storage offsets on each iteration

Using the T5-small model, time spent in Gather ops for a sequence length of 512 goes from ~60ms to ~5ms using the fast path or ~25ms using the general path.

```
 rten models/t5-small/encoder_model.rten -s encoder_sequence_length=512
```