### PR TITLE
Bump up x64 int8 tile size

### DIFF
--- a/src/gemm/kernels/x86_64.rs
+++ b/src/gemm/kernels/x86_64.rs
@@ -456,9 +456,8 @@ pub struct Avx2Int8Kernel {
 }
 
 impl Avx2Int8Kernel {
-    // Tile size matches AVX2 register
-    const MR: usize = 8;
-    const NR: usize = 8;
+    const MR: usize = 6;
+    const NR: usize = 16;
 }
 
 unsafe impl Kernel<u8, i8, i32> for Avx2Int8Kernel {
@@ -661,8 +660,7 @@ pub struct Avx512Int8Kernel {
 #[cfg(feature = "avx512")]
 impl Avx512Int8Kernel {
     const MR: usize = 8;
-    // Tile size matches AVX-512 register
-    const NR: usize = 16;
+    const NR: usize = 32;
 }
 
 #[cfg(feature = "avx512")]


### PR DESCRIPTION
Make `NR` 2x the vector width instead of 1x. This follows a similar change in the Arm and wasm32 kernels. The tile sizes for the int8 -> int32 kernels now align with the f32 kernels.

For AVX2 this improves performance for M=N=K=1024 by ~10%. For AVX512 with VNNI the improvement is smaller (4% on a client Ice Lake i5).