### PR TITLE
Make GEMM functions return errors on invalid inputs

### DIFF
--- a/src/gemm/errors.rs
+++ b/src/gemm/errors.rs
@@ -1,0 +1,40 @@
+use std::error::Error;
+use std::fmt;
+use std::fmt::Display;
+
+/// Errors with matrix multiplication inputs.
+#[derive(Clone, Debug, PartialEq)]
+pub enum GemmError {
+    /// Columns of LHS and RHS inputs do not match.
+    KSizeMismatch,
+    /// Bias vector length does not match the corresponding output matrix size.
+    WrongBiasSize,
+    /// The buffer provided for the output is too short.
+    OutputNotLargeEnough,
+    /// The data was packed with a kernel that uses a different layout than
+    /// the current kernel.
+    PackedDataKernelMismatch,
+    /// The data was packed with different cache blocking parameters than are
+    /// currently being used.
+    PackedDataBlockingMismatch,
+}
+
+impl Display for GemmError {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::KSizeMismatch => {
+                write!(fmt, "columns of matrix `a` must match rows of matrix `b`")
+            }
+            Self::WrongBiasSize => write!(fmt, "bias vector length is incorrect"),
+            Self::OutputNotLargeEnough => write!(fmt, "output buffer is too small"),
+            Self::PackedDataKernelMismatch => {
+                write!(fmt, "matrix was packed with a different kernel")
+            }
+            Self::PackedDataBlockingMismatch => {
+                write!(fmt, "matrix was packed with a different blocking size")
+            }
+        }
+    }
+}
+
+impl Error for GemmError {}

--- a/src/ops/conv.rs
+++ b/src/ops/conv.rs
@@ -57,7 +57,8 @@ where
             GemmInputB::Unpacked(in_mat.view()),
             1., // alpha
             bias_vec,
-        );
+        )
+        .unwrap();
         n_init += out_item.len();
     }
 
@@ -282,7 +283,8 @@ where
                     GemmInputB::Im2Col(&im2col),
                     1., // alpha
                     bias_vec,
-                );
+                )
+                .unwrap();
                 n_init.fetch_add(out_mat.len(), Ordering::SeqCst);
             });
     }
@@ -558,7 +560,8 @@ pub fn conv_transpose(
             GemmInputB::Unpacked(input_mat.view()),
             1.,   // alpha
             None, // bias
-        );
+        )
+        .unwrap();
 
         // Safety: `gemm_uninit` initialized col2im_mat.
         let col2im_mat = unsafe { col2im_mat.view().assume_init() };

--- a/src/ops/matmul.rs
+++ b/src/ops/matmul.rs
@@ -60,7 +60,8 @@ where
                 alpha,
                 beta,
                 None, // bias
-            );
+            )
+            .unwrap();
             output
         }
         _ => {
@@ -73,7 +74,8 @@ where
                 GemmInputB::Unpacked(b.nd_view()),
                 alpha,
                 None, // bias
-            );
+            )
+            .unwrap();
             // Safety: `gemm_uninit` initialized all elements
             unsafe { output.assume_init() }
         }
@@ -286,7 +288,8 @@ where
                 b_input,
                 alpha.unwrap_or(1.),
                 bias,
-            );
+            )
+            .unwrap();
         });
 
     // Safety: Loop above initialized all output elements.
@@ -560,6 +563,7 @@ mod tests {
             alpha,
             beta,
         )
+        .unwrap()
     }
 
     /// Multiply matrices in `a` by corresponding matrices in `b` and write to
@@ -618,6 +622,7 @@ mod tests {
                     0., /* beta */
                     bias,
                 )
+                .unwrap()
             });
 
         match (a_is_vec, b_is_vec) {

--- a/src/ops/rnn.rs
+++ b/src/ops/rnn.rs
@@ -241,7 +241,8 @@ pub fn gru(
                 1.,   // alpha
                 0.,   // beta
                 None, // bias
-            );
+            )
+            .unwrap();
             if let Some(input_bias) = input_bias {
                 add_in_place(gates.as_dyn_mut(), input_bias.as_dyn());
             }
@@ -256,7 +257,8 @@ pub fn gru(
                 1.,   // alpha
                 0.,   // beta
                 None, // bias
-            );
+            )
+            .unwrap();
             if let Some(hidden_bias) = hidden_bias {
                 add_in_place(hidden_scratch.as_dyn_mut(), hidden_bias.as_dyn());
             }
@@ -496,7 +498,8 @@ pub fn lstm(
                 1.,   // alpha
                 0.,   // beta
                 None, // bias
-            );
+            )
+            .unwrap();
             if let Some(input_bias) = input_bias {
                 add_in_place(gates.as_dyn_mut(), input_bias.as_dyn());
             }
@@ -509,7 +512,8 @@ pub fn lstm(
                 1.,   // alpha
                 1.,   // beta
                 None, // bias
-            );
+            )
+            .unwrap();
             if let Some(hidden_bias) = hidden_bias {
                 add_in_place(gates.as_dyn_mut(), hidden_bias.as_dyn());
             }


### PR DESCRIPTION
As the interface evolves the number of ways that inputs can be invalid is
growing. Change the interface to return an error instead of panicking to make
testing these cases easier.

Asserts around the size of the input were removed when validating pre-packed
inputs. The size is part of the pre-packed input, so a mismatch is not possible.

