### PR TITLE
Unify APIs for kernels exported by rten-vecmath

### DIFF
--- a/rten-simd/src/dispatch.rs
+++ b/rten-simd/src/dispatch.rs
@@ -77,10 +77,10 @@ pub fn dispatch<Op: SimdOp>(op: Op) -> Op::Output {
 /// Trait for SIMD operations which can be evaluated using different SIMD
 /// vector types.
 ///
-/// To dispatch the operation, create a [`SimdDispatcher`] and call
-/// [`dispatch(op)`](SimdDispatcher::dispatch).
+/// To dispatch the operation using the preferred instruction set for the
+/// current system, call the [`dispatch`](SimdOp::dispatch) method.
 pub trait SimdOp {
-    /// Output type returned by `eval`.
+    /// Output type returned by the operation.
     type Output;
 
     /// Evaluate the operator using a given SIMD vector type.
@@ -90,6 +90,17 @@ pub trait SimdOp {
     /// The caller must ensure that the `S` is a supported SIMD vector type
     /// on the current system.
     unsafe fn eval<S: SimdFloat>(self) -> Self::Output;
+
+    /// Evaluate this operator using the default SIMD dispatch configuration
+    /// for the current platform.
+    ///
+    /// To customize the dispatch, use the [`SimdDispatcher`] API directly.
+    fn dispatch(self) -> Self::Output
+    where
+        Self: Sized,
+    {
+        SimdDispatcher::default().dispatch(self)
+    }
 }
 
 /// Trait for evaluating a unary function on a SIMD vector.

--- a/rten-simd/src/span.rs
+++ b/rten-simd/src/span.rs
@@ -103,6 +103,18 @@ impl<T> MutPtrLen<T> {
             len: self.len,
         }
     }
+
+    /// Convert `self` into a slice.
+    ///
+    /// # Safety
+    ///
+    /// The caller must uphold all the invariants specified in
+    /// [`std::slice::from_raw_parts_mut`]. In particular all elements must be
+    /// initialized, and there must be no other mutable references to any
+    /// elements in the slice.
+    pub unsafe fn as_slice<'a>(self) -> &'a mut [T] {
+        std::slice::from_raw_parts_mut(self.ptr, self.len)
+    }
 }
 
 impl<'a, T> From<&'a mut [T]> for MutPtrLen<T> {

--- a/rten-vecmath/src/lib.rs
+++ b/rten-vecmath/src/lib.rs
@@ -43,6 +43,6 @@ pub use exp::{Exp, Sigmoid, Silu, Swish};
 pub use tanh::Tanh;
 
 // Normalization and reduction functions.
-pub use normalize::{normalize, normalize_mut};
-pub use softmax::{softmax, softmax_mut};
-pub use sum::{sum, sum_square, sum_square_sub};
+pub use normalize::{Normalize, NormalizeOptions};
+pub use softmax::Softmax;
+pub use sum::{Sum, SumSquare, SumSquareSub};

--- a/rten-vecmath/src/lib.rs
+++ b/rten-vecmath/src/lib.rs
@@ -52,6 +52,25 @@
 //! Softmax::new_mut(&mut data).dispatch();
 //! ```
 //!
+//! ### Applying softmax with separate input and output buffers
+//!
+//! This example reads data from an input and writes to an uninitialized output
+//! buffer. The softmax operation returns the initialized slice.
+//!
+//! ```
+//! use rten_simd::dispatch::SimdOp;
+//! use rten_vecmath::Softmax;
+//!
+//! let data = [1., 0.5, 2.0];
+//! let mut output = Vec::with_capacity(data.len());
+//! let output_uninit = &mut output.spare_capacity_mut()[..data.len()];
+//! let output_init = Softmax::new(&data, output_uninit).dispatch();
+//!
+//! // Safety: The softmax operation initialized all output elements.
+//! let init_len = output_init.len();
+//! unsafe { output.set_len(init_len) };
+//! ```
+//!
 //! ### Computing the sum of a list of floats
 //!
 //! ```

--- a/rten-vecmath/src/lib.rs
+++ b/rten-vecmath/src/lib.rs
@@ -1,7 +1,25 @@
-//! SIMD-vectorized implementations of functions used in neural networks.
+//! SIMD-vectorized implementations of operations used in neural networks.
 //!
-//! The functions are implemented by structs which implement the SIMD operation
-//! traits from [rten-simd](rten_simd).
+//! These implementations are used as kernels for operations in the
+//! [rten](https://crates.io/crates/rten) crate.
+//!
+//! ## Constructing and dispatching operations
+//!
+//! The operations are implemented by structs which implement the SIMD operation
+//! traits from [rten-simd](rten_simd). To apply an operation to data, first
+//! construct the operation using the struct from this crate, then use a
+//! dispatch method from the [`SimdOp`](rten_simd::dispatch::SimdOp) or
+//! [`SimdUnaryOp`](rten_simd::dispatch::SimdUnaryOp) traits to execute the
+//! operation using the preferred SIMD instruction set.
+//!
+//! ## In-place versus mutating operations
+//!
+//! Some operations support both updating data in place or reading input from
+//! one slice and writing to another. For unary operations this is controlled by
+//! dispatching with either [`map`](rten_simd::dispatch::SimdUnaryOp::map) or
+//! [`map_mut`](rten_simd::dispatch::SimdUnaryOp::map_mut). For other operations
+//! this is handled by exposing different constructors for the in-place and
+//! mutating cases, such as [`Softmax::new`] and [`Softmax::new_mut`].
 //!
 //! ## Examples
 //!
@@ -22,6 +40,26 @@
 //! let src = [1., 0.5, 2.0];
 //! let mut dest = [MaybeUninit::uninit(); 3];
 //! erf_op.map(&src, &mut dest);
+//! ```
+//!
+//! ### Applying softmax in place
+//!
+//! ```
+//! use rten_simd::dispatch::SimdOp;
+//! use rten_vecmath::Softmax;
+//!
+//! let mut data = [1., 0.5, 2.0];
+//! Softmax::new_mut(&mut data).dispatch();
+//! ```
+//!
+//! ### Computing the sum of a list of floats
+//!
+//! ```
+//! use rten_simd::dispatch::SimdOp;
+//! use rten_vecmath::Sum;
+//!
+//! let data = [1., 0.5, 2.0];
+//! let sum = Sum::new(&data).dispatch();
 //! ```
 
 mod erf;

--- a/rten-vecmath/src/normalize.rs
+++ b/rten-vecmath/src/normalize.rs
@@ -1,24 +1,77 @@
 use std::mem::MaybeUninit;
 
-use rten_simd::dispatch::{dispatch, SimdOp};
+use rten_simd::dispatch::SimdOp;
 use rten_simd::span::{MutPtrLen, PtrLen};
 use rten_simd::SimdFloat;
 
-struct Normalize<'a> {
+/// Normalize the mean and variance of elements in a slice.
+///
+/// This normalizes elements according to the formula:
+///
+/// ```text
+/// output[i] = (input[i] - pre_scale_bias) * scale * element_scale[i] + bias + element_bias[i]
+/// ```
+///
+/// # Panics
+///
+/// Dispatching the operation panics if any of the slices have different lengths.
+pub struct Normalize<'a> {
     input: PtrLen<f32>,
     output: MutPtrLen<MaybeUninit<f32>>,
+    opts: NormalizeOptions<'a>,
+}
 
