### PR TITLE
Unify reference implementations of `MatMul` and `MatMulInteger`

### DIFF
--- a/rten-tensor/src/layout.rs
+++ b/rten-tensor/src/layout.rs
@@ -458,7 +458,9 @@ impl<const N: usize> NdLayout<N> {
     pub fn broadcast<const M: usize>(&self, to_shape: [usize; M]) -> NdLayout<M> {
         assert!(
             self.can_broadcast_to(&to_shape),
-            "Cannot broadcast to specified shape"
+            "cannot broadcast {:?} to {:?}",
+            self.shape(),
+            to_shape,
         );
         let mut strides = [0usize; M];
         for (i, stride) in broadcast_strides(&self.shape(), &self.strides(), &to_shape).enumerate()
@@ -698,7 +700,9 @@ impl DynLayout {
     pub fn broadcast(&self, to_shape: &[usize]) -> DynLayout {
         assert!(
             self.can_broadcast_to(to_shape),
-            "Cannot broadcast to specified shape"
+            "cannot broadcast shape {:?} to {:?}",
+            self.shape(),
+            to_shape
         );
 
         let mut shape_and_strides = SmallVec::with_capacity(to_shape.len() * 2);

--- a/src/gemm.rs
+++ b/src/gemm.rs
@@ -12,7 +12,9 @@ use std::ops::{Add, Mul, Range};
 
 use rayon::prelude::*;
 use rten_tensor::prelude::*;
-use rten_tensor::{Alloc, GlobalAlloc, Matrix, MatrixLayout, MatrixMut, NdTensorView, Storage};
+use rten_tensor::{
+    Alloc, GlobalAlloc, Matrix, MatrixLayout, MatrixMut, NdTensorView, Storage, StorageMut,
+};
 
 use crate::iter_util::{range_chunks, MaybeParIter};
 use crate::number::Identities;
@@ -796,7 +798,7 @@ impl<'a, T> OutputTiles<'a, T> {
     /// `tile_rows` * `tile_cols`.
     fn new(mut data: MatrixMut<'a, T>, tile_rows: usize, tile_cols: usize) -> OutputTiles<'a, T> {
         OutputTiles {
-            data: data.data_mut().unwrap().as_mut_ptr(),
+            data: data.storage_mut().as_mut_ptr(),
             rows: data.rows(),
             cols: data.cols(),
             row_stride: data.stride(0),


### PR DESCRIPTION
This will make it easier to write tests that cover different data type combinations.

This also fixes a couple of issues I encountered while working on this:

- `GemmExecutor::gemm` would panic if the output row stride was larger than the minimum required (the output column count)
- Make `Tensor::broadcast` errors more helpful if the target shape is incompatible with the source shape