### PR TITLE
Make packing of GEMM inputs more flexible

### DIFF
--- a/src/gemm/kernels/aarch64.rs
+++ b/src/gemm/kernels/aarch64.rs
@@ -3,11 +3,12 @@ use std::mem::MaybeUninit;
 use std::ops::Range;
 
 use rten_simd::vec_count;
-use rten_tensor::Matrix;
+use rten_tensor::{Matrix, MatrixLayout};
 
 use super::simd_generic::{simd_gemm, simd_gemv};
-use super::{Kernel, Lhs, TempTile};
-use crate::gemm::packing::{pack_a_block, pack_b_block};
+use super::{Kernel, Lhs, PackedLayout, TempTile};
+use crate::gemm::packing::{pack_a_block, pack_b_block, packed_a_layout, packed_b_layout};
+use crate::number::{cast_pod_mut_slice, cast_pod_slice};
 
 pub struct ArmNeonKernel {
     _private: (),
@@ -37,23 +38,35 @@ unsafe impl Kernel<f32, f32, f32> for ArmNeonKernel {
         Self::NR
     }
 
+    fn packed_a_layout(&self, a: Matrix, rows: usize, cols: usize) -> PackedLayout {
+        let mut info = packed_a_layout::<f32, { Self::MR }>(rows, cols);
+        info.must_pack = a.col_stride() != 1;
+        info
+    }
+
     fn pack_a_block(
         &self,
-        out: &mut [MaybeUninit<f32>],
+        out: &mut [MaybeUninit<u8>],
         a: Matrix,
         rows: Range<usize>,
         cols: Range<usize>,
     ) {
+        let out = cast_pod_mut_slice(out).expect("incorrect alignment for packing buffer");
         pack_a_block::<f32, { Self::MR }>(out, a, rows, cols);
+    }
+
+    fn packed_b_layout(&self, rows: usize, cols: usize) -> PackedLayout {
+        packed_b_layout::<f32, { Self::NR }>(rows, cols)
     }
 
     fn pack_b_block(
         &self,
-        out: &mut [MaybeUninit<f32>],
+        out: &mut [MaybeUninit<u8>],
         b: Matrix,
         rows: Range<usize>,
         cols: Range<usize>,
     ) {
+        let out = cast_pod_mut_slice(out).expect("incorrect alignment for packing buffer");
         pack_b_block::<f32, { Self::NR }>(out, b, rows, cols);
     }
 
@@ -62,7 +75,7 @@ unsafe impl Kernel<f32, f32, f32> for ArmNeonKernel {
         tile_ptr: *mut f32,
         tile_row_stride: usize,
         a: Lhs<f32>,
-        b: &[f32],
+        b: &[u8],
         used_rows: usize,
         used_cols: usize,
         depth: usize,
@@ -72,6 +85,8 @@ unsafe impl Kernel<f32, f32, f32> for ArmNeonKernel {
         const MR: usize = ArmNeonKernel::MR;
         const NR: usize = ArmNeonKernel::NR;
         const NR_REGS: usize = vec_count::<float32x4_t>(NR);
+
+        let b = cast_pod_slice(b).unwrap();
 
         if used_cols == NR {
             simd_gemm::<float32x4_t, MR, NR_REGS>(

--- a/src/gemm/kernels/simd_generic.rs
+++ b/src/gemm/kernels/simd_generic.rs
@@ -231,8 +231,14 @@ pub unsafe fn simd_gemm<S: SimdFloat, const MR: usize, const NR_REGS: usize>(
     assert!(depth > 0);
     let (a_ptr, a_row_stride) = match a {
         Lhs::Packed(data) => {
-            assert!(data.len() >= depth * MR);
-            (data.as_ptr(), 1)
+            let min_len = depth * MR * size_of::<f32>();
+            assert!(
+                data.len() >= min_len,
+                "packed data len {} smaller than required {}",
+                data.len(),
+                min_len
+            );
+            (data.as_ptr() as *const f32, 1)
         }
         Lhs::Unpacked {
             data,
@@ -365,8 +371,14 @@ pub unsafe fn simd_gemm_tail<S: SimdFloat, const MR: usize, const NR_REGS: usize
     assert!(depth > 0);
     let (a_ptr, a_row_stride) = match a {
         Lhs::Packed(data) => {
-            assert!(data.len() >= depth * MR);
-            (data.as_ptr(), 1)
+            let min_len = depth * MR * size_of::<f32>();
+            assert!(
+                data.len() >= min_len,
+                "packed data len {} smaller than required {}",
+                data.len(),
+                min_len
+            );
+            (data.as_ptr() as *const f32, 1)
         }
         Lhs::Unpacked {
             data,

--- a/src/gemm/packing.rs
+++ b/src/gemm/packing.rs
@@ -1,7 +1,18 @@
 use std::mem::MaybeUninit;
 use std::ops::Range;
 
-use rten_tensor::{Matrix, MatrixLayout, Storage};
+use rten_tensor::{Alloc, Matrix, MatrixLayout, Storage};
+
+use super::kernels::PackedLayout;
+use crate::number::{cast_pod_mut_slice, cast_pod_slice};
+
+/// Return the required size and other metadata for packing an "A" matrix with
+/// [`pack_a_block`].
+pub fn packed_a_layout<T, const MR: usize>(rows: usize, cols: usize) -> PackedLayout {
+    let size = rows.next_multiple_of(MR) * cols * size_of::<T>();
+    let panel_stride = MR * cols * size_of::<T>();
+    PackedLayout::new(size, align_of::<T>(), panel_stride)
+}
 
 /// Pack a block of the "A" matrix for use by a GEMM kernel.
 ///
@@ -87,6 +98,14 @@ pub fn pack_a_block<T: Copy + Default, const MR: usize>(
             }
         }
     }
+}
+
+/// Return the required size and other metadata for packing a "B" matrix with
+/// [`pack_b_block`].
+pub fn packed_b_layout<T, const NR: usize>(rows: usize, cols: usize) -> PackedLayout {
+    let size = cols.next_multiple_of(NR) * rows * size_of::<T>();
+    let panel_stride = NR * rows * size_of::<T>();
+    PackedLayout::new(size, align_of::<T>(), panel_stride)
 }
 
 /// Pack a block of the "B" matrix for use by a GEMM kernel.
@@ -181,6 +200,143 @@ pub fn pack_b_block<T: Copy + Default, const NR: usize>(
                     });
                 }
             }
+        }
+    }
+}
+
+// Element type used by [`PackingBuffer`]. This must have an alignment that is
+// at least as large as the alignment required by any of the kernels.
+pub type PackElem = u32;
+
+/// Buffer used for storing a block of a packed matrix.
+///
+/// The data type and layout of the contents is determined by the GEMM kernel,
+/// subject to the constraints:
+///
+///  - There is a maximum alignment the kernel can request. See [`PackElem`].
+///  - The stored data must all be plain `Copy` types for which any bit pattern
+///    is valid.
+#[derive(Clone)]
+pub struct PackingBuffer {
+    buf: Vec<PackElem>,
+    used_len: usize,
+}
+
+impl PackingBuffer {
+    /// Construct an empty packing buffer.
+    ///
+    /// No allocation happens until `alloc` is called.
+    pub const fn new() -> PackingBuffer {
+        PackingBuffer {
+            buf: Vec::new(),
+            used_len: 0,
+        }
+    }
+
+    /// Clear the buffer and reserve space for a packed input.
+    ///
+    /// Returns an uninitialized slice of `layout.size()` bytes which the
+    /// caller must fill.
+    pub fn alloc(&mut self, layout: &PackedLayout) -> &mut [MaybeUninit<u8>] {
+        assert!(layout.align() <= align_of::<PackElem>());
+
+        let buf_len = layout.size().div_ceil(size_of::<PackElem>());
+        self.buf.clear();
+        self.buf.reserve(buf_len);
+        self.used_len = 0;
+
+        let uninit_data = &mut self.buf.spare_capacity_mut()[..buf_len];
+        cast_pod_mut_slice(uninit_data).unwrap()
+    }
+
+    /// Clear the buffer and allocate a new one using `alloc`.
+    ///
+    /// When the packing buffer is no longer needed it can be extracted using
+    /// [`into_vec`](Self::into_vec) to be returned to the pool that `alloc`
+    /// allocates from.
+    pub fn alloc_in<A: Alloc>(
+        &mut self,
+        alloc: A,
+        layout: &PackedLayout,
+    ) -> &mut [MaybeUninit<u8>] {
+        assert!(layout.align() <= align_of::<PackElem>());
+
+        let buf_len = layout.size().div_ceil(size_of::<PackElem>());
+        self.buf = alloc.alloc::<PackElem>(buf_len);
+        self.used_len = 0;
+
+        let uninit_data = &mut self.buf.spare_capacity_mut()[..buf_len];
+        cast_pod_mut_slice(uninit_data).unwrap()
+    }
+
+    /// Set the number of bytes in the buffer which have been initialized.
+    pub unsafe fn set_len(&mut self, initialized_len: usize) {
+        let rounded_len = initialized_len.next_multiple_of(size_of::<PackElem>());
+        assert_eq!(rounded_len, initialized_len);
+
+        let buf_len = rounded_len / size_of::<PackElem>();
+        assert!(buf_len <= self.buf.capacity());
+        self.buf.set_len(buf_len);
+        self.used_len = initialized_len;
+    }
+
+    /// Return the contents of the buffer as a slice of bytes.
+    pub fn as_bytes(&self) -> &[u8] {
+        &cast_pod_slice(&self.buf).unwrap()[..self.used_len]
+    }
+
+    /// Extract the buffer from self.
+    pub fn into_vec(self) -> Vec<PackElem> {
+        self.buf
+    }
+}
+
+impl Default for PackingBuffer {
+    fn default() -> Self {
+        PackingBuffer::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::mem::MaybeUninit;
+
+    use super::{PackedLayout, PackingBuffer};
+
+    #[test]
+    fn test_packing_buffer() {
+        struct Case {
+            size: usize,
+            align: usize,
+            panel_stride: usize,
+        }
+
+        let cases = [Case {
+            size: 256,
+            align: 4,
+            panel_stride: 64,
+        }];
+
+        for Case {
+            size,
+            align,
+            panel_stride,
+        } in cases
+        {
+            let mut buf = PackingBuffer::new();
+            assert_eq!(buf.as_bytes().len(), 0);
+
+            let layout = PackedLayout::new(size, align, panel_stride);
+            let uninit_data = buf.alloc(&layout);
+            assert_eq!(uninit_data.len(), layout.size());
+
+            uninit_data.fill(MaybeUninit::new(0));
+
+            unsafe {
+                buf.set_len(layout.size());
+            }
+
+            assert_eq!(buf.as_bytes().len(), layout.size());
         }
     }
 }

--- a/src/number.rs
+++ b/src/number.rs
@@ -232,6 +232,7 @@ impl Pod for i8 {}
 impl Pod for u8 {}
 impl Pod for f32 {}
 impl Pod for i32 {}
+impl Pod for u32 {}
 impl Pod for u64 {}
 impl<T: Pod> Pod for MaybeUninit<T> {}
 


### PR DESCRIPTION
Previously the GEMM code assumed that data would be packed in the same format as the LHS / RHS input types, and with a fixed layout. To support new data types, especially int8, more flexibility will be needed.

 - int8 matmuls using dot product rather than FMA instructions will use a different blocked layout

 - For some architectures / data types it will make sense to expand inputs to a wider data type during packing rather than in the kernel

 - For some architectures / data types the kernel can operate on an unpacked LHS matrix, if it has unit column stride. For others packing will always be required.

To enable this:

 - Add `Kernel` methods which return descriptors specifying the size and alignment required for packing a particular A or B input.

 - Modify kernel interface to use opaque `[u8]` slices for packing buffer contents. The kernel implementations will cast this to a slice of the type they use internally.

 - Add a `PackingBuffer` struct which wraps a `Vec<u32>` buffer and provides an API for reserving space in the buffer and casting its contents to `[u8]` slices for the kernel and its packing methods.

The `PackedAMatrix` and `PackedBMatrix` types still have assumptions about the internal layout of packed buffers which will need to removed. That will happen in subsequent commits.

Part of https://github.com/robertknight/rten/issues/347.