### PR TITLE
Vectorize QuantizeLinear, second stage of DynamicQuantizeLinear

### DIFF
--- a/rten-simd/src/arch.rs
+++ b/rten-simd/src/arch.rs
@@ -1,7 +1,10 @@
 //! Architecture-specific functionality.
 
-/// Dummy arch which implements SIMD vector types for Rust scalars (i32, f32 etc.)
+/// Dummy arch which implements SIMD traits for Rust scalars (i32, f32 etc.)
 mod scalar;
+
+/// Dummy arch which implements SIMD traits for arrays
+mod array;
 
 #[cfg(target_arch = "x86_64")]
 mod x86_64;

--- a/rten-simd/src/arch/aarch64.rs
+++ b/rten-simd/src/arch/aarch64.rs
@@ -1,9 +1,10 @@
 use std::arch::aarch64::{
     float32x4_t, int32x4_t, uint32x4_t, vabsq_f32, vaddq_f32, vaddq_s32, vaddvq_f32, vandq_u32,
     vbslq_f32, vbslq_s32, vceqq_s32, vcgeq_f32, vcgeq_s32, vcgtq_s32, vcleq_f32, vcleq_s32,
-    vcltq_f32, vcltq_s32, vcvtq_s32_f32, vdivq_f32, vdupq_n_f32, vdupq_n_s32, vfmaq_f32, vld1q_f32,
-    vld1q_s32, vld1q_u32, vmaxq_f32, vmaxq_s32, vminq_f32, vminq_s32, vmulq_f32, vmulq_s32,
-    vreinterpretq_f32_s32, vshlq_n_s32, vst1q_f32, vst1q_s32, vst1q_u32, vsubq_f32, vsubq_s32,
+    vcltq_f32, vcltq_s32, vcvtnq_s32_f32, vcvtq_s32_f32, vdivq_f32, vdupq_n_f32, vdupq_n_s32,
+    vfmaq_f32, vld1q_f32, vld1q_s32, vld1q_u32, vmaxq_f32, vmaxq_s32, vminq_f32, vminq_s32,
+    vmulq_f32, vmulq_s32, vreinterpretq_f32_s32, vshlq_n_s32, vst1q_f32, vst1q_s32, vst1q_u32,
+    vsubq_f32, vsubq_s32,
 };
 
 use crate::{Simd, SimdFloat, SimdInt, SimdMask};
