### PR TITLE
Run tests under WASM in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,16 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-    - name: Install Rust wasm32-unknown-unknown target
-      run: rustup target add wasm32-unknown-unknown
+    - name: Install Rust WASM targets
+      run: |
+        rustup target add wasm32-unknown-unknown
+        rustup target add wasm32-wasip1
+      if: ${{ matrix.os == 'ubuntu-latest' }}
+    - name: Install wasmtime
+      run: |
+        curl https://wasmtime.dev/install.sh -sSf | bash
+        ls $HOME/.wasmtime/bin
+        echo "$HOME/.wasmtime/bin" >> "$GITHUB_PATH"
       if: ${{ matrix.os == 'ubuntu-latest' }}
     - name: Install Rust nightly toolchain
       run: rustup toolchain install nightly
@@ -42,6 +50,10 @@ jobs:
       if: ${{ matrix.os == 'ubuntu-latest' }}
     - name: Build (WASM)
       run: make wasm
+      if: ${{ matrix.os == 'ubuntu-latest' }}
+    - name: Test (WASM)
+      run: |
+        make wasm-test wasm-test-simd
       if: ${{ matrix.os == 'ubuntu-latest' }}
     - name: Lint
       run: |

--- a/Makefile
+++ b/Makefile
@@ -62,13 +62,13 @@ wasm-all: wasm wasm-nosimd
 # WASM tests run with `--nocapture` as otherwise assertion failure panic messages
 # are not printed if a test assert fails.
 .PHONY: wasm-tests
-wasm-tests:
+wasm-test:
 	rm -f target/wasm32-wasi/debug/deps/rten-*.wasm
 	RUSTFLAGS="-C target-feature=+simd128" cargo build --target wasm32-wasip1 --tests -p rten
 	wasmtime --dir . target/wasm32-wasip1/debug/deps/rten-*.wasm --nocapture
 
 .PHONY: wasm-tests
-wasm-tests-simd:
+wasm-test-simd:
 	rm -f target/wasm32-wasi/debug/deps/rten_simd-*.wasm
 	RUSTFLAGS="-C target-feature=+simd128" cargo build --target wasm32-wasip1 --tests -p rten-simd
 	wasmtime --dir . target/wasm32-wasip1/debug/deps/rten_simd-*.wasm --nocapture


### PR DESCRIPTION
The WASM test targets are also renamed for consistency with `make test`.