### PR TITLE
Fix x86 macOS build and run `cargo check` for Intel macOS in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
     - name: Install Rust nightly toolchain
       run: rustup toolchain install nightly
       if: ${{ matrix.os == 'ubuntu-latest' }}
+    - name: Install Rust x86_64-apple-darwin target
+      run: rustup target add x86_64-apple-darwin
+      if: ${{ matrix.os == 'macos-14' }}
     - name: Cache
       uses: actions/cache@v3
       with:
@@ -57,6 +60,9 @@ jobs:
       run: |
         make wasm-test wasm-test-simd
       if: ${{ matrix.os == 'ubuntu-latest' }}
+    - name: Build (Intel macOS)
+      run: cargo check --workspace --target x86_64-apple-darwin
+      if: ${{ matrix.os == 'macos-14' }}
     - name: Lint
       run: |
         make checkformatting

--- a/rten-simd/src/isa_detection.rs
+++ b/rten-simd/src/isa_detection.rs
@@ -54,7 +54,7 @@ pub mod macos {
         let sysctl_ret = unsafe {
             sysctlbyname(
                 name.as_ptr(),
-                std::mem::transmute(&mut result),
+                &mut result as *mut i64 as *mut c_void,
                 &mut size,
                 std::ptr::null(),
                 0,

--- a/rten-simd/src/isa_detection.rs
+++ b/rten-simd/src/isa_detection.rs
@@ -10,7 +10,7 @@ pub mod macos {
     /// See https://github.com/golang/go/issues/43089. Go chose to use the
     /// `commpage` to get the info. We use `sysctlbyname` instead since it is
     /// a documented API.
-    fn test_for_avx512_on_macos() -> bool {
+    pub(super) fn test_for_avx512_on_macos() -> bool {
         use std::sync::OnceLock;
 
         static AVX512_AVAILABLE: OnceLock<bool> = OnceLock::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,8 +56,8 @@
 //!
 //! - `f32`, `i32`, `i8`, `u8`
 //! - `i64` and `bool` tensors are supported by converting them to `i32` as
-//! part of the model conversion process. When preparing model inputs that
-//! expect these data types in ONNX, you will need to convert them to `i32`.
+//!   part of the model conversion process. When preparing model inputs that
+//!   expect these data types in ONNX, you will need to convert them to `i32`.
 //!
 //! Some operators support a more limited set of data types than described in
 //! the ONNX specification. Please file an issue if you need an operator to


### PR DESCRIPTION
Fix build that was broken by https://github.com/robertknight/rten/pull/552 and add a CI step to catch this.