### PR TITLE
Make im2col packing part of the gemm module

### DIFF
--- a/rten-simd/src/arch/aarch64.rs
+++ b/rten-simd/src/arch/aarch64.rs
@@ -2,8 +2,8 @@ use std::arch::aarch64::{
     float32x4_t, int32x4_t, uint32x4_t, vabsq_f32, vaddq_f32, vaddq_s32, vaddvq_f32, vandq_u32,
     vbslq_f32, vbslq_s32, vceqq_s32, vcgeq_f32, vcgeq_s32, vcgtq_s32, vcleq_f32, vcleq_s32,
     vcltq_f32, vcltq_s32, vcvtq_s32_f32, vdivq_f32, vdupq_n_f32, vdupq_n_s32, vfmaq_f32, vld1q_f32,
-    vld1q_s32, vld1q_u32, vmaxq_f32, vmulq_f32, vreinterpretq_f32_s32, vshlq_n_s32, vst1q_f32,
-    vst1q_s32, vst1q_u32, vsubq_f32, vsubq_s32,
+    vld1q_s32, vld1q_u32, vmaxq_f32, vmaxq_s32, vminq_s32, vmulq_f32, vreinterpretq_f32_s32,
+    vshlq_n_s32, vst1q_f32, vst1q_s32, vst1q_u32, vsubq_f32, vsubq_s32,
 };
 
 use crate::{Simd, SimdFloat, SimdInt, SimdMask};
