### PR TITLE
Bump tile size for wasm32 and Arm (non-dot product) int8 kernels

### DIFF
--- a/src/gemm/kernels/aarch64.rs
+++ b/src/gemm/kernels/aarch64.rs
@@ -357,7 +357,7 @@ pub struct ArmInt8Kernel {
 
 impl ArmInt8Kernel {
     const MR: usize = 8;
-    const NR: usize = 4;
+    const NR: usize = 8;
 }
 
 unsafe impl Kernel<u8, i8, i32> for ArmInt8Kernel {

--- a/src/gemm/kernels/wasm.rs
+++ b/src/gemm/kernels/wasm.rs
@@ -186,7 +186,7 @@ pub struct WasmInt8Kernel {
 
 impl WasmInt8Kernel {
     const MR: usize = 8;
-    const NR: usize = 4;
+    const NR: usize = 8;
 }
 
 unsafe impl Kernel<u8, i8, i32> for WasmInt8Kernel {


### PR DESCRIPTION
Following https://github.com/robertknight/rten/pull/580, bump up the tile size for the wasm32 and Arm fallback kernels as well.

On the `bench_gemm_mix` benchmark using wasmtime this is a ~20% improvement (37 => 44GF for M=N=K=1024, single thread). For Arm fallback about 6% (65 => 69GF for M=N=K=1024, single thread).