### PR TITLE
Inline `simd_{op}` functions into `SimdUnaryOp::eval` impls

### DIFF
--- a/rten-simd/src/dispatch.rs
+++ b/rten-simd/src/dispatch.rs
@@ -113,6 +113,23 @@ pub trait SimdUnaryOp {
     /// on the current system.
     unsafe fn eval<S: SimdFloat>(&self, x: S) -> S;
 
+    /// Evaluate the unary function on elements in `x`.
+    ///
+    /// This is a shorthand for `Self::default().eval(x)`. It is mainly useful
+    /// when one vectorized operation needs to call another as part of its
+    /// implementation.
+    ///
+    /// # Safety
+    ///
+    /// See safety notes for [`eval`](SimdUnaryOp::eval).
+    #[inline(always)]
+    unsafe fn apply<S: SimdFloat>(x: S) -> S
+    where
+        Self: Default,
+    {
+        Self::default().eval(x)
+    }
+
     /// Evaluate the unary function on `x`.
     fn scalar_eval(&self, x: f32) -> f32 {
         // Safety: `f32` is a supported "SIMD" type on all platforms.

--- a/rten-vecmath/src/softmax.rs
+++ b/rten-vecmath/src/softmax.rs
@@ -1,64 +1,20 @@
 use std::marker::PhantomData;
 use std::mem::MaybeUninit;
 
-use rten_simd::dispatch::SimdOp;
+use rten_simd::dispatch::{SimdOp, SimdUnaryOp};
 use rten_simd::functional::{simd_fold, simd_map};
 use rten_simd::span::{MutPtrLen, PtrLen};
 use rten_simd::{SimdFloat, SimdMask};
 
-use crate::exp::simd_exp;
-
-/// Apply the softmax operation over elements in `xs` and write results to
-/// `out`.
-///
-/// The implementation uses a three-pass approach for numerical stability.
-/// See https://ogunlao.github.io/2020/04/26/you_dont_really_know_softmax.html
-/// and https://arxiv.org/abs/2001.04438.
-#[inline(always)]
-unsafe fn simd_softmax<S: SimdFloat>(input: PtrLen<f32>, out: MutPtrLen<MaybeUninit<f32>>) {
-    let max_val = simd_fold(
-        input,
-        S::splat(f32::MIN),
-        #[inline(always)]
-        |max, x| max.max(x),
-    );
-    let max_val = max_val.fold_splat(f32::MIN, |max: f32, x: f32| max.max(x));
-
-    // *x = (*x - max_val).exp()
-    let mut prev_exp_sum = S::zero();
-    let mut exp_sum = S::zero();
-    simd_map(
-        input,
-        out,
-        #[inline(always)]
-        |x: S| {
-            let y = simd_exp(x.sub(max_val));
-            prev_exp_sum = exp_sum;
-            exp_sum = exp_sum.add(y);
-            y
-        },
-    );
-
-    // Undo the last update to `exp_sum` for unused lanes.
-    let remainder = input.len() % S::LEN;
-    if remainder != 0 {
-        let remainder_mask = S::Mask::first_n(remainder);
-        exp_sum = prev_exp_sum.blend(exp_sum, remainder_mask);
-    }
-
-    // *x /= exp_sum
-    let exp_sum = exp_sum.fold_splat(0., |sum, x| sum + x);
-    simd_map(
-        out.assume_init().into(),
-        out,
-        #[inline(always)]
-        |x: S| x.div(exp_sum),
-    );
-}
+use crate::Exp;
 
 /// Computes the [softmax][softmax] function over a slice of floats.
 ///
-/// [softmax]: https://en.wikipedia.org/wiki/Softmax_function
+/// The implementation uses a three-pass approach for numerical stability.
+/// See <https://ogunlao.github.io/2020/04/26/you_dont_really_know_softmax.html>.
+/// and <https://arxiv.org/abs/2001.04438>.
+///
+/// [softmax]: <https://en.wikipedia.org/wiki/Softmax_function>
 pub struct Softmax<'a> {
     input: PtrLen<f32>,
     output: MutPtrLen<MaybeUninit<f32>>,
@@ -95,7 +51,46 @@ impl<'a> SimdOp for Softmax<'a> {
 
     #[inline(always)]
     unsafe fn eval<S: SimdFloat>(self) -> Self::Output {
-        simd_softmax::<S>(self.input, self.output);
+        let (input, output) = (self.input, self.output);
+
+        let max_val = simd_fold(
+            input,
+            S::splat(f32::MIN),
+            #[inline(always)]
+            |max, x| max.max(x),
+        );
+        let max_val = max_val.fold_splat(f32::MIN, |max: f32, x: f32| max.max(x));
+
+        // *x = (*x - max_val).exp()
+        let mut prev_exp_sum = S::zero();
+        let mut exp_sum = S::zero();
+        simd_map(
+            input,
+            output,
+            #[inline(always)]
+            |x: S| {
+                let y = Exp::apply(x.sub(max_val));
+                prev_exp_sum = exp_sum;
+                exp_sum = exp_sum.add(y);
+                y
+            },
+        );
+
+        // Undo the last update to `exp_sum` for unused lanes.
+        let remainder = input.len() % S::LEN;
+        if remainder != 0 {
+            let remainder_mask = S::Mask::first_n(remainder);
+            exp_sum = prev_exp_sum.blend(exp_sum, remainder_mask);
+        }
+
+        // *x /= exp_sum
+        let exp_sum = exp_sum.fold_splat(0., |sum, x| sum + x);
+        simd_map(
+            output.assume_init().into(),
+            output,
+            #[inline(always)]
+            |x: S| x.div(exp_sum),
+        );
 
         // Safety: `simd_softmax` initialized all elements of `self.output`.
         unsafe { self.output.assume_init().as_slice() }


### PR DESCRIPTION
Previously the implementation of vectorized ops was split into two parts: a `simd_{op}` internal function and the `SimdUnaryOp::eval` impl which provided a way for SIMD dispatch to invoke `simd_{op}`. The main reason for the separation was so that one SIMD operation could invoke another easily by calling eg. `simd_exp(x)`.

Remove this separation by inlining the `simd_{op}` function into the `eval` impl. To assist with one SIMD op calling another, add a `SimdUnaryOp::apply` helper. This means that eg. softmax can calling exp using `Exp::apply(x)`.

An upside of this change is that consumers of the crate can more easily call the operations in their own vectorized ops. The downside is that it adds some indirection for the reader.