### PR TITLE
Skip Python lint on macOS CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ jobs:
   ci:
     strategy:
       matrix:
+        # The macOS build tests Arm and macOS-specific code paths.
+        # The Linux build tests everything else (x64, wasm, Python ...)
         os: [ubuntu-latest, macos-14]
     runs-on: ${{ matrix.os }}
     steps:
@@ -66,6 +68,7 @@ jobs:
       run: |
         python -m venv .venv
         .venv/bin/pip install --upgrade pip
+      if: ${{ matrix.os == 'ubuntu-latest' }}
     - name: Python Lint
       run: |
         source .venv/bin/activate
@@ -73,3 +76,4 @@ jobs:
         pip install -e .
         pip install -r requirements.dev.txt
         make check
+      if: ${{ matrix.os == 'ubuntu-latest' }}


### PR DESCRIPTION
The Python code is the same across all platforms so we only need to run linting on one, and it runs a lot faster in the Linux CI. From skimming the build logs [^1] it looks like an `onnx` wheel gets built in the macOS CI whereas Linux CI uses a pre-built wheel.

[^1]: https://github.com/robertknight/rten/actions/runs/12973539398/job/36182308596?pr=554