### PR TITLE
Add AVX-512 int8 GEMM using VNNI

### DIFF
--- a/rten-simd/src/arch/aarch64.rs
+++ b/rten-simd/src/arch/aarch64.rs
@@ -2,7 +2,7 @@ use std::arch::aarch64::{
     float32x4_t, int32x4_t, uint32x4_t, vabsq_f32, vaddq_f32, vaddq_s32, vaddvq_f32, vandq_u32,
     vbslq_f32, vbslq_s32, vceqq_s32, vcgeq_f32, vcgeq_s32, vcgtq_s32, vcleq_f32, vcleq_s32,
     vcltq_f32, vcltq_s32, vcvtq_s32_f32, vdivq_f32, vdupq_n_f32, vdupq_n_s32, vfmaq_f32, vld1q_f32,
-    vld1q_s32, vld1q_u32, vmaxq_f32, vmaxq_s32, vminq_f32, vminq_s32, vmulq_f32,
+    vld1q_s32, vld1q_u32, vmaxq_f32, vmaxq_s32, vminq_f32, vminq_s32, vmulq_f32, vmulq_s32,
     vreinterpretq_f32_s32, vshlq_n_s32, vst1q_f32, vst1q_s32, vst1q_u32, vsubq_f32, vsubq_s32,
 };
 
