### PR TITLE
Add int8 fallback kernel for older Arm CPUs that don't support UDOT

### DIFF
--- a/src/gemm/packing/int8.rs
+++ b/src/gemm/packing/int8.rs
@@ -42,6 +42,7 @@ pub fn packed_b_layout<const NR: usize>(b_rows: usize, b_cols: usize) -> PackedL
 /// transposed `[NR, 4]` microtile of `B` is then multiplied with a `[MR, 4]`
 /// microtile of `A` using dot product instructions. The column sums are used
 /// to handle subtraction of the zero point.
+#[allow(unused)]
 pub fn pack_b<const NR: usize>(out: &mut [MaybeUninit<i8>], b: Matrix<i8>) {
     pack_b_impl::<NR, _>(
         out,


### PR DESCRIPTION
This uses a sequence of instructions to emulate UDOT using widening multiplies and pairwise adds.

In the process the helpers for instantiating `GemmExecutor` with different kernels were refactored into a generic trait to make it easier to exercise each of the available kernels for a given set of input and output types.

With the changes on this branch I was able to successfully run the Whisper example on a Raspberry Pi Zero 2 (Quad-core Arm Cortex A53, 512MB RAM) using the base and tiny models, at ~0.9x real time for base and ~2.1x for tiny.