### PR TITLE
Use macros to simplify invoking operators with different input types

### DIFF
--- a/src/ops/gather.rs
+++ b/src/ops/gather.rs
@@ -8,7 +8,8 @@ use smallvec::SmallVec;
 use crate::number::IsNaN;
 use crate::ops::reduce::{cmp_nan_greater, cmp_nan_less};
 use crate::ops::{
-    resolve_axis, resolve_index, Input, InputList, IntoOpResult, OpError, Operator, OutputList,
+    map_input, resolve_axis, resolve_index, Input, InputList, IntoOpResult, OpError, Operator,
+    OutputList,
 };
 use crate::tensor_pool::{AutoReturn, TensorPool};
 
@@ -136,12 +137,10 @@ impl Operator for Gather {
     fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let input = inputs.require(0)?;
         let indices = inputs.require_as::<i32>(1)?;
-        match input {
-            Input::Int32Tensor(input) => gather(pool, input, self.axis, indices).into_op_result(),
-            Input::FloatTensor(input) => gather(pool, input, self.axis, indices).into_op_result(),
-            Input::UInt8Tensor(input) => gather(pool, input, self.axis, indices).into_op_result(),
-            Input::Int8Tensor(input) => gather(pool, input, self.axis, indices).into_op_result(),
-        }
+
+        map_input!(input, x, {
+            gather(pool, x, self.axis, indices).into_op_result()
+        })
     }
 }
 
@@ -281,20 +280,10 @@ impl Operator for GatherElements {
     fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let input = inputs.require(0)?;
         let indices = inputs.require_as::<i32>(1)?;
-        match input {
-            Input::Int32Tensor(input) => {
-                gather_elements(pool, input, indices, self.axis).into_op_result()
-            }
-            Input::FloatTensor(input) => {
-                gather_elements(pool, input, indices, self.axis).into_op_result()
-            }
-            Input::Int8Tensor(input) => {
-                gather_elements(pool, input, indices, self.axis).into_op_result()
-            }
-            Input::UInt8Tensor(input) => {
-                gather_elements(pool, input, indices, self.axis).into_op_result()
-            }
-        }
+
+        map_input!(input, x, {
+            gather_elements(pool, x, indices, self.axis).into_op_result()
+        })
     }
 }
 
@@ -408,20 +397,10 @@ impl Operator for GatherND {
     fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let input = inputs.require(0)?;
         let indices = inputs.require_as::<i32>(1)?;
-        match input {
-            Input::Int32Tensor(input) => {
-                gather_nd(pool, input, indices, self.batch_dims).into_op_result()
-            }
-            Input::FloatTensor(input) => {
-                gather_nd(pool, input, indices, self.batch_dims).into_op_result()
-            }
-            Input::Int8Tensor(input) => {
-                gather_nd(pool, input, indices, self.batch_dims).into_op_result()
-            }
-            Input::UInt8Tensor(input) => {
-                gather_nd(pool, input, indices, self.batch_dims).into_op_result()
-            }
-        }
+
+        map_input!(input, x, {
+            gather_nd(pool, x, indices, self.batch_dims).into_op_result()
+        })
     }
 }
 
@@ -526,27 +505,11 @@ impl Operator for ScatterElements {
     fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let data = inputs.require(0)?;
         let indices = inputs.require_as::<i32>(1)?;
-        let updates = inputs.require(2)?;
 
-        match (data, updates) {
-            (Input::Int32Tensor(data), Input::Int32Tensor(updates)) => {
-                scatter_elements(pool, data, indices, updates, self.axis, self.reduction)
-                    .into_op_result()
-            }
-            (Input::FloatTensor(data), Input::FloatTensor(updates)) => {
-                scatter_elements(pool, data, indices, updates, self.axis, self.reduction)
-                    .into_op_result()
-            }
-            (Input::Int8Tensor(data), Input::Int8Tensor(updates)) => {
-                scatter_elements(pool, data, indices, updates, self.axis, self.reduction)
-                    .into_op_result()
-            }
-            (Input::UInt8Tensor(data), Input::UInt8Tensor(updates)) => {
-                scatter_elements(pool, data, indices, updates, self.axis, self.reduction)
-                    .into_op_result()
-            }
-            _ => Err(OpError::UnsupportedType),
-        }
+        map_input!(data, x, {
+            let updates = inputs.require_as(2)?;
+            scatter_elements(pool, x, indices, updates, self.axis, self.reduction).into_op_result()
+        })
     }
 }
 