@@ -106,6 +106,11 @@ impl SimdInt for int32x4_t {
     #[inline]
     unsafe fn sub(self, rhs: Self) -> Self {
         vsubq_s32(self, rhs)
+    }
+
+    #[inline]
+    unsafe fn mul(self, rhs: Self) -> Self {
+        vmulq_s32(self, rhs)
     }
 
     #[inline]

--- a/rten-simd/src/arch/scalar.rs
+++ b/rten-simd/src/arch/scalar.rs
@@ -113,6 +113,11 @@ impl SimdInt for i32 {
     }
 
     #[inline]
+    unsafe fn mul(self, rhs: Self) -> Self {
+        self * rhs
+    }
+
+    #[inline]
     unsafe fn shl<const COUNT: i32>(self) -> Self {
         self << COUNT
     }

--- a/rten-simd/src/arch/wasm.rs
+++ b/rten-simd/src/arch/wasm.rs
@@ -1,8 +1,8 @@
 use std::arch::wasm32::{
     f32x4_abs, f32x4_add, f32x4_div, f32x4_extract_lane, f32x4_ge, f32x4_le, f32x4_lt, f32x4_max,
     f32x4_min, f32x4_mul, f32x4_splat, f32x4_sub, i32x4, i32x4_add, i32x4_eq, i32x4_ge, i32x4_gt,
-    i32x4_le, i32x4_lt, i32x4_max, i32x4_min, i32x4_shl, i32x4_shuffle, i32x4_splat, i32x4_sub,
-    i32x4_trunc_sat_f32x4, v128, v128_and, v128_bitselect, v128_load, v128_store,
+    i32x4_le, i32x4_lt, i32x4_max, i32x4_min, i32x4_mul, i32x4_shl, i32x4_shuffle, i32x4_splat,
+    i32x4_sub, i32x4_trunc_sat_f32x4, v128, v128_and, v128_bitselect, v128_load, v128_store,
 };
 
 #[cfg(target_feature = "relaxed-simd")]
@@ -117,6 +117,11 @@ impl SimdInt for v128i {
     #[inline]
     unsafe fn sub(self, rhs: Self) -> Self {
         Self(i32x4_sub(self.0, rhs.0))
+    }
+
+    #[inline]
+    unsafe fn mul(self, rhs: Self) -> Self {
+        Self(i32x4_mul(self.0, rhs.0))
     }
 
     #[inline]

--- a/rten-simd/src/arch/x86_64.rs
+++ b/rten-simd/src/arch/x86_64.rs
@@ -3,10 +3,11 @@ use std::arch::x86_64::{
     _mm256_blendv_epi8, _mm256_blendv_ps, _mm256_castps256_ps128, _mm256_castsi256_ps,
     _mm256_cmp_ps, _mm256_cmpeq_epi32, _mm256_cmpgt_epi32, _mm256_cvttps_epi32, _mm256_div_ps,
     _mm256_extractf128_ps, _mm256_fmadd_ps, _mm256_loadu_ps, _mm256_loadu_si256, _mm256_max_epi32,
-    _mm256_max_ps, _mm256_min_epi32, _mm256_min_ps, _mm256_mul_ps, _mm256_or_si256,
-    _mm256_set1_epi32, _mm256_set1_ps, _mm256_setr_epi32, _mm256_slli_epi32, _mm256_storeu_ps,
-    _mm256_storeu_si256, _mm256_sub_epi32, _mm256_sub_ps, _mm_add_ps, _mm_cvtss_f32, _mm_movehl_ps,
-    _mm_prefetch, _mm_shuffle_ps, _CMP_GE_OQ, _CMP_LE_OQ, _CMP_LT_OQ, _MM_HINT_ET0, _MM_HINT_T0,
+    _mm256_max_ps, _mm256_min_epi32, _mm256_min_ps, _mm256_mul_ps, _mm256_mullo_epi32,
+    _mm256_or_si256, _mm256_set1_epi32, _mm256_set1_ps, _mm256_setr_epi32, _mm256_slli_epi32,
+    _mm256_storeu_ps, _mm256_storeu_si256, _mm256_sub_epi32, _mm256_sub_ps, _mm_add_ps,
+    _mm_cvtss_f32, _mm_movehl_ps, _mm_prefetch, _mm_shuffle_ps, _CMP_GE_OQ, _CMP_LE_OQ, _CMP_LT_OQ,
+    _MM_HINT_ET0, _MM_HINT_T0,
 };
 use std::mem::transmute;
 
@@ -138,6 +139,12 @@ impl SimdInt for __m256i {
     #[target_feature(enable = "avx2")]
     unsafe fn sub(self, rhs: Self) -> Self {
         _mm256_sub_epi32(self, rhs)
+    }
+
+    #[inline]
+    #[target_feature(enable = "avx2")]
+    unsafe fn mul(self, rhs: Self) -> Self {
+        _mm256_mullo_epi32(self, rhs)
     }
 
     #[inline]
@@ -328,9 +335,10 @@ use std::arch::x86_64::{
     _mm512_castsi512_ps, _mm512_cmp_epi32_mask, _mm512_cmp_ps_mask, _mm512_cvttps_epi32,
     _mm512_div_ps, _mm512_fmadd_ps, _mm512_loadu_ps, _mm512_loadu_si512, _mm512_mask_blend_epi32,
     _mm512_mask_blend_ps, _mm512_mask_i32gather_ps, _mm512_max_epi32, _mm512_max_ps,
-    _mm512_min_epi32, _mm512_min_ps, _mm512_mul_ps, _mm512_reduce_add_ps, _mm512_set1_epi32,
-    _mm512_set1_ps, _mm512_setzero_si512, _mm512_sllv_epi32, _mm512_storeu_epi32, _mm512_storeu_ps,
-    _mm512_sub_epi32, _mm512_sub_ps, _MM_CMPINT_EQ, _MM_CMPINT_LE, _MM_CMPINT_LT,
+    _mm512_min_epi32, _mm512_min_ps, _mm512_mul_ps, _mm512_mullo_epi32, _mm512_reduce_add_ps,
+    _mm512_set1_epi32, _mm512_set1_ps, _mm512_setzero_si512, _mm512_sllv_epi32,
+    _mm512_storeu_epi32, _mm512_storeu_ps, _mm512_sub_epi32, _mm512_sub_ps, _MM_CMPINT_EQ,
+    _MM_CMPINT_LE, _MM_CMPINT_LT,
 };
 
 #[cfg(feature = "avx512")]
@@ -465,6 +473,12 @@ impl SimdInt for __m512i {
     #[target_feature(enable = "avx512f")]
     unsafe fn sub(self, rhs: Self) -> Self {
         _mm512_sub_epi32(self, rhs)
+    }
+
+    #[inline]
+    #[target_feature(enable = "avx512f")]
+    unsafe fn mul(self, rhs: Self) -> Self {
+        _mm512_mullo_epi32(self, rhs)
     }
 
     #[inline]

--- a/rten-simd/src/arch/x86_64.rs
+++ b/rten-simd/src/arch/x86_64.rs
@@ -390,18 +390,6 @@ impl Simd for __m512i {
 
     #[inline]
     #[target_feature(enable = "avx512f")]
-    unsafe fn min(self, rhs: Self) -> Self {
-        _mm512_min_epi32(self, rhs)
-    }
-
-    #[inline]
-    #[target_feature(enable = "avx512f")]
-    unsafe fn max(self, rhs: Self) -> Self {
-        _mm512_max_epi32(self, rhs)
-    }
-
-    #[inline]
-    #[target_feature(enable = "avx512f")]
     unsafe fn load(ptr: *const i32) -> Self {
         _mm512_loadu_si512(ptr)
     }
@@ -453,6 +441,18 @@ impl SimdInt for __m512i {
     #[target_feature(enable = "avx512f")]
     unsafe fn gt(self, other: Self) -> Self::Mask {
         other.lt(self)
+    }
+
+    #[inline]
+    #[target_feature(enable = "avx512f")]
+    unsafe fn min(self, rhs: Self) -> Self {
+        _mm512_min_epi32(self, rhs)
+    }
+
+    #[inline]
+    #[target_feature(enable = "avx512f")]
+    unsafe fn max(self, rhs: Self) -> Self {
+        _mm512_max_epi32(self, rhs)
     }
 
     #[inline]
@@ -604,7 +604,7 @@ impl SimdFloat for __m512 {
 
     #[inline]
     #[target_feature(enable = "avx512f")]
-    unsafe fn mix(self, rhs: Self) -> Self {
+    unsafe fn min(self, rhs: Self) -> Self {
         _mm512_min_ps(self, rhs)
     }
 

--- a/rten-simd/src/isa_detection.rs
+++ b/rten-simd/src/isa_detection.rs
@@ -9,9 +9,24 @@
 #[cfg(feature = "avx512")]
 #[cfg(target_os = "macos")]
 fn test_for_avx512_on_macos() -> bool {
-    use std::ffi::CStr;
-    use std::os::raw::{c_char, c_int, c_void};
     use std::sync::OnceLock;
+
+    static AVX512_AVAILABLE: OnceLock<bool> = OnceLock::new();
+
+    *AVX512_AVAILABLE.get_or_init(|| unsafe {
+        // We test for the minimum AVX-512 extensions we require, but not
+        // avx512f, as that is implied if the extensions are supported.
+        get_sysctl_bool(b"hw.optional.avx512vl\0") && get_sysctl_bool(b"hw.optional.avx512bw\0")
+    })
+}
+
+/// Get a sysctl int value by name and interpret it as a boolean.
+///
+/// `name` must be a nul-terminated.
+#[cfg(feature = "avx512")]
+#[cfg(target_os = "macos")]
+unsafe fn get_sysctl_bool(name: &[u8]) -> bool {
+    use std::os::raw::{c_char, c_int, c_void};
 
     #[link(name = "c")]
     extern "C" {
@@ -25,36 +40,41 @@ fn test_for_avx512_on_macos() -> bool {
         ) -> c_int;
     }
 
-    static AVX512_AVAILABLE: OnceLock<bool> = OnceLock::new();
+    use std::ffi::CStr;
 
-    *AVX512_AVAILABLE.get_or_init(|| {
-        unsafe {
-            let mut ret = 0u64;
-            let mut size = std::mem::size_of::<u64>();
+    let mut ret = 0u64;
+    let mut size = std::mem::size_of::<u64>();
 
-            // We test only for avx512vl, as this implies avx512f.
-            let sysctl_ret = sysctlbyname(
-                CStr::from_bytes_with_nul(b"hw.optional.avx512vl\0")
-                    .unwrap()
-                    .as_ptr(),
-                std::mem::transmute(&mut ret),
-                &mut size,
-                std::ptr::null(),
-                0,
-            );
-            sysctl_ret == 0 && ret == 1
-        }
-    })
+    let sysctl_ret = sysctlbyname(
+        CStr::from_bytes_with_nul(name).unwrap().as_ptr(),
+        std::mem::transmute(&mut ret),
+        &mut size,
+        std::ptr::null(),
+        0,
+    );
+
+    sysctl_ret == 0 && ret == 1
 }
 
-/// Test if the current system has basic AVX-512 support (AVX-512 F, AVX-512 VL).
+/// Test if the current system has basic AVX-512 support.
+///
+/// "Basic support" is defined as:
+///  - AVX512F
+///  - AVX512VL
+///  - AVX512BW
+///
+/// These features are available on Skylake (2016) and later.
+/// See https://en.wikipedia.org/wiki/Advanced_Vector_Extensions#AVX-512_CPU_compatibility_table.
 ///
 /// This is unfortunately not as simple as using `is_x86_feature_detected`
 /// because that can return incorrect results on macOS.
 #[cfg(feature = "avx512")]
 #[cfg(target_arch = "x86_64")]
 pub fn is_avx512_supported() -> bool {
-    if is_x86_feature_detected!("avx512f") && is_x86_feature_detected!("avx512vl") {
+    if is_x86_feature_detected!("avx512f")
+        && is_x86_feature_detected!("avx512vl")
+        && is_x86_feature_detected!("avx512bw")
+    {
         true
     } else {
         #[cfg(target_os = "macos")]

--- a/rten-simd/src/vec.rs
+++ b/rten-simd/src/vec.rs
@@ -207,6 +207,9 @@ pub trait SimdInt: Simd<Elem = i32> {
     /// Compute `self + rhs`.
     unsafe fn add(self, rhs: Self) -> Self;
 
+    /// Compute `self * rhs`, keeping the low 32-bits of each result.
+    unsafe fn mul(self, rhs: Self) -> Self;
+
     /// Compute `self - rhs`.
     unsafe fn sub(self, rhs: Self) -> Self;
 

--- a/src/gemm.rs
+++ b/src/gemm.rs
@@ -551,6 +551,13 @@ impl Default for GemmExecutor<f32, f32, f32> {
 
 impl Default for GemmExecutor<u8, i8, i32> {
     fn default() -> Self {
+        #[cfg(feature = "avx512")]
+        #[cfg(target_arch = "x86_64")]
+        if let Some(gemm) =
+            Self::from_kernel::<kernels::x86_64::Avx512Int8Kernel>(KernelType::Avx512)
+        {
+            return gemm;
+        }
         #[cfg(target_arch = "x86_64")]
         if let Some(gemm) = Self::from_kernel::<kernels::x86_64::Avx2Int8Kernel>(KernelType::Fma) {
             return gemm;

--- a/src/gemm/kernels/simd_generic.rs
+++ b/src/gemm/kernels/simd_generic.rs
@@ -1,6 +1,6 @@
 use std::mem::MaybeUninit;
 
-use rten_simd::SimdFloat;
+use rten_simd::{SimdFloat, SimdInt};
 use rten_tensor::{Matrix, MatrixLayout, Storage};
 
 use super::Lhs;
@@ -378,6 +378,139 @@ pub unsafe fn simd_gemm<S: SimdFloat, const MR: usize, const NR_REGS: usize, con
                 let out_val = S::load(out_ptr).mul(beta_broadcast);
                 let out_val = tmp[i][j].mul_add(alpha_broadcast, out_val);
                 out_val.store(out_ptr);
+            }
+        }
+    }
+}
+
+/// Compute an i32 matrix multiplication tile with maximum size `MR x NR` using
+/// packed blocks of A and B int8 inputs. `NR` must equal `S::LEN`.
+///
+/// Whether int8 values in `a` and `b` are treated as signed depends on the
+/// `dot_product` function.
+///
+/// `dot_product(a, b, c)` is a function that computes `c + dot(a, b)` where
+/// `c` contains packed i32 values and `a` and `b` contain groups of 4 packed
+/// 8-bit integers.
+///
+/// If `accumulate` is true, the output referenced by `tile_ptr` must be
+/// initialized and the result will be added to it. If false, the `tile_ptr`
+/// may be uninitialized and will be initialized with the result.
+#[inline(always)]
+pub unsafe fn simd_int8_gemm<S: SimdInt, const MR: usize, const NR: usize>(
+    tile_ptr: *mut i32,
+    tile_row_stride: usize,
+    a: &[u8],
+    b: &[u8],
+    used_rows: usize,
+    used_cols: usize,
+    depth: usize,
+    accumulate: bool,
+    a_zero_points: [i32; MR],
+    b_zero_points: [i32; NR],
+    a_row_sums: &[i32; MR],
+    b_col_sums: &[i32; NR],
+    dot_product: unsafe fn(S, S, S) -> S,
+) {
+    assert_eq!(S::LEN, NR);
+
+    // The value for each element in the output tile is computed as:
+    //
+    // c = (a[0] - a_zero_point) * (b[0] - b_zero_point) + ...
+    //
+    // (or `c += ...` when beta=1)
+    //
+    // Where `a_zero_point` is the zero point for the row of A and
+    // `b_zero_point` is the zero point for the column of B.
+    //
+    // This can be expanded and re-arranged into:
+    //
+    // c = a[0]b[0] - a[0] * b_zero_point - b[0] * a_zero_point + a_zero_point * b_zero_point + ...
+    // c = dot(a, b) - sum(a) * b_zero_point - sum(b) * a_zero_point + k * a_zero_point * b_zero_point
+    // c = k * a_zero_point * b_zero_point + dot(a, b) - sum(a) * b_zero_point - sum(b) * a_zero_point
+    //
+    // The `k * a_zero_point * b_zero_point` term is computed first as the
+    // initial value of the accumulator tile, then we loop over K and add
+    // the dot product of each row and column. Finally the scaled row
+    // and column sums are subtracted.
+
+    let a_ptr = a.as_ptr();
+    let b_ptr = b.as_ptr();
+
+    let n_depth_tiles = depth.div_ceil(4);
+    let b_zero = S::load(b_zero_points.as_ptr() as *const i32);
+
+    // Initialize output tile with `k * a_zero_point[row] * b_zero_point[col]`
+    let k_mul_b_zero = S::splat(depth as i32).mul(b_zero);
+    let mut tmp = [k_mul_b_zero; MR];
+    for row in 0..MR {
+        let a_zero = S::splat(a_zero_points[row]);
+        tmp[row] = tmp[row].mul(a_zero);
+    }
+
+    // Loop over K dimension and compute dot product of panel of A with panel of
+    // B.
+    for k_block in 0..n_depth_tiles {
+        // Load `[4, NR]` microtile from B
+        let b_vec = S::load(b_ptr.add(k_block * NR * 4) as *const i32);
+
+        // Each iteration broadcasts 4x int 8 values from A, computes NR
+        // dot products and accumulates into the output tile.
+        for row in 0..MR {
+            let a_val = *(a_ptr.add(k_block * MR * 4 + row * 4) as *const i32);
+            let a_vec = S::splat(a_val);
+            tmp[row] = dot_product(a_vec, b_vec, tmp[row]);
+        }
+    }
+
+    // Scale zero points by row and column sums and subtract from output tile.
+    let b_col_sums = S::load(b_col_sums.as_ptr());
+    for row in 0..MR {
+        let a_zero = S::splat(a_zero_points[row]);
+        let a_sum = S::splat(a_row_sums[row]);
+
+        let a_sum_mul_b_zero = a_sum.mul(b_zero);
+        let b_sum_mul_a_zero = b_col_sums.mul(a_zero);
+        tmp[row] = tmp[row].sub(a_sum_mul_b_zero);
+        tmp[row] = tmp[row].sub(b_sum_mul_a_zero);
+    }
+
+    // Write from accumulator in registers back to output.
+    let output_tile_ptr = |row| tile_ptr.add(row * tile_row_stride);
+
+    if !accumulate {
+        if used_rows == MR && used_cols == NR {
+            // Full output tile
+            for row in 0..MR {
+                let tile_ptr = output_tile_ptr(row);
+                tmp[row].store(tile_ptr);
+            }
+        } else {
+            // Partial output tile
+            for r in 0..used_rows {
+                let tile_ptr = output_tile_ptr(r);
+                let tmp = tmp[r].to_array();
+                for c in 0..used_cols {
+                    tile_ptr.add(c).write(tmp[c]);
+                }
+            }
+        }
+    } else {
+        if used_rows == MR && used_cols == NR {
+            // Full output tile
+            for row in 0..MR {
+                let tile_ptr = output_tile_ptr(row);
+                let out = S::load(tile_ptr).add(tmp[row]);
+                out.store(tile_ptr);
+            }
+        } else {
+            // Partial output tile
+            for r in 0..used_rows {
+                let tile_ptr = output_tile_ptr(r);
+                let tmp = tmp[r].to_array();
+                for c in 0..used_cols {
+                    *tile_ptr.add(c) += tmp[c];
+                }
             }
         }
     }

--- a/src/gemm/kernels/simd_generic.rs
+++ b/src/gemm/kernels/simd_generic.rs
@@ -438,7 +438,7 @@ pub unsafe fn simd_int8_gemm<S: SimdInt, const MR: usize, const NR: usize>(
     let b_ptr = b.as_ptr();
 
     let n_depth_tiles = depth.div_ceil(4);
-    let b_zero = S::load(b_zero_points.as_ptr() as *const i32);
+    let b_zero = S::load(b_zero_points.as_ptr());
 
     // Initialize output tile with `k * a_zero_point[row] * b_zero_point[col]`
     let k_mul_b_zero = S::splat(depth as i32).mul(b_zero);
@@ -478,6 +478,7 @@ pub unsafe fn simd_int8_gemm<S: SimdInt, const MR: usize, const NR: usize>(
     // Write from accumulator in registers back to output.
     let output_tile_ptr = |row| tile_ptr.add(row * tile_row_stride);
 
+    #[allow(clippy::collapsible_else_if)]
     if !accumulate {
         if used_rows == MR && used_cols == NR {
             // Full output tile

--- a/src/gemm/kernels/x86_64.rs
+++ b/src/gemm/kernels/x86_64.rs
@@ -573,7 +573,7 @@ unsafe impl Kernel<u8, i8, i32> for Avx2Int8Kernel {
             b_zero_points,
             a_row_sums,
             b_col_sums,
-            avx2_int8_dot_product,
+            avx2_u8i8i32_dot_product,
         )
     }
 
@@ -594,7 +594,7 @@ unsafe impl Kernel<u8, i8, i32> for Avx2Int8Kernel {
 /// Compute 8x dot products between `u8` values in `a`, `i8` values in `b` and
 /// add the `i32` results to `c`.
 #[inline(always)]
-unsafe fn avx2_int8_dot_product(a: __m256i, b: __m256i, c: __m256i) -> __m256i {
+unsafe fn avx2_u8i8i32_dot_product(a: __m256i, b: __m256i, c: __m256i) -> __m256i {
     use core::arch::x86_64::{
         _mm256_add_epi32, _mm256_madd_epi16, _mm256_maddubs_epi16, _mm256_set1_epi16,
     };
@@ -749,7 +749,7 @@ unsafe impl Kernel<u8, i8, i32> for Avx512Int8Kernel {
                 b_zero_points,
                 a_row_sums,
                 b_col_sums,
-                avx512_vnni_int8_dot_product,
+                avx512_vnni_u8i8i32_dot_product,
             )
         } else {
             simd_int8_gemm::<_, { Self::MR }, { Self::NR }>(
@@ -765,7 +765,7 @@ unsafe impl Kernel<u8, i8, i32> for Avx512Int8Kernel {
                 b_zero_points,
                 a_row_sums,
                 b_col_sums,
-                avx512_int8_dot_product,
+                avx512_u8i8i32_dot_product,
             )
         }
     }
@@ -788,7 +788,7 @@ unsafe impl Kernel<u8, i8, i32> for Avx512Int8Kernel {
 /// add the `i32` results to `c`.
 #[cfg(feature = "avx512")]
 #[inline(always)]
-unsafe fn avx512_int8_dot_product(a: __m512i, b: __m512i, c: __m512i) -> __m512i {
+unsafe fn avx512_u8i8i32_dot_product(a: __m512i, b: __m512i, c: __m512i) -> __m512i {
     use core::arch::x86_64::{
         _mm512_add_epi32, _mm512_madd_epi16, _mm512_maddubs_epi16, _mm512_set1_epi16,
     };
@@ -806,7 +806,7 @@ unsafe fn avx512_int8_dot_product(a: __m512i, b: __m512i, c: __m512i) -> __m512i
 #[cfg(feature = "avx512")]
 #[target_feature(enable = "avx512f")]
 #[inline]
-unsafe fn avx512_vnni_int8_dot_product(a: __m512i, b: __m512i, mut c: __m512i) -> __m512i {
+unsafe fn avx512_vnni_u8i8i32_dot_product(a: __m512i, b: __m512i, mut c: __m512i) -> __m512i {
     // Use inline asm rather than an intrinsic here to avoid needing to mark
     // this function as using the `avx512vnni` feature. If we did that, the
     // entire kernel function needs to have the same target feature statically

--- a/src/gemm/packing/int8.rs
+++ b/src/gemm/packing/int8.rs
@@ -204,8 +204,8 @@ pub fn extract_packed_a<const MR: usize>(a: &[u8]) -> (&[u8], &[i32; MR]) {
 pub fn extract_packed_b<const NR: usize>(b: &[u8]) -> (&[u8], &[i32; NR]) {
     let col_sum_offset = b.len() - NR * size_of::<i32>();
     let (packed_elements, col_sums) = b.split_at(col_sum_offset);
-    let row_sums: &[i32] = cast_pod_slice(col_sums).unwrap();
-    (packed_elements, row_sums.try_into().unwrap())
+    let col_sums: &[i32] = cast_pod_slice(col_sums).unwrap();
+    (packed_elements, col_sums.try_into().unwrap())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This converts the recently added int8 GEMM kernel for AVX-2 into a portable SIMD version which takes the dot product function as an argument, then adds an AVX-512 int8 kernel using it. This kernel has two versions, one using the same sequence of 3 instructions for the dot product as the AVX-2 version and another using a single VNNI instruction.