### PR TITLE
Unify gemm APIs with and without bias arguments

### DIFF
--- a/src/ops/conv.rs
+++ b/src/ops/conv.rs
@@ -52,7 +52,7 @@ where
             .reshaped_in(pool, [in_c, in_h * in_w])
             .auto_return(pool);
 
-        gemm.gemm_uninit_bias(
+        gemm.gemm_uninit(
             out_item.data_mut().unwrap(),
             out_row_stride,
             GemmInputA::Unpacked(kernel_mat.view()),
@@ -277,7 +277,7 @@ where
                 let bias_vec = bias
                     .as_ref()
                     .map(|b| BiasVector::Column(&b.data().unwrap()[out_chans.clone()]));
-                gemm.gemm_uninit_bias(
+                gemm.gemm_uninit(
                     out_mat.data_mut().unwrap(),
                     out_row_stride,
                     prepacked_kernel
@@ -560,7 +560,8 @@ pub fn conv_transpose(
             col2im_row_stride,
             GemmInputA::Unpacked(kernel_mat),
             GemmInputB::Unpacked(input_mat.view()),
-            1., /* alpha */
+            1.,   // alpha
+            None, // bias
         );
 
         // Safety: `gemm_uninit` initialized col2im_mat.

--- a/src/ops/matmul.rs
+++ b/src/ops/matmul.rs
@@ -59,6 +59,7 @@ where
                 GemmInputB::Unpacked(b.nd_view()),
                 alpha,
                 beta,
+                None, // bias
             );
             output
         }
@@ -71,6 +72,7 @@ where
                 GemmInputA::Unpacked(a.nd_view()),
                 GemmInputB::Unpacked(b.nd_view()),
                 alpha,
+                None, // bias
             );
             // Safety: `gemm_uninit` initialized all elements
             unsafe { output.assume_init() }
@@ -277,7 +279,7 @@ where
                 GemmInputB::Unpacked(b_mat)
             };
 
-            gemm.gemm_uninit_bias(
+            gemm.gemm_uninit(
                 out_mat,
                 out_row_stride,
                 a_input,
@@ -589,7 +591,7 @@ mod tests {
             .zip(c.inner_iter_mut::<2>())
             .for_each(|((a, b), mut c)| {
                 let c_row_stride = c.stride(0);
-                gemm.gemm_bias(
+                gemm.gemm(
                     c.data_mut().unwrap(),
                     c_row_stride,
                     GemmInputA::Unpacked(a),

--- a/src/ops/rnn.rs
+++ b/src/ops/rnn.rs
@@ -238,8 +238,9 @@ pub fn gru(
                 gates_row_stride,
                 GemmInputA::Unpacked(in_item),
                 input_weights,
-                1., /* alpha */
-                0., /* beta */
+                1.,   // alpha
+                0.,   // beta
+                None, // bias
             );
             if let Some(input_bias) = input_bias {
                 add_in_place(gates.as_dyn_mut(), input_bias.as_dyn());
@@ -252,8 +253,9 @@ pub fn gru(
                 hidden_scratch_row_stride,
                 GemmInputA::Unpacked(hidden_item),
                 hidden_weights,
-                1., /* alpha */
-                0., /* beta */
+                1.,   // alpha
+                0.,   // beta
+                None, // bias
             );
             if let Some(hidden_bias) = hidden_bias {
                 add_in_place(hidden_scratch.as_dyn_mut(), hidden_bias.as_dyn());
@@ -491,8 +493,9 @@ pub fn lstm(
                 gates_row_stride,
                 GemmInputA::Unpacked(in_item),
                 input_weights,
-                1., /* alpha */
-                0., /* beta */
+                1.,   // alpha
+                0.,   // beta
+                None, // bias
             );
             if let Some(input_bias) = input_bias {
                 add_in_place(gates.as_dyn_mut(), input_bias.as_dyn());
@@ -503,8 +506,9 @@ pub fn lstm(
                 gates_row_stride,
                 GemmInputA::Unpacked(hidden_item),
                 hidden_weights,
-                1., /* alpha */
-                1., /* beta */
+                1.,   // alpha
+                1.,   // beta
+                None, // bias
             );
             if let Some(hidden_bias) = hidden_bias {
                 add_in_place(gates.as_dyn_mut(), hidden_bias.as_dyn());


### PR DESCRIPTION
Combine the `GemmExecutor` methods that take biases and those that don't. This streamlines the API a little. When new GEMM "extensions" are added in future, they should probably be part of an options struct to avoid having methods for the cross-product of GEMM extensions.

This highlights a few existing places where code calls `GemmExecutor::gemm` without a bias and then immediately adds one. This could likely be fused.