@@ -632,23 +595,11 @@ impl Operator for ScatterND {
     fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let data = inputs.require(0)?;
         let indices = inputs.require_as::<i32>(1)?;
-        let updates = inputs.require(2)?;
 
-        match (data, updates) {
-            (Input::Int32Tensor(data), Input::Int32Tensor(updates)) => {
-                scatter_nd(pool, data, indices, updates, self.reduction).into_op_result()
-            }
-            (Input::FloatTensor(data), Input::FloatTensor(updates)) => {
-                scatter_nd(pool, data, indices, updates, self.reduction).into_op_result()
-            }
-            (Input::Int8Tensor(data), Input::Int8Tensor(updates)) => {
-                scatter_nd(pool, data, indices, updates, self.reduction).into_op_result()
-            }
-            (Input::UInt8Tensor(data), Input::UInt8Tensor(updates)) => {
-                scatter_nd(pool, data, indices, updates, self.reduction).into_op_result()
-            }
-            _ => Err(OpError::UnsupportedType),
-        }
+        map_input!(data, x, {
+            let updates = inputs.require_as(2)?;
+            scatter_nd(pool, x, indices, updates, self.reduction).into_op_result()
+        })
     }
 }
 

--- a/src/ops/identity.rs
+++ b/src/ops/identity.rs
@@ -1,7 +1,9 @@
 use rten_tensor::prelude::*;
 use rten_tensor::{Tensor, TensorView};
 
