### PR TITLE
Implement minimal u8 x i8 -> i32 quantized GEMM support

### DIFF
--- a/src/gemm.rs
+++ b/src/gemm.rs
@@ -174,6 +174,8 @@ impl<T> GemmInputA<'_, T> {
 
 /// Trait implemented by GEMM input types.
 pub trait GemmInT: Copy + Default + Send + Sync + Identities + Pod {}
+impl GemmInT for i8 {}
+impl GemmInT for u8 {}
 impl GemmInT for f32 {}
 
 /// Trait implemented by GEMM output types.
@@ -188,6 +190,7 @@ pub trait GemmOutT:
     + Pod
 {
 }
+impl GemmOutT for i32 {}
 impl GemmOutT for f32 {}
 
 /// Right-hand or "B" input for a GEMM operation.

--- a/src/gemm.rs
+++ b/src/gemm.rs
@@ -1564,7 +1564,7 @@ mod tests {
     #[test]
     fn test_gemm_transposed() -> Result<(), Box<dyn Error>> {
         let mut rng = XorShiftRng::new(1234);
-        let mut a = NdTensor::rand([20, 30], &mut rng);
+        let mut a = NdTensor::<f32, 2>::rand([20, 30], &mut rng);
         let mut b = NdTensor::rand([10, 20], &mut rng);
 
         // Transpose the input matrices. This will alter their row and column
@@ -2144,7 +2144,7 @@ mod tests {
 
             let mut rng = XorShiftRng::new(1234);
             let mut result = NdTensor::zeros([m, n]);
-            let a = NdTensor::rand([m, k], &mut rng);
+            let a = NdTensor::<f32, 2>::rand([m, k], &mut rng);
             let b = if transpose_b {
                 let mut b = NdTensor::rand([n, k], &mut rng);
                 b.transpose();

--- a/src/gemm/errors.rs
+++ b/src/gemm/errors.rs
@@ -9,6 +9,8 @@ pub enum GemmError {
     KSizeMismatch,
     /// Bias vector length does not match the corresponding output matrix size.
     WrongBiasSize,
+    /// Quantization parameter size does not match corresponding input size.
+    WrongQuantParamSize,
     /// The buffer provided for the output is too short.
     OutputNotLargeEnough,
     /// The data was packed with a kernel that uses a different layout than
@@ -26,6 +28,9 @@ impl Display for GemmError {
                 write!(fmt, "columns of matrix `a` must match rows of matrix `b`")
             }
             Self::WrongBiasSize => write!(fmt, "bias vector length is incorrect"),
+            Self::WrongQuantParamSize => {
+                write!(fmt, "quantization parameter size does not match input")
+            }
             Self::OutputNotLargeEnough => write!(fmt, "output buffer is too small"),
             Self::PackedDataKernelMismatch => {
                 write!(fmt, "matrix was packed with a different kernel")

--- a/src/gemm/kernels/generic.rs
+++ b/src/gemm/kernels/generic.rs
@@ -5,7 +5,7 @@ use rten_simd::vec_count;
 use rten_tensor::{Matrix, MatrixLayout};
 
 use super::simd_generic::{simd_gemv, GemmDispatch};
-use super::{Kernel, Lhs, PackedLayout, TempTile};
+use super::{Kernel, Lhs, PackedLayout, QuantParams, TempTile};
 use crate::gemm::packing::{pack_a_block, pack_b_block, packed_a_layout, packed_b_layout};
 use crate::gemm::Im2Col;
 use crate::number::{cast_pod_mut_slice, cast_pod_slice};
@@ -44,7 +44,13 @@ unsafe impl Kernel<f32, f32, f32> for GenericKernel {
         "base"
     }
 
-    fn packed_a_layout(&self, a: Matrix, rows: usize, cols: usize) -> PackedLayout {
+    fn packed_a_layout(
+        &self,
+        a: Matrix,
+        rows: usize,
+        cols: usize,
+        _quant: Option<QuantParams<f32>>,
+    ) -> PackedLayout {
         let mut info = packed_a_layout::<f32, { Self::MR }>(rows, cols);
         info.must_pack = a.col_stride() != 1;
         info
@@ -56,12 +62,18 @@ unsafe impl Kernel<f32, f32, f32> for GenericKernel {
         a: Matrix,
         rows: Range<usize>,
         cols: Range<usize>,
+        _quant: Option<QuantParams<f32>>,
     ) {
         let out = cast_pod_mut_slice(out).unwrap();
         pack_a_block::<f32, { Self::MR }>(out, a, rows, cols);
     }
 
-    fn packed_b_layout(&self, rows: usize, cols: usize) -> PackedLayout {
+    fn packed_b_layout(
+        &self,
+        rows: usize,
+        cols: usize,
+        _quant: Option<QuantParams<f32>>,
+    ) -> PackedLayout {
         packed_b_layout::<f32, { Self::NR }>(rows, cols)
     }
 
@@ -71,6 +83,7 @@ unsafe impl Kernel<f32, f32, f32> for GenericKernel {
         b: Matrix,
         rows: Range<usize>,
         cols: Range<usize>,
+        _quant: Option<QuantParams<f32>>,
     ) {
         let out = cast_pod_mut_slice(out).unwrap();
         pack_b_block::<f32, { Self::NR }>(out, b, rows, cols);
@@ -103,6 +116,8 @@ unsafe impl Kernel<f32, f32, f32> for GenericKernel {
         depth: usize,
         alpha: f32,
         beta: f32,
+        _a_quant: Option<QuantParams<f32>>,
+        _b_quant: Option<QuantParams<f32>>,
     ) {
         const MR: usize = GenericKernel::MR;
         const NR: usize = GenericKernel::NR;
@@ -156,10 +171,216 @@ unsafe impl Kernel<f32, f32, f32> for GenericKernel {
         b: Matrix,
         alpha: f32,
         beta: f32,
+        _a_quant: Option<QuantParams<f32>>,
+        _b_quant: Option<QuantParams<f32>>,
     ) {
         // Safety - f32 "SIMD" type is always supported
         unsafe {
             simd_gemv::<f32, 4>(out, a, b, alpha, beta);
+        }
+    }
+}
+
+unsafe impl Kernel<u8, i8, i32> for GenericKernel {
+    fn new() -> Option<Self> {
+        Some(GenericKernel { _private: () })
+    }
+
+    fn mr(&self) -> usize {
+        Self::MR
+    }
+
+    fn nr(&self) -> usize {
+        Self::NR
+    }
+
+    fn name(&self) -> &'static str {
+        "generic-i8"
+    }
+
+    fn packed_a_layout(
+        &self,
+        _a: Matrix<u8>,
+        rows: usize,
+        cols: usize,
+        _quant: Option<QuantParams<u8>>,
+    ) -> PackedLayout {
+        let mut info = packed_a_layout::<u8, { Self::MR }>(rows, cols);
+        info.must_pack = true;
+        info
+    }
+
+    fn pack_a_block(
+        &self,
+        out: &mut [MaybeUninit<u8>],
+        a: Matrix<u8>,
+        rows: Range<usize>,
+        cols: Range<usize>,
+        _quant: Option<QuantParams<u8>>,
+    ) {
+        let out = cast_pod_mut_slice(out).unwrap();
+        pack_a_block::<u8, { Self::MR }>(out, a, rows, cols);
+    }
+
+    fn packed_b_layout(
+        &self,
+        rows: usize,
+        cols: usize,
+        _quant: Option<QuantParams<i8>>,
+    ) -> PackedLayout {
+        packed_b_layout::<i8, { Self::NR }>(rows, cols)
+    }
+
+    fn pack_b_block(
+        &self,
+        out: &mut [MaybeUninit<u8>],
+        b: Matrix<i8>,
+        rows: Range<usize>,
+        cols: Range<usize>,
+        _quant: Option<QuantParams<i8>>,
+    ) {
+        let out = cast_pod_mut_slice(out).unwrap();
+        pack_b_block::<i8, { Self::NR }>(out, b, rows, cols);
+    }
+
+    fn pack_im2col(
+        &self,
+        _out: &mut [MaybeUninit<u8>],
+        _image: &Im2Col<i8>,
+        _rows: Range<usize>,
+        _cols: Range<usize>,
+    ) {
+        unimplemented!("im2col packing not implemented");
+    }
+
+    unsafe fn kernel(
+        &self,
+        tile_ptr: *mut i32,
+        tile_row_stride: usize,
+        a: Lhs<u8>,
+        b: &[u8],
+        used_rows: usize,
+        used_cols: usize,
+        depth: usize,
+        alpha: f32,
+        beta: i32,
+        a_quant: Option<QuantParams<u8>>,
+        b_quant: Option<QuantParams<i8>>,
+    ) {
+        assert_eq!(alpha, 1.);
+        assert!(beta == 0 || beta == 1, "unsupported beta value");
+        assert!(used_rows <= MR);
+        assert!(used_cols <= NR);
+
+        const MR: usize = GenericKernel::MR;
+        const NR: usize = GenericKernel::NR;
+
+        let a_data = match a {
+            Lhs::Packed(packed) => packed,
+            Lhs::Unpacked { .. } => panic!("inputs must be packed"),
+        };
+        let a_row_stride = depth;
+
+        let mut a_zero_point = [0u8; MR];
+        if let Some(a_quant) = a_quant {
+            #[allow(clippy::manual_memcpy)]
+            for row in 0..used_rows {
+                a_zero_point[row] = a_quant.zero_point[row];
+            }
+        }
+        let mut b_zero_point = [0i8; NR];
+        if let Some(b_quant) = b_quant {
+            #[allow(clippy::manual_memcpy)]
+            for col in 0..used_cols {
+                b_zero_point[col] = b_quant.zero_point[col];
+            }
+        }
+
+        let b: &[i8] = cast_pod_slice(b).unwrap();
+        let use_tmp_tile = used_cols < NR || used_rows < MR;
+
+        let mut tmp_tile = TempTile::<i32, MR, NR>::new();
+        let (dest_ptr, dest_row_stride, dest_beta) = if !use_tmp_tile {
+            (tile_ptr, tile_row_stride, beta)
+        } else {
+            (tmp_tile.as_mut_ptr() as *mut i32, NR, 0)
+        };
+
+        let mut tmp = [[0i32; NR]; MR];
+        for k in 0..depth {
+            for row in 0..MR {
+                let a_i32 = unsafe { *a_data.get_unchecked(row * a_row_stride + k) } as i32
+                    - a_zero_point[row] as i32;
+                for col in 0..NR {
+                    let b_i32 =
+                        unsafe { *b.get_unchecked(k * NR + col) } as i32 - b_zero_point[col] as i32;
+                    tmp[row][col] += a_i32 * b_i32;
+                }
+            }
+        }
+
+        if dest_beta == 0 {
+            for row in 0..used_rows {
+                for col in 0..used_cols {
+                    dest_ptr
+                        .add(row * dest_row_stride + col)
+                        .write(tmp[row][col]);
+                }
+            }
+        } else {
+            // nb. We require that beta is 0 or 1, so here it is 1.
+            for row in 0..used_rows {
+                for col in 0..used_cols {
+                    *dest_ptr.add(row * dest_row_stride + col) += tmp[row][col];
+                }
+            }
+        }
+
+        if use_tmp_tile {
+            tmp_tile.accumulate_into(
+                tile_ptr as *mut MaybeUninit<i32>,
+                used_rows,
+                used_cols,
+                tile_row_stride,
+                beta,
+            );
+        }
+    }
+
+    fn gemv_kernel(
+        &self,
+        out: &mut [MaybeUninit<i32>],
+        a: &[u8],
+        b: Matrix<i8>,
+        alpha: f32,
+        beta: i32,
+        a_quant: Option<QuantParams<u8>>,
+        b_quant: Option<QuantParams<i8>>,
+    ) {
+        assert!(beta == 0 || beta == 1);
+        assert_eq!(alpha, 1.);
+        assert_eq!(b.rows(), a.len());
+        assert_eq!(out.len(), b.cols());
+
+        let a_zero = a_quant.map(|aq| aq.zero_point[0] as i32).unwrap_or(0);
+        let depth = a.len();
+
+        for (out, col) in out.iter_mut().zip(0..b.cols()) {
+            let b_zero = b_quant.map(|bq| bq.zero_point[col] as i32).unwrap_or(0);
+            let mut acc = 0;
+            for k in 0..depth {
+                let a_el = unsafe { *a.get_unchecked(k) } as i32 - a_zero;
+                let b_el = unsafe { *b.get_unchecked([k, col]) } as i32 - b_zero;
+                acc += a_el * b_el;
+            }
+            if beta == 0 {
+                out.write(acc);
+            } else {
+                // Safety: Output is initialized when beta is non-zero
+                unsafe {
+                    out.write(out.assume_init() + acc);
+                }
+            }
         }
     }
 }

--- a/src/gemm/kernels/wasm.rs
+++ b/src/gemm/kernels/wasm.rs
@@ -6,7 +6,7 @@ use rten_simd::vec_count;
 use rten_tensor::{Matrix, MatrixLayout};
 
 use super::simd_generic::{simd_gemv, GemmDispatch};
-use super::{Kernel, Lhs, PackedLayout, TempTile};
+use super::{Kernel, Lhs, PackedLayout, QuantParams, TempTile};
 use crate::gemm::packing::{pack_a_block, pack_b_block, packed_a_layout, packed_b_layout};
 use crate::gemm::Im2Col;
 use crate::number::{cast_pod_mut_slice, cast_pod_slice};
@@ -43,7 +43,13 @@ unsafe impl Kernel<f32, f32, f32> for WasmKernel {
         Self::NR
     }
 
-    fn packed_a_layout(&self, a: Matrix, rows: usize, cols: usize) -> PackedLayout {
+    fn packed_a_layout(
+        &self,
+        a: Matrix,
+        rows: usize,
+        cols: usize,
+        _quant: Option<QuantParams<f32>>,
+    ) -> PackedLayout {
         let mut info = packed_a_layout::<f32, { Self::MR }>(rows, cols);
         info.must_pack = a.col_stride() != 1;
         info
@@ -55,12 +61,18 @@ unsafe impl Kernel<f32, f32, f32> for WasmKernel {
         a: Matrix,
         rows: Range<usize>,
         cols: Range<usize>,
+        _quant: Option<QuantParams<f32>>,
     ) {
         let out = cast_pod_mut_slice(out).unwrap();
         pack_a_block::<f32, { Self::MR }>(out, a, rows, cols);
     }
 
-    fn packed_b_layout(&self, rows: usize, cols: usize) -> PackedLayout {
+    fn packed_b_layout(
+        &self,
+        rows: usize,
+        cols: usize,
+        _quant: Option<QuantParams<f32>>,
+    ) -> PackedLayout {
         packed_b_layout::<f32, { Self::NR }>(rows, cols)
     }
 
@@ -70,6 +82,7 @@ unsafe impl Kernel<f32, f32, f32> for WasmKernel {
         b: Matrix,
         rows: Range<usize>,
         cols: Range<usize>,
+        _quant: Option<QuantParams<f32>>,
     ) {
         let out = cast_pod_mut_slice(out).unwrap();
         pack_b_block::<f32, { Self::NR }>(out, b, rows, cols);
@@ -102,6 +115,8 @@ unsafe impl Kernel<f32, f32, f32> for WasmKernel {
         depth: usize,
         alpha: f32,
         beta: f32,
+        _a_quant: Option<QuantParams<f32>>,
+        _b_quant: Option<QuantParams<f32>>,
     ) {
         const MR: usize = WasmKernel::MR;
         const NR: usize = WasmKernel::NR;
@@ -155,6 +170,8 @@ unsafe impl Kernel<f32, f32, f32> for WasmKernel {
         b: Matrix,
         alpha: f32,
         beta: f32,
+        _a_quant: Option<QuantParams<f32>>,
+        _b_quant: Option<QuantParams<f32>>,
     ) {
         // Safety - WASM SIMD types are supported if this kernel was constructed.
         unsafe {

--- a/src/number.rs
+++ b/src/number.rs
@@ -43,24 +43,38 @@ pub trait Identities {
     fn zero() -> Self;
 }
 
-impl Identities for f32 {
-    fn one() -> f32 {
-        1.
-    }
+macro_rules! impl_float_identities {
+    ($type:ty) => {
+        impl Identities for $type {
+            fn one() -> Self {
+                1.
+            }
 
-    fn zero() -> f32 {
-        0.
-    }
+            fn zero() -> Self {
+                0.
+            }
+        }
+    };
 }
 
-impl Identities for i32 {
-    fn one() -> i32 {
-        1
-    }
-    fn zero() -> i32 {
-        0
-    }
+macro_rules! impl_int_identities {
+    ($type:ty) => {
+        impl Identities for $type {
+            fn one() -> Self {
+                1
+            }
+
+            fn zero() -> Self {
+                0
+            }
+        }
+    };
 }
+
+impl_float_identities!(f32);
+impl_int_identities!(i32);
+impl_int_identities!(i8);
+impl_int_identities!(u8);
 
 /// Test if a number is a float NaN ("Not a number") value.
 pub trait IsNaN {

--- a/src/ops/conv.rs
+++ b/src/ops/conv.rs
@@ -57,6 +57,8 @@ where
             GemmInputB::Unpacked(in_mat.view()),
             1., // alpha
             bias_vec,
+            None, // a_quant
+            None, // b_quant
         )
         .unwrap();
         n_init += out_item.len();
@@ -287,6 +289,8 @@ where
                     GemmInputB::Im2Col(&im2col),
                     1., // alpha
                     bias_vec,
+                    None, // a_quant
+                    None, // b_quant
                 )
                 .unwrap();
                 n_init.fetch_add(out_mat.len(), Ordering::SeqCst);
@@ -319,7 +323,7 @@ impl Operator for Conv {
         let input = inputs.require_as(0)?;
         let weight = inputs.require_as(1)?;
         let bias = inputs.get_as(2)?;
-        conv(
+        conv::<f32, f32, f32>(
             pool,
             input,
             weight,
@@ -564,6 +568,8 @@ pub fn conv_transpose(
             GemmInputB::Unpacked(input_mat.view()),
             1.,   // alpha
             None, // bias
+            None, // a_quant
+            None, // b_quant
         )
         .unwrap();
 
@@ -1623,8 +1629,8 @@ mod tests {
         // This has a small spatial shape, so it measures overhead around the
         // inner loop. A larger spatial shape would be more affected by the
         // efficiency of the innermost loops.
-        let input = Tensor::rand(&[1, 576, 14, 14], &mut rng);
-        let kernel = Tensor::rand(&[576, 1, 3, 3], &mut rng);
+        let input = Tensor::<f32>::rand(&[1, 576, 14, 14], &mut rng);
+        let kernel = Tensor::<f32>::rand(&[576, 1, 3, 3], &mut rng);
 
         let n_groups = input.size(1);
         let padding = Padding::Fixed([1, 1, 1, 1].into());

--- a/src/ops/rnn.rs
+++ b/src/ops/rnn.rs
@@ -241,6 +241,8 @@ pub fn gru(
                 1.,   // alpha
                 0.,   // beta
                 None, // bias
+                None, // a_quant
+                None, // b_quant
             )
             .unwrap();
             if let Some(input_bias) = input_bias {
@@ -257,6 +259,8 @@ pub fn gru(
                 1.,   // alpha
                 0.,   // beta
                 None, // bias
+                None, // a_quant
+                None, // b_quant
             )
             .unwrap();
             if let Some(hidden_bias) = hidden_bias {
@@ -498,6 +502,8 @@ pub fn lstm(
                 1.,   // alpha
                 0.,   // beta
                 None, // bias
+                None, // a_quant
+                None, // b_quant
             )
             .unwrap();
             if let Some(input_bias) = input_bias {
@@ -512,6 +518,8 @@ pub fn lstm(
                 1.,   // alpha
                 1.,   // beta
                 None, // bias
+                None, // a_quant
+                None, // b_quant
             )
             .unwrap();
             if let Some(hidden_bias) = hidden_bias {


### PR DESCRIPTION
Add support for passing quantization parameters (ie. zero points) to the GEMM kernel and `GemmExecutor` and use this to implement a minimal (and still very slow) generic u8 x i8 -> i32 kernel. Then convert `MatMulInteger` to this instead of its temporary implementation. Also add tests that do int8 matmul for all square matrices up to 20x20 in size plus varying other "interesting" sizes.

After this will come work on optimized int8 kernels using the native dot product instructions on various platforms.

In the current design both quantized and non-quantized GEMMs share the same interface. f32 GEMMs just don't use the quantization parameters. This is convenient as it allows much of the existing logic and tests to be re-used, but it may end up not being the best design.

---

**TODO:**

- [x] Adapt Arm, Wasm, AVX-512 kernels to interface changes
- [x] Tests for quant parameter length validation