### PR TITLE
Support subgraphs and use safer quantization settings in ort-quantize.py

### DIFF
--- a/tools/ort-quantize.py
+++ b/tools/ort-quantize.py
@@ -10,4 +10,32 @@ args = parser.parse_args()
 
 output = args.output or args.input.replace(".onnx", ".quant.onnx")
 
-quantize_dynamic(args.input, output)
+quantize_dynamic(
+    args.input,
+    output,
+    # Avoid a saturation issue on x86-64 systems that don't support VNNI by
+    # reducing the range of quantized values from 8 to 7 bits.
+    #
+    # Specifically the VPMADDUBSW instruction used in int8 matmul operations
+    # can saturate when adding pairs of signed i16 values.
+    #
+    # See https://onnxruntime.ai/docs/performance/model-optimizations/quantization.html#when-to-use-reduce-range-and-per-channel-quantization.
+    reduce_range=True,
+    # Use per-channel rather than per-tensor quantization.
+    #
+    # The effect of this is that separate zero points and scales are used per
+    # row or column of an input matrix in quantized matmuls (`MatMulInteger`
+    # ops).
+    #
+    # Turning this on increases compute slightly, but allows tolerating a
+    # wider range of weight values in a tensor. Since transformer models are
+    # prone to having outlier weights, this seems like a good idea. Also
+    # RTen internally broadcasts scalar zero points to vectors anyway.
+    per_channel=True,
+    extra_options={
+        # Enable quantization of models with control flow operators. This
+        # includes Hugging Face "merged" transformer decoder models, which is
+        # what various RTen examples use.
+        "EnableSubgraph": True,
+    },
+)


### PR DESCRIPTION
 - Enable quantization of ops in subgraphs (ie. `If` operators). This affects RTen examples using "merged" transformer decoder models, such as Whisper and TrOCR.

 - Enable `reduce_range` and `per_channel` settings. The former avoids errors due to saturation x64 systems which don't support VNNI. The latter uses more granular quantization to reduce the accuracy impact, especially with reduced-range enabled.

With these changes I was able to run quantized versions of the decoders for the TrOCR and Whisper examples.