### PR TITLE
Fix AVX-512 build

### DIFF
--- a/rten-simd/src/arch/x86_64.rs
+++ b/rten-simd/src/arch/x86_64.rs
@@ -311,7 +311,7 @@ use std::arch::x86_64::{
     _mm512_div_ps, _mm512_fmadd_ps, _mm512_loadu_ps, _mm512_loadu_si512, _mm512_mask_blend_epi32,
     _mm512_mask_blend_ps, _mm512_mask_i32gather_ps, _mm512_max_ps, _mm512_mul_ps,
     _mm512_reduce_add_ps, _mm512_set1_epi32, _mm512_set1_ps, _mm512_setzero_si512,
-    _mm512_sllv_epi32, _mm512_storeu_ps, _mm512_storeu_si512, _mm512_sub_epi32, _mm512_sub_ps,
+    _mm512_sllv_epi32, _mm512_storeu_epi32, _mm512_storeu_ps, _mm512_sub_epi32, _mm512_sub_ps,
     _MM_CMPINT_EQ, _MM_CMPINT_LE, _MM_CMPINT_LT,
 };
 
@@ -379,7 +379,7 @@ impl Simd for __m512i {
     #[inline]
     #[target_feature(enable = "avx512f")]
     unsafe fn store(self, ptr: *mut i32) {
-        _mm512_storeu_si512(ptr, self)
+        _mm512_storeu_epi32(ptr, self)
     }
 
     #[inline]

--- a/rten-vecmath/src/softmax.rs
+++ b/rten-vecmath/src/softmax.rs
@@ -144,7 +144,7 @@ mod tests {
             let mut actual = vec![0.; input.len()];
             Softmax::new(&input, actual.as_mut_slice().as_uninit()).dispatch();
 
-            check_f32s_are_equal_ulps(triples(&input, &actual, &expected), 2. /* max ULPs */);
+            check_f32s_are_equal_ulps(triples(&input, &actual, &expected), 3. /* max ULPs */);
         }
     }
 


### PR DESCRIPTION
Fix a compile error in the `Simd::store` impl for `__m512i` and make the rten-vecmath tests pass by allowing a fractionally larger difference between the vectorized and scalar variants for softmax. This is expected since softmax involves sum reductions and those occur in a different order in the SIMD version.