### PR TITLE
Convert Arm int8 kernels to use UDOT instead of USDOT

### DIFF
--- a/rten-simd/src/arch/aarch64.rs
+++ b/rten-simd/src/arch/aarch64.rs
@@ -157,15 +157,20 @@ impl SimdInt for int32x4_t {
         c_ptr: *const i8,
         d_ptr: *const i8,
     ) -> Self {
-        use core::arch::aarch64::{vld1q_s8, vreinterpretq_s32_s8};
-        let mut bytes: [i8; 16] = [0; 16];
-        for i in 0..Self::LEN {
-            bytes[i * 4] = *a_ptr.add(i);
-            bytes[i * 4 + 1] = *b_ptr.add(i);
-            bytes[i * 4 + 2] = *c_ptr.add(i);
-            bytes[i * 4 + 3] = *d_ptr.add(i);
-        }
-        vreinterpretq_s32_s8(vld1q_s8(bytes.as_ptr()))
+        use core::arch::aarch64::{
+            vcombine_s32, vld1_dup_s32, vreinterpret_s16_s8, vreinterpret_s32_s16,
+            vreinterpret_s8_s32, vzip1_s8, vzip_s16,
+        };
+
+        let a = vld1_dup_s32(a_ptr as *const i32);
+        let b = vld1_dup_s32(b_ptr as *const i32);
+        let c = vld1_dup_s32(c_ptr as *const i32);
+        let d = vld1_dup_s32(d_ptr as *const i32);
+
+        let ab = vzip1_s8(vreinterpret_s8_s32(a), vreinterpret_s8_s32(b));
+        let cd = vzip1_s8(vreinterpret_s8_s32(c), vreinterpret_s8_s32(d));
+        let abcd = vzip_s16(vreinterpret_s16_s8(ab), vreinterpret_s16_s8(cd));
+        vcombine_s32(vreinterpret_s32_s16(abcd.0), vreinterpret_s32_s16(abcd.1))
     }
 
     #[inline]

--- a/rten-simd/src/arch/aarch64.rs
+++ b/rten-simd/src/arch/aarch64.rs
@@ -2,9 +2,9 @@ use std::arch::aarch64::{
     float32x4_t, int32x4_t, uint32x4_t, vabsq_f32, vaddq_f32, vaddq_s32, vaddvq_f32, vandq_u32,
     vbslq_f32, vbslq_s32, vceqq_s32, vcgeq_f32, vcgeq_s32, vcgtq_s32, vcleq_f32, vcleq_s32,
     vcltq_f32, vcltq_s32, vcvtnq_s32_f32, vcvtq_s32_f32, vdivq_f32, vdupq_n_f32, vdupq_n_s32,
-    vfmaq_f32, vld1q_f32, vld1q_s32, vld1q_u32, vmaxq_f32, vmaxq_s32, vminq_f32, vminq_s32,
-    vmulq_f32, vmulq_s32, vreinterpretq_f32_s32, vshlq_n_s32, vst1q_f32, vst1q_s32, vst1q_u32,
-    vsubq_f32, vsubq_s32,
+    veorq_s32, vfmaq_f32, vld1q_f32, vld1q_s32, vld1q_u32, vmaxq_f32, vmaxq_s32, vminq_f32,
+    vminq_s32, vmulq_f32, vmulq_s32, vreinterpretq_f32_s32, vshlq_n_s32, vst1q_f32, vst1q_s32,
+    vst1q_u32, vsubq_f32, vsubq_s32,
 };
 
 use crate::{Simd, SimdFloat, SimdInt, SimdMask};
@@ -166,6 +166,11 @@ impl SimdInt for int32x4_t {
             bytes[i * 4 + 3] = *d_ptr.add(i);
         }
         vreinterpretq_s32_s8(vld1q_s8(bytes.as_ptr()))
+    }
+
+    #[inline]
+    unsafe fn xor(self, rhs: Self) -> Self {
+        veorq_s32(self, rhs)
     }
 }
 

--- a/rten-simd/src/arch/scalar.rs
+++ b/rten-simd/src/arch/scalar.rs
@@ -152,6 +152,11 @@ impl SimdInt for i32 {
     unsafe fn sum(self) -> i32 {
         self
     }
+
+    #[inline]
+    unsafe fn xor(self, rhs: Self) -> i32 {
+        self ^ rhs
+    }
 }
 
 /// Treat an `f32` as a single-lane SIMD "vector".

