### PR TITLE
Instantiate main GEMM loop per number of used rows

### DIFF
--- a/src/gemm/kernels/aarch64.rs
+++ b/src/gemm/kernels/aarch64.rs
@@ -5,7 +5,7 @@ use std::ops::Range;
 use rten_simd::vec_count;
 use rten_tensor::{Matrix, MatrixLayout};
 
-use super::simd_generic::{simd_gemm, simd_gemv};
+use super::simd_generic::{simd_gemv, GemmDispatch};
 use super::{Kernel, Lhs, PackedLayout, TempTile};
 use crate::gemm::packing::{pack_a_block, pack_b_block, packed_a_layout, packed_b_layout};
 use crate::number::{cast_pod_mut_slice, cast_pod_slice};
@@ -88,29 +88,36 @@ unsafe impl Kernel<f32, f32, f32> for ArmNeonKernel {
 
         let b = cast_pod_slice(b).unwrap();
 
-        if used_cols == NR {
-            simd_gemm::<float32x4_t, MR, NR_REGS>(
-                tile_ptr,
-                tile_row_stride,
-                a,
-                used_rows,
-                b,
-                depth,
-                alpha,
-                beta,
-            );
+        let mut tmp_tile = TempTile::<f32, MR, NR>::new();
+        let (dest_ptr, dest_row_stride, dest_beta) = if used_cols == NR {
+            (tile_ptr, tile_row_stride, beta)
         } else {
-            let mut tmp_tile = TempTile::<f32, MR, NR>::new();
-            simd_gemm::<float32x4_t, MR, NR_REGS>(
-                tmp_tile.as_mut_ptr() as *mut f32,
-                NR,
-                a,
-                used_rows,
-                b,
-                depth,
-                alpha,
-                0.,
-            );
+            (tmp_tile.as_mut_ptr() as *mut f32, NR, 0.)
+        };
+
+        let gemm = GemmDispatch::<float32x4_t, MR, NR_REGS>::new(
+            dest_ptr,
+            dest_row_stride,
+            a,
+            b,
+            depth,
+            alpha,
+            dest_beta,
+        );
+
+        match used_rows {
+            8 => gemm.dispatch::<8>(),
+            7 => gemm.dispatch::<7>(),
+            6 => gemm.dispatch::<6>(),
+            5 => gemm.dispatch::<5>(),
+            4 => gemm.dispatch::<4>(),
+            3 => gemm.dispatch::<3>(),
+            2 => gemm.dispatch::<2>(),
+            1 => gemm.dispatch::<1>(),
+            _ => panic!("unsupported `used_rows` {}", used_rows),
+        }
+
+        if used_cols != NR {
             tmp_tile.accumulate_into(
                 tile_ptr as *mut MaybeUninit<f32>,
                 used_rows,

--- a/src/gemm/kernels/wasm.rs
+++ b/src/gemm/kernels/wasm.rs
@@ -5,7 +5,7 @@ use rten_simd::arch::wasm::v128f;
 use rten_simd::vec_count;
 use rten_tensor::{Matrix, MatrixLayout};
 
-use super::simd_generic::{simd_gemm, simd_gemv};
+use super::simd_generic::{simd_gemv, GemmDispatch};
 use super::{Kernel, Lhs, PackedLayout, TempTile};
 use crate::gemm::packing::{pack_a_block, pack_b_block, packed_a_layout, packed_b_layout};
 use crate::number::{cast_pod_mut_slice, cast_pod_slice};
@@ -90,29 +90,37 @@ unsafe impl Kernel<f32, f32, f32> for WasmKernel {
         const NR: usize = WasmKernel::NR;
         const NR_REGS: usize = vec_count::<v128f>(NR);
 
-        if used_cols == NR {
-            simd_gemm::<v128f, MR, NR_REGS>(
-                tile_ptr,
-                tile_row_stride,
-                a,
-                used_rows,
-                cast_pod_slice(b).unwrap(),
-                depth,
-                alpha,
-                beta,
-            );
+        let b = cast_pod_slice(b).unwrap();
+        let mut tmp_tile = TempTile::<f32, MR, NR>::new();
+        let (dest_ptr, dest_row_stride, dest_beta) = if used_cols == NR {
+            (tile_ptr, tile_row_stride, beta)
         } else {
-            let mut tmp_tile = TempTile::<f32, MR, NR>::new();
-            simd_gemm::<v128f, MR, NR_REGS>(
-                tmp_tile.as_mut_ptr() as *mut f32,
-                NR,
-                a,
-                used_rows,
-                cast_pod_slice(b).unwrap(),
-                depth,
-                alpha,
-                0.,
-            );
+            (tmp_tile.as_mut_ptr() as *mut f32, NR, 0.)
+        };
+
+        let gemm = GemmDispatch::<v128f, MR, NR_REGS>::new(
+            dest_ptr,
+            dest_row_stride,
+            a,
+            b,
+            depth,
+            alpha,
+            dest_beta,
+        );
+
+        match used_rows {
+            8 => gemm.dispatch::<8>(),
+            7 => gemm.dispatch::<7>(),
+            6 => gemm.dispatch::<6>(),
+            5 => gemm.dispatch::<5>(),
+            4 => gemm.dispatch::<4>(),
+            3 => gemm.dispatch::<3>(),
+            2 => gemm.dispatch::<2>(),
+            1 => gemm.dispatch::<1>(),
+            _ => panic!("unsupported `used_rows` {}", used_rows),
+        }
+
+        if used_cols != NR {
             tmp_tile.accumulate_into(
                 tile_ptr as *mut MaybeUninit<f32>,
                 used_rows,


### PR DESCRIPTION
Make handling of tail tiles with fewer than MR rows more efficient by
instantiating ukernel bodies for each possible number of used rows. The entry
point for each kernel switches on the actual number of used rows and jumps to
the appropriate implementation. Adds ~32KB to the binary size of the CLI.