### PR TITLE
Support NR being a multiple of vector width in int8 GEMM

### DIFF
--- a/src/gemm/kernels/wasm.rs
+++ b/src/gemm/kernels/wasm.rs
@@ -261,9 +261,11 @@ unsafe impl Kernel<u8, i8, i32> for WasmInt8Kernel {
         rows: Range<usize>,
         cols: Range<usize>,
     ) {
+        const NR_REGS: usize = vec_count::<v128f>(WasmInt8Kernel::NR);
+
         // Safety: WASM SIMD is supported.
         unsafe {
-            image.pack_block_i8_dot_cast_u8::<v128i>(out, rows, cols);
+            image.pack_block_i8_dot_cast_u8::<v128i, NR_REGS>(out, rows, cols);
         }
     }
 
@@ -291,7 +293,8 @@ unsafe impl Kernel<u8, i8, i32> for WasmInt8Kernel {
         let (a_data, a_row_sums) = packing::int8::extract_packed_a::<{ Self::MR }>(a_data);
         let (b, b_col_sums) = packing::int8::extract_packed_b::<{ Self::NR }>(b);
 
-        simd_int8_gemm::<_, { Self::MR }, { Self::NR }>(
+        const NR_REGS: usize = vec_count::<v128f>(WasmInt8Kernel::NR);
+        simd_int8_gemm::<_, { Self::MR }, { Self::NR }, NR_REGS>(
             tile_ptr,
             tile_row_stride,
             a_data,

--- a/src/gemm/kernels/x86_64.rs
+++ b/src/gemm/kernels/x86_64.rs
@@ -546,8 +546,10 @@ unsafe impl Kernel<u8, i8, i32> for Avx2Int8Kernel {
             rows: Range<usize>,
             cols: Range<usize>,
         ) {
+            const NR_REGS: usize = vec_count::<__m256i>(Avx2Int8Kernel::NR);
+
             let out = cast_pod_mut_slice(out).unwrap();
-            image.pack_block_i8_dot::<__m256i>(out, rows, cols);
+            image.pack_block_i8_dot::<__m256i, NR_REGS>(out, rows, cols);
         }
 
         unsafe {
@@ -580,7 +582,8 @@ unsafe impl Kernel<u8, i8, i32> for Avx2Int8Kernel {
         let (a_data, a_row_sums) = packing::int8::extract_packed_a::<{ Self::MR }>(a_data);
         let (b, b_col_sums) = packing::int8::extract_packed_b::<{ Self::NR }>(b);
 
-        simd_int8_gemm::<_, { Self::MR }, { Self::NR }>(
+        const NR_REGS: usize = vec_count::<__m256i>(Avx2Int8Kernel::NR);
+        simd_int8_gemm::<_, { Self::MR }, { Self::NR }, NR_REGS>(
             tile_ptr,
             tile_row_stride,
             a_data,
@@ -752,8 +755,10 @@ unsafe impl Kernel<u8, i8, i32> for Avx512Int8Kernel {
             rows: Range<usize>,
             cols: Range<usize>,
         ) {
+            const NR_REGS: usize = vec_count::<__m512i>(Avx512Int8Kernel::NR);
+
             let out = cast_pod_mut_slice(out).unwrap();
-            image.pack_block_i8_dot::<__m512i>(out, rows, cols);
+            image.pack_block_i8_dot::<__m512i, NR_REGS>(out, rows, cols);
         }
 
         unsafe {
@@ -787,8 +792,9 @@ unsafe impl Kernel<u8, i8, i32> for Avx512Int8Kernel {
         let (a_data, a_row_sums) = packing::int8::extract_packed_a::<{ Self::MR }>(a_data);
         let (b, b_col_sums) = packing::int8::extract_packed_b::<{ Self::NR }>(b);
 
+        const NR_REGS: usize = vec_count::<__m512i>(Avx512Int8Kernel::NR);
         if self.have_vnni {
-            simd_int8_gemm::<_, { Self::MR }, { Self::NR }>(
+            simd_int8_gemm::<_, { Self::MR }, { Self::NR }, NR_REGS>(
                 tile_ptr,
                 tile_row_stride,
                 a_data,
@@ -804,7 +810,7 @@ unsafe impl Kernel<u8, i8, i32> for Avx512Int8Kernel {
                 avx512_vnni_u8i8i32_dot_product,
             )
         } else {
-            simd_int8_gemm::<_, { Self::MR }, { Self::NR }>(
+            simd_int8_gemm::<_, { Self::MR }, { Self::NR }, NR_REGS>(
                 tile_ptr,
                 tile_row_stride,
                 a_data,


### PR DESCRIPTION
Refactor int8 GEMM so that NR is not fixed to the i32 vector width (`S::LEN`) but can be a multiple (`NR_REGS`).

To test this, and also because it is improves performance, increase the accumulator tile size from MR=8, NR=4 to MR=8, NR=8 on Arm.

Before (M3 Pro, 5 P core):

```
Testing kernel arm-int8-udot
m 512 n 512 k 512 iters 512. Duration 227.909ms (0.445ms/iter). GFLOPS 603.0
m 1024 n 1024 k 1024 iters 64. Duration 159.544ms (2.493ms/iter). GFLOPS 861.4
m 128 n 2048 k 512 iters 512. Duration 252.584ms (0.493ms/iter). GFLOPS 544.1
m 2048 n 128 k 512 iters 512. Duration 232.714ms (0.455ms/iter). GFLOPS 590.6
m 1 n 4096 k 512 iters 512. Duration 34.840ms (0.068ms/iter). GFLOPS 61.6
m 1 n 4096 k 512 iters 512. Duration 23.628ms (0.046ms/iter). GFLOPS 90.9
```

After:

```
Testing kernel arm-int8-udot
m 512 n 512 k 512 iters 512. Duration 183.188ms (0.358ms/iter). GFLOPS 750.3
m 1024 n 1024 k 1024 iters 64. Duration 122.990ms (1.922ms/iter). GFLOPS 1117.5
m 128 n 2048 k 512 iters 512. Duration 214.845ms (0.420ms/iter). GFLOPS 639.7
m 2048 n 128 k 512 iters 512. Duration 184.914ms (0.361ms/iter). GFLOPS 743.3
m 1 n 4096 k 512 iters 512. Duration 34.383ms (0.067ms/iter). GFLOPS 62.5
m 1 n 4096 k 512 iters 512. Duration 22.843ms (0.045ms/iter). GFLOPS 94.0
```

A tile size of MR=4, NR=16 was better still, but I need to test on some other systems.