### PR TITLE
Implement optimized int8 gemv kernel using portable SIMD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,11 +59,19 @@ wasm-nosimd:
 .PHONY: wasm-all
 wasm-all: wasm wasm-nosimd
 
+# WASM tests run with `--nocapture` as otherwise assertion failure panic messages
+# are not printed if a test assert fails.
 .PHONY: wasm-tests
 wasm-tests:
 	rm -f target/wasm32-wasi/debug/deps/rten-*.wasm
 	RUSTFLAGS="-C target-feature=+simd128" cargo build --target wasm32-wasip1 --tests -p rten
-	wasmtime --dir . target/wasm32-wasip1/debug/deps/rten-*.wasm
+	wasmtime --dir . target/wasm32-wasip1/debug/deps/rten-*.wasm --nocapture
+
+.PHONY: wasm-tests
+wasm-tests-simd:
+	rm -f target/wasm32-wasi/debug/deps/rten_simd-*.wasm
+	RUSTFLAGS="-C target-feature=+simd128" cargo build --target wasm32-wasip1 --tests -p rten-simd
+	wasmtime --dir . target/wasm32-wasip1/debug/deps/rten_simd-*.wasm --nocapture
 
 src/schema_generated.rs: src/schema.fbs
 	flatc -o src/ --rust src/schema.fbs

--- a/rten-simd/src/arch/scalar.rs
+++ b/rten-simd/src/arch/scalar.rs
@@ -147,6 +147,11 @@ impl SimdInt for i32 {
     unsafe fn load_extend_i8(ptr: *const i8) -> Self {
         *ptr as i32
     }
+
+    #[inline]
+    unsafe fn sum(self) -> i32 {
+        self
+    }
 }
 
 /// Treat an `f32` as a single-lane SIMD "vector".

--- a/rten-simd/src/arch/scalar.rs
+++ b/rten-simd/src/arch/scalar.rs
@@ -132,6 +132,21 @@ impl SimdInt for i32 {
     unsafe fn saturating_cast_u8(self) -> impl Simd<Elem = u8> {
         self.clamp(0, 255) as u8
     }
+
+    #[inline]
+    unsafe fn load_interleave_i8(
+        a0: *const i8,
+        a1: *const i8,
+        a2: *const i8,
+        a3: *const i8,
+    ) -> Self {
+        i32::from_le_bytes([*a0 as u8, *a1 as u8, *a2 as u8, *a3 as u8])
+    }
+
+    #[inline]
+    unsafe fn load_extend_i8(ptr: *const i8) -> Self {
+        *ptr as i32
+    }
 }
 
 /// Treat an `f32` as a single-lane SIMD "vector".

--- a/rten-simd/src/arch/wasm.rs
+++ b/rten-simd/src/arch/wasm.rs
@@ -305,3 +305,10 @@ impl SimdFloat for v128f {
         f32x4_extract_lane::<0>(sum)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::vec::tests::test_simdint;
+
+    test_simdint!(v128i_simdint, crate::arch::wasm::v128i);
+}