-use crate::ops::{Input, InputList, IntoOpResult, OpError, Operator, Output, OutputList};
+use crate::ops::{
+    map_input, Input, InputList, IntoOpResult, OpError, Operator, Output, OutputList,
+};
 use crate::tensor_pool::TensorPool;
 
 fn identity<T: Copy>(pool: &TensorPool, src: TensorView<T>) -> Tensor<T> {
@@ -18,12 +20,7 @@ impl Operator for Identity {
 
     fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let input = inputs.require(0)?;
-        let result: Output = match input {
-            Input::Int32Tensor(t) => identity(pool, t).into(),
-            Input::FloatTensor(t) => identity(pool, t).into(),
-            _ => return Err(OpError::UnsupportedType),
-        };
-        result.into_op_result()
+        map_input!(input, x, { identity(pool, x).into_op_result() })
     }
 
     fn can_run_in_place(&self) -> bool {

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -1077,6 +1077,40 @@ pub fn resolve_axes<'a, I: ExactSizeIterator<Item = &'a i32>>(
     Ok(resolved_axes)
 }
 
+/// Extract the typed tensor view from `$input` and pass it to `$block`, using
+/// the variable name specified by `$typed_input`.
+macro_rules! map_input {
+    ($input:expr, $typed_input:ident, $block:tt) => {
+        match $input {
+            Input::FloatTensor($typed_input) => $block,
+            Input::Int32Tensor($typed_input) => $block,
+            Input::UInt8Tensor($typed_input) => $block,
+            Input::Int8Tensor($typed_input) => $block,
+        }
+    };
+}
+
+use map_input;
+
+/// Extract the typed owned tensor from `$input` and pass it to `$block` as
+/// mutable value, using the variable name specified by `$typed_input`.
+macro_rules! map_output {
+    ($input:expr, $typed_input:ident, $block:tt) => {
+        match $input {
+            #[allow(unused_mut)]
+            Output::FloatTensor(mut $typed_input) => $block,
+            #[allow(unused_mut)]
+            Output::Int32Tensor(mut $typed_input) => $block,
+            #[allow(unused_mut)]
+            Output::UInt8Tensor(mut $typed_input) => $block,
+            #[allow(unused_mut)]
+            Output::Int8Tensor(mut $typed_input) => $block,
+        }
+    };
+}
+
+use map_output;
+
 #[cfg(test)]
 mod tests {
     use rten_tensor::prelude::*;

--- a/src/ops/pad.rs
+++ b/src/ops/pad.rs
@@ -1,7 +1,9 @@
 use rten_tensor::prelude::*;
 use rten_tensor::{NdTensorView, SliceItem, Tensor, TensorView};
 
-use crate::ops::{static_dims, Input, InputList, IntoOpResult, OpError, Operator, OutputList};
+use crate::ops::{
+    map_input, static_dims, Input, InputList, IntoOpResult, OpError, Operator, OutputList,
+};
 use crate::tensor_pool::TensorPool;
 
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -187,24 +189,10 @@ impl Operator for Pad {
             ));
         }
 
-        match input {
-            Input::Int32Tensor(t) => {
-                let const_val = inputs.get_as_scalar::<i32>(2)?.unwrap_or(0);
-                pad(pool, t, &pads, self.mode, const_val).into_op_result()
-            }
-            Input::Int8Tensor(t) => {
-                let const_val = inputs.get_as_scalar::<i8>(2)?.unwrap_or(0);
-                pad(pool, t, &pads, self.mode, const_val).into_op_result()
-            }
-            Input::UInt8Tensor(t) => {
-                let const_val = inputs.get_as_scalar::<u8>(2)?.unwrap_or(0);
-                pad(pool, t, &pads, self.mode, const_val).into_op_result()
-            }
-            Input::FloatTensor(t) => {
-                let const_val = inputs.get_as_scalar::<f32>(2)?.unwrap_or(0.);
-                pad(pool, t, &pads, self.mode, const_val).into_op_result()
-            }
-        }
+        map_input!(input, x, {
+            let const_val = inputs.get_as_scalar(2)?.unwrap_or_default();
+            pad(pool, x, &pads, self.mode, const_val).into_op_result()
+        })
     }
 }
 

--- a/src/ops/split.rs
+++ b/src/ops/split.rs
@@ -1,7 +1,9 @@
 use rten_tensor::prelude::*;
 use rten_tensor::{NdTensorView, SliceItem, Tensor, TensorView};
 
-use crate::ops::{resolve_axis, static_dims, Input, InputList, OpError, Operator, OutputList};
+use crate::ops::{
+    map_input, resolve_axis, static_dims, Input, InputList, OpError, Operator, OutputList,
+};
 use crate::tensor_pool::TensorPool;
 
 pub fn split<T: Copy>(
@@ -61,19 +63,10 @@ impl Operator for Split {
         let splits = inputs.require_as::<i32>(1)?;
         let splits = static_dims!(splits, 1)?;
 
-        macro_rules! split {
-            ($x:ident) => {
-                split(pool, $x, self.axis, &splits)
-                    .map(|tensors| tensors.into_iter().map(|t| t.into()).collect())
-            };
-        }
-
-        match input {
-            Input::FloatTensor(x) => split!(x),
-            Input::Int32Tensor(x) => split!(x),
-            Input::Int8Tensor(x) => split!(x),
-            Input::UInt8Tensor(x) => split!(x),
-        }
+        map_input!(input, x, {
+            split(pool, x, self.axis, &splits)
+                .map(|tensors| tensors.into_iter().map(|t| t.into()).collect())
+        })
     }
 }
 


### PR DESCRIPTION
Add macros to simplify instantiating and invoking a generic operator function according to the type of an input. This initial version only supports the case where an operator supports all available tensor types.