--- a/rten-simd/src/arch/wasm.rs
+++ b/rten-simd/src/arch/wasm.rs
@@ -3,7 +3,7 @@ use std::arch::wasm32::{
     f32x4_min, f32x4_mul, f32x4_nearest, f32x4_splat, f32x4_sub, i32x4, i32x4_add, i32x4_eq,
     i32x4_ge, i32x4_gt, i32x4_le, i32x4_lt, i32x4_max, i32x4_min, i32x4_mul, i32x4_shl,
     i32x4_shuffle, i32x4_splat, i32x4_sub, i32x4_trunc_sat_f32x4, v128, v128_and, v128_bitselect,
-    v128_load, v128_store,
+    v128_load, v128_store, v128_xor,
 };
 
 #[cfg(target_feature = "relaxed-simd")]
@@ -175,6 +175,11 @@ impl SimdInt for v128i {
             bytes[i * 4 + 3] = *d_ptr.add(i);
         }
         Self(v128_load(bytes.as_ptr() as *const v128))
+    }
+
+    #[inline]
+    unsafe fn xor(self, rhs: Self) -> Self {
+        Self(v128_xor(self.0, rhs.0))
     }
 }
 

--- a/rten-simd/src/arch/x86_64.rs
+++ b/rten-simd/src/arch/x86_64.rs
@@ -6,8 +6,8 @@ use std::arch::x86_64::{
     _mm256_max_epi32, _mm256_max_ps, _mm256_min_epi32, _mm256_min_ps, _mm256_mul_ps,
     _mm256_mullo_epi32, _mm256_or_si256, _mm256_set1_epi32, _mm256_set1_ps, _mm256_setr_epi32,
     _mm256_slli_epi32, _mm256_storeu_ps, _mm256_storeu_si256, _mm256_sub_epi32, _mm256_sub_ps,
-    _mm_add_ps, _mm_cvtss_f32, _mm_loadl_epi64, _mm_movehl_ps, _mm_prefetch, _mm_shuffle_ps,
-    _CMP_GE_OQ, _CMP_LE_OQ, _CMP_LT_OQ, _MM_HINT_ET0, _MM_HINT_T0,
+    _mm256_xor_si256, _mm_add_ps, _mm_cvtss_f32, _mm_loadl_epi64, _mm_movehl_ps, _mm_prefetch,
+    _mm_shuffle_ps, _CMP_GE_OQ, _CMP_LE_OQ, _CMP_LT_OQ, _MM_HINT_ET0, _MM_HINT_T0,
 };
 use std::mem::{transmute, MaybeUninit};
 
@@ -228,6 +228,12 @@ impl SimdInt for __m256i {
         use core::arch::x86_64::_mm256_cvtepi8_epi32;
         _mm256_cvtepi8_epi32(_mm_loadl_epi64(ptr as *const __m128i))
     }
+
+    #[inline]
+    #[target_feature(enable = "avx2")]
+    unsafe fn xor(self, other: Self) -> Self {
+        _mm256_xor_si256(self, other)
+    }
 }
 
 impl Simd for __m256 {
@@ -402,7 +408,7 @@ use std::arch::x86_64::{
     _mm512_max_ps, _mm512_min_epi32, _mm512_min_ps, _mm512_mul_ps, _mm512_mullo_epi32,
     _mm512_reduce_add_ps, _mm512_set1_epi32, _mm512_set1_ps, _mm512_setzero_si512,
     _mm512_sllv_epi32, _mm512_storeu_epi32, _mm512_storeu_ps, _mm512_sub_epi32, _mm512_sub_ps,
-    _MM_CMPINT_EQ, _MM_CMPINT_LE, _MM_CMPINT_LT,
+    _mm512_xor_si512, _MM_CMPINT_EQ, _MM_CMPINT_LE, _MM_CMPINT_LT,
 };
 
 #[cfg(feature = "avx512")]
@@ -595,6 +601,12 @@ impl SimdInt for __m512i {
     unsafe fn load_extend_i8(ptr: *const i8) -> Self {
         use core::arch::x86_64::{_mm512_cvtepi8_epi32, _mm_loadu_si128};
         _mm512_cvtepi8_epi32(_mm_loadu_si128(ptr as *const __m128i))
+    }
+
+    #[inline]
+    #[target_feature(enable = "avx512f")]
+    unsafe fn xor(self, other: Self) -> Self {
+        _mm512_xor_si512(self, other)
     }
 }
 

--- a/rten-simd/src/vec.rs
+++ b/rten-simd/src/vec.rs
@@ -245,6 +245,9 @@ pub trait SimdInt: Simd<Elem = i32> {
         }
         acc
     }
+
+    /// Bitwise XOR this value with `rhs`.
+    unsafe fn xor(self, rhs: Self) -> Self;
 }
 
 /// Trait for SIMD vectors containing single-precision floats.

