### PR TITLE
Implement im2col packing for int8 GEMM

### DIFF
--- a/rten-simd/src/vec.rs
+++ b/rten-simd/src/vec.rs
@@ -71,6 +71,7 @@ pub trait Simd: Copy + Sized {
     type Array: Copy
         + std::fmt::Debug
         + std::ops::Index<usize, Output = Self::Elem>
+        + std::ops::IndexMut<usize, Output = Self::Elem>
         + AsRef<[Self::Elem]>;
 
     /// Combine elements of `self` and `rhs` according to a mask.

--- a/src/gemm/kernels.rs
+++ b/src/gemm/kernels.rs
@@ -158,6 +158,22 @@ pub unsafe trait Kernel<LhsT, RhsT, OutT>: Sync {
         false
     }
 
+    /// Step size used when packing an image usage [`pack_im2col`](Kernel::pack_im2col).
+    ///
+    /// The length of the offset arrays in [`Im2Col::row_offsets`] must be a
+    /// multiple of this.
+    fn im2col_row_count_step(&self) -> usize {
+        1
+    }
+
+    /// Step size used when packing an image usage [`pack_im2col`](Kernel::pack_im2col).
+    ///
+    /// The length of the offset arrays in [`Im2Col::col_offsets`] must be a
+    /// multiple of this.
+    fn im2col_col_count_step(&self) -> usize {
+        self.nr()
+    }
+
     /// Return the layout of a packing buffer required to pack an A / LHS input.
     fn packed_a_layout(
         &self,

--- a/src/gemm/kernels.rs
+++ b/src/gemm/kernels.rs
@@ -148,6 +148,12 @@ pub unsafe trait Kernel<LhsT, RhsT, OutT>: Sync {
     /// Return a name for this kernel for use in logging etc.
     fn name(&self) -> &'static str;
 
+    /// Return true if this kernel may encounter saturation in a data type that
+    /// is smaller than the accumulator.
+    ///
+    /// The caller will have to prepare inputs (usually the weights) to avoid
+    /// this. This is primarily an issue for x64 systems without VNNI.
+    /// See https://oneapi-src.github.io/oneDNN/dev_guide_int8_computations.html.
     fn may_saturate(&self) -> bool {
         false
     }

--- a/src/gemm/kernels/aarch64.rs
+++ b/src/gemm/kernels/aarch64.rs
@@ -187,6 +187,10 @@ macro_rules! impl_arm_int8_common {
             Self::NR
         }
 
+        fn im2col_row_count_step(&self) -> usize {
+            4
+        }
+
         fn packed_a_layout(
             &self,
             _a: Matrix<u8>,
@@ -233,12 +237,13 @@ macro_rules! impl_arm_int8_common {
 
         fn pack_im2col(
             &self,
-            _out: &mut [MaybeUninit<u8>],
-            _image: &Im2Col<i8>,
-            _rows: Range<usize>,
-            _cols: Range<usize>,
+            out: &mut [MaybeUninit<u8>],
+            image: &Im2Col<i8>,
+            rows: Range<usize>,
+            cols: Range<usize>,
         ) {
-            unimplemented!("pack_im2col not implemented");
+            // Safety: Arm Neon is supported
+            unsafe { image.pack_block_i8_dot_cast_u8::<int32x4_t>(out, rows, cols) }
         }
     };
 }

--- a/src/gemm/kernels/generic.rs
+++ b/src/gemm/kernels/generic.rs
@@ -245,12 +245,18 @@ unsafe impl Kernel<u8, i8, i32> for GenericKernel {
 
     fn pack_im2col(
         &self,
-        _out: &mut [MaybeUninit<u8>],
-        _image: &Im2Col<i8>,
-        _rows: Range<usize>,
-        _cols: Range<usize>,
+        out: &mut [MaybeUninit<u8>],
+        image: &Im2Col<i8>,
+        rows: Range<usize>,
+        cols: Range<usize>,
     ) {
-        unimplemented!("im2col packing not implemented");
+        const NR_REGS: usize = vec_count::<f32>(GenericKernel::NR);
+
+        // Safety: Scalar "SIMD" types are always supported
+        let out = cast_pod_mut_slice(out).unwrap();
+        unsafe {
+            image.pack_block::<i32, NR_REGS>(out, Self::NR, rows, cols);
+        }
     }
 
     unsafe fn kernel(

--- a/src/gemm/kernels/wasm.rs
+++ b/src/gemm/kernels/wasm.rs
@@ -206,6 +206,10 @@ unsafe impl Kernel<u8, i8, i32> for WasmInt8Kernel {
         Self::NR
     }
 
+    fn im2col_row_count_step(&self) -> usize {
+        4
+    }
+
     fn packed_a_layout(
         &self,
         _a: Matrix<u8>,
@@ -252,12 +256,15 @@ unsafe impl Kernel<u8, i8, i32> for WasmInt8Kernel {
 
     fn pack_im2col(
         &self,
-        _out: &mut [MaybeUninit<u8>],
-        _image: &Im2Col<i8>,
-        _rows: Range<usize>,
-        _cols: Range<usize>,
+        out: &mut [MaybeUninit<u8>],
+        image: &Im2Col<i8>,
+        rows: Range<usize>,
+        cols: Range<usize>,
     ) {
-        unimplemented!("pack_im2col not implemented");
+        // Safety: WASM SIMD is supported.
+        unsafe {
+            image.pack_block_i8_dot_cast_u8::<v128i>(out, rows, cols);
+        }
     }
 
     unsafe fn kernel(

--- a/src/gemm/packing/int8.rs
+++ b/src/gemm/packing/int8.rs
@@ -64,8 +64,7 @@ pub fn pack_b<const NR: usize>(out: &mut [MaybeUninit<i8>], b: Matrix<i8>) {
 ///
 /// For example `-125` (i8::MIN + 3) becomes `3` (u8::MIN + 3).
 #[inline]
-#[allow(unused)]
-fn shift_cast_i8_u8(x: i8) -> u8 {
+pub fn shift_cast_i8_u8(x: i8) -> u8 {
     x as u8 ^ 0x80
 }
 

--- a/src/ops/conv.rs
+++ b/src/ops/conv.rs
@@ -275,6 +275,7 @@ where
                     [stride_y, stride_x],
                     [dilation_y, dilation_x],
                     gemm.im2col_col_count_step(),
+                    gemm.im2col_row_count_step(),
                 );
 
                 let bias_vec = bias


### PR DESCRIPTION
Implement a method similar to `Im2Col::pack_block` that packs the image using the different layout used by int8 kernels.

On non-x64 systems there is an unnecessary u8 -> i8 -> u8 double conversion that happens because the `Conv` operator will receive the image in u8 format, it will create a copy in i8 format and then the kernel will re-convert back to u8 when packing. When a native u8 x u8 -> i32 GEMM is added in future, this can be avoided.

**TODO:**

- [x] Benchmark vs. f32 im2col