@@ -111,6 +111,16 @@ impl SimdInt for int32x4_t {
     #[inline]
     unsafe fn shl<const COUNT: i32>(self) -> Self {
         vshlq_n_s32(self, COUNT)
+    }
+
+    #[inline]
+    unsafe fn max(self, rhs: Self) -> Self {
+        vmaxq_s32(self, rhs)
+    }
+
+    #[inline]
+    unsafe fn min(self, rhs: Self) -> Self {
+        vminq_s32(self, rhs)
     }
 
     #[inline]

--- a/rten-simd/src/arch/scalar.rs
+++ b/rten-simd/src/arch/scalar.rs
@@ -93,6 +93,16 @@ impl SimdInt for i32 {
     }
 
     #[inline]
+    unsafe fn max(self, rhs: Self) -> Self {
+        Ord::max(self, rhs)
+    }
+
+    #[inline]
+    unsafe fn min(self, rhs: Self) -> Self {
+        Ord::min(self, rhs)
+    }
+
+    #[inline]
     unsafe fn add(self, rhs: Self) -> Self {
         self + rhs
     }

--- a/rten-simd/src/arch/wasm.rs
+++ b/rten-simd/src/arch/wasm.rs
@@ -1,8 +1,8 @@
 use std::arch::wasm32::{
     f32x4_abs, f32x4_add, f32x4_div, f32x4_extract_lane, f32x4_ge, f32x4_le, f32x4_lt, f32x4_max,
     f32x4_mul, f32x4_splat, f32x4_sub, i32x4, i32x4_add, i32x4_eq, i32x4_ge, i32x4_gt, i32x4_le,
-    i32x4_lt, i32x4_shl, i32x4_shuffle, i32x4_splat, i32x4_sub, i32x4_trunc_sat_f32x4, v128,
-    v128_and, v128_bitselect, v128_load, v128_store,
+    i32x4_lt, i32x4_max, i32x4_min, i32x4_shl, i32x4_shuffle, i32x4_splat, i32x4_sub,
+    i32x4_trunc_sat_f32x4, v128, v128_and, v128_bitselect, v128_load, v128_store,
 };
 
 use crate::{Simd, SimdFloat, SimdInt, SimdMask};
@@ -119,6 +119,16 @@ impl SimdInt for v128i {
     #[inline]
     unsafe fn shl<const COUNT: i32>(self) -> Self {
         Self(i32x4_shl(self.0, COUNT as u32))
+    }
+
+    #[inline]
+    unsafe fn min(self, rhs: Self) -> Self {
+        Self(i32x4_min(self.0, rhs.0))
+    }
+
+    #[inline]
+    unsafe fn max(self, rhs: Self) -> Self {
+        Self(i32x4_max(self.0, rhs.0))
     }
 
     #[inline]

--- a/rten-simd/src/arch/x86_64.rs
+++ b/rten-simd/src/arch/x86_64.rs
@@ -2,11 +2,11 @@ use std::arch::x86_64::{
     __m256, __m256i, _mm256_add_epi32, _mm256_add_ps, _mm256_and_si256, _mm256_andnot_ps,
     _mm256_blendv_epi8, _mm256_blendv_ps, _mm256_castps256_ps128, _mm256_castsi256_ps,
     _mm256_cmp_ps, _mm256_cmpeq_epi32, _mm256_cmpgt_epi32, _mm256_cvttps_epi32, _mm256_div_ps,
-    _mm256_extractf128_ps, _mm256_fmadd_ps, _mm256_loadu_ps, _mm256_loadu_si256, _mm256_max_ps,
-    _mm256_mul_ps, _mm256_or_si256, _mm256_set1_epi32, _mm256_set1_ps, _mm256_setr_epi32,
-    _mm256_slli_epi32, _mm256_storeu_ps, _mm256_storeu_si256, _mm256_sub_epi32, _mm256_sub_ps,
-    _mm_add_ps, _mm_cvtss_f32, _mm_movehl_ps, _mm_prefetch, _mm_shuffle_ps, _CMP_GE_OQ, _CMP_LE_OQ,
-    _CMP_LT_OQ, _MM_HINT_ET0, _MM_HINT_T0,
+    _mm256_extractf128_ps, _mm256_fmadd_ps, _mm256_loadu_ps, _mm256_loadu_si256, _mm256_max_epi32,
+    _mm256_max_ps, _mm256_min_epi32, _mm256_mul_ps, _mm256_or_si256, _mm256_set1_epi32,
+    _mm256_set1_ps, _mm256_setr_epi32, _mm256_slli_epi32, _mm256_storeu_ps, _mm256_storeu_si256,
+    _mm256_sub_epi32, _mm256_sub_ps, _mm_add_ps, _mm_cvtss_f32, _mm_movehl_ps, _mm_prefetch,
+    _mm_shuffle_ps, _CMP_GE_OQ, _CMP_LE_OQ, _CMP_LT_OQ, _MM_HINT_ET0, _MM_HINT_T0,
 };
 use std::mem::transmute;
 
@@ -144,6 +144,18 @@ impl SimdInt for __m256i {
     #[target_feature(enable = "avx2")]
     unsafe fn shl<const COUNT: i32>(self) -> Self {
         _mm256_slli_epi32(self, COUNT)
+    }
+
+    #[inline]
+    #[target_feature(enable = "avx2")]
+    unsafe fn max(self, rhs: Self) -> Self {
+        _mm256_max_epi32(self, rhs)
+    }
+
+    #[inline]
+    #[target_feature(enable = "avx2")]
+    unsafe fn min(self, rhs: Self) -> Self {
+        _mm256_min_epi32(self, rhs)
     }
 
     #[inline]
@@ -309,10 +321,10 @@ use std::arch::x86_64::{
     __m512, __m512i, __mmask16, _mm512_abs_ps, _mm512_add_epi32, _mm512_add_ps,
     _mm512_castsi512_ps, _mm512_cmp_epi32_mask, _mm512_cmp_ps_mask, _mm512_cvttps_epi32,
     _mm512_div_ps, _mm512_fmadd_ps, _mm512_loadu_ps, _mm512_loadu_si512, _mm512_mask_blend_epi32,
-    _mm512_mask_blend_ps, _mm512_mask_i32gather_ps, _mm512_max_ps, _mm512_mul_ps,
-    _mm512_reduce_add_ps, _mm512_set1_epi32, _mm512_set1_ps, _mm512_setzero_si512,
-    _mm512_sllv_epi32, _mm512_storeu_epi32, _mm512_storeu_ps, _mm512_sub_epi32, _mm512_sub_ps,
-    _MM_CMPINT_EQ, _MM_CMPINT_LE, _MM_CMPINT_LT,
+    _mm512_mask_blend_ps, _mm512_mask_i32gather_ps, _mm512_max_epi32, _mm512_max_ps,
+    _mm512_min_epi32, _mm512_mul_ps, _mm512_reduce_add_ps, _mm512_set1_epi32, _mm512_set1_ps,
+    _mm512_setzero_si512, _mm512_sllv_epi32, _mm512_storeu_epi32, _mm512_storeu_ps,
+    _mm512_sub_epi32, _mm512_sub_ps, _MM_CMPINT_EQ, _MM_CMPINT_LE, _MM_CMPINT_LT,
 };
 
 #[cfg(feature = "avx512")]
@@ -368,6 +380,18 @@ impl Simd for __m512i {
     #[target_feature(enable = "avx512f")]
     unsafe fn blend(self, other: Self, mask: Self::Mask) -> Self {
         _mm512_mask_blend_epi32(mask, self, other)
+    }
+
+    #[inline]
+    #[target_feature(enable = "avx512f")]
+    unsafe fn min(self, rhs: Self) -> Self {
+        _mm512_min_epi32(self, rhs)
+    }
+
+    #[inline]
+    #[target_feature(enable = "avx512f")]
+    unsafe fn max(self, rhs: Self) -> Self {
+        _mm512_max_epi32(self, rhs)
     }
 
     #[inline]

--- a/rten-simd/src/vec.rs
+++ b/rten-simd/src/vec.rs
@@ -207,6 +207,12 @@ pub trait SimdInt: Simd<Elem = i32> {
     /// Compute `self - rhs`.
     unsafe fn sub(self, rhs: Self) -> Self;
 
+    /// Compute minimum of self and `rhs`.
+    unsafe fn min(self, rhs: Self) -> Self;
+
+    /// Compute maximum of self and `rhs`.
+    unsafe fn max(self, rhs: Self) -> Self;
+
     /// Shift the bits in each element left by `count`.
     unsafe fn shl<const COUNT: i32>(self) -> Self;
 

--- a/src/gemm.rs
+++ b/src/gemm.rs
@@ -15,12 +15,14 @@ use rten_tensor::prelude::*;
 use rten_tensor::{Alloc, GlobalAlloc, Matrix, MatrixLayout, MatrixMut, NdTensorView, Storage};
 
 use crate::iter_util::{range_chunks, MaybeParIter};
-use crate::number::{cast_pod_mut_slice, Identities, Pod};
+use crate::number::{Identities, Pod};
 use crate::tensor_pool::ExtractBuffer;
 
+mod im2col;
 mod kernels;
 mod packing;
 
+pub use im2col::{ColOffsets, Im2Col, RowOffsets};
 use kernels::generic::GenericKernel;
 use kernels::Kernel;
 use packing::{PackElem, PackingBuffer};
@@ -167,7 +169,7 @@ impl<T> GemmInputA<'_, T> {
 }
 
 /// Trait implemented by GEMM input types.
-pub trait GemmInT: Copy + Send + Sync + Identities + Pod {}
+pub trait GemmInT: Copy + Default + Send + Sync + Identities + Pod {}
 impl GemmInT for f32 {}
 
 /// Trait implemented by GEMM output types.
@@ -184,48 +186,6 @@ pub trait GemmOutT:
 }
 impl GemmOutT for f32 {}
 
-/// A virtual matrix which has a known size, but may not actually be
-/// materialized in memory. The GEMM implementation will call
-/// [`VirtualMatrix::pack_b`] to pack blocks of this matrix into a buffer as it
-/// needs them.
-///
-/// This is useful for operations such as im2col-based convolution, which
-/// involve creating potentially large temporary matrices.
-///
-/// # Safety
-///
-/// Implementations of [`pack_b`](VirtualMatrix::pack_b) must initialize the
-/// entire buffer passed to them.
-pub unsafe trait VirtualMatrix<T>: Sync {
-    /// Return the number of rows in the virtual matrix.
-    fn rows(&self) -> usize;
-
-    /// Return the number of columns in the virtual matrix.
-    fn cols(&self) -> usize;
-
-    /// Called by the GEMM implementation to pack a block of the virtual matrix
-    /// into temporary buffer where it can be efficiently processed.
-    ///
-    /// Implementations must copy the subregion of the matrix specified by
-    /// `rows` and `cols` into `out` with a specific memory layout:
-    ///
-    ///  - The columns specified by `cols` are divided into a sequence of
-    ///    panels, each wth `panel_width` columns and `rows.len()` rows.
-    ///    `panel_width` will depend on the matrix multiplication kernel used, but
-    ///    will be a small value like 4 (SSE) or 16 (AVX2).
-    ///  - Each panel should be written to `out` sequentially. Within each
-    ///    panel, elements should be written out in row-major order.
-    ///  - `cols.len()` may not be an even multiple of `panel_width`. In that
-    ///    case the final panel should be zero-padded.
-    fn pack_b(
-        &self,
-        out: &mut [MaybeUninit<T>],
-        panel_width: usize,
-        rows: Range<usize>,
-        cols: Range<usize>,
-    );
-}
-
 /// Right-hand or "B" input for a GEMM operation.
 #[derive(Copy, Clone)]
 pub enum GemmInputB<'a, T> {
@@ -235,17 +195,16 @@ pub enum GemmInputB<'a, T> {
     /// A matrix which has been pre-packed by [`GemmExecutor::prepack_b`].
     Packed(&'a PackedBMatrix<T>),
 
-    /// A virtual matrix, blocks of which will be materialized on-demand
-    /// during GEMM execution. See [`VirtualMatrix`].
-    Virtual(&'a dyn VirtualMatrix<T>),
+    /// An image which is transformed into a matrix using an im2col transformation.
+    Im2Col(&'a Im2Col<'a, T>),
 }
 
-impl<T> GemmInputB<'_, T> {
+impl<T: Copy + Default> GemmInputB<'_, T> {
     pub fn rows(&self) -> usize {
         match self {
             Self::Unpacked(m) => m.rows(),
             Self::Packed(pm) => pm.base.depth_size,
-            Self::Virtual(vm) => vm.rows(),
+            Self::Im2Col(im) => im.rows(),
         }
     }
 
@@ -253,7 +212,7 @@ impl<T> GemmInputB<'_, T> {
         match self {
             Self::Unpacked(m) => m.cols(),
             Self::Packed(pm) => pm.base.nm_size,
-            Self::Virtual(vm) => vm.cols(),
+            Self::Im2Col(im) => im.cols(),
         }
     }
 }
@@ -415,10 +374,10 @@ impl<LhsT: GemmInT, RhsT: GemmInT, OutT: GemmOutT> GemmExecutor<LhsT, RhsT, OutT
         }
     }
 