--- a/src/gemm/kernels.rs
+++ b/src/gemm/kernels.rs
@@ -341,12 +341,17 @@ impl<T: GemmOutT, const MR: usize, const NR: usize> TempTile<T, MR, NR> {
 fn extract_zero_points<T: Copy + Into<i32>, const MAX_LEN: usize>(
     quant: Option<QuantParams<T>>,
     len: usize,
+    adjust: impl Fn(i32) -> i32,
 ) -> [i32; MAX_LEN] {
     let mut zero_points = [0; MAX_LEN];
+    for row in 0..len {
+        zero_points[row] = adjust(0);
+    }
     if let Some(quant) = quant {
         #[allow(clippy::manual_memcpy)]
         for row in 0..len {
-            zero_points[row] = quant.zero_point[row].into();
+            let val: i32 = quant.zero_point[row].into();
+            zero_points[row] = adjust(val);
         }
     }
     zero_points

--- a/src/gemm/kernels/x86_64.rs
+++ b/src/gemm/kernels/x86_64.rs
@@ -554,8 +554,8 @@ unsafe impl Kernel<u8, i8, i32> for Avx2Int8Kernel {
             Lhs::Unpacked { .. } => panic!("lhs must be packed"),
         };
 
-        let a_zero_points = extract_zero_points(a_quant, used_rows);
-        let b_zero_points = extract_zero_points(b_quant, used_cols);
+        let a_zero_points = extract_zero_points(a_quant, used_rows, |x| x);
+        let b_zero_points = extract_zero_points(b_quant, used_cols, |x| x);
         let (a_data, a_row_sums) = packing::int8::extract_packed_a::<{ Self::MR }>(a_data);
         let (b, b_col_sums) = packing::int8::extract_packed_b::<{ Self::NR }>(b);
 
@@ -598,7 +598,7 @@ unsafe impl Kernel<u8, i8, i32> for Avx2Int8Kernel {
             a_zero: u8,
             b_zero: Option<&[i8]>,
         ) {
-            simd_int8_gemv(
+            simd_int8_gemv::<_, false /* CAST_B_U8 */>(
                 out,
                 a,
                 b,
@@ -739,8 +739,8 @@ unsafe impl Kernel<u8, i8, i32> for Avx512Int8Kernel {
             Lhs::Unpacked { .. } => panic!("lhs must be packed"),
         };
 
-        let a_zero_points = extract_zero_points(a_quant, used_rows);
-        let b_zero_points = extract_zero_points(b_quant, used_cols);
+        let a_zero_points = extract_zero_points(a_quant, used_rows, |x| x);
+        let b_zero_points = extract_zero_points(b_quant, used_cols, |x| x);
         let (a_data, a_row_sums) = packing::int8::extract_packed_a::<{ Self::MR }>(a_data);
         let (b, b_col_sums) = packing::int8::extract_packed_b::<{ Self::NR }>(b);
 
@@ -803,7 +803,7 @@ unsafe impl Kernel<u8, i8, i32> for Avx512Int8Kernel {
             a_zero: u8,
             b_zero: Option<&[i8]>,
         ) {
-            simd_int8_gemv(
+            simd_int8_gemv::<_, false /* CAST_B_U8 */>(
                 out,
                 a,
                 b,

--- a/src/gemm/packing.rs
+++ b/src/gemm/packing.rs
@@ -26,6 +26,9 @@ impl<'a, T> SliceWriter<'a, T> {
     }
 
     /// Write the next element in the slice.
+    ///
+    /// Safety: The number of elements already written must be less than the
+    /// length of the slice.
     unsafe fn write_unchecked(&mut self, val: T) {
         debug_assert!(self.offset < self.slice.len());
         self.slice.get_unchecked_mut(self.offset).write(val);
@@ -33,6 +36,9 @@ impl<'a, T> SliceWriter<'a, T> {
     }
 
     /// Write `len` copies of `val` to the slice.
+    ///
+    /// Safety: The number of elements already written must be less than or
+    /// equal to `slice.len() - len`.
     unsafe fn write_n_unchecked(&mut self, len: usize, val: T)
     where
         T: Copy,


### PR DESCRIPTION
Convert the Arm int8 kernels to use the more widely supported UDOT instruction
(mandatory from Arm v8.4) instead of USDOT (mandatory from Arm v8.6).

This change requires converting the B input from signed to unsigned while
packing by adding 128, thus preserving the position of each value within the
numeric range. Each column zero point is adjusted accordingly. This is
done with a bit flip trick I found in ORT.

In the process of testing the gemv changes, the `SimdInt::load_interleave_i8` baseline implementation for Arm was replaced with an optimized version.