--- a/rten-simd/src/arch/wasm.rs
+++ b/rten-simd/src/arch/wasm.rs
@@ -149,6 +149,33 @@ impl SimdInt for v128i {
     unsafe fn saturating_cast_u8(self) -> impl Simd<Elem = u8> {
         Simd::to_array(self).map(|c| c.clamp(0, u8::MAX as i32) as u8)
     }
+
+    #[inline]
+    unsafe fn load_extend_i8(ptr: *const i8) -> Self {
+        use core::arch::wasm32::{i16x8_extend_low_i8x16, i32x4_extend_low_i16x8, i64x2};
+        let tmp: i64 = std::ptr::read_unaligned(ptr as *const i64);
+        let tmp = i64x2(tmp, tmp);
+        let tmp = i16x8_extend_low_i8x16(tmp);
+        let tmp = i32x4_extend_low_i16x8(tmp);
+        Self(tmp)
+    }
+
+    #[inline]
+    unsafe fn load_interleave_i8(
+        a_ptr: *const i8,
+        b_ptr: *const i8,
+        c_ptr: *const i8,
+        d_ptr: *const i8,
+    ) -> Self {
+        let mut bytes: [i8; 16] = [0; 16];
+        for i in 0..Self::LEN {
+            bytes[i * 4] = *a_ptr.add(i);
+            bytes[i * 4 + 1] = *b_ptr.add(i);
+            bytes[i * 4 + 2] = *c_ptr.add(i);
+            bytes[i * 4 + 3] = *d_ptr.add(i);
+        }
+        Self(v128_load(bytes.as_ptr() as *const v128))
+    }
 }
 
 impl Simd for v128f {

--- a/rten-simd/src/arch/x86_64.rs
+++ b/rten-simd/src/arch/x86_64.rs
@@ -743,3 +743,13 @@ impl SimdFloat for __m512 {
         _mm512_reduce_add_ps(self)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::vec::tests::test_simdint;
+
+    test_simdint!(avx2_simdint, core::arch::x86_64::__m256i);
+
+    #[cfg(feature = "avx512")]
+    test_simdint!(avx512_simdint, core::arch::x86_64::__m512i);
+}

--- a/rten-simd/src/arch/x86_64.rs
+++ b/rten-simd/src/arch/x86_64.rs
@@ -1,13 +1,13 @@
 use std::arch::x86_64::{
-    __m256, __m256i, _mm256_add_epi32, _mm256_add_ps, _mm256_and_si256, _mm256_andnot_ps,
+    __m128i, __m256, __m256i, _mm256_add_epi32, _mm256_add_ps, _mm256_and_si256, _mm256_andnot_ps,
     _mm256_blendv_epi8, _mm256_blendv_ps, _mm256_castps256_ps128, _mm256_castsi256_ps,
     _mm256_cmp_ps, _mm256_cmpeq_epi32, _mm256_cmpgt_epi32, _mm256_cvtps_epi32, _mm256_cvttps_epi32,
     _mm256_div_ps, _mm256_extractf128_ps, _mm256_fmadd_ps, _mm256_loadu_ps, _mm256_loadu_si256,
     _mm256_max_epi32, _mm256_max_ps, _mm256_min_epi32, _mm256_min_ps, _mm256_mul_ps,
     _mm256_mullo_epi32, _mm256_or_si256, _mm256_set1_epi32, _mm256_set1_ps, _mm256_setr_epi32,
     _mm256_slli_epi32, _mm256_storeu_ps, _mm256_storeu_si256, _mm256_sub_epi32, _mm256_sub_ps,
-    _mm_add_ps, _mm_cvtss_f32, _mm_movehl_ps, _mm_prefetch, _mm_shuffle_ps, _CMP_GE_OQ, _CMP_LE_OQ,
-    _CMP_LT_OQ, _MM_HINT_ET0, _MM_HINT_T0,
+    _mm_add_ps, _mm_cvtss_f32, _mm_loadl_epi64, _mm_movehl_ps, _mm_prefetch, _mm_shuffle_ps,
+    _CMP_GE_OQ, _CMP_LE_OQ, _CMP_LT_OQ, _MM_HINT_ET0, _MM_HINT_T0,
 };
 use std::mem::{transmute, MaybeUninit};
 
@@ -195,6 +195,38 @@ impl SimdInt for __m256i {
         let mut dest: [MaybeUninit<u8>; 8] = [MaybeUninit::uninit(); 8];
         _mm_storel_epi64(dest.as_mut_ptr() as *mut __m128i, lower_128);
         transmute::<[MaybeUninit<u8>; 8], [u8; 8]>(dest)
+    }
+
+    #[inline]
+    unsafe fn load_interleave_i8(
+        a_ptr: *const i8,
+        b_ptr: *const i8,
+        c_ptr: *const i8,
+        d_ptr: *const i8,
+    ) -> Self {
+        use core::arch::x86_64::{
+            _mm256_castsi128_si256, _mm256_insertf128_si256, _mm_unpackhi_epi16,
+            _mm_unpacklo_epi16, _mm_unpacklo_epi8,
+        };
+        let a = _mm_loadl_epi64(a_ptr as *const __m128i);
+        let b = _mm_loadl_epi64(b_ptr as *const __m128i);
+        let c = _mm_loadl_epi64(c_ptr as *const __m128i);
+        let d = _mm_loadl_epi64(d_ptr as *const __m128i);
+
+        let ab = _mm_unpacklo_epi8(a, b); // A0 B0 ... A7 B7
+        let cd = _mm_unpacklo_epi8(c, d); // C0 C1 ... C7 D7
+
+        let abcd_lo = _mm_unpacklo_epi16(ab, cd); // A0 B0 C0 D0 ...
+        let abcd_hi = _mm_unpackhi_epi16(ab, cd); // A3 B3 C3 D3 ...
+
+        let lo = _mm256_castsi128_si256(abcd_lo);
+        _mm256_insertf128_si256(lo, abcd_hi, 1)
+    }
+
+    #[inline]
+    unsafe fn load_extend_i8(ptr: *const i8) -> Self {
+        use core::arch::x86_64::_mm256_cvtepi8_epi32;
+        _mm256_cvtepi8_epi32(_mm_loadl_epi64(ptr as *const __m128i))
     }
 }
 
