### PR TITLE
Implement `ConvInteger` operator

### DIFF
--- a/rten-convert/rten_convert/converter.py
+++ b/rten-convert/rten_convert/converter.py
@@ -734,7 +734,7 @@ def op_node_from_onnx_operator(
             attrs.valueType = scalar_type
             attrs.value = scalar
 
-        case "Conv":
+        case "Conv" | "ConvInteger":
             attrs = sg.ConvAttrsT()
             attrs.dilations = read_dilations(op_reader)
             attrs.groups = op_reader.get_attr("group", "int", 1)

--- a/rten-convert/rten_convert/schema_generated.py
+++ b/rten-convert/rten_convert/schema_generated.py
@@ -117,6 +117,7 @@ class OperatorType(object):
     DynamicQuantizeLinear = 107
     MatMulInteger = 108
     DepthToSpace = 109
+    ConvInteger = 110
 
 
 class RNNDirection(object):
@@ -205,91 +206,91 @@ def OperatorAttrsCreator(unionType, table):
     from flatbuffers.table import Table
     if not isinstance(table, Table):
         return None
-    if unionType == OperatorAttrs().ArgMaxAttrs:
+    if unionType == OperatorAttrs.ArgMaxAttrs:
         return ArgMaxAttrsT.InitFromBuf(table.Bytes, table.Pos)
-    if unionType == OperatorAttrs().AveragePoolAttrs:
+    if unionType == OperatorAttrs.AveragePoolAttrs:
         return AveragePoolAttrsT.InitFromBuf(table.Bytes, table.Pos)
-    if unionType == OperatorAttrs().BatchNormalizationAttrs:
+    if unionType == OperatorAttrs.BatchNormalizationAttrs:
         return BatchNormalizationAttrsT.InitFromBuf(table.Bytes, table.Pos)
-    if unionType == OperatorAttrs().CastAttrs:
+    if unionType == OperatorAttrs.CastAttrs:
         return CastAttrsT.InitFromBuf(table.Bytes, table.Pos)
-    if unionType == OperatorAttrs().ConcatAttrs:
+    if unionType == OperatorAttrs.ConcatAttrs:
         return ConcatAttrsT.InitFromBuf(table.Bytes, table.Pos)
-    if unionType == OperatorAttrs().ConstantOfShapeAttrs:
+    if unionType == OperatorAttrs.ConstantOfShapeAttrs:
         return ConstantOfShapeAttrsT.InitFromBuf(table.Bytes, table.Pos)
-    if unionType == OperatorAttrs().ConvAttrs:
+    if unionType == OperatorAttrs.ConvAttrs:
         return ConvAttrsT.InitFromBuf(table.Bytes, table.Pos)
-    if unionType == OperatorAttrs().ConvTransposeAttrs:
+    if unionType == OperatorAttrs.ConvTransposeAttrs:
         return ConvTransposeAttrsT.InitFromBuf(table.Bytes, table.Pos)
-    if unionType == OperatorAttrs().FlattenAttrs:
+    if unionType == OperatorAttrs.FlattenAttrs:
         return FlattenAttrsT.InitFromBuf(table.Bytes, table.Pos)
-    if unionType == OperatorAttrs().GatherAttrs:
+    if unionType == OperatorAttrs.GatherAttrs:
         return GatherAttrsT.InitFromBuf(table.Bytes, table.Pos)
-    if unionType == OperatorAttrs().GemmAttrs:
+    if unionType == OperatorAttrs.GemmAttrs:
         return GemmAttrsT.InitFromBuf(table.Bytes, table.Pos)
-    if unionType == OperatorAttrs().GRUAttrs:
+    if unionType == OperatorAttrs.GRUAttrs:
         return GRUAttrsT.InitFromBuf(table.Bytes, table.Pos)
-    if unionType == OperatorAttrs().LeakyReluAttrs:
+    if unionType == OperatorAttrs.LeakyReluAttrs:
         return LeakyReluAttrsT.InitFromBuf(table.Bytes, table.Pos)
-    if unionType == OperatorAttrs().LSTMAttrs:
+    if unionType == OperatorAttrs.LSTMAttrs:
         return LSTMAttrsT.InitFromBuf(table.Bytes, table.Pos)
-    if unionType == OperatorAttrs().MaxPoolAttrs:
+    if unionType == OperatorAttrs.MaxPoolAttrs:
         return MaxPoolAttrsT.InitFromBuf(table.Bytes, table.Pos)
-    if unionType == OperatorAttrs().ReduceMeanAttrs:
+    if unionType == OperatorAttrs.ReduceMeanAttrs:
         return ReduceMeanAttrsT.InitFromBuf(table.Bytes, table.Pos)
-    if unionType == OperatorAttrs().ReshapeAttrs:
+    if unionType == OperatorAttrs.ReshapeAttrs:
         return ReshapeAttrsT.InitFromBuf(table.Bytes, table.Pos)
-    if unionType == OperatorAttrs().ResizeAttrs:
+    if unionType == OperatorAttrs.ResizeAttrs:
         return ResizeAttrsT.InitFromBuf(table.Bytes, table.Pos)
-    if unionType == OperatorAttrs().SplitAttrs:
+    if unionType == OperatorAttrs.SplitAttrs:
         return SplitAttrsT.InitFromBuf(table.Bytes, table.Pos)
-    if unionType == OperatorAttrs().SoftmaxAttrs:
+    if unionType == OperatorAttrs.SoftmaxAttrs:
         return SoftmaxAttrsT.InitFromBuf(table.Bytes, table.Pos)
-    if unionType == OperatorAttrs().TransposeAttrs:
+    if unionType == OperatorAttrs.TransposeAttrs:
         return TransposeAttrsT.InitFromBuf(table.Bytes, table.Pos)
-    if unionType == OperatorAttrs().ModAttrs:
+    if unionType == OperatorAttrs.ModAttrs:
         return ModAttrsT.InitFromBuf(table.Bytes, table.Pos)
-    if unionType == OperatorAttrs().ScatterElementsAttrs:
+    if unionType == OperatorAttrs.ScatterElementsAttrs:
         return ScatterElementsAttrsT.InitFromBuf(table.Bytes, table.Pos)
-    if unionType == OperatorAttrs().OneHotAttrs:
+    if unionType == OperatorAttrs.OneHotAttrs:
         return OneHotAttrsT.InitFromBuf(table.Bytes, table.Pos)
-    if unionType == OperatorAttrs().TopKAttrs:
+    if unionType == OperatorAttrs.TopKAttrs:
         return TopKAttrsT.InitFromBuf(table.Bytes, table.Pos)
-    if unionType == OperatorAttrs().HardSigmoidAttrs:
+    if unionType == OperatorAttrs.HardSigmoidAttrs:
         return HardSigmoidAttrsT.InitFromBuf(table.Bytes, table.Pos)
-    if unionType == OperatorAttrs().TriluAttrs:
+    if unionType == OperatorAttrs.TriluAttrs:
         return TriluAttrsT.InitFromBuf(table.Bytes, table.Pos)
-    if unionType == OperatorAttrs().ScatterNDAttrs:
+    if unionType == OperatorAttrs.ScatterNDAttrs:
         return ScatterNDAttrsT.InitFromBuf(table.Bytes, table.Pos)
-    if unionType == OperatorAttrs().NonMaxSuppressionAttrs:
+    if unionType == OperatorAttrs.NonMaxSuppressionAttrs:
         return NonMaxSuppressionAttrsT.InitFromBuf(table.Bytes, table.Pos)
-    if unionType == OperatorAttrs().LayerNormalizationAttrs:
+    if unionType == OperatorAttrs.LayerNormalizationAttrs:
         return LayerNormalizationAttrsT.InitFromBuf(table.Bytes, table.Pos)
-    if unionType == OperatorAttrs().RandomUniformAttrs:
+    if unionType == OperatorAttrs.RandomUniformAttrs:
         return RandomUniformAttrsT.InitFromBuf(table.Bytes, table.Pos)
-    if unionType == OperatorAttrs().EluAttrs:
+    if unionType == OperatorAttrs.EluAttrs:
         return EluAttrsT.InitFromBuf(table.Bytes, table.Pos)
-    if unionType == OperatorAttrs().RandomUniformLikeAttrs:
+    if unionType == OperatorAttrs.RandomUniformLikeAttrs:
         return RandomUniformLikeAttrsT.InitFromBuf(table.Bytes, table.Pos)
-    if unionType == OperatorAttrs().RandomNormalAttrs:
+    if unionType == OperatorAttrs.RandomNormalAttrs:
         return RandomNormalAttrsT.InitFromBuf(table.Bytes, table.Pos)
-    if unionType == OperatorAttrs().RandomNormalLikeAttrs:
+    if unionType == OperatorAttrs.RandomNormalLikeAttrs:
         return RandomNormalLikeAttrsT.InitFromBuf(table.Bytes, table.Pos)
-    if unionType == OperatorAttrs().GatherNDAttrs:
+    if unionType == OperatorAttrs.GatherNDAttrs:
         return GatherNDAttrsT.InitFromBuf(table.Bytes, table.Pos)
-    if unionType == OperatorAttrs().GeluAttrs:
+    if unionType == OperatorAttrs.GeluAttrs:
         return GeluAttrsT.InitFromBuf(table.Bytes, table.Pos)
-    if unionType == OperatorAttrs().EinsumAttrs:
+    if unionType == OperatorAttrs.EinsumAttrs:
         return EinsumAttrsT.InitFromBuf(table.Bytes, table.Pos)
-    if unionType == OperatorAttrs().IfAttrs:
+    if unionType == OperatorAttrs.IfAttrs:
         return IfAttrsT.InitFromBuf(table.Bytes, table.Pos)
-    if unionType == OperatorAttrs().PadAttrs:
+    if unionType == OperatorAttrs.PadAttrs:
         return PadAttrsT.InitFromBuf(table.Bytes, table.Pos)
-    if unionType == OperatorAttrs().DequantizeLinearAttrs:
+    if unionType == OperatorAttrs.DequantizeLinearAttrs:
         return DequantizeLinearAttrsT.InitFromBuf(table.Bytes, table.Pos)
-    if unionType == OperatorAttrs().QuantizeLinearAttrs:
+    if unionType == OperatorAttrs.QuantizeLinearAttrs:
         return QuantizeLinearAttrsT.InitFromBuf(table.Bytes, table.Pos)
-    if unionType == OperatorAttrs().DepthToSpaceAttrs:
+    if unionType == OperatorAttrs.DepthToSpaceAttrs:
         return DepthToSpaceAttrsT.InitFromBuf(table.Bytes, table.Pos)
     return None
 
@@ -308,9 +309,9 @@ def ScalarCreator(unionType, table):
     from flatbuffers.table import Table
     if not isinstance(table, Table):
         return None
-    if unionType == Scalar().IntScalar:
+    if unionType == Scalar.IntScalar:
         return IntScalarT.InitFromBuf(table.Bytes, table.Pos)
-    if unionType == Scalar().FloatScalar:
+    if unionType == Scalar.FloatScalar:
         return FloatScalarT.InitFromBuf(table.Bytes, table.Pos)
     return None
 
@@ -343,11 +344,11 @@ def NodeKindCreator(unionType, table):
     from flatbuffers.table import Table
     if not isinstance(table, Table):
         return None
-    if unionType == NodeKind().OperatorNode:
+    if unionType == NodeKind.OperatorNode:
         return OperatorNodeT.InitFromBuf(table.Bytes, table.Pos)
-    if unionType == NodeKind().ConstantNode:
+    if unionType == NodeKind.ConstantNode:
         return ConstantNodeT.InitFromBuf(table.Bytes, table.Pos)
-    if unionType == NodeKind().ValueNode:
+    if unionType == NodeKind.ValueNode:
         return ValueNodeT.InitFromBuf(table.Bytes, table.Pos)
     return None
 
@@ -363,13 +364,13 @@ def ConstantDataCreator(unionType, table):
     from flatbuffers.table import Table
     if not isinstance(table, Table):
         return None
-    if unionType == ConstantData().FloatData:
+    if unionType == ConstantData.FloatData:
         return FloatDataT.InitFromBuf(table.Bytes, table.Pos)
-    if unionType == ConstantData().Int32Data:
+    if unionType == ConstantData.Int32Data:
         return Int32DataT.InitFromBuf(table.Bytes, table.Pos)
-    if unionType == ConstantData().Int8Data:
+    if unionType == ConstantData.Int8Data:
         return Int8DataT.InitFromBuf(table.Bytes, table.Pos)
-    if unionType == ConstantData().UInt8Data:
+    if unionType == ConstantData.UInt8Data:
         return UInt8DataT.InitFromBuf(table.Bytes, table.Pos)
     return None
 

--- a/src/gemm/im2col.rs
+++ b/src/gemm/im2col.rs
@@ -302,14 +302,13 @@ impl Im2Col<'_, i8> {
                         let out_ptr = out_ptr.add(out_offset + idx * K_TILE + i);
                         let src_elem = *img_ptr.add(offsets_array[idx] as usize);
 
-                        // This should be compiled to a conditional move.
-                        let elem = if pad_mask_array[idx] { src_elem } else { 0 };
-
                         if CAST_B_U8 {
-                            let elem = shift_cast_i8_u8(elem);
+                            let src_elem = shift_cast_i8_u8(src_elem);
+                            let elem = if pad_mask_array[idx] { src_elem } else { 0 };
                             col_sums[idx] += elem as i32;
                             out_ptr.write(MaybeUninit::new(elem as i8));
                         } else {
+                            let elem = if pad_mask_array[idx] { src_elem } else { 0 };
                             col_sums[idx] += elem as i32;
                             out_ptr.write(MaybeUninit::new(elem));
                         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,6 +125,7 @@ mod model_metadata;
 mod number;
 mod op_registry;
 mod optimize;
+mod shift_cast;
 mod slice_cast;
 mod slice_reductions;
 mod tensor_pool;

--- a/src/op_registry.rs
+++ b/src/op_registry.rs
@@ -96,6 +96,7 @@ impl OpRegistry {
         register_op!(Clip);
         register_op!(Concat);
         register_op!(Conv);
+        register_op!(ConvInteger);
         register_op!(ConstantOfShape);
         register_op!(ConvTranspose);
         register_op!(Cos);
@@ -446,6 +447,18 @@ impl_read_op!(Conv, attrs_as_conv_attrs, |attrs: sg::ConvAttrs| {
     let strides = vec_from_attr(attrs.strides(), &[1, 1]);
     let dilations = vec_from_attr(attrs.dilations(), &[1, 1]);
     Ok(ops::Conv {
+        groups,
+        padding,
+        strides,
+        dilations,
+    })
+});
+impl_read_op!(ConvInteger, attrs_as_conv_attrs, |attrs: sg::ConvAttrs| {
+    let groups = attrs.groups() as usize;
+    let padding = padding_from_attrs(attrs.auto_pad(), attrs.pads());
+    let strides = vec_from_attr(attrs.strides(), &[1, 1]);
+    let dilations = vec_from_attr(attrs.dilations(), &[1, 1]);
+    Ok(ops::ConvInteger {
         groups,
         padding,
         strides,

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -71,7 +71,7 @@ pub use binary_elementwise::{
 };
 pub use concat::{concat, tile, Concat, Tile};
 pub use control_flow::If;
-pub use conv::{conv, conv_transpose, Conv, ConvTranspose};
+pub use conv::{conv, conv_integer, conv_transpose, Conv, ConvInteger, ConvTranspose};
 pub use convert::Cast;
 pub use einsum::{einsum, Einsum};
 pub use gather::{

--- a/src/schema.fbs
+++ b/src/schema.fbs
@@ -123,6 +123,7 @@ enum OperatorType: ubyte {
   DynamicQuantizeLinear,
   MatMulInteger,
   DepthToSpace,
+  ConvInteger,
 }
 
 enum RNNDirection: ubyte {
@@ -177,7 +178,7 @@ union OperatorAttrs {
   CastAttrs,
   ConcatAttrs,
   ConstantOfShapeAttrs,
-  ConvAttrs,
+  ConvAttrs, // Also used for ConvInteger
   ConvTransposeAttrs,
   FlattenAttrs,
   GatherAttrs, // Also used for GatherElements

--- a/src/schema_generated.rs
+++ b/src/schema_generated.rs
@@ -18,13 +18,13 @@ pub const ENUM_MIN_OPERATOR_TYPE: u8 = 0;
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
-pub const ENUM_MAX_OPERATOR_TYPE: u8 = 109;
+pub const ENUM_MAX_OPERATOR_TYPE: u8 = 110;
 #[deprecated(
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 110] = [
+pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 111] = [
     OperatorType::Add,
     OperatorType::ArgMin,
     OperatorType::ArgMax,
@@ -135,6 +135,7 @@ pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 110] = [
     OperatorType::DynamicQuantizeLinear,
     OperatorType::MatMulInteger,
     OperatorType::DepthToSpace,
+    OperatorType::ConvInteger,
 ];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -252,9 +253,10 @@ impl OperatorType {
     pub const DynamicQuantizeLinear: Self = Self(107);
     pub const MatMulInteger: Self = Self(108);
     pub const DepthToSpace: Self = Self(109);
+    pub const ConvInteger: Self = Self(110);
 
     pub const ENUM_MIN: u8 = 0;
-    pub const ENUM_MAX: u8 = 109;
+    pub const ENUM_MAX: u8 = 110;
     pub const ENUM_VALUES: &'static [Self] = &[
         Self::Add,
         Self::ArgMin,
@@ -366,6 +368,7 @@ impl OperatorType {
         Self::DynamicQuantizeLinear,
         Self::MatMulInteger,
         Self::DepthToSpace,
+        Self::ConvInteger,
     ];
     /// Returns the variant's name or "" if unknown.
     pub fn variant_name(self) -> Option<&'static str> {
@@ -480,6 +483,7 @@ impl OperatorType {
             Self::DynamicQuantizeLinear => Some("DynamicQuantizeLinear"),
             Self::MatMulInteger => Some("MatMulInteger"),
             Self::DepthToSpace => Some("DepthToSpace"),
+            Self::ConvInteger => Some("ConvInteger"),
             _ => None,
         }
     }

--- a/src/shift_cast.rs
+++ b/src/shift_cast.rs
@@ -1,0 +1,135 @@
+use rten_tensor::prelude::*;
+use rten_tensor::{Alloc, CowTensor, TensorView};
+
+/// Conversion from one numeric type to another that preserves the value's
+/// offset from the minimum value.
+///
+/// This trait is also implemented for some collection types, which can
+/// avoid allocating a new collection if the source and target types are the
+/// same.
+///
+/// Converting `0i8` to `u8` via a normal cast returns 0, but a shift cast
+/// returns `128u8`, since `0i8 - i8::MIN = 128` and `128u8 - u8::MIN = 128`.
+pub trait ShiftCast<T> {
+    /// Return a value of type T that has the same difference from `T::MIN`
+    /// as `self` has from `Self::MIN`.
+    fn shift_cast(self) -> T;
+
+    /// Variant of [`shift_cast`](ShiftCast::shift_cast) that takes an allocator.
+    fn shift_cast_in(self, _alloc: impl Alloc) -> T
+    where
+        Self: Sized,
+    {
+        self.shift_cast()
+    }
+}
+
+macro_rules! impl_noop_cast {
+    ($type:ty) => {
+        impl ShiftCast<$type> for $type {
+            fn shift_cast(self) -> Self {
+                self
+            }
+        }
+    };
+}
+
+impl_noop_cast!(i8);
+impl ShiftCast<u8> for i8 {
+    fn shift_cast(self) -> u8 {
+        (self as u8) ^ 0x80
+    }
+}
+
+impl_noop_cast!(u8);
+impl ShiftCast<i8> for u8 {
+    fn shift_cast(self) -> i8 {
+        (self ^ 0x80) as i8
+    }
+}
+
+impl<'a, T> ShiftCast<CowTensor<'a, T>> for TensorView<'a, T> {
+    fn shift_cast(self) -> CowTensor<'a, T> {
+        self.as_cow()
+    }
+}
+
+impl<'a> ShiftCast<CowTensor<'a, u8>> for TensorView<'a, i8> {
+    fn shift_cast(self) -> CowTensor<'a, u8> {
+        self.map(|&x| x.shift_cast()).into_cow()
+    }
+
+    fn shift_cast_in(self, alloc: impl Alloc) -> CowTensor<'a, u8> {
+        self.map_in(alloc, |&x| x.shift_cast()).into_cow()
+    }
+}
+
+impl<'a> ShiftCast<CowTensor<'a, i8>> for TensorView<'a, u8> {
+    fn shift_cast(self) -> CowTensor<'a, i8> {
+        self.map(|&x| x.shift_cast()).into_cow()
+    }
+
+    fn shift_cast_in(self, alloc: impl Alloc) -> CowTensor<'a, i8> {
+        self.map_in(alloc, |&x| x.shift_cast()).into_cow()
+    }
+}
+
+impl<T, U> ShiftCast<Vec<U>> for Vec<T>
+where
+    T: ShiftCast<U>,
+{
+    fn shift_cast(self) -> Vec<U> {
+        self.into_iter().map(|x| x.shift_cast()).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rten_tensor::prelude::*;
+    use rten_tensor::Tensor;
+
+    use super::{CowTensor, ShiftCast};
+
+    #[test]
+    fn test_shift_cast_scalar() {
+        const LEN: usize = 5;
+
+        let input = [-128i8, -1, 0, 1, 127];
+        let expected = [0u8, 127, 128, 129, 255];
+
+        let actual: [u8; LEN] = input.map(|x| x.shift_cast());
+        assert_eq!(actual, expected);
+
+        let actual_noop: [u8; LEN] = actual.map(|x| x.shift_cast());
+        assert_eq!(actual_noop, expected);
+
+        let actual_inverse: [i8; LEN] = expected.map(|x| x.shift_cast());
+        assert_eq!(actual_inverse, input);
+
+        let actual_inverse_noop: [i8; LEN] = input.map(|x| x.shift_cast());
+        assert_eq!(actual_inverse_noop, input);
+    }
+
+    #[test]
+    fn test_shift_cast_tensor() {
+        let input = Tensor::from([-128i8, -1, 0, 1, 127]);
+        let expected = Tensor::from([0u8, 127, 128, 129, 255]);
+
+        let actual: CowTensor<u8> = input.view().shift_cast();
+        assert_eq!(actual, expected);
+
+        let noop_cast: CowTensor<u8> = actual.view().shift_cast();
+        assert_eq!(noop_cast, actual);
+
+        let actual_inverse: CowTensor<i8> = expected.view().shift_cast();
+        assert_eq!(actual_inverse, input);
+    }
+
+    #[test]
+    fn test_shift_cast_vec() {
+        let input: Vec<_> = [-128i8, -1, 0, 1, 127].into();
+        let expected = [0u8, 127, 128, 129, 255];
+        let actual: Vec<u8> = input.shift_cast();
+        assert_eq!(actual, expected);
+    }
+}


### PR DESCRIPTION
Implement the [ConvInteger](https://onnx.ai/onnx/operators/onnx__ConvInteger.html) operator.

This follows the implementation of `Conv` for f32, with the addition of zero point inputs and the removal of the bias input.

In the process fix handling of padding elements in int8 im2col packing when conversion from i8 -> u8 is enabled.

**TODO:**
- [x] Implement depthwise convolution
- [x] Decide which int8 formats to support and implement necessary conversions. This PR currently implements input=i8, weights=u8 because that conveniently maps to the already supported `u8 x i8 -> i32` GEMM support, but this is not a super useful combination. ORT only supports input=u8, weights=u8 and there are issues open to support input=u8, weights=i8.
- [x] Benchmark
- [x] Decide what to do on x64 systems if `ConvInteger` weights are not in the safe range (i7/u7). Validate weights at load time? (deferred to https://github.com/robertknight/rten/issues/574)