@@ -132,6 +133,11 @@ impl SimdInt for int32x4_t {
     unsafe fn reinterpret_as_float(self) -> Self::Float {
         vreinterpretq_f32_s32(self)
     }
+
+    #[inline]
+    unsafe fn saturating_cast_u8(self) -> impl Simd<Elem = u8> {
+        self.to_array().map(|c| c.clamp(0, u8::MAX as i32) as u8)
+    }
 }
 
 impl Simd for float32x4_t {
@@ -195,6 +201,11 @@ impl SimdFloat for float32x4_t {
     #[inline]
     unsafe fn to_int_trunc(self) -> Self::Int {
         vcvtq_s32_f32(self)
+    }
+
+    #[inline]
+    unsafe fn to_int_round(self) -> Self::Int {
+        vcvtnq_s32_f32(self)
     }
 
     #[inline]

--- a/rten-simd/src/arch/array.rs
+++ b/rten-simd/src/arch/array.rs
@@ -1,0 +1,64 @@
+use crate::{Simd, SimdMask};
+
+impl<const N: usize> SimdMask for [bool; N]
+where
+    [bool; N]: Default,
+{
+    type Array = Self;
+
+    unsafe fn and(self, rhs: Self) -> Self {
+        std::array::from_fn(|i| self[i] && rhs[i])
+    }
+
+    unsafe fn to_array(self) -> Self {
+        self
+    }
+
+    unsafe fn from_array(mask: Self) -> Self {
+        mask
+    }
+}
+
+macro_rules! impl_simd_for_array {
+    ($type:ty) => {
+        impl<const N: usize> Simd for [$type; N]
+        where
+            [bool; N]: Default,
+        {
+            const LEN: usize = N;
+
+            type Array = Self;
+            type Elem = $type;
+            type Mask = [bool; N];
+
+            #[inline]
+            unsafe fn blend(self, rhs: Self, mask: Self::Mask) -> Self {
+                std::array::from_fn(|i| if !mask[i] { self[i] } else { rhs[i] })
+            }
+
+            #[inline]
+            unsafe fn load(ptr: *const $type) -> Self {
+                std::array::from_fn(|i| *ptr.add(i))
+            }
+
+            #[inline]
+            unsafe fn splat(val: $type) -> Self {
+                [val; N]
+            }
+
+            #[inline]
+            unsafe fn store(self, ptr: *mut $type) {
+                for i in 0..Self::LEN {
+                    ptr.add(i).write(self[i]);
+                }
+            }
+
+            #[inline]
+            unsafe fn to_array(self) -> Self::Array {
+                self
+            }
+        }
+    };
+}
+
+impl_simd_for_array!(u8);

--- a/rten-simd/src/arch/scalar.rs
+++ b/rten-simd/src/arch/scalar.rs
@@ -60,6 +60,7 @@ macro_rules! impl_simd {
     };
 }
 
+impl_simd!(u8);
 impl_simd!(i32);
 impl_simd!(f32);
 
@@ -126,6 +127,11 @@ impl SimdInt for i32 {
     unsafe fn reinterpret_as_float(self) -> Self::Float {
         f32::from_bits(self as u32)
     }
+
+    #[inline]
+    unsafe fn saturating_cast_u8(self) -> impl Simd<Elem = u8> {
+        self.clamp(0, 255) as u8
+    }
 }
 
 /// Treat an `f32` as a single-lane SIMD "vector".
@@ -160,6 +166,11 @@ impl SimdFloat for f32 {
     #[inline]
     unsafe fn to_int_trunc(self) -> Self::Int {
         self as i32
+    }
+
+    #[inline]
+    unsafe fn to_int_round(self) -> Self::Int {
+        self.round_ties_even() as i32
     }
 
     #[inline]

--- a/rten-simd/src/arch/wasm.rs
+++ b/rten-simd/src/arch/wasm.rs
@@ -1,8 +1,9 @@
 use std::arch::wasm32::{
     f32x4_abs, f32x4_add, f32x4_div, f32x4_extract_lane, f32x4_ge, f32x4_le, f32x4_lt, f32x4_max,
-    f32x4_min, f32x4_mul, f32x4_splat, f32x4_sub, i32x4, i32x4_add, i32x4_eq, i32x4_ge, i32x4_gt,
-    i32x4_le, i32x4_lt, i32x4_max, i32x4_min, i32x4_mul, i32x4_shl, i32x4_shuffle, i32x4_splat,
-    i32x4_sub, i32x4_trunc_sat_f32x4, v128, v128_and, v128_bitselect, v128_load, v128_store,
+    f32x4_min, f32x4_mul, f32x4_nearest, f32x4_splat, f32x4_sub, i32x4, i32x4_add, i32x4_eq,
+    i32x4_ge, i32x4_gt, i32x4_le, i32x4_lt, i32x4_max, i32x4_min, i32x4_mul, i32x4_shl,
+    i32x4_shuffle, i32x4_splat, i32x4_sub, i32x4_trunc_sat_f32x4, v128, v128_and, v128_bitselect,
+    v128_load, v128_store,
 };
 
 #[cfg(target_feature = "relaxed-simd")]
@@ -143,6 +144,11 @@ impl SimdInt for v128i {
     unsafe fn reinterpret_as_float(self) -> Self::Float {
         v128f(self.0)
     }
+
+    #[inline]
+    unsafe fn saturating_cast_u8(self) -> impl Simd<Elem = u8> {
+        Simd::to_array(self).map(|c| c.clamp(0, u8::MAX as i32) as u8)
+    }
 }
 
 impl Simd for v128f {
@@ -213,6 +219,11 @@ impl SimdFloat for v128f {
     #[inline]
     unsafe fn to_int_trunc(self) -> Self::Int {
         v128i(i32x4_trunc_sat_f32x4(self.0))
+    }
+
+    #[inline]
+    unsafe fn to_int_round(self) -> Self::Int {
+        v128i(i32x4_trunc_sat_f32x4(f32x4_nearest(self.0)))
     }
 
     #[inline]

--- a/rten-simd/src/vec.rs
+++ b/rten-simd/src/vec.rs
@@ -224,6 +224,9 @@ pub trait SimdInt: Simd<Elem = i32> {
 
     /// Reinterpret the bits of each element as a float.
     unsafe fn reinterpret_as_float(self) -> Self::Float;
+
+    /// Convert each lane in `self` to a `u8` value with saturation.
+    unsafe fn saturating_cast_u8(self) -> impl Simd<Elem = u8>;
 }
 
 /// Trait for SIMD vectors containing single-precision floats.
@@ -263,8 +266,11 @@ pub trait SimdFloat: Simd<Elem = f32> {
     /// Compute `self - rhs`.
     unsafe fn sub(self, rhs: Self) -> Self;
 
-    /// Convert this float to an int with truncation.
+    /// Convert each f32 lane to an i32 with truncation.
     unsafe fn to_int_trunc(self) -> Self::Int;
+
+    /// Convert each f32 lane to an i32 with rounding.
+    unsafe fn to_int_round(self) -> Self::Int;
 
     /// Compute `self * rhs`.
     unsafe fn mul(self, rhs: Self) -> Self;

--- a/rten-vecmath/src/lib.rs
+++ b/rten-vecmath/src/lib.rs
@@ -85,6 +85,7 @@ mod erf;
 mod exp;
 mod min_max;
 mod normalize;
+mod quantize;
 mod softmax;
 mod sum;
 mod tanh;
@@ -98,6 +99,7 @@ mod testing;
 // Unary functions.
 pub use erf::{Erf, Gelu};
 pub use exp::{Exp, Sigmoid, Silu, Swish};
+pub use quantize::Quantize;
 pub use tanh::Tanh;
 
 // Normalization and reduction functions.

--- a/rten-vecmath/src/quantize.rs
+++ b/rten-vecmath/src/quantize.rs
@@ -1,0 +1,110 @@
+use std::mem::{transmute, MaybeUninit};
+
+use rten_simd::dispatch::SimdOp;
+use rten_simd::{Simd, SimdFloat, SimdInt};
+
+/// Quantize a slice of `f32` elements to 8-bit integers using the formula:
+///
+/// ```text
+/// y = saturate(round(x * inv_scale) + zero_point)
+/// ```
+///
+/// Where `round` rounds to the nearest `i32` value with ties to even and
+/// `saturate` converts `i32` to the small integer type `To` with saturation.
+pub struct Quantize<'s, 'd, To> {
+    src: &'s [f32],
+    dest: &'d mut [MaybeUninit<To>],
+    inv_scale: f32,
+    zero_point: To,
+}
+
+impl<'s, 'd, To> Quantize<'s, 'd, To> {
+    pub fn new(
+        src: &'s [f32],
+        dest: &'d mut [MaybeUninit<To>],
+        inv_scale: f32,
+        zero_point: To,
+    ) -> Self {
+        assert_eq!(src.len(), dest.len());
+        Quantize {
+            src,
+            dest,
+            inv_scale,
+            zero_point,
+        }
+    }
+}
+
+impl<'d> SimdOp for Quantize<'_, 'd, u8> {
+    type Output = &'d mut [u8];
+
+    unsafe fn eval<S: SimdFloat>(self) -> Self::Output {
+        let mut n = self.src.len();
+        let mut src_ptr = self.src.as_ptr();
+        let mut dest_ptr = self.dest.as_mut_ptr();
+
+        let zp_vec = S::Int::splat(self.zero_point as i32);
+        let scale_vec = S::splat(self.inv_scale);
+
+        while n >= S::LEN {
+            let q = S::load(src_ptr)
+                .mul(scale_vec)
+                .to_int_round()
+                .add(zp_vec)
+                .saturating_cast_u8();
+            q.store(dest_ptr as *mut u8);
+
+            src_ptr = src_ptr.add(S::LEN);
+            dest_ptr = dest_ptr.add(S::LEN);
+            n -= S::LEN;
+        }
+
+        while n > 0 {
+            let x = *src_ptr;
+            let y = (x * self.inv_scale).round_ties_even() as i32;
+            let y = (y + self.zero_point as i32).clamp(0, u8::MAX as i32);
+            dest_ptr.write(MaybeUninit::new(y as u8));
+
+            src_ptr = src_ptr.add(1);
+            dest_ptr = dest_ptr.add(1);
+            n -= 1;
+        }
+
+        transmute::<&mut [MaybeUninit<u8>], &mut [u8]>(self.dest)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rten_simd::dispatch::SimdOp;
+
+    use super::Quantize;
+
+    fn reference_quantize(src: &[f32], inv_scale: f32, zero_point: u8) -> Vec<u8> {
+        src.iter()
+            .map(|x| {
+                let tmp = (x * inv_scale).round_ties_even() + zero_point as f32;
+                tmp as u8 // Saturating cast
+            })
+            .collect()
+    }
+
+    #[test]
+    fn test_quantize() {
+        let mut rng = fastrand::Rng::with_seed(1234);
+
+        // Larger than max SIMD vector length, not a multiple of one, so we have
+        // a tail.
+        let len = 17;
+        let src: Vec<f32> = std::iter::from_fn(|| Some(rng.f32())).take(len).collect();
+        let inv_scale = 5.2;
+        let zero_point = 10;
+        let expected = reference_quantize(&src, inv_scale, zero_point);
+
+        let mut buf = Vec::with_capacity(src.len());
+        let actual = &mut buf.spare_capacity_mut();
+        let actual = Quantize::new(&src, actual, inv_scale, zero_point).dispatch();
+
+        assert_eq!(actual, expected);
+    }
+}


### PR DESCRIPTION
Use SIMD operations for QuantizeLinear in the f32 -> u8 case, which also forms the second stage of DynamicQuantizeLinear. This makes DQL about ~3.5x faster under AVX2.