@@ -531,6 +563,38 @@ impl SimdInt for __m512i {
         // For AVX-512 the compiler can generate something reasonably fast for
         // this. This doesn't work with AVX2.
         self.to_array().map(|c| c.clamp(0, u8::MAX as i32) as u8)
+    }
+
+    #[inline]
+    #[target_feature(enable = "avx512f")]
+    unsafe fn load_interleave_i8(
+        a_ptr: *const i8,
+        b_ptr: *const i8,
+        c_ptr: *const i8,
+        d_ptr: *const i8,
+    ) -> Self {
+        use core::arch::x86_64::{_mm512_castsi256_si512, _mm512_insertf32x8};
+        let lo = <__m256i as SimdInt>::load_interleave_i8(a_ptr, b_ptr, c_ptr, d_ptr);
+        let lo = _mm512_castsi256_si512(lo);
+        let hi = <__m256i as SimdInt>::load_interleave_i8(
+            a_ptr.add(8),
+            b_ptr.add(8),
+            c_ptr.add(8),
+            d_ptr.add(8),
+        );
+        let result = _mm512_insertf32x8(
+            transmute::<__m512i, __m512>(lo),
+            transmute::<__m256i, __m256>(hi),
+            1,
+        );
+        transmute::<__m512, __m512i>(result)
+    }
+
+    #[inline]
+    #[target_feature(enable = "avx512f")]
+    unsafe fn load_extend_i8(ptr: *const i8) -> Self {
+        use core::arch::x86_64::{_mm512_cvtepi8_epi32, _mm_loadu_si128};
+        _mm512_cvtepi8_epi32(_mm_loadu_si128(ptr as *const __m128i))
     }
 }
 

--- a/rten-simd/src/vec.rs
+++ b/rten-simd/src/vec.rs
@@ -352,3 +352,72 @@ pub trait SimdFloat: Simd<Elem = f32> {
         Self::splat(reduced)
     }
 }
