### PR TITLE
Refine `graph::build::Expr` APIs

### DIFF
--- a/src/graph/builder.rs
+++ b/src/graph/builder.rs
@@ -34,7 +34,7 @@ enum ExprKind {
 /// let sqrt_2 = Expr::constant((2.0f32).sqrt());
 /// let one = Expr::constant(1.0);
 /// let half = Expr::constant(0.5);
-/// let expr = x.clone() * (Expr::unary(Erf {}, x / sqrt_2) + one) * half;
+/// let expr = x.clone() * ((x / sqrt_2).unary(Erf {}) + one) * half;
 /// let graph: Graph = expr.build_graph(["x"]);
 /// ```
 ///
@@ -118,19 +118,19 @@ impl Expr {
         Expr::from(ExprKind::Constant(value.into()))
     }
 
-    /// Create a unary operator expression.
-    pub fn unary<Op: Operator + Send + Sync>(op: Op, input: Expr) -> Expr {
+    /// Create an expression which applies a unary operator to this expression.
+    pub fn unary<Op: Operator + Send + Sync>(&self, op: Op) -> Expr {
         Expr::from(ExprKind::Operator(OperatorExpr {
             op: Cell::new(Some(Box::new(op))),
-            inputs: [input].into(),
+            inputs: [self.clone()].into(),
         }))
     }
 
-    /// Create a binary operator expression.
-    pub fn binary<Op: Operator + Send + Sync>(op: Op, lhs: Expr, rhs: Expr) -> Expr {
+    /// Create an expression which applies a binary operator to this expression.
+    pub fn binary<Op: Operator + Send + Sync>(&self, op: Op, rhs: Expr) -> Expr {
         Expr::from(ExprKind::Operator(OperatorExpr {
             op: Cell::new(Some(Box::new(op))),
-            inputs: [lhs, rhs].into(),
+            inputs: [self.clone(), rhs].into(),
         }))
     }
 
@@ -210,7 +210,7 @@ macro_rules! impl_binary_op {
             type Output = Expr;
 
             fn $op_method(self, rhs: Expr) -> Expr {
-                Expr::binary(crate::ops::$op_struct {}, self, rhs)
+                self.binary(crate::ops::$op_struct {}, rhs)
             }
         }
     };

--- a/src/graph/builder.rs
+++ b/src/graph/builder.rs
@@ -213,6 +213,17 @@ macro_rules! impl_binary_op {
                 self.binary(crate::ops::$op_struct {}, rhs)
             }
         }
+
+        impl<V> $op_trait<V> for Expr
+        where
+            V: Into<Tensor<f32>>,
+        {
+            type Output = Expr;
+
+            fn $op_method(self, rhs: V) -> Expr {
+                self.binary(crate::ops::$op_struct {}, Expr::constant(rhs))
+            }
+        }
     };
 }
 