+impl<'a> Normalize<'a> {
+    /// Create a normalize operation which reads `input` and writes the normalized
+    /// output to `output`.
+    pub fn new(
+        input: &'a [f32],
+        output: &'a mut [MaybeUninit<f32>],
+        opts: NormalizeOptions<'a>,
+    ) -> Self {
+        Normalize {
+            input: input.into(),
+            output: output.into(),
+            opts,
+        }
+    }
+
+    /// Create a normalize operation which normalizes `input` in-place.
+    pub fn new_mut(input: &'a mut [f32], opts: NormalizeOptions<'a>) -> Self {
+        let output: MutPtrLen<f32> = input.into();
+        Normalize {
+            input: input.into(),
+            output: output.as_uninit(),
+            opts,
+        }
+    }
+}
+
+/// Configuration for the [`Normalize`] operation.
+pub struct NormalizeOptions<'a> {
     /// Bias to subtract before scaling.
-    pre_scale_bias: f32,
+    pub pre_scale_bias: f32,
 
-    scale: f32,
-    element_scale: Option<&'a [f32]>,
+    pub scale: f32,
+    pub element_scale: Option<&'a [f32]>,
 
     /// Constant bias to add after scaling
-    bias: f32,
+    pub bias: f32,
 
     /// Per-element bias to add after scaling