+
+#[cfg(test)]
+pub mod tests {
+    /// Generate tests for a `SimdInt` implementation.
+    macro_rules! test_simdint {
+        ($modname:ident, $type_import_path:ty) => {
+            mod $modname {
+                use crate::vec::{Simd, SimdInt};
+                use $type_import_path as SimdVec;
+
+                const LEN: usize = <SimdVec as Simd>::LEN;
+
+                #[test]
+                fn test_load_extend_i8() {
+                    let src: Vec<i8> = (0..).take(LEN).collect();
+                    let vec = unsafe { <SimdVec as SimdInt>::load_extend_i8(src.as_ptr()) };
+                    let actual = unsafe { vec.to_array() };
+                    let expected: Vec<_> = src.iter().map(|x| *x as i32).collect();
+                    assert_eq!(actual.as_ref(), expected);
+                }
+
+                #[test]
+                fn test_load_interleave_i8() {
+                    let group_step = 5;
+                    let a: Vec<_> = (0..).step_by(group_step).take(LEN).collect();
+                    let b: Vec<_> = (1..).step_by(group_step).take(LEN).collect();
+                    let c: Vec<_> = (2..).step_by(group_step).take(LEN).collect();
+                    let d: Vec<_> = (3..).step_by(group_step).take(LEN).collect();
+
+                    let mut expected = Vec::new();
+                    for step in 0..LEN {
+                        let base = step * group_step;
+                        for i in 0..4 {
+                            expected.push((base + i) as i8);
+                        }
+                    }
+
+                    let vec = unsafe {
+                        <SimdVec as SimdInt>::load_interleave_i8(
+                            a.as_ptr(),
+                            b.as_ptr(),
+                            c.as_ptr(),
+                            d.as_ptr(),
+                        )
+                    };
+                    let actual = unsafe { vec.to_array() };
+                    let actual: Vec<i8> = actual
+                        .as_ref()
+                        .iter()
+                        .flat_map(|x| x.to_le_bytes().map(|b| b as i8))
+                        .collect();
+
+                    assert_eq!(actual.as_ref(), expected);
+                }
+
+                #[test]
+                fn test_sum() {
+                    let src: Vec<i32> = (0..).take(LEN).collect();
+                    let vec = unsafe { <SimdVec as Simd>::load(src.as_ptr()) };
+                    let actual = unsafe { vec.sum() };
+                    let expected: i32 = src.iter().sum();
+                    assert_eq!(actual, expected);
+                }
+            }
+        };
+    }
+
+    pub(crate) use test_simdint;
+}

--- a/rten-simd/src/vec.rs
+++ b/rten-simd/src/vec.rs
@@ -236,6 +236,15 @@ pub trait SimdInt: Simd<Elem = i32> {
     /// The returned vector contains `[a[0], b[0], c[0], d[0], ...
     /// a[N], b[N], c[N], d[N]]` where `N == Self::LEN`.
     unsafe fn load_interleave_i8(a: *const i8, b: *const i8, c: *const i8, d: *const i8) -> Self;
+
+    /// Horizontally sum the lanes in this vector.
+    unsafe fn sum(self) -> i32 {
+        let mut acc = 0;
+        for x in self.to_array().as_ref() {
+            acc += x;
+        }
+        acc
+    }
 }
 
 /// Trait for SIMD vectors containing single-precision floats.

--- a/rten-simd/src/vec.rs
+++ b/rten-simd/src/vec.rs
@@ -227,6 +227,15 @@ pub trait SimdInt: Simd<Elem = i32> {
 
     /// Convert each lane in `self` to a `u8` value with saturation.
     unsafe fn saturating_cast_u8(self) -> impl Simd<Elem = u8>;
+
+    /// Load `S::LEN` i8 values from `ptr` and sign-extend to i32.
+    unsafe fn load_extend_i8(ptr: *const i8) -> Self;
+
+    /// Load and interleave 4 groups of i8 values.
+    ///
+    /// The returned vector contains `[a[0], b[0], c[0], d[0], ...
+    /// a[N], b[N], c[N], d[N]]` where `N == Self::LEN`.
+    unsafe fn load_interleave_i8(a: *const i8, b: *const i8, c: *const i8, d: *const i8) -> Self;
 }
 
 /// Trait for SIMD vectors containing single-precision floats.


### PR DESCRIPTION
Add a gemv kernel for u8 x i8 -> i32 vector-matrix products using rten-simd primitives.

**TODO:**

- [x] Implement new rten-simd methods for WASM
- [x] Implement new rten-simd methods for Arm
- [x] Support transposed B matrix
- [x] Support non-contiguous, non-transposed B matrix
- [ ] ~~Use VNNI for AVX512 if available~~ (Will land this separately)