@@ -233,7 +244,7 @@ mod tests {
         // re-use of the same expression (`x_sqr`) and generate a graph from it.
         let x = Expr::value("x");
         let x_sqr = x.clone() * x.clone();
-        let x_4_plus_2 = x_sqr.clone() * x_sqr.clone() + Expr::constant(2.0);
+        let x_4_plus_2 = x_sqr.clone() * x_sqr.clone() + 2.0;
         let graph = x_4_plus_2.build_graph(["x"]);
 
         // Verify graph generates expected value from input when run.

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -825,8 +825,8 @@ mod tests {
     use crate::graph::builder::Expr;
     use crate::graph::{CaptureEnv, Constant, Graph, Node, NodeId};
     use crate::ops::{
-        Add, Erf, FusedMatMul, LayerNormalization, MatMul, RmsNormalization, Sigmoid, Swish,
-        Transpose,
+        Add, Erf, FusedMatMul, LayerNormalization, MatMul, Pow, ReduceMean, RmsNormalization,
+        Sigmoid, Sqrt, Swish, Transpose,
     };
 
     fn optimize_graph(graph: Graph) -> Result<Graph, OptimizeError> {
@@ -852,28 +852,54 @@ mod tests {
         ArcTensorView::from_data(&[], slice)
     }
 
-    // Helpers to construct expressions for various operators.
-    mod op_expr {
-        use crate::graph::builder::Expr;
-        use crate::ops::{Pow, ReduceMean, Sqrt};
+    /// Extends [`Expr`] with methods to create expressions for specific
+    /// operations.
+    ///
+    /// For example `a.matmul(b)` returns an expression for a `MatMul` graph
+    /// node with `a` and `b` as inputs.
+    trait OpExprs {
+        fn erf(&self) -> Expr;
+        fn matmul(&self, rhs: Expr) -> Expr;
+        fn mean(&self) -> Expr;
+        fn sigmoid(&self) -> Expr;
+        fn square(&self) -> Expr;
+        fn sqrt(&self) -> Expr;
+        fn transpose(&self) -> Expr;
+    }
 
-        /// Take the mean over the last axis
-        pub fn mean(x: Expr) -> Expr {
+    impl OpExprs for Expr {
+        fn erf(&self) -> Expr {
+            Expr::unary(Erf {}, self.clone())
+        }
+
+        fn matmul(&self, rhs: Expr) -> Expr {
+            Expr::binary(MatMul {}, self.clone(), rhs)
+        }
+
+        fn mean(&self) -> Expr {
             Expr::unary(
                 ReduceMean {
                     axes: Some(vec![-1]),
                     keep_dims: false,
                 },
-                x,
+                self.clone(),
             )
         }
 
-        pub fn square(x: Expr) -> Expr {
-            Expr::binary(Pow {}, x, Expr::constant(2.0))
+        fn sigmoid(&self) -> Expr {
+            Expr::unary(Sigmoid {}, self.clone())
         }
 
-        pub fn sqrt(x: Expr) -> Expr {
-            Expr::unary(Sqrt {}, x)
+        fn square(&self) -> Expr {
+            Expr::binary(Pow {}, self.clone(), Expr::constant(2.0))
+        }
+
+        fn sqrt(&self) -> Expr {
+            Expr::unary(Sqrt {}, self.clone())
+        }
+
+        fn transpose(&self) -> Expr {
+            Expr::unary(Transpose { perm: None }, self.clone())
         }
     }
 
@@ -969,9 +995,7 @@ mod tests {
         let graph = {
             let x = Expr::value("x");
             let y = Expr::value("y");
-            let x_transposed = Expr::unary(Transpose { perm: None }, x.clone());
-            let expr = Expr::binary(MatMul {}, x_transposed, y);
-            expr.build_graph(["x", "y"])
+            x.transpose().matmul(y).build_graph(["x", "y"])
         };
 
         let graph = optimize_graph(graph).unwrap();
@@ -984,7 +1008,7 @@ mod tests {
     fn test_fuse_silu() {
         let graph = {
             let x = Expr::value("x");
-            let expr = x.clone() * Expr::unary(Sigmoid {}, x);
+            let expr = x.clone() * x.sigmoid();
             expr.build_graph(["x"])
         };
 
@@ -999,7 +1023,7 @@ mod tests {
         let graph = {
             let x = Expr::value("x");
             let beta = Expr::constant(1.7);
-            let expr = x.clone() * Expr::unary(Sigmoid {}, x.clone() * beta);
+            let expr = x.clone() * (x.clone() * beta).sigmoid();
             expr.build_graph(["x"])
         };
 
@@ -1016,7 +1040,7 @@ mod tests {
             let a = Expr::value("a");
             let b = Expr::value("b");
             let bias = Expr::constant([1., 2., 3.]);
-            let expr = Expr::binary(MatMul {}, a, b) + bias;
+            let expr = a.matmul(b) + bias;
             expr.build_graph(["a", "b"])
         };
 
@@ -1035,7 +1059,7 @@ mod tests {
             let b = Expr::value("b");
             let c = Expr::constant(0.5);
             let d = Expr::constant(0.3);
-            let expr = Expr::binary(MatMul {}, a * c, b * d);
+            let expr = (a * c).matmul(b * d);
             expr.build_graph(["a", "b"])
         };
 
@@ -1052,7 +1076,7 @@ mod tests {
             let a = Expr::value("a");
             let b = Expr::value("b");
             let c = Expr::constant(0.5);
-            let expr = Expr::binary(MatMul {}, a, b / c);
+            let expr = a.matmul(b) / c;
             expr.build_graph(["a", "b"])
         };
 
@@ -1069,8 +1093,8 @@ mod tests {
         // Two consecutive decomposed Silu operations
         let graph = {
             let x = Expr::value("x");
-            let y = x.clone() * Expr::unary(Sigmoid {}, x);
-            let z = y.clone() * Expr::unary(Sigmoid {}, y);
+            let y = x.clone() * x.sigmoid();
+            let z = y.clone() * y.sigmoid();
             z.build_graph(["x"])
         };
 
@@ -1093,7 +1117,7 @@ mod tests {
             let sqrt_2 = Expr::constant((2.0f32).sqrt());
             let one = Expr::constant(1.0);
             let half = Expr::constant(0.5);
-            let expr = x.clone() * (Expr::unary(Erf {}, x / sqrt_2) + one) * half;
+            let expr = x.clone() * ((x / sqrt_2).erf() + one) * half;
             expr.build_graph(["x"])
         };
 
@@ -1104,16 +1128,14 @@ mod tests {
     }
 
     fn layer_norm_graph(with_bias: bool) -> Graph {
-        use op_expr::{mean, sqrt, square};
-
         // Center mean
         let epsilon = Expr::constant(1e-6);
         let x = Expr::value("x");
-        let x_mean = mean(x.clone());
+        let x_mean = x.mean();
         let x_sub_mean = x.clone() - x_mean;
 
         // Normalize variance
-        let normalized = x_sub_mean.clone() / sqrt(mean(square(x_sub_mean.clone())) + epsilon);
+        let normalized = x_sub_mean.clone() / (x_sub_mean.square().mean() + epsilon).sqrt();
 
         // Shift and scale result
         let scale = Expr::constant([3., 4., 5.]);
@@ -1149,13 +1171,11 @@ mod tests {
 
     #[test]
     fn test_fuse_rms_norm() {
-        use op_expr::{mean, sqrt, square};
-
         // See https://arxiv.org/pdf/1910.07467
         let graph = {
             let x = Expr::value("x");
             let epsilon = 1e-6;
-            let rms = sqrt(mean(square(x.clone())) + Expr::constant(epsilon));
+            let rms = (x.square().mean() + Expr::constant(epsilon)).sqrt();
             let scale = Expr::constant([3., 4., 5.]);
             let expr = x * (Expr::constant(1.) / rms) * scale;
             expr.build_graph(["x"])

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -869,37 +869,34 @@ mod tests {
 
     impl OpExprs for Expr {
         fn erf(&self) -> Expr {
-            Expr::unary(Erf {}, self.clone())
+            self.unary(Erf {})
         }
 
         fn matmul(&self, rhs: Expr) -> Expr {
-            Expr::binary(MatMul {}, self.clone(), rhs)
+            self.binary(MatMul {}, rhs)
         }
 
         fn mean(&self) -> Expr {
-            Expr::unary(
-                ReduceMean {
-                    axes: Some(vec![-1]),
-                    keep_dims: false,
-                },
-                self.clone(),
-            )
+            self.unary(ReduceMean {
+                axes: Some(vec![-1]),
+                keep_dims: false,
+            })
         }
 
         fn sigmoid(&self) -> Expr {
-            Expr::unary(Sigmoid {}, self.clone())
+            self.unary(Sigmoid {})
         }
 
         fn square(&self) -> Expr {
-            Expr::binary(Pow {}, self.clone(), Expr::constant(2.0))
+            self.binary(Pow {}, Expr::constant(2.0))
         }
 
         fn sqrt(&self) -> Expr {
-            Expr::unary(Sqrt {}, self.clone())
+            self.unary(Sqrt {})
         }
 
         fn transpose(&self) -> Expr {
-            Expr::unary(Transpose { perm: None }, self.clone())
+            self.unary(Transpose { perm: None })
         }
     }
 

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -1019,7 +1019,7 @@ mod tests {
     fn test_fuse_swish() {
         let graph = {
             let x = Expr::value("x");
-            let beta = Expr::constant(1.7);
+            let beta = 1.7;
             let expr = x.clone() * (x.clone() * beta).sigmoid();
             expr.build_graph(["x"])
         };
@@ -1036,7 +1036,7 @@ mod tests {
         let graph = {
             let a = Expr::value("a");
             let b = Expr::value("b");
-            let bias = Expr::constant([1., 2., 3.]);
+            let bias = [1., 2., 3.];
             let expr = a.matmul(b) + bias;
             expr.build_graph(["a", "b"])
         };
@@ -1054,9 +1054,7 @@ mod tests {
         let graph = {
             let a = Expr::value("a");
             let b = Expr::value("b");
-            let c = Expr::constant(0.5);
-            let d = Expr::constant(0.3);
-            let expr = (a * c).matmul(b * d);
+            let expr = (a * 0.5).matmul(b * 0.3);
             expr.build_graph(["a", "b"])
         };
 
@@ -1072,8 +1070,7 @@ mod tests {
         let graph = {
             let a = Expr::value("a");
             let b = Expr::value("b");
-            let c = Expr::constant(0.5);
-            let expr = a.matmul(b) / c;
+            let expr = a.matmul(b) / 0.5;
             expr.build_graph(["a", "b"])
         };
 
@@ -1111,10 +1108,8 @@ mod tests {
     fn test_fuse_gelu() {
         let graph = {
             let x = Expr::value("x");
-            let sqrt_2 = Expr::constant((2.0f32).sqrt());
-            let one = Expr::constant(1.0);
-            let half = Expr::constant(0.5);
-            let expr = x.clone() * ((x / sqrt_2).erf() + one) * half;
+            let sqrt_2 = (2.0f32).sqrt();
+            let expr = x.clone() * ((x / sqrt_2).erf() + 1.0) * 0.5;
             expr.build_graph(["x"])
         };
 
@@ -1126,7 +1121,7 @@ mod tests {
 
     fn layer_norm_graph(with_bias: bool) -> Graph {
         // Center mean
-        let epsilon = Expr::constant(1e-6);
+        let epsilon = 1e-6;
         let x = Expr::value("x");
         let x_mean = x.mean();
         let x_sub_mean = x.clone() - x_mean;
@@ -1135,9 +1130,9 @@ mod tests {
         let normalized = x_sub_mean.clone() / (x_sub_mean.square().mean() + epsilon).sqrt();
 
         // Shift and scale result
-        let scale = Expr::constant([3., 4., 5.]);
+        let scale = [3., 4., 5.];
         let expr = if with_bias {
-            let bias = Expr::constant([1., 2., 3.]);
+            let bias = [1., 2., 3.];
             normalized * scale + bias
         } else {
             normalized * scale
@@ -1172,8 +1167,8 @@ mod tests {
         let graph = {
             let x = Expr::value("x");
             let epsilon = 1e-6;
-            let rms = (x.square().mean() + Expr::constant(epsilon)).sqrt();
-            let scale = Expr::constant([3., 4., 5.]);
+            let rms = (x.square().mean() + epsilon).sqrt();
+            let scale = [3., 4., 5.];
             let expr = x * (Expr::constant(1.) / rms) * scale;
             expr.build_graph(["x"])
         };


### PR DESCRIPTION
Refine the `Expr` APIs and associated helpers in `optimize.rs` to be simpler to use. `Expr::{unary, binary}` are now methods, the helpers in `optimize.rs` are moved into an extension trait and binary operators for `Expr` accept any `Into<Tensor<f32>>` as the RHS, so `some_expr + 2.0` just works without having to first wrap up the constant as an expression using `some_expr + Expr::constant(2.0)`.