### PR TITLE
Revise range reduction in int8 GEMM tests to match real model inputs

### DIFF
--- a/src/gemm.rs
+++ b/src/gemm.rs
@@ -1620,12 +1620,17 @@ mod tests {
     //
     // This works around an issue under AVX2 where the `vpmaddubsw` instruction
     // can encounter saturation when adding two signed 16-bit values into a
-    // 16-bit result. Each of the two 16-bit inputs are the result of a `u8 x i8`
-    // multiplication. By limiting the range of either the u8 or i8 input, we
-    // can avoid saturation. `(i16::MAX / 2).isqrt() == 127`, so if we ensure
-    // both int8 values are <= 127, saturation won't occur.
+    // 16-bit result. Each of the two 16-bit inputs are the result of a `u8 x
+    // i8` multiplication. By limiting the range of either the u8 or i8 input,
+    // we can avoid saturation. This issue does not affect the VNNI instruction
+    // used on newer x64 systems.
     //
-    // This issue does not affect the VNNI instruction used on newer x64 systems.
+    // To match the workaround in ONNX Runtime's quantizer when
+    // `reduce_range=True` is enabled, the range of the RHS (ie. the weights)
+    // is limited.
+    //
+    // To avoid saturation we require `a_max * b_max * 2 <= i16::MAX`. This
+    // re-arranges to `b_max <= (i16::MAX / 2) / 255 <= 64`.
     struct ReducedRangeRng {
         rng: XorShiftRng,
     }
@@ -1637,8 +1642,8 @@ mod tests {
             }
         }
 
-        fn next_u8(&mut self) -> u8 {
-            (self.rng.next_u64() % 128) as u8
+        fn next_i8(&mut self) -> i8 {
+            (self.rng.next_u64() % 65) as i8
         }
     }
 
@@ -1723,6 +1728,7 @@ mod tests {
     fn test_gemm_various_input_sizes<LhsT, RhsT, OutT>(
         gemm: Option<&GemmExecutor<LhsT, RhsT, OutT>>,
         mut lhs_gen: Option<&mut dyn FnMut() -> LhsT>,
+        mut rhs_gen: Option<&mut dyn FnMut() -> RhsT>,
     ) -> Result<(), Box<dyn Error>>
     where
         LhsT: GemmInT,
@@ -1773,7 +1779,11 @@ mod tests {
             } else {
                 NdTensor::<LhsT, 2>::rand(lhs_size, &mut rng)
             };
-            let b = NdTensor::<RhsT, 2>::rand(rhs_size, &mut rng);
+            let b = if let Some(rhs_gen) = rhs_gen.as_mut() {
+                NdTensor::<RhsT, 2>::from_simple_fn(rhs_size, rhs_gen)
+            } else {
+                NdTensor::<RhsT, 2>::rand(rhs_size, &mut rng)
+            };
 
             let result = run_matmul(a.view(), b.view(), None, gemm).unwrap();
             let expected = reference_matmul(a.view(), b.view(), None);
@@ -1793,7 +1803,7 @@ mod tests {
     #[test]
     fn test_gemm_f32() -> Result<(), Box<dyn Error>> {
         for gemm in all_gemms::<f32, f32, f32>() {
-            test_gemm_various_input_sizes(Some(&gemm), None)?;
+            test_gemm_various_input_sizes(Some(&gemm), None, None)?;
         }
         Ok(())
     }
@@ -1802,15 +1812,15 @@ mod tests {
     fn test_gemm_u8i8_i32() -> Result<(), Box<dyn Error>> {
         for gemm in all_gemms::<u8, i8, i32>() {
             let mut rng = ReducedRangeRng::new();
-            test_gemm_various_input_sizes(Some(&gemm), Some(&mut || rng.next_u8()))?;
+            test_gemm_various_input_sizes(Some(&gemm), None, Some(&mut || rng.next_i8()))?;
         }
         Ok(())
     }
 
     #[test]
     fn test_gemm_u8i8_i32_zero_point() {
-        let mut lhs_rng = ReducedRangeRng::new();
-        let mut rhs_rng = XorShiftRng::new(1234);
+        let mut lhs_rng = XorShiftRng::new(1234);
+        let mut rhs_rng = ReducedRangeRng::new();
 
         #[derive(Copy, Clone)]
         struct Case {
@@ -1837,8 +1847,8 @@ mod tests {
 
         for gemm in all_gemms::<u8, i8, i32>() {
             for Case { m, n, k } in cases {
-                let a = NdTensor::<u8, 2>::from_simple_fn([m, k], || lhs_rng.next_u8());
-                let b = NdTensor::<i8, 2>::rand([k, n], &mut rhs_rng);
+                let a = NdTensor::<u8, 2>::rand([m, k], &mut lhs_rng);
+                let b = NdTensor::<i8, 2>::from_simple_fn([k, n], || rhs_rng.next_i8());
 
                 let a_zero_point: Vec<_> = (0..a.rows()).map(|x| x as u8).collect();
                 let b_zero_point: Vec<_> = (0..b.cols()).map(|x| x as i8).collect();
@@ -1916,10 +1926,10 @@ mod tests {
 
     #[test]
     fn test_gemv_u8i8_i32_transposed() -> Result<(), Box<dyn Error>> {
-        let mut lhs_rng = ReducedRangeRng::new();
-        let mut rng = XorShiftRng::new(1234);
-        let a = NdTensor::<u8, 2>::from_simple_fn([1, 8], || lhs_rng.next_u8());
-        let mut b = NdTensor::<i8, 2>::rand([5, 8], &mut rng);
+        let mut lhs_rng = XorShiftRng::new(1234);
+        let mut rhs_rng = ReducedRangeRng::new();
+        let a = NdTensor::<u8, 2>::rand([1, 8], &mut lhs_rng);
+        let mut b = NdTensor::<i8, 2>::from_simple_fn([5, 8], || rhs_rng.next_i8());
 
         // Transpose the input B matrix. This will alter the row and column
         // strides and shapes, but not re-order the data.

--- a/src/gemm/kernels.rs
+++ b/src/gemm/kernels.rs
@@ -148,6 +148,10 @@ pub unsafe trait Kernel<LhsT, RhsT, OutT>: Sync {
     /// Return a name for this kernel for use in logging etc.
     fn name(&self) -> &'static str;
 
+    fn may_saturate(&self) -> bool {
+        false
+    }
+
     /// Return the layout of a packing buffer required to pack an A / LHS input.
     fn packed_a_layout(
         &self,

--- a/src/gemm/kernels/x86_64.rs
+++ b/src/gemm/kernels/x86_64.rs
@@ -479,6 +479,10 @@ unsafe impl Kernel<u8, i8, i32> for Avx2Int8Kernel {
         Self::NR
     }
 
+    fn may_saturate(&self) -> bool {
+        true
+    }
+
     fn packed_a_layout(
         &self,
         _a: Matrix<u8>,
@@ -661,6 +665,10 @@ unsafe impl Kernel<u8, i8, i32> for Avx512Int8Kernel {
 
     fn nr(&self) -> usize {
         Self::NR
+    }
+
+    fn may_saturate(&self) -> bool {
+        !self.have_vnni
     }
 
     fn packed_a_layout(


### PR DESCRIPTION
Range reduction in int8 GEMM tests was done in such a way that it was possible to write kernels which passed the tests but failed in real usage due to encountering saturation issues. Change range reduction in the tests to match how it is done in real models, where it is applied to the RHS inputs (ie. the weights) during quantization, not the LHS. Also only apply range reduction for kernels where we expect this to happen.