### PR TITLE
Fix wasmtime install in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,9 @@ jobs:
       if: ${{ matrix.os == 'ubuntu-latest' }}
     - name: Install wasmtime
       run: |
-        curl https://wasmtime.dev/install.sh -sSf | bash
-        ls $HOME/.wasmtime/bin
-        echo "$HOME/.wasmtime/bin" >> "$GITHUB_PATH"
+        mkdir -p ~/.wasmtime
+        curl -L https://github.com/bytecodealliance/wasmtime/releases/download/v29.0.1/wasmtime-v29.0.1-x86_64-linux.tar.xz | tar xf - --xz -C ~/.wasmtime --strip-components=1
+        echo "$HOME/.wasmtime" >> "$GITHUB_PATH"
       if: ${{ matrix.os == 'ubuntu-latest' }}
     - name: Install Rust nightly toolchain
       run: rustup toolchain install nightly


### PR DESCRIPTION
Installing wasmtime via the curl script failed in
https://github.com/robertknight/rten/actions/runs/13107387960/job/36564377746?pr=572.

To try and make it more reliable, download a tarball of a fixed wasmtime version and extract this manually.