### PR TITLE
Add missing `#[inline(always)]` to `Quantize` SIMD op

### DIFF
--- a/rten-simd/src/arch/x86_64.rs
+++ b/rten-simd/src/arch/x86_64.rs
@@ -171,6 +171,7 @@ impl SimdInt for __m256i {
     }
 
     #[inline]
+    #[target_feature(enable = "avx2")]
     unsafe fn saturating_cast_u8(self) -> impl Simd<Elem = u8> {
         use std::arch::x86_64::{
             __m128i, _mm256_castsi256_si128, _mm256_packus_epi16, _mm256_packus_epi32,

--- a/rten-vecmath/src/quantize.rs
+++ b/rten-vecmath/src/quantize.rs
@@ -38,6 +38,7 @@ impl<'s, 'd, To> Quantize<'s, 'd, To> {
 impl<'d> SimdOp for Quantize<'_, 'd, u8> {
     type Output = &'d mut [u8];
 
+    #[inline(always)]
     unsafe fn eval<S: SimdFloat>(self) -> Self::Output {
         let mut n = self.src.len();
         let mut src_ptr = self.src.as_ptr();


### PR DESCRIPTION
Fix calls to SIMD intrinsics not being inlined reliably.

Also add `target_feature` to an AVX2 SIMD impl for consistency with other methods.