### PR TITLE
Set default number of threads to performance core count on macOS

### DIFF
--- a/rten-simd/src/isa_detection.rs
+++ b/rten-simd/src/isa_detection.rs
@@ -1,59 +1,76 @@
 //! Functions for testing the availability of instruction sets at runtime.
 
-/// Detect availability of AVX-512 on macOS, where `is_x86_feature_detected`
-/// can return false even if AVX-512 is available.
-///
-/// See https://github.com/golang/go/issues/43089. Go chose to use the
-/// `commpage` to get the info. We use `sysctlbyname` instead since it is
-/// a documented API.
-#[cfg(feature = "avx512")]
+/// Functions for reading system info on macOS.
 #[cfg(target_os = "macos")]
-fn test_for_avx512_on_macos() -> bool {
-    use std::sync::OnceLock;
+#[allow(unused)]
+mod macos {
+    /// Detect availability of AVX-512 on macOS, where `is_x86_feature_detected`
+    /// can return false even if AVX-512 is available.
+    ///
+    /// See https://github.com/golang/go/issues/43089. Go chose to use the
+    /// `commpage` to get the info. We use `sysctlbyname` instead since it is
+    /// a documented API.
+    fn test_for_avx512_on_macos() -> bool {
+        use std::sync::OnceLock;
 
-    static AVX512_AVAILABLE: OnceLock<bool> = OnceLock::new();
+        static AVX512_AVAILABLE: OnceLock<bool> = OnceLock::new();
 
-    *AVX512_AVAILABLE.get_or_init(|| unsafe {
-        // We test for the minimum AVX-512 extensions we require, but not
-        // avx512f, as that is implied if the extensions are supported.
-        get_sysctl_bool(b"hw.optional.avx512vl\0") && get_sysctl_bool(b"hw.optional.avx512bw\0")
-    })
-}
-
-/// Get a sysctl int value by name and interpret it as a boolean.
-///
-/// `name` must be a nul-terminated.
-#[cfg(feature = "avx512")]
-#[cfg(target_os = "macos")]
-unsafe fn get_sysctl_bool(name: &[u8]) -> bool {
-    use std::os::raw::{c_char, c_int, c_void};
-
-    #[link(name = "c")]
-    extern "C" {
-        /// See https://developer.apple.com/documentation/kernel/1387446-sysctlbyname.
-        fn sysctlbyname(
-            name: *const c_char,
-            oldp: *mut c_void,
-            oldlenp: *mut usize,
-            newp: *const c_void,
-            newlen: usize,
-        ) -> c_int;
+        *AVX512_AVAILABLE.get_or_init(|| {
+            // We test for the minimum AVX-512 extensions we require, but not
+            // avx512f, as that is implied if the extensions are supported.
+            sysctl_bool(c"hw.optional.avx512vl").unwrap_or(false)
+                && sysctl_bool(c"hw.optional.avx512bw").unwrap_or(false)
+        })
     }
 
-    use std::ffi::CStr;
+    /// Error code returned by `sysctlbyname`.
+    #[derive(Copy, Clone, Debug, PartialEq)]
+    pub struct SysctlError(i32);
 
-    let mut ret = 0u64;
-    let mut size = std::mem::size_of::<u64>();
+    /// Read system info on macOS via the `sysctlbyname` API.
+    ///
+    /// See the output of `sysctl -a` on the command line for available settings.
+    ///
+    /// See also [Apple's documentation](https://developer.apple.com/documentation/kernel/1387446-sysctlbyname).
+    pub fn sysctl_int(name: &std::ffi::CStr) -> Result<i64, SysctlError> {
+        use std::os::raw::{c_char, c_int, c_void};
 
-    let sysctl_ret = sysctlbyname(
-        CStr::from_bytes_with_nul(name).unwrap().as_ptr(),
-        std::mem::transmute(&mut ret),
-        &mut size,
-        std::ptr::null(),
-        0,
-    );
+        #[link(name = "c")]
+        extern "C" {
+            /// See https://developer.apple.com/documentation/kernel/1387446-sysctlbyname.
+            fn sysctlbyname(
+                name: *const c_char,
+                oldp: *mut c_void,
+                oldlenp: *mut usize,
+                newp: *const c_void,
+                newlen: usize,
+            ) -> c_int;
+        }
 
-    sysctl_ret == 0 && ret == 1
+        // Use i64 for the return type per example in Apple's docs.
+        let mut result = 0i64;
+        let mut size = std::mem::size_of::<i64>();
+
+        let sysctl_ret = unsafe {
+            sysctlbyname(
+                name.as_ptr(),
+                std::mem::transmute(&mut result),
+                &mut size,
+                std::ptr::null(),
+                0,
+            )
+        };
+
+        if sysctl_ret != 0 {
+            return Err(SysctlError(sysctl_ret));
+        }
+        Ok(result)
+    }
+
+    /// Read a system configuration integer value and interpret it as a boolean.
+    pub fn sysctl_bool(name: &std::ffi::CStr) -> Result<bool, SysctlError> {
+        sysctl_int(name).map(|val| val == 1)
+    }
 }
 
 /// Test if the current system has basic AVX-512 support.
@@ -68,7 +85,6 @@ unsafe fn get_sysctl_bool(name: &[u8]) -> bool {
 ///
 /// This is unfortunately not as simple as using `is_x86_feature_detected`
 /// because that can return incorrect results on macOS.
-#[cfg(feature = "avx512")]
 #[cfg(target_arch = "x86_64")]
 pub fn is_avx512_supported() -> bool {
     if is_x86_feature_detected!("avx512f")
@@ -79,11 +95,24 @@ pub fn is_avx512_supported() -> bool {
     } else {
         #[cfg(target_os = "macos")]
         {
-            test_for_avx512_on_macos()
+            macos::test_for_avx512_on_macos()
         }
         #[cfg(not(target_os = "macos"))]
         {
             false
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(target_arch = "x86_64")]
+    use super::is_avx512_supported;
+
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn test_is_avx512_supported() {
+        // Just test that the function runs.
+        is_avx512_supported();
     }
 }

--- a/rten-simd/src/isa_detection.rs
+++ b/rten-simd/src/isa_detection.rs
@@ -81,7 +81,7 @@ pub mod macos {
 ///  - AVX512BW
 ///
 /// These features are available on Skylake (2016) and later.
-/// See https://en.wikipedia.org/wiki/Advanced_Vector_Extensions#AVX-512_CPU_compatibility_table.
+/// See <https://en.wikipedia.org/wiki/Advanced_Vector_Extensions#AVX-512_CPU_compatibility_table>.
 ///
 /// This is unfortunately not as simple as using `is_x86_feature_detected`
 /// because that can return incorrect results on macOS.

--- a/rten-simd/src/isa_detection.rs
+++ b/rten-simd/src/isa_detection.rs
@@ -3,7 +3,7 @@
 /// Functions for reading system info on macOS.
 #[cfg(target_os = "macos")]
 #[allow(unused)]
-mod macos {
+pub mod macos {
     /// Detect availability of AVX-512 on macOS, where `is_x86_feature_detected`
     /// can return false even if AVX-512 is available.
     ///


### PR DESCRIPTION
On Apple Silicon systems with a mix of performance and efficiency cores,
performance is better if the number of threads is set to the performance core
count, rather than the total number of cores.

Fixes https://github.com/robertknight/rten/issues/342.
