### PR TITLE
Add masked word prediction example for BERT base models

### DIFF
--- a/rten-examples/Cargo.toml
+++ b/rten-examples/Cargo.toml
@@ -104,6 +104,11 @@ path = "src/gpt2.rs"
 test = false
 
 [[bin]]
+name = "modernbert"
+path = "src/modernbert.rs"
+test = false
+
+[[bin]]
 name = "jina_similarity"
 path = "src/jina_similarity.rs"
 test = false

--- a/rten-examples/README.md
+++ b/rten-examples/README.md
@@ -20,21 +20,26 @@ The general steps to run an example are:
    package:
 
    ```sh
-   $ rten-convert <onnx_model> <output_model>
+   $ pip install rten-convert
+   $ rten-convert model.onnx
    ```
 
-3. Run the example using:
+   This will create a `model.rten` file in the same directory as the ONNX
+   model.
+
+3. Run the example from the `rten-examples` directory using:
 
    ```sh
    $ cargo run -r --bin <example_name> <model_path> <...args>
    ```
 
    Where `...args` refers to the example-specific arguments, such as input data.
+
+   Note the `-r` flag to create a **release build**. This is required as the
+   examples will run very slowly in debug builds.
+
    The syntax and flags for an individual example can be displayed using its
    `--help` command:
