### PR TITLE
Implement baseline int8 kernel for WASM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,12 @@ wasm-test-simd:
 	RUSTFLAGS="-C target-feature=+simd128" cargo build --target wasm32-wasip1 --tests -p rten-simd
 	wasmtime --dir . target/wasm32-wasip1/debug/deps/rten_simd-*.wasm --nocapture
 
+.PHONY: wasm-bench-gemm
+wasm-bench-gemm:
+	rm -f target/wasm32-wasi/release/deps/rten-*.wasm
+	RUSTFLAGS="-C target-feature=+simd128" cargo build --target wasm32-wasip1 --tests -p rten -r
+	wasmtime --dir . target/wasm32-wasip1/release/deps/rten-*.wasm --nocapture --ignored bench_gemm_mix
+
 src/schema_generated.rs: src/schema.fbs
 	flatc -o src/ --rust src/schema.fbs
 	cargo fmt

--- a/rten-simd/src/arch/wasm.rs
+++ b/rten-simd/src/arch/wasm.rs
@@ -14,12 +14,12 @@ use crate::{Simd, SimdFloat, SimdInt, SimdMask};
 /// Wrapper around a WASM v128 type that marks it as containing integers.
 #[allow(non_camel_case_types)]
 #[derive(Copy, Clone, Debug)]
-pub struct v128i(v128);
+pub struct v128i(pub v128);
 
 /// Wrapper around a WASM v128 type that marks it as containing floats.
 #[allow(non_camel_case_types)]
 #[derive(Copy, Clone, Debug)]
-pub struct v128f(v128);
+pub struct v128f(pub v128);
 
 impl SimdMask for v128i {
     type Array = [bool; 4];

--- a/src/gemm.rs
+++ b/src/gemm.rs
@@ -278,6 +278,10 @@ enum Int8KernelType {
     ArmDot,
     #[cfg(target_arch = "aarch64")]
     ArmNeon,
+
+    #[cfg(target_arch = "wasm32")]
+    #[cfg(target_feature = "simd128")]
+    Wasm,
 }
 
 /// Executes matrix multiplication operations.
@@ -626,6 +630,9 @@ impl WithKernel for GemmExecutor<u8, i8, i32> {
             Int8KernelType::ArmNeon => Self::from_kernel::<kernels::aarch64::ArmInt8Kernel>(),
             #[cfg(target_arch = "aarch64")]
             Int8KernelType::ArmDot => Self::from_kernel::<kernels::aarch64::ArmInt8DotKernel>(),
+            #[cfg(target_arch = "wasm32")]
+            #[cfg(target_feature = "simd128")]
+            Int8KernelType::Wasm => Self::from_kernel::<kernels::wasm::WasmInt8Kernel>(),
             Int8KernelType::Generic => Self::from_kernel::<GenericKernel>(),
         }
     }
