### PR TITLE
Push handling of non-full width tiles down into GEMM kernels

### DIFF
--- a/src/gemm/kernels/generic.rs
+++ b/src/gemm/kernels/generic.rs
@@ -5,7 +5,7 @@ use rten_simd::vec_count;
 use rten_tensor::Matrix;
 
 use super::simd_generic::{simd_gemm, simd_gemv};
-use super::{Kernel, Lhs};
+use super::{Kernel, Lhs, TempTile};
 use crate::gemm::packing::{pack_a_block, pack_b_block};
 
 /// This is the base kernel that does not use architecture-specific intrinsics
@@ -67,8 +67,9 @@ unsafe impl Kernel<f32, f32, f32> for GenericKernel {
         tile_ptr: *mut f32,
         tile_row_stride: usize,
         a: Lhs<f32>,
-        used_rows: usize,
         b: &[f32],
+        used_rows: usize,
+        used_cols: usize,
         depth: usize,
         alpha: f32,
         beta: f32,
@@ -76,16 +77,38 @@ unsafe impl Kernel<f32, f32, f32> for GenericKernel {
         const MR: usize = GenericKernel::MR;
         const NR: usize = GenericKernel::NR;
         const NR_REGS: usize = vec_count::<f32>(NR);
-        simd_gemm::<f32, MR, NR_REGS>(
-            tile_ptr,
-            tile_row_stride,
-            a,
-            used_rows,
-            b,
-            depth,
-            alpha,
-            beta,
-        );
+
+        if used_cols == NR {
+            simd_gemm::<f32, MR, NR_REGS>(
+                tile_ptr,
+                tile_row_stride,
+                a,
+                used_rows,
+                b,
+                depth,
+                alpha,
+                beta,
+            );
+        } else {
+            let mut tmp_tile = TempTile::<f32, MR, NR>::new();
+            simd_gemm::<f32, MR, NR_REGS>(
+                tmp_tile.as_mut_ptr() as *mut f32,
+                NR,
+                a,
+                used_rows,
+                b,
+                depth,
+                alpha,
+                0.,
+            );
+            tmp_tile.accumulate_into(
+                tile_ptr as *mut MaybeUninit<f32>,
+                used_rows,
+                used_cols,
+                tile_row_stride,
+                beta,
+            );
+        }
     }
 
     fn gemv_kernel(

--- a/src/gemm/kernels/wasm.rs
+++ b/src/gemm/kernels/wasm.rs
@@ -6,7 +6,7 @@ use rten_simd::vec_count;
 use rten_tensor::Matrix;
 
 use super::simd_generic::{simd_gemm, simd_gemv};
-use super::{Kernel, Lhs};
+use super::{Kernel, Lhs, TempTile};
 use crate::gemm::packing::{pack_a_block, pack_b_block};
 
 pub struct WasmKernel {
@@ -66,8 +66,9 @@ unsafe impl Kernel<f32, f32, f32> for WasmKernel {
         tile_ptr: *mut f32,
         tile_row_stride: usize,
         a: Lhs<f32>,
-        used_rows: usize,
         b: &[f32],
+        used_rows: usize,
+        used_cols: usize,
         depth: usize,
         alpha: f32,
         beta: f32,
@@ -76,16 +77,37 @@ unsafe impl Kernel<f32, f32, f32> for WasmKernel {
         const NR: usize = WasmKernel::NR;
         const NR_REGS: usize = vec_count::<v128f>(NR);
 
-        simd_gemm::<v128f, MR, NR_REGS>(
-            tile_ptr,
-            tile_row_stride,
-            a,
-            used_rows,
-            b,
-            depth,
-            alpha,
-            beta,
-        );
+        if used_cols == NR {
+            simd_gemm::<v128f, MR, NR_REGS>(
+                tile_ptr,
+                tile_row_stride,
+                a,
+                used_rows,
+                b,
+                depth,
+                alpha,
+                beta,
+            );
+        } else {
+            let mut tmp_tile = TempTile::<f32, MR, NR>::new();
+            simd_gemm::<v128f, MR, NR_REGS>(
+                tmp_tile.as_mut_ptr() as *mut f32,
+                NR,
+                a,
+                used_rows,
+                b,
+                depth,
+                alpha,
+                0.,
+            );
+            tmp_tile.accumulate_into(
+                tile_ptr as *mut MaybeUninit<f32>,
+                used_rows,
+                used_cols,
+                tile_row_stride,
+                beta,
+            );
+        }
     }
 
     fn gemv_kernel(


### PR DESCRIPTION
For tiles with fewer than NR columns, the GEMM impl creates a temporary tile on the stack, runs the kernel on that and copies the result into the real output tile afterwards. For architectures with masked loads and stores more efficient approaches are possible. As a step to enable this, move handling of non-full width tiles into the arch-specific kernels.