-    /// Return the panel width used when packing the "B" matrix.
+    /// Return column count step for building an [`Im2Col`] input.
     ///
-    /// This information is useful for implementations of [`VirtualMatrix`].
-    pub fn b_panel_width(&self) -> usize {
+    /// The number of columns in [`ColOffsets`] must be a multiple of this.
+    pub fn im2col_col_count_step(&self) -> usize {
         self.kernel.nr()
     }
 
@@ -976,7 +935,7 @@ fn gemm_impl<LhsT: GemmInT, RhsT: GemmInT, OutT: GemmOutT>(
                 let mut thread_local_packed_b: Option<PackingBuffer> = None;
 
                 let rhs_block = match b {
-                    GemmInputB::Unpacked(_) | GemmInputB::Virtual(_) => PACKED_B.with(|cell| {
+                    GemmInputB::Unpacked(_) | GemmInputB::Im2Col(_) => PACKED_B.with(|cell| {
                         let mut packed_b = cell.take();
 
                         let layout = kernel.packed_b_layout(depth_range.len(), col_end - col_start);
@@ -989,12 +948,9 @@ fn gemm_impl<LhsT: GemmInT, RhsT: GemmInT, OutT: GemmOutT>(
                                 depth_range.clone(),
                                 col_start..col_end,
                             ),
-                            GemmInputB::Virtual(vm) => vm.pack_b(
-                                // Cast [MaybeUninit<u8>] => [MaybeUninit<RhsT>] as im2col packing
-                                // currently assumes the packed data is in the same format as the
-                                // RHS input.
-                                cast_pod_mut_slice(packed_uninit).unwrap(),
-                                kernel.nr(),
+                            GemmInputB::Im2Col(im) => kernel.pack_im2col(
+                                packed_uninit,
+                                im,
                                 depth_range.clone(),
                                 col_start..col_end,
                             ),
@@ -1248,19 +1204,15 @@ fn gemm_block<LhsT, RhsT, OutT: GemmOutT>(
 #[cfg(test)]
 mod tests {
     use std::error::Error;
-    use std::mem::MaybeUninit;
-    use std::ops::Range;
     use std::time::Instant;
 
     use rten_bench::run_bench;
     use rten_tensor::prelude::*;
     use rten_tensor::rng::XorShiftRng;
     use rten_tensor::test_util::expect_equal;
-    use rten_tensor::{Matrix, MatrixLayout, NdTensor, Tensor};
+    use rten_tensor::{Matrix, NdTensor, Tensor};
 
-    use super::{
-        gemm, BiasVector, GemmExecutor, GemmInputA, GemmInputB, KernelType, VirtualMatrix,
-    };
+    use super::{gemm, BiasVector, GemmExecutor, GemmInputA, GemmInputB, KernelType};
 
     fn reference_matmul_alpha_beta(a: &Tensor, b: &Tensor, alpha: f32, beta: f32) -> Tensor {
         let [a_rows, _a_cols]: [usize; 2] = a.shape().try_into().expect("input should be a matrix");
@@ -1733,103 +1685,8 @@ mod tests {
     }
 
     #[test]
-    fn test_gemm_virtual() -> Result<(), Box<dyn Error>> {
-        let mut rng = XorShiftRng::new(1234);
-
-        struct Packer<'a> {
-            tensor: Matrix<'a, f32>,
-        }
-
-        // Safety: `pack_b` initializes the entire buffer.
-        unsafe impl<'a> VirtualMatrix<f32> for Packer<'a> {
-            fn rows(&self) -> usize {
-                self.tensor.rows()
-            }
-
-            fn cols(&self) -> usize {
-                self.tensor.cols()
-            }
-
-            fn pack_b(
-                &self,
-                out: &mut [MaybeUninit<f32>],
-                panel_width: usize,
-                rows: Range<usize>,
-                cols: Range<usize>,
-            ) {
-                let out_cols = cols.len().next_multiple_of(panel_width);
-                let mut out_iter = out.iter_mut();
-
-                for panel_start_col in (0..out_cols).step_by(panel_width) {
-                    for row in rows.clone() {
-                        for panel_col in 0..panel_width {
-                            let col = panel_start_col + panel_col;
-                            out_iter.next().unwrap().write(
-                                self.tensor
-                                    .get([row, cols.start + col])
-                                    .copied()
-                                    .unwrap_or(0.),
-                            );
-                        }
-                    }
-                }
-            }
-        }
-
-        struct Case {
-            m: usize,
-            n: usize,
-            k: usize,
-        }
-
-        let cases = [
-            // Single block along all dimensions.
-            Case {
-                m: 10,
-                k: 20,
-                n: 30,
-            },
-            // Multiple depth blocks.
-            Case {
-                m: 10,
-                k: DEPTH_BLOCK_SIZE + 50,
-                n: 20,
-            },
-            // Multiple column blocks
-            Case {
-                m: 10,
-                k: 10,
-                n: COL_BLOCK_SIZE + 50,
-            },
-        ];
-
-        for case in cases {
-            let mut result = Tensor::zeros(&[case.m, case.n]);
-            let result_row_stride = result.stride(0);
-            let mut expected = result.clone();
-
-            let a = Tensor::rand(&[case.m, case.k], &mut rng);
-            let b = Tensor::rand(&[case.k, case.n], &mut rng);
-            let gemm = GemmExecutor::new();
-
-            let packer = Packer {
-                tensor: b.nd_view(),
-            };
-
-            gemm.gemm(
-                result.data_mut().unwrap(),
-                result_row_stride,
-                GemmInputA::Unpacked(a.nd_view()),
-                GemmInputB::Virtual(&packer),
-                1.,   // alpha
-                1.,   // beta
-                None, // bias
-            );
-            reference_gemm(&mut expected, &a, &b, 1., 1., None);
-
-            expect_equal(&result, &expected)?;
-        }
-
+    fn test_gemm_im2col() -> Result<(), Box<dyn Error>> {
+        // TODO
         Ok(())
     }
 

--- a/src/gemm/im2col.rs
+++ b/src/gemm/im2col.rs
@@ -1,0 +1,176 @@
+use std::mem::MaybeUninit;
+use std::ops::Range;
+
+use rten_simd::{SimdInt, SimdMask};
+
+use rten_tensor::{NdTensorView, Storage};
+
+/// Maps rows of an [`Im2Col`] matrix to locations in the source image.
+///
+/// For efficiency when packing the image, the locations are premultiplied by
+/// the corresponding stride.
+pub struct RowOffsets {
+    /// Map of row index to `channel * channel_stride`.
+    pub chan: Vec<i32>,
+
+    /// Map of row index to `row * row_stride`.
+    pub y: Vec<i32>,
+
+    /// Map of row index to `col * col_stride`.
+    pub x: Vec<i32>,
+}
+
+/// Maps columns of an [`Im2Col`] matrix to locations in the source image.
+///
+/// For efficiency when packing the image, the locations are premultiplied by
+/// the corresponding stride.
+pub struct ColOffsets {
+    /// Map of column index to `row * row_stride`.
+    pub y: Vec<i32>,
+
+    /// Map of column index to `col * col_stride`.
+    pub x: Vec<i32>,
+}
+
+/// A matrix formed by unrolling patches of an image into columns.
+///
+/// The input image has shape [C,H,W] and is transformed into a matrix with
+/// shape [C * Kh * kW, Oh * Ow] where Kh/Kw are convolution kernel sizes and
+/// Oh/Ow are the number of patches in the Y and X directions.
+///
+/// The matrix is _virtual_ as it is not materialized fully in memory. Instead
+/// blocks of the matrix are materialized during computation.
+pub struct Im2Col<'a, T> {
+    pub image: NdTensorView<'a, T, 3>,
+
+    /// Map of im2col row index to input image coordinate, premultiplied with
+    /// the corresponding stride.
+    pub row_offsets: RowOffsets,
+
+    /// Map of im2col column index to input image coordinate, premultiplied with
+    /// the corresponding stride. The length of arrays in `col_offsets` is
+    /// rounded up to the nearest multiple of the panel width. `n_cols` contains
+    /// the actual number of columns in the virtual matrix.
+    pub col_offsets: ColOffsets,
+
+    /// Number of columns in the im2col matrix.
+    pub n_cols: usize,
+
+    /// Maximum valid sum of `row_offsets.y + col_offsets.y`. Values above this
+    /// correspond to the padding region.
+    pub max_y_offset: i32,
+
+    /// Maximum valid sum of `row_offsets.x + col_offsets.x`. Values above this
+    /// correspond to the padding region.
+    pub max_x_offset: i32,
+}
+
+impl<T: Copy + Default> Im2Col<'_, T> {
+    /// Return the number of rows in the im2col matrix.
+    pub fn rows(&self) -> usize {
+        self.row_offsets.chan.len()
+    }
+
+    /// Return the number of columns in the im2col matrix.
+    pub fn cols(&self) -> usize {
+        self.n_cols
+    }
+
+    /// Pack part of an image into a packing buffer.
+    ///
+    /// `NR_REGS` specifies the width of each column panel as a multiple of
+    /// `S::LEN` elements. In other words, `panel_width` must exactly equal
+    /// `NR_REGS * S::LEN`.
+    ///
+    /// # Safety
+    ///
+    /// Caller must ensure SIMD type is supported.
+    #[inline(always)]
+    pub(super) unsafe fn pack_block<S: SimdInt, const NR_REGS: usize>(
+        &self,
+        out: &mut [MaybeUninit<T>],
+        panel_width: usize,
+        rows: Range<usize>,
+        cols: Range<usize>,
+    ) {
+        assert_eq!(panel_width, S::LEN * NR_REGS);
+
+        let col_range = cols.start..cols.end.next_multiple_of(panel_width);
+        let used_size = rows.len() * col_range.len();
+        assert_eq!(out.len(), used_size);
+
+        let col_y_offsets = &self.col_offsets.y[col_range.clone()];
+        let col_x_offsets = &self.col_offsets.x[col_range.clone()];
+        let row_chan_offsets = &self.row_offsets.chan[rows.clone()];
+        let row_y_offsets = &self.row_offsets.y[rows.clone()];
+        let row_x_offsets = &self.row_offsets.x[rows.clone()];
+
+        let img_ptr = self.image.storage().as_ptr();
+
+        // Loop over column panels, then rows, then `S::LEN`-wide column groups
+        // within each panel.
+        let out_ptr = out.as_mut_ptr();
+        let mut out_offset = 0;
+
+        for start_col in (0..col_y_offsets.len()).step_by(S::LEN * NR_REGS) {
+            let col_y_offset: [S; NR_REGS] = std::array::from_fn(|i| {
+                S::load(col_y_offsets.as_ptr().add(start_col + S::LEN * i))
+            });
+            let col_x_offset: [S; NR_REGS] = std::array::from_fn(|i| {
+                S::load(col_x_offsets.as_ptr().add(start_col + S::LEN * i))
+            });
+            let max_x_offset = S::splat(self.max_x_offset);
+            let max_y_offset = S::splat(self.max_y_offset);
+
+            for ((&row_chan_offset, &row_y_offset), &row_x_offset) in row_chan_offsets
+                .iter()
+                .zip(row_y_offsets.iter())
+                .zip(row_x_offsets.iter())
+            {
+                let row_chan_offset = S::splat(row_chan_offset);
+                let row_y_offset = S::splat(row_y_offset);
+                let row_x_offset = S::splat(row_x_offset);
+
+                for i in 0..NR_REGS {
+                    let y_offset = col_y_offset[i].add(row_y_offset);
+                    let x_offset = col_x_offset[i].add(row_x_offset);
+                    let offsets = row_chan_offset.add(y_offset).add(x_offset);
+
+                    // Create mask to specify offsets which are valid. Others
+                    // correspond to the padding region.
+                    let zero = S::zero();
+                    let pad_mask = y_offset
+                        .ge(zero)
+                        .and(y_offset.le(max_y_offset))
+                        .and(x_offset.ge(zero))
+                        .and(x_offset.le(max_x_offset));
+
+                    // Set offsets to zero for padding elements. We require
+                    // this offset is always valid.
+                    let offsets_array = zero.blend(offsets, pad_mask).to_array();
+                    let pad_mask_array = pad_mask.to_array();
+
+                    // Gather elements and store in packing buffer.
+                    for idx in 0..S::LEN {
+                        let out_ptr: *mut T = std::mem::transmute(out_ptr.add(out_offset + idx));
+                        let src_elem = *img_ptr.add(offsets_array[idx] as usize);
+
+                        // This should be compiled to a conditional move.
+                        let elem = if pad_mask_array[idx] {
+                            src_elem
+                        } else {
+                            T::default()
+                        };
+
+                        out_ptr.write(elem);
+                    }
+
+                    out_offset += S::LEN;
+                }
+            }
+        }
+
+        // Check we initialized as many elements as used.
+        assert_eq!(out_offset, used_size);
+    }
+}

--- a/src/gemm/kernels.rs
+++ b/src/gemm/kernels.rs
@@ -1,7 +1,7 @@
 use std::mem::MaybeUninit;
 use std::ops::Range;
 
-use super::GemmOutT;
+use super::{GemmOutT, Im2Col};
 use rten_tensor::Matrix;
 
 pub mod generic;
@@ -156,6 +156,16 @@ pub unsafe trait Kernel<LhsT, RhsT, OutT>: Sync {
         &self,
         out: &mut [MaybeUninit<u8>],
         b: Matrix<RhsT>,
+        rows: Range<usize>,
+        cols: Range<usize>,
+    );
+
+    /// Pack a block of an image as the B input for use by this kernel, using
+    /// an im2col transformation to flatten the image into a matrix.
+    fn pack_im2col(
+        &self,
+        out: &mut [MaybeUninit<u8>],
+        image: &Im2Col<RhsT>,
         rows: Range<usize>,
         cols: Range<usize>,
     );

--- a/src/ops/conv/im2col.rs
+++ b/src/ops/conv/im2col.rs
@@ -1,386 +1,114 @@
-use std::mem::MaybeUninit;
-use std::ops::Range;
-
-use rten_simd::{vec_count, SimdInt, SimdMask};
-
-#[cfg(feature = "avx512")]
-use rten_simd::isa_detection::is_avx512_supported;
-
 use rten_tensor::prelude::*;
-use rten_tensor::{NdTensorView, Storage};
+use rten_tensor::NdTensorView;
 
-use crate::gemm::{KernelType, VirtualMatrix};
+use crate::gemm::{ColOffsets, Im2Col, RowOffsets};
 use crate::ops::pooling::calc_output_size_and_padding;
 use crate::ops::Padding;
 
-struct RowOffsets {
-    /// Map of row index to `channel * channel_stride`.
-    chan: Vec<i32>,
-
-    /// Map of row index to `row * row_stride`.
-    y: Vec<i32>,
-
-    /// Map of row index to `col * col_stride`.
-    x: Vec<i32>,
-}
-
-struct ColOffsets {
-    /// Map of column index to `row * row_stride`.
-    y: Vec<i32>,
-
-    /// Map of column index to `col * col_stride`.
-    x: Vec<i32>,
-}
-
-/// Unrolls patches of an image as columns of a virtual matrix.
+/// Build a virtual [`Im2Col`] matrix from an image and convolution parameters.
 ///
-/// The input image has shape [C,H,W] and is transformed into a matrix with
-/// shape [C * Kh * kW, Oh * Ow] where Kh/Kw are convolution kernel sizes and
-/// Oh/Ow are the number of patches in the Y and X directions.
-///
-/// The transform is virtual because the matrix is not actually materialized
-/// in memory. Instead blocks of it are produced on-demand during a matrix
-/// multiplication operation.
-pub struct VirtualIm2Col<'a, T> {
-    image: NdTensorView<'a, T, 3>,
+/// The number of columns in the matrix is padded to a multiple of `col_count_step`.
+pub fn build_im2col<T>(
+    image: NdTensorView<T, 3>,
+    kernel: [usize; 2],
+    padding: [usize; 4],
+    strides: [usize; 2],
+    dilations: [usize; 2],
+    col_count_step: usize,
+) -> Im2Col<T> {
+    // Ensure image has at least one cell.
+    assert!(image.len() > 0);
 
-    /// Map of im2col row index to input image coordinate, premultiplied with
-    /// the corresponding stride.
-    row_offsets: RowOffsets,
+    let [chans, h, w] = image.shape();
+    let [k_h, k_w] = kernel;
+    let [stride_h, stride_w] = strides;
+    let [dilation_y, dilation_x] = dilations;
+    let [pad_top, pad_left, _pad_bottom, _pad_right] = padding;
+    let (y_patches, x_patches, _) = calc_output_size_and_padding(
+        (h, w),
+        (k_h, k_w),
+        (stride_h, stride_w),
+        Padding::Fixed(padding.into()),
+        Some((dilation_y, dilation_x)),
+    )
+    .expect("invalid im2col params");
 
-    /// Map of im2col column index to input image coordinate, premultiplied with
-    /// the corresponding stride. The length of `col_offsets` is rounded up
-    /// to the nearest multiple of the panel width. `n_cols` contains the
-    /// number of columns in the virtual matrix.
-    col_offsets: ColOffsets,
+    let [im_stride_c, im_stride_h, im_stride_w]: [i32; 3] =
+        image.strides().map(|s| s.try_into().unwrap());
 
-    /// Number of columns in the im2col matrix.
-    n_cols: usize,
+    // Build lookup table of row index in the virtual im2col matrix to
+    // offsets in the image.
+    let n_rows = chans * k_h * k_w;
+    let mut row_chan_offsets = Vec::<i32>::with_capacity(n_rows);
+    let mut row_y_offsets = Vec::<i32>::with_capacity(n_rows);
+    let mut row_x_offsets = Vec::<i32>::with_capacity(n_rows);
+    for chan in 0..chans {
+        // Offset to image channel
+        row_chan_offsets.extend(std::iter::repeat(chan as i32 * im_stride_c).take(k_h * k_w));
 
-    /// Maximum valid sum of `row_offsets.y + col_offsets.y`. Values above this
-    /// correspond to the padding region.
-    max_y_offset: i32,
+        for k_y in 0..k_h {
+            // Offset from top-left corner of patch
+            row_y_offsets
+                .extend(std::iter::repeat(im_stride_h * k_y as i32 * dilation_y as i32).take(k_w));
+            row_x_offsets.extend(
+                (0..k_w as i32)
+                    .map(|k_x| im_stride_w * k_x * dilation_x as i32)
+                    .take(k_w),
+            );
+        }
+    }
 
-    /// Maximum valid sum of `row_offsets.x + col_offsets.x`. Values above this
-    /// correspond to the padding region.
-    max_x_offset: i32,
+    // Build lookup table of column index in the virtual im2col matrix to
+    // offsets in the image.
+    let n_cols = x_patches * y_patches;
+    let n_cols_padded = n_cols.next_multiple_of(col_count_step);
 
-    /// Gemm kernel that is going to be used.
-    gemm_kernel: KernelType,
-}
+    // Main loop for the used columns.
+    let mut col_y_offsets = Vec::with_capacity(n_cols_padded);
+    let mut col_x_offsets = Vec::with_capacity(n_cols_padded);
+    for patch_y in 0..y_patches {
+        let img_y = (patch_y as i32 * stride_h as i32) - pad_top as i32;
+        col_y_offsets.extend(std::iter::repeat(img_y * im_stride_h).take(x_patches));
+        col_x_offsets.extend((0..x_patches).map(|patch_x| {
+            let img_x = (patch_x as i32 * stride_w as i32) - pad_left as i32;
+            img_x * im_stride_w
+        }));
+    }
 
-impl<'a, T: Copy + Default> VirtualIm2Col<'a, T> {
-    /// Create a virtual im2col matrix from a [C, H, W] input tensor and
-    /// convolution parameters.
-    pub fn new(
-        gemm_kernel: KernelType,
-        image: NdTensorView<'a, T, 3>,
-        kernel: [usize; 2],
-        padding: [usize; 4],
-        strides: [usize; 2],
-        dilations: [usize; 2],
-        panel_width: usize,
-    ) -> VirtualIm2Col<'a, T> {
-        // Ensure image has at least one cell.
-        assert!(image.len() > 0);
+    // Remainder loop for columns added to pad count to a multiple of
+    // `col_count_step`. This is slower as it uses divisions.
+    for col in n_cols..n_cols_padded {
+        let patch_y = col as i32 / x_patches as i32;
+        let patch_x = col as i32 % x_patches as i32;
+        let img_x = (patch_x * stride_w as i32) - pad_left as i32;
+        let img_y = (patch_y * stride_h as i32) - pad_top as i32;
+        col_y_offsets.push(img_y * im_stride_h);
+        col_x_offsets.push(img_x * im_stride_w);
+    }
 
-        let [chans, h, w] = image.shape();
-        let [k_h, k_w] = kernel;
-        let [stride_h, stride_w] = strides;
-        let [dilation_y, dilation_x] = dilations;
-        let [pad_top, pad_left, _pad_bottom, _pad_right] = padding;
-        let (y_patches, x_patches, _) = calc_output_size_and_padding(
-            (h, w),
-            (k_h, k_w),
-            (stride_h, stride_w),
-            Padding::Fixed(padding.into()),
-            Some((dilation_y, dilation_x)),
-        )
+    // Compute max valid X / Y offsets for testing whether an element is in
+    // the padding region or not.
+    let max_y_offset: i32 = ((image.size(1) - 1) * image.stride(1))
+        .try_into()
+        .expect("invalid im2col params");
+    let max_x_offset: i32 = ((image.size(2) - 1) * image.stride(2))
+        .try_into()
         .expect("invalid im2col params");
 
-        let [im_stride_c, im_stride_h, im_stride_w]: [i32; 3] =
-            image.strides().map(|s| s.try_into().unwrap());
+    Im2Col {
+        image,
+        row_offsets: RowOffsets {
+            chan: row_chan_offsets,
+            y: row_y_offsets,
+            x: row_x_offsets,
+        },
+        col_offsets: ColOffsets {
+            y: col_y_offsets,
+            x: col_x_offsets,
+        },
+        n_cols,
 
-        // Build lookup table of row index in the virtual im2col matrix to
-        // offsets in the image.
-        let n_rows = chans * k_h * k_w;
-        let mut row_chan_offsets = Vec::<i32>::with_capacity(n_rows);
-        let mut row_y_offsets = Vec::<i32>::with_capacity(n_rows);
-        let mut row_x_offsets = Vec::<i32>::with_capacity(n_rows);
-        for chan in 0..chans {
-            // Offset to image channel
-            row_chan_offsets.extend(std::iter::repeat(chan as i32 * im_stride_c).take(k_h * k_w));
-
-            for k_y in 0..k_h {
-                // Offset from top-left corner of patch
-                row_y_offsets.extend(
-                    std::iter::repeat(im_stride_h * k_y as i32 * dilation_y as i32).take(k_w),
-                );
-                row_x_offsets.extend(
-                    (0..k_w as i32)
-                        .map(|k_x| im_stride_w * k_x * dilation_x as i32)
-                        .take(k_w),
-                );
-            }
-        }
-
-        // Build lookup table of column index in the virtual im2col matrix to
-        // offsets in the image.
-        let n_cols = x_patches * y_patches;
-        let n_cols_padded = n_cols.next_multiple_of(panel_width);
-
-        // Main loop for the used columns.
-        let mut col_y_offsets = Vec::with_capacity(n_cols_padded);
-        let mut col_x_offsets = Vec::with_capacity(n_cols_padded);
-        for patch_y in 0..y_patches {
-            let img_y = (patch_y as i32 * stride_h as i32) - pad_top as i32;
-            col_y_offsets.extend(std::iter::repeat(img_y * im_stride_h).take(x_patches));
-            col_x_offsets.extend((0..x_patches).map(|patch_x| {
-                let img_x = (patch_x as i32 * stride_w as i32) - pad_left as i32;
-                img_x * im_stride_w
-            }));
-        }
-
-        // Remainder loop for columns added to pad count to a multiple of
-        // `panel_width`. This is slower as it uses divisions.
-        for col in n_cols..n_cols_padded {
-            let patch_y = col as i32 / x_patches as i32;
-            let patch_x = col as i32 % x_patches as i32;
-            let img_x = (patch_x * stride_w as i32) - pad_left as i32;
-            let img_y = (patch_y * stride_h as i32) - pad_top as i32;
-            col_y_offsets.push(img_y * im_stride_h);
-            col_x_offsets.push(img_x * im_stride_w);
-        }
-
-        // Compute max valid X / Y offsets for testing whether an element is in
-        // the padding region or not.
-        let max_y_offset: i32 = ((image.size(1) - 1) * image.stride(1))
-            .try_into()
-            .expect("invalid im2col params");
-        let max_x_offset: i32 = ((image.size(2) - 1) * image.stride(2))
-            .try_into()
-            .expect("invalid im2col params");
-
-        VirtualIm2Col {
-            gemm_kernel,
-            image,
-            row_offsets: RowOffsets {
-                chan: row_chan_offsets,
-                y: row_y_offsets,
-                x: row_x_offsets,
-            },
-            col_offsets: ColOffsets {
-                y: col_y_offsets,
-                x: col_x_offsets,
-            },
-            n_cols,
-
-            max_y_offset,
-            max_x_offset,
-        }
-    }
-
-    /// Pack part of an image according to the requirements of
-    /// [`VirtualMatrix::pack_b`].
-    ///
-    /// `NR_REGS` specifies the width of each column panel as a multiple of
-    /// `S::LEN` elements. In other words, `panel_width` must exactly equal
-    /// `NR_REGS * S::LEN`.
-    #[inline(always)]
-    unsafe fn pack_b_impl<S: SimdInt, const NR_REGS: usize>(
-        &self,
-        out: &mut [MaybeUninit<T>],
-        panel_width: usize,
-        rows: Range<usize>,
-        cols: Range<usize>,
-    ) {
-        assert_eq!(panel_width, S::LEN * NR_REGS);
-
-        let col_range = cols.start..cols.end.next_multiple_of(panel_width);
-        let used_size = rows.len() * col_range.len();
-        assert_eq!(out.len(), used_size);
-
-        let col_y_offsets = &self.col_offsets.y[col_range.clone()];
-        let col_x_offsets = &self.col_offsets.x[col_range.clone()];
-        let row_chan_offsets = &self.row_offsets.chan[rows.clone()];
-        let row_y_offsets = &self.row_offsets.y[rows.clone()];
-        let row_x_offsets = &self.row_offsets.x[rows.clone()];
-
-        let img_ptr = self.image.storage().as_ptr();
-
-        // Loop over column panels, then rows, then `S::LEN`-wide column groups
-        // within each panel.
-        let out_ptr = out.as_mut_ptr();
-        let mut out_offset = 0;
-
-        for start_col in (0..col_y_offsets.len()).step_by(S::LEN * NR_REGS) {
-            let col_y_offset: [S; NR_REGS] = std::array::from_fn(|i| {
-                S::load(col_y_offsets.as_ptr().add(start_col + S::LEN * i))
-            });
-            let col_x_offset: [S; NR_REGS] = std::array::from_fn(|i| {
-                S::load(col_x_offsets.as_ptr().add(start_col + S::LEN * i))
-            });
-            let max_x_offset = S::splat(self.max_x_offset);
-            let max_y_offset = S::splat(self.max_y_offset);
-
-            for ((&row_chan_offset, &row_y_offset), &row_x_offset) in row_chan_offsets
-                .iter()
-                .zip(row_y_offsets.iter())
-                .zip(row_x_offsets.iter())
-            {
-                let row_chan_offset = S::splat(row_chan_offset);
-                let row_y_offset = S::splat(row_y_offset);
-                let row_x_offset = S::splat(row_x_offset);
-
-                for i in 0..NR_REGS {
-                    let y_offset = col_y_offset[i].add(row_y_offset);
-                    let x_offset = col_x_offset[i].add(row_x_offset);
-                    let offsets = row_chan_offset.add(y_offset).add(x_offset);
-
-                    // Create mask to specify offsets which are valid. Others
-                    // correspond to the padding region.
-                    let zero = S::zero();
-                    let pad_mask = y_offset
-                        .ge(zero)
-                        .and(y_offset.le(max_y_offset))
-                        .and(x_offset.ge(zero))
-                        .and(x_offset.le(max_x_offset));
-
-                    // Set offsets to zero for padding elements. We require
-                    // this offset is always valid.
-                    let offsets_array = zero.blend(offsets, pad_mask).to_array();
-                    let pad_mask_array = pad_mask.to_array();
-
-                    // Gather elements and store in packing buffer.
-                    for idx in 0..S::LEN {
-                        let out_ptr: *mut T = std::mem::transmute(out_ptr.add(out_offset + idx));
-                        let src_elem = *img_ptr.add(offsets_array[idx] as usize);
-
-                        // This should be compiled to a conditional move.
-                        let elem = if pad_mask_array[idx] {
-                            src_elem
-                        } else {
-                            T::default()
-                        };
-
-                        out_ptr.write(elem);
-                    }
-
-                    out_offset += S::LEN;
-                }
-            }
-        }
-
-        // Check we initialized as many elements as used.
-        assert_eq!(out_offset, used_size);
-    }
-}
-
-impl VirtualIm2Col<'_, f32> {
-    #[cfg(target_arch = "x86_64")]
-    #[target_feature(enable = "avx2")]
-    #[target_feature(enable = "fma")]
-    unsafe fn pack_b_impl_avx(
-        &self,
-        out: &mut [MaybeUninit<f32>],
-        panel_width: usize,
-        rows: Range<usize>,
-        cols: Range<usize>,
-    ) {
-        use std::arch::x86_64::__m256i;
-        const NR_REGS: usize = vec_count::<__m256i>(KERNEL_FMA_NR);
-        self.pack_b_impl::<__m256i, NR_REGS>(out, panel_width, rows.clone(), cols.clone());
-    }
-
-    #[cfg(feature = "avx512")]
-    #[cfg(target_arch = "x86_64")]
-    #[target_feature(enable = "avx512f")]
-    #[target_feature(enable = "avx512vl")]
-    unsafe fn pack_b_impl_avx512(
-        &self,
-        out: &mut [MaybeUninit<f32>],
-        panel_width: usize,
-        rows: Range<usize>,
-        cols: Range<usize>,
-    ) {
-        use std::arch::x86_64::__m512i;
-        const NR_REGS: usize = vec_count::<__m512i>(KERNEL_AVX512_NR);
-        self.pack_b_impl::<__m512i, NR_REGS>(out, panel_width, rows.clone(), cols.clone());
-    }
-}
-
-// Micro-tile widths assumed for different GEMM kernels. This must be kept
-// in sync with the corresponding GEMM kernels in `crate::gemm::kernels`.
-#[cfg(target_arch = "aarch64")]
-const KERNEL_ARM_NEON_NR: usize = 8;
-
-#[cfg(feature = "avx512")]
-#[cfg(target_arch = "x86_64")]
-const KERNEL_AVX512_NR: usize = 32;
-
-const KERNEL_BASE_NR: usize = 4;
-
-#[cfg(target_arch = "x86_64")]
-const KERNEL_FMA_NR: usize = 16;
-
-#[cfg(target_arch = "wasm32")]
-#[cfg(target_feature = "simd128")]
-const KERNEL_WASM_NR: usize = 8;
-
-// Safety: `pack_b` initializes the entire buffer passed to it.
-unsafe impl VirtualMatrix<f32> for VirtualIm2Col<'_, f32> {
-    fn rows(&self) -> usize {
-        self.row_offsets.chan.len()
-    }
-
-    fn cols(&self) -> usize {
-        self.n_cols
-    }
-
-    fn pack_b(
-        &self,
-        out: &mut [MaybeUninit<f32>],
-        panel_width: usize,
-        rows: Range<usize>,
-        cols: Range<usize>,
-    ) {
-        match (self.gemm_kernel, panel_width) {
-            #[cfg(feature = "avx512")]
-            #[cfg(target_arch = "x86_64")]
-            (KernelType::Avx512, KERNEL_AVX512_NR) => unsafe {
-                assert!(is_avx512_supported());
-                self.pack_b_impl_avx512(out, panel_width, rows.clone(), cols.clone());
-            },
-            #[cfg(target_arch = "x86_64")]
-            (KernelType::Fma, KERNEL_FMA_NR) => unsafe {
-                assert!(is_x86_feature_detected!("avx2"));
-                self.pack_b_impl_avx(out, panel_width, rows.clone(), cols.clone());
-            },
-            #[cfg(target_arch = "aarch64")]
-            (KernelType::ArmNeon, KERNEL_ARM_NEON_NR) => unsafe {
-                // Safety: Neon is always available.
-                use std::arch::aarch64::int32x4_t;
-                const NR_REGS: usize = vec_count::<int32x4_t>(KERNEL_ARM_NEON_NR);
-                self.pack_b_impl::<int32x4_t, NR_REGS>(out, panel_width, rows, cols);
-            },
-            #[cfg(target_arch = "wasm32")]
-            #[cfg(target_feature = "simd128")]
-            (KernelType::Wasm, KERNEL_WASM_NR) => unsafe {
-                // Safety: SIMD support is checked when WASM binary is loaded.
-                use rten_simd::arch::wasm::v128i;
-                const NR_REGS: usize = vec_count::<v128i>(KERNEL_WASM_NR);
-                self.pack_b_impl::<v128i, NR_REGS>(out, panel_width, rows, cols);
-            },
-            (KernelType::Generic, KERNEL_BASE_NR) => unsafe {
-                const NR_REGS: usize = vec_count::<f32>(KERNEL_BASE_NR);
-                self.pack_b_impl::<i32, NR_REGS>(out, panel_width, rows, cols);
-            },
-            _ => {
-                panic!(
-                    "unsupported (kernel, panel_width) for im2col: ({:?}, {})",
-                    self.gemm_kernel, panel_width
-                );
-            }
-        }
+        max_y_offset,
+        max_x_offset,
     }
 }


### PR DESCRIPTION
im2col packing was done outside of the `gemm` module via the `VirtualMatrix` abstraction. This wasn't a good abstraction since im2col packing is deeply tied to the kernel implementation and needs to know about the packing buffer layout and NR / NR_REGS parameters.

Refactor this by splitting the im2col module into two parts:

 - The code that builds the image <-> im2col row/column mappings, which has no unsafe code and minimal kernel-specific knowledge (just the step/increment which the column count must be a multiple of). This lives in `ops::conv::im2col`.

 - The code that packs part of an image using the pre-built row/col mappings. This is now handled by the gemm module in `gemm::im2col`.

TODO:
- [x] Safety notes in `pack_im2col` impls
- [x] Enforce that generated image offsets are in bounds (eg. clamp offsets to image storage len)
- [x] Test for im2col gemm inputs. This can use a simplified version of `build_im2col`
- [ ] Check performance is unchanged (nb. there may be a hit from bounds-checking the input image during packing, but this should be negligible