### PR TITLE
Fix ArgMin op

### DIFF
--- a/src/ops/reduce.rs
+++ b/src/ops/reduce.rs
@@ -168,7 +168,7 @@ impl Operator for ArgMin {
 
     fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
         let input = inputs.require(0)?;
-        dispatch_single_axis_reduce_op!(pool, input, arg_max, self.axis, self.keep_dims)
+        dispatch_single_axis_reduce_op!(pool, input, arg_min, self.axis, self.keep_dims)
     }
 }
 


### PR DESCRIPTION
Fix regression introduced in fee3f09372e3d35abd70005c42c66a425c18ac33 where ArgMin dispatched to `arg_max` instead of `arg_min` 😔 