-    element_bias: Option<&'a [f32]>,
+    pub element_bias: Option<&'a [f32]>,
+}
+
+impl Default for NormalizeOptions<'_> {
+    fn default() -> Self {
+        NormalizeOptions {
+            pre_scale_bias: 0.,
+            scale: 1.,
+            element_scale: None,
+            bias: 0.,
+            element_bias: None,
+        }
+    }
 }
 
 impl SimdOp for Normalize<'_> {
@@ -29,11 +82,14 @@ impl SimdOp for Normalize<'_> {
         let Self {
             input,
             output,
-            pre_scale_bias,
-            scale,
-            element_scale,
-            bias,
-            element_bias,
+            opts:
+                NormalizeOptions {
+                    pre_scale_bias,
+                    scale,
+                    element_scale,
+                    bias,
+                    element_bias,
+                },
         } = self;
 
         assert_eq!(input.len(), output.len());
@@ -96,63 +152,10 @@ impl SimdOp for Normalize<'_> {
     }
 }
 
-/// Normalize elements in a slice.
-///
-/// This normalizes elements according to the formula:
-///
-/// ```text
-/// output[i] = (input[i] - pre_scale_bias) * scale * element_scale[i] + bias + element_bias[i]
-/// ```
-///
-/// # Panics
-///
-/// Panics if any of the slices have different lengths.
-pub fn normalize(
-    input: &[f32],
-    output: &mut [MaybeUninit<f32>],
-    pre_scale_bias: f32,
-    scale: f32,
-    element_scale: Option<&[f32]>,
-    bias: f32,
-    element_bias: Option<&[f32]>,
-) {
-    let simd_op = Normalize {
-        input: input.into(),
-        output: output.into(),
-        pre_scale_bias,
-        scale,
-        element_scale,
-        bias,
-        element_bias,
-    };
-    dispatch(simd_op)
-}
-
-/// Variant of [`normalize`] which updates elements in-place.
-pub fn normalize_mut(
-    input: &mut [f32],
-    pre_scale_bias: f32,
-    scale: f32,
-    element_scale: Option<&[f32]>,
-    bias: f32,
-    element_bias: Option<&[f32]>,
-) {
-    let output: MutPtrLen<f32> = input.into();
-    let simd_op = Normalize {
-        input: input.into(),
-        output: output.as_uninit(),
-        pre_scale_bias,
-        scale,
-        element_scale,
-        bias,
-        element_bias,
-    };
-    dispatch(simd_op)
-}
-
 #[cfg(test)]
 mod tests {
-    use super::normalize_mut;
+    use super::{Normalize, NormalizeOptions};
+    use rten_simd::dispatch::SimdOp;
 
     fn reference_normalize_mut(
         data: &mut [f32],
@@ -190,15 +193,17 @@ mod tests {
         );
 
         let mut actual = data.clone();
-        normalize_mut(
+        Normalize::new_mut(
             &mut actual[..],
-            pre_scale_bias,
-            scale,
-            Some(&element_scale),
-            bias,
-            Some(&element_bias),
-        );
-
+            NormalizeOptions {
+                pre_scale_bias,
+                scale,
+                element_scale: Some(&element_scale),
+                bias,
+                element_bias: Some(&element_bias),
+            },
+        )
+        .dispatch();
         assert_eq!(actual, expected);
 
         // Without per-element scale and bias
@@ -206,7 +211,17 @@ mod tests {
         reference_normalize_mut(&mut expected[..], pre_scale_bias, scale, None, bias, None);
 
         let mut actual = data.clone();
-        normalize_mut(&mut actual[..], pre_scale_bias, scale, None, bias, None);
+        Normalize::new_mut(
+            &mut actual[..],
+            NormalizeOptions {
+                pre_scale_bias,
+                scale,
+                element_scale: None,
+                bias,
+                element_bias: None,
+            },
+        )
+        .dispatch();
 
         assert_eq!(actual, expected);
     }

--- a/src/ops/norm.rs
+++ b/src/ops/norm.rs
@@ -94,10 +94,8 @@ impl<'a> From<(&'a [f32], &'a mut [MaybeUninit<f32>])> for NormalizeData<'a> {
 /// Normalize the mean and variance of elements in `data` and apply a scale
 /// and bias to the result.
 ///
-/// ```text
-/// Y = (X - mean) / sqrt(variance + epsilon) * scale + bias
-/// ```
-fn normalize_slice(data: NormalizeData, opts: NormalizeOptions) {
+/// Returns the normalized elements.
+fn normalize_slice<'a>(data: NormalizeData<'a>, opts: NormalizeOptions<'a>) -> &'a mut [f32] {
     let NormalizeOptions {
         mean_normalize,
         epsilon,
@@ -676,7 +674,7 @@ pub fn softmax(pool: &TensorPool, input: TensorView, axis: isize) -> Result<Tens
 
 pub fn softmax_in_place(output: &mut Tensor, axis: isize) -> Result<(), OpError> {
     softmax_lanes(output, axis, |lane| {
-        vecmath::Softmax::new_mut(lane).dispatch()
+        vecmath::Softmax::new_mut(lane).dispatch();
     })?;
     Ok(())
 }

--- a/src/ops/reduce.rs
+++ b/src/ops/reduce.rs
@@ -1,10 +1,11 @@
 use std::borrow::Cow;
 use std::cmp::Ordering;
 
+use rten_simd::dispatch::SimdOp;
 use rten_tensor;
 use rten_tensor::prelude::*;
 use rten_tensor::{NdTensor, NdTensorView, Tensor, TensorView};
-use rten_vecmath::{sum, sum_square};
+use rten_vecmath as vecmath;
 
 use crate::number::{Identities, IsNaN};
 use crate::ops::layout::squeeze_in_place;
@@ -401,7 +402,7 @@ pub fn reduce_mean(
     struct MeanKernel {}
     impl ReduceKernel<f32> for MeanKernel {
         fn reduce_slice(&self, slice: &[f32]) -> f32 {
-            sum(slice) / slice.len() as f32
+            vecmath::Sum::new(slice).dispatch() / slice.len() as f32
         }
     }
 
@@ -441,7 +442,7 @@ pub fn reduce_l2(
     struct L2ReduceKernel {}
     impl ReduceKernel<f32> for L2ReduceKernel {
         fn reduce_slice(&self, slice: &[f32]) -> f32 {
-            sum_square(slice).sqrt()
+            vecmath::SumSquare::new(slice).dispatch().sqrt()
         }
     }
 


### PR DESCRIPTION
https://github.com/robertknight/rten/pull/494 revised the APIs for unary op kernels (GELU, Swish, Erf etc.) to separate construction of operation descriptors and dispatching the operations.

This PR applies the same conceptual change to the normalization and reduction kernels in rten-vecmath. The resulting APIs are slightly more complex to use, but it makes the crate as a whole more consistent and reduces the surface area by only having one export per operation. The documentation has been updated accordingly.