@@ -644,6 +651,12 @@ impl WithKernel for GemmExecutor<u8, i8, i32> {
         {
             types.push(Int8KernelType::ArmDot);
             types.push(Int8KernelType::ArmNeon);
+        }
+
+        #[cfg(target_arch = "wasm32")]
+        #[cfg(target_feature = "simd128")]
+        {
+            types.push(Int8KernelType::Wasm);
         }
 
         types.push(Int8KernelType::Generic);
@@ -668,6 +681,10 @@ impl Default for GemmExecutor<u8, i8, i32> {
         {
             try_kernel!(Int8KernelType::ArmDot);
             try_kernel!(Int8KernelType::ArmNeon);
+        }
+        #[cfg(target_arch = "wasm32")]
+        {
+            try_kernel!(Int8KernelType::Wasm);
         }
         Self::with_generic_kernel()
     }

--- a/src/gemm/kernels/wasm.rs
+++ b/src/gemm/kernels/wasm.rs
@@ -5,10 +5,10 @@ use rten_simd::arch::wasm::{v128f, v128i};
 use rten_simd::vec_count;
 use rten_tensor::{Matrix, MatrixLayout};
 
-use super::simd_generic::{simd_gemv, GemmDispatch};
-use super::{Kernel, Lhs, PackedLayout, QuantParams, TempTile};
+use super::simd_generic::{simd_gemv, simd_int8_gemm, simd_int8_gemv, GemmDispatch};
+use super::{extract_zero_points, Kernel, Lhs, PackedLayout, QuantParams, TempTile};
 use crate::gemm::packing::{pack_a_block, pack_b_block, packed_a_layout, packed_b_layout};
-use crate::gemm::Im2Col;
+use crate::gemm::{packing, Im2Col};
 use crate::slice_cast::{cast_pod_mut_slice, cast_pod_slice};
 
 pub struct WasmKernel {
@@ -178,4 +178,183 @@ unsafe impl Kernel<f32, f32, f32> for WasmKernel {
             simd_gemv::<v128f, 4>(out, a, b, alpha, beta);
         }
     }
+}
+
+pub struct WasmInt8Kernel {
+    _private: (),
+}
+
+impl WasmInt8Kernel {
+    const MR: usize = 8;
+    const NR: usize = 4;
+}
+
+unsafe impl Kernel<u8, i8, i32> for WasmInt8Kernel {
+    fn new() -> Option<Self> {
+        Some(WasmInt8Kernel { _private: () })
+    }
+
+    fn name(&self) -> &'static str {
+        "wasm-int8"
+    }
+
+    fn mr(&self) -> usize {
+        Self::MR
+    }
+
+    fn nr(&self) -> usize {
+        Self::NR
+    }
+
+    fn packed_a_layout(
+        &self,
+        _a: Matrix<u8>,
+        rows: usize,
+        cols: usize,
+        _quant: Option<QuantParams<u8>>,
+    ) -> PackedLayout {
+        let mut layout = packing::int8::packed_a_layout::<{ Self::MR }>(rows, cols);
+        layout.must_pack = true;
+        layout
+    }
+
+    fn pack_a_block(
+        &self,
+        out: &mut [MaybeUninit<u8>],
+        a: Matrix<u8>,
+        rows: Range<usize>,
+        cols: Range<usize>,
+        _quant: Option<QuantParams<u8>>,
+    ) {
+        let out = cast_pod_mut_slice(out).unwrap();
+        packing::int8::pack_a::<{ Self::MR }>(out, a.slice((rows, cols)))
+    }
+
+    fn packed_b_layout(
+        &self,
+        rows: usize,
+        cols: usize,
+        _quant: Option<QuantParams<i8>>,
+    ) -> PackedLayout {
+        packing::int8::packed_b_layout::<{ Self::NR }>(rows, cols)
+    }
+
+    fn pack_b_block(
+        &self,
+        out: &mut [MaybeUninit<u8>],
+        b: Matrix<i8>,
+        rows: Range<usize>,
+        cols: Range<usize>,
+        _quant: Option<QuantParams<i8>>,
+    ) {
+        packing::int8::pack_b_cast_i8_u8::<{ Self::NR }>(out, b.slice((rows, cols)))
+    }
+
+    fn pack_im2col(
+        &self,
+        _out: &mut [MaybeUninit<u8>],
+        _image: &Im2Col<i8>,
+        _rows: Range<usize>,
+        _cols: Range<usize>,
+    ) {
+        unimplemented!("pack_im2col not implemented");
+    }
+
+    unsafe fn kernel(
+        &self,
+        tile_ptr: *mut i32,
+        tile_row_stride: usize,
+        a: Lhs<u8>,
+        b: &[u8],
+        used_rows: usize,
+        used_cols: usize,
+        depth: usize,
+        _alpha: f32,
+        beta: i32,
+        a_quant: Option<QuantParams<u8>>,
+        b_quant: Option<QuantParams<i8>>,
+    ) {
+        let a_data = match a {
+            Lhs::Packed(data) => data,
+            Lhs::Unpacked { .. } => panic!("lhs must be packed"),
+        };
+
+        let a_zero_points = extract_zero_points(a_quant, used_rows, |x| x);
+        let b_zero_points = extract_zero_points(b_quant, used_cols, |x| x + I8_U8_SHIFT);
+        let (a_data, a_row_sums) = packing::int8::extract_packed_a::<{ Self::MR }>(a_data);
+        let (b, b_col_sums) = packing::int8::extract_packed_b::<{ Self::NR }>(b);
+
+        simd_int8_gemm::<_, { Self::MR }, { Self::NR }>(
+            tile_ptr,
+            tile_row_stride,
+            a_data,
+            b,
+            used_rows,
+            used_cols,
+            depth,
+            beta != 0, // accumulate
+            a_zero_points,
+            b_zero_points,
+            a_row_sums,
+            b_col_sums,
+            wasm_u8u8_i32_dot_product,
+        )
+    }
+
+    fn gemv_kernel(
+        &self,
+        out: &mut [MaybeUninit<i32>],
+        a: &[u8],
+        b: Matrix<i8>,
+        _alpha: f32,
+        beta: i32,
+        a_quant: Option<QuantParams<u8>>,
+        b_quant: Option<QuantParams<i8>>,
+    ) {
+        let a_zero = a_quant.map(|aq| aq.zero_point[0]).unwrap_or(0);
+        let b_zero = b_quant.map(|bq| bq.zero_point);
+        let accumulate = beta != 0;
+
+        // Safety: Target features were checked when kernel was constructed.
+        unsafe {
+            simd_int8_gemv::<_, true /* CAST_B_U8 */>(
+                out,
+                a,
+                b,
+                accumulate,
+                a_zero,
+                b_zero,
+                wasm_u8u8_i32_dot_product,
+            )
+        }
+    }
+}
+
+/// Adjustment to apply to zero points in kernel where corresponding input
+/// was shifted from i8 to u8 when packing.
+const I8_U8_SHIFT: i32 = 128;
+
+/// Compute i32 dot product of each group of 4 u8 integers in `a` and `b` and
+/// add to i32x4 accumulator in `c`.
+///
+/// Adapted from the reference lowing of `i32x4.dot_i8x16_i7x16_add_s` given
+/// in https://github.com/WebAssembly/relaxed-simd/issues/52.
+#[inline]
+fn wasm_u8u8_i32_dot_product(a: v128i, b: v128i, c: v128i) -> v128i {
+    use std::arch::wasm32::{
+        i32x4_add, i32x4_extadd_pairwise_u16x8, i32x4_shuffle, u16x8_extmul_high_u8x16,
+        u16x8_extmul_low_u8x16,
+    };
+
+    let mul_lo = u16x8_extmul_low_u8x16(a.0, b.0);
+    let mul_hi = u16x8_extmul_high_u8x16(a.0, b.0);
+
+    let pair_sum_lo = i32x4_extadd_pairwise_u16x8(mul_lo);
+    let pair_sum_hi = i32x4_extadd_pairwise_u16x8(mul_hi);
+
+    let pair_sum_even = i32x4_shuffle::<0, 2, 4, 6>(pair_sum_lo, pair_sum_hi);
+    let pair_sum_odd = i32x4_shuffle::<1, 3, 5, 7>(pair_sum_lo, pair_sum_hi);
+
+    let quad_sum = i32x4_add(pair_sum_even, pair_sum_odd);
+    v128i(i32x4_add(quad_sum, c.0))
 }

--- a/src/threading.rs
+++ b/src/threading.rs
@@ -29,6 +29,7 @@ impl ThreadPool {
 /// This may be less than the total number of cores on systems with heterogenous
 /// cores (eg. a mix of performance and efficiency).
 fn optimal_core_count() -> u32 {
+    #[allow(unused_mut)]
     let mut core_count = num_cpus::get_physical().max(1) as u32;
 
     #[cfg(target_os = "macos")]


### PR DESCRIPTION
This initial implementation performs about the same as f32 or slightly slower.

Faster kernels should be possible via one of:

 - Upconverting to i16 during packing and using `i32x4_dot_i16x8`
 - Using `i32x4.dot_i8x16_i7x16_add_s` if the `relaxed-simd` target feature is
   enabled
