### PR TITLE
Refactor more operators to use `map_input`/`map_output`

### DIFF
--- a/src/ops/fused.rs
+++ b/src/ops/fused.rs
@@ -20,21 +20,19 @@ impl PermuteSpec {
             return Err(OpError::MissingInputs);
         };
 
+        macro_rules! permute {
+            ($t:ident) => {
+                if let Some(perm) = self.perm.as_ref() {
+                    $t.permute(perm);
+                } else {
+                    $t.transpose();
+                }
+            };
+        }
+
         match input {
-            Input::Int32Tensor(ref mut t) => {
-                if let Some(perm) = self.perm.as_ref() {
-                    t.permute(perm);
-                } else {
-                    t.transpose();
-                }
-            }
-            Input::FloatTensor(ref mut t) => {
-                if let Some(perm) = self.perm.as_ref() {
-                    t.permute(perm);
-                } else {
-                    t.transpose();
-                }
-            }
+            Input::Int32Tensor(ref mut t) => permute!(t),
+            Input::FloatTensor(ref mut t) => permute!(t),
             _ => return Err(OpError::UnsupportedType),
         }
 

--- a/src/ops/trilu.rs
+++ b/src/ops/trilu.rs
@@ -1,7 +1,7 @@
 use rten_tensor::prelude::*;
 use rten_tensor::{Tensor, TensorView};
 
-use crate::ops::{Input, InputList, IntoOpResult, OpError, Operator, OutputList};
+use crate::ops::{map_input, Input, InputList, IntoOpResult, OpError, Operator, OutputList};
 use crate::tensor_pool::TensorPool;
 
 pub fn trilu<T: Copy + Default>(
@@ -47,11 +47,9 @@ impl Operator for Trilu {
         let input = inputs.require(0)?;
         let k = inputs.get_as_scalar(1)?.unwrap_or(0);
 
-        match input {
-            Input::FloatTensor(input) => trilu(pool, input, k, self.upper).into_op_result(),
-            Input::Int32Tensor(input) => trilu(pool, input, k, self.upper).into_op_result(),
-            _ => Err(OpError::UnsupportedType),
-        }
+        map_input!(input, input, [FloatTensor, Int32Tensor], {
+            trilu(pool, input, k, self.upper).into_op_result()
+        })
     }
 }
 


### PR DESCRIPTION
Add support for specifying a list of supported tensor types in `map_input` and `map_output`, then use this to convert additional operators to use these macros for dispatching to the appropriate implementation.