-
-   Note the `-r` flag to create a release build. This is required as the
-   examples will run very slowly in debug builds.
 
    ```sh
    $ cargo run -r --bin <example_name> -- --help
@@ -42,6 +47,13 @@ The general steps to run an example are:
 
    Note the `--` before `--help`. Without this `cargo` will print its own help
    info.
+
+   You can also run examples from the root of rten repository by specifying
+   the rten-examples package name:
+
+   ```sh
+   $ cargo run -p rten-examples -r --bin <example_name> -- <...args>
+   ```
 
 ## Reference implementations
 

--- a/rten-examples/README.md
+++ b/rten-examples/README.md
@@ -90,6 +90,7 @@ on the [SQuAD](https://paperswithcode.com/dataset/squad) dataset
 - **gpt2** - Text generation using the [GPT-2](https://openai.com/index/better-language-models/)
 language model.
 - **jina_similarity** - Sentence similarity using vector embeddings of sentences
+- **modernbert** - Masked word prediction using [ModernBERT](https://huggingface.co/blog/modernbert). Also works with the base version of the original BERT model.
 - **qwen2_chat** - Chatbot using [Qwen2](https://github.com/QwenLM/Qwen2)
 
 ### Audio

--- a/rten-examples/src/modernbert.rs
+++ b/rten-examples/src/modernbert.rs
@@ -1,0 +1,200 @@
+use std::collections::VecDeque;
+use std::error::Error;
+
+use rten::{Model, Operators};
+use rten_tensor::prelude::*;
+use rten_tensor::NdTensor;
+use rten_text::{TokenId, Tokenizer, TokenizerError};
+
+struct Args {
+    model: String,
+    tokenizer: String,
+    input: String,
+    show_token_ids: bool,
+}
+
+fn parse_args() -> Result<Args, lexopt::Error> {
+    use lexopt::prelude::*;
+
+    let mut values = VecDeque::new();
+    let mut parser = lexopt::Parser::from_env();
+    let mut show_token_ids = false;
+
+    while let Some(arg) = parser.next()? {
+        match arg {
+            Value(val) => values.push_back(val.string()?),
+            Long("help") => {
+                println!(
+                    "Predict masked words in a sentence.
+
+Usage: {bin_name} [options] <model> <tokenizer> <input>
+
+Args:
+
+  <model>       - Input BERT model
+  <tokenizer>   - `tokenizer.json` file
+  <input>       - Text with \"[MASK]\" spans to fill in
+
+Options:
+
+ -t, --token-ids  - Show token IDs for input and output text
+",
+                    bin_name = parser.bin_name().unwrap_or("modernbert")
+                );
+                std::process::exit(0);
+            }
+            Short('t') | Long("token-ids") => {
+                show_token_ids = true;
+            }
+            _ => return Err(arg.unexpected()),
+        }
+    }
+
+    let model = values.pop_front().ok_or("missing `model` arg")?;
+    let tokenizer = values.pop_front().ok_or("missing `tokenizer` arg")?;
+    let input = values.make_contiguous().join(" ");
+
+    let args = Args {
+        model,
+        tokenizer,
+        input,
+        show_token_ids,
+    };
+
+    Ok(args)
+}
+
+/// Predict masked words in a sentence using [ModernBERT].
+///
+/// First download the ModernBERT model in ONNX format from
+/// https://huggingface.co/answerdotai/ModernBERT-base/tree/main, as well
+/// as the `tokenizer.json` file.
+///
+/// Convert the model using `rten-convert`:
+///
+/// ```
+/// rten-convert modernbert.onnx
+/// ```
+///
+/// Run the example using:
+///
+/// ```
+/// cargo run --release --bin modernbert modernbert.rten tokenizer.json "Earth is a [MASK]."
+/// ```
+///
+/// This should print "Earth is a planet." Note the period at the end of the
+/// input sentence. Without that the model may predict the masked token is
+/// simply a new line.
+///
+/// This example also works with classic BERT models such as
+/// https://huggingface.co/google-bert/bert-base-uncased.
+///
+/// [ModernBERT]: https://huggingface.co/answerdotai/ModernBERT-base
+fn main() -> Result<(), Box<dyn Error>> {
+    let args = parse_args()?;
+    let model = Model::load_file(args.model)?;
+    let tokenizer = Tokenizer::from_file(&args.tokenizer)?;
+    let cls_token = tokenizer.get_token_id("[CLS]")?;
+    let sep_token = tokenizer.get_token_id("[SEP]")?;
+    let mask_token = tokenizer.get_token_id("[MASK]")?;
+
+    // Encode input, replacing occurrences of "[MASK]" by the corresponding
+    // special token ID.
+
+    let tokenize_piece = |piece| -> Result<Vec<TokenId>, TokenizerError> {
+        let ids = tokenizer
+            .encode(piece, None)?
+            .into_token_ids()
+            .into_iter()
+            // `Tokenizer::encode` adds [CLS] and [SEP] tokens. Remove these
+            // as we only want to insert them around the whole input ID sequence.
+            .filter(|id| ![cls_token, sep_token].contains(id))
+            .collect();
+        Ok(ids)
+    };
+
+    let mut input_ids = Vec::from([cls_token]);
+    let mut mask_indices = Vec::new();
+    let mut remainder = args.input.as_str();
+    while let Some(mask_pos) = remainder.find("[MASK]") {
+        // `trim_end` replicates the behavior of the `lstrip` attribute for
+        // the `[MASK]` special token in tokenizer.json.
+        let piece_str = remainder[..mask_pos].trim_end();
+        input_ids.extend(tokenize_piece(piece_str)?);
+        mask_indices.push(input_ids.len());
+        input_ids.push(mask_token);
+        remainder = &remainder[mask_pos + "[MASK]".len()..];
+    }
+    if !remainder.is_empty() {
+        input_ids.extend(tokenize_piece(remainder)?);
+    }
+    input_ids.push(sep_token);
+
+    if args.show_token_ids {
+        println!("Input IDs: {:?}", input_ids);
+    }
+
+    // Prepare model inputs
+    let input_ids = NdTensor::from_data([1, input_ids.len()], input_ids).map(|id| *id as i32);
+    let attention_mask = NdTensor::full(input_ids.shape(), 1);
+
+    let input_ids_id = model.node_id("input_ids")?;
+    let attention_mask_id = model.node_id("attention_mask")?;
+    let logits_id = model.node_id("logits")?;
+
+    let mut model_inputs = Vec::from([
+        (input_ids_id, input_ids.view().into()),
+        (attention_mask_id, attention_mask.into()),
+    ]);
+
+    // ModernBERT doesn't have a `token_type_ids` input, but this example also
+    // works with older BERT models that do. If using such a model, such as
+    // "bert-base-uncased", provide this input.
+    if let Ok(token_type_ids_id) = model.node_id("token_type_ids") {
+        let token_type_ids = NdTensor::full(input_ids.shape(), 0);
+        model_inputs.push((token_type_ids_id, token_type_ids.into()));
+    }
+
+    // Run model and predict masked words.
+    let [logits] = model.run_n(model_inputs, [logits_id], None)?;
+
+    // Get the most likely token for each position, filter out special tokens
+    // and decode into text.
+    let logits: NdTensor<f32, 3> = logits.try_into()?;
+    let mut output_ids: NdTensor<i32, 2> = logits
+        .arg_max(2 /* axis */, false /* keep_dims */)?
+        .try_into()?;
+    let mut output_ids = output_ids.slice_mut(0); // Remove batch dim
+
+    if args.show_token_ids {
+        println!("Output IDs: {:?}", output_ids.to_vec());
+    }
+
+    // Discard output tokens other than those corresponding to `[MASK]` tokens
+    // in the input.
+    for pos in 0..output_ids.size(0) {
+        if !mask_indices.contains(&pos) {
+            output_ids[pos] = input_ids[[0, pos]];
+        }
+    }
+
+    let output_ids: Vec<TokenId> = output_ids
+        .iter()
+        .filter_map(|id| {
+            let id = *id as TokenId;
+
+            // Strip special tokens.
+            if ![cls_token, sep_token].contains(&id) {
+                Some(id)
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    let text = tokenizer.decode(&output_ids)?;
+
+    println!("{}", text);
+
+    Ok(())
+}

--- a/rten-examples/src/modernbert_reference.py
+++ b/rten-examples/src/modernbert_reference.py
@@ -1,0 +1,44 @@
+from argparse import ArgumentParser
+
+from transformers import AutoTokenizer, AutoModelForMaskedLM
+
+parser = ArgumentParser(
+    description="Replace [MASK] tokens in the input text with model predictions."
+)
+parser.add_argument(
+    "-m",
+    "--model",
+    type=str,
+    help="Name of the model to use",
+
+    # nb. If you get an error that this model is not supported, see
+    # https://huggingface.co/answerdotai/ModernBERT-base/discussions/3.
+    #
+    # You can also use an older BERT model such as "bert-base-uncased".
+    default="answerdotai/ModernBERT-base",
+)
+parser.add_argument("text", type=str, help="Input text containing [MASK] tokens")
+args = parser.parse_args()
+
+tokenizer = AutoTokenizer.from_pretrained(args.model)
+model = AutoModelForMaskedLM.from_pretrained(args.model)
+inputs = tokenizer(args.text, return_tensors="pt")
+
+# Print input and output token IDs to enable comparison against RTen's
+# tokenization and model output.
+input_ids = inputs["input_ids"][0].tolist()
+print("Input IDs:", input_ids)
+
+outputs = model(**inputs)
+
+raw_output_ids = outputs.logits[0].argmax(axis=-1)
+print("Output IDs:", raw_output_ids.tolist())
+
+# Keep only the output IDs for positions where the input contained a mask token.
+output_ids = input_ids.copy()
+for pos in range(len(output_ids)):
+    if output_ids[pos] == tokenizer.mask_token_id:
+        output_ids[pos] = raw_output_ids[pos]
+
+predicted_text = tokenizer.decode(output_ids, skip_special_tokens=True)
+print(predicted_text)

--- a/rten-text/src/tokenizer.rs
+++ b/rten-text/src/tokenizer.rs
@@ -46,6 +46,12 @@ impl<'a> From<&'a str> for EncoderInput<'a> {
     }
 }
 
+impl<'a> From<&'a String> for EncoderInput<'a> {
+    fn from(val: &'a String) -> EncoderInput<'a> {
+        EncoderInput::Item(val)
+    }
+}
+
 /// Construct a tokenizer input with a pair of sequences.
 impl<'a> From<(&'a str, &'a str)> for EncoderInput<'a> {
     fn from(val: (&'a str, &'a str)) -> EncoderInput<'a> {


### PR DESCRIPTION
Add a basic BERT example that uses a base model for masked word prediction. It is specifically intended for use with ModernBERT but also works with the OG BERT model and DistilBERT.

The tokenization code is verbose because rten-text treats special tokens as ordinary text. That's good for safety when tokenizing untrusted user input, but awkward for contexts where the input is trusted. Also the `decode` API is missing an equivalent of `strip_special_tokens=True`.