### PR TITLE
Add utility for better table-driven tests, convert some existing tests to use it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -483,6 +483,7 @@ name = "rten-text"
 version = "0.16.0"
 dependencies = [
  "fancy-regex",
+ "rten-testing",
  "serde",
  "serde_json",
  "unicode-normalization",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -408,6 +408,7 @@ dependencies = [
  "lexopt",
  "rten",
  "rten-tensor",
+ "rten-testing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,6 +438,7 @@ dependencies = [
  "fastrand",
  "rten",
  "rten-tensor",
+ "rten-testing",
  "rten-text",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -456,6 +456,7 @@ version = "0.16.0"
 dependencies = [
  "rten-bench",
  "rten-tensor",
+ "rten-testing",
  "serde",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -470,6 +470,7 @@ version = "0.16.0"
 name = "rten-tensor"
 version = "0.16.0"
 dependencies = [
+ "rten-testing",
  "serde",
  "serde_json",
  "smallvec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,6 +388,7 @@ dependencies = [
  "rten-bench",
  "rten-simd",
  "rten-tensor",
+ "rten-testing",
  "rten-vecmath",
  "rustc-hash",
  "serde_json",
@@ -470,6 +471,10 @@ dependencies = [
  "serde_json",
  "smallvec",
 ]
+
+[[package]]
+name = "rten-testing"
+version = "0.1.0"
 
 [[package]]
 name = "rten-text"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,12 @@ members = [
   "rten-text",
   "rten-vecmath",
 
+  # Example crates. These are not published.
+  "rten-examples",
+
   # Development crates. These are not published.
   "rten-bench",
-  "rten-examples",
+  "rten-testing",
 ]
 default-members = [
   ".",
@@ -56,6 +59,7 @@ num_cpus = "1.16.0"
 [dev-dependencies]
 libm = "0.2.6"
 rten-bench = { path = "./rten-bench" }
+rten-testing = { path = "./rten-testing" }
 serde_json = { workspace = true }
 
 [lib]

--- a/rten-cli/Cargo.toml
+++ b/rten-cli/Cargo.toml
@@ -15,6 +15,9 @@ rten = { path = "../", version = "0.16.0", features=["mmap", "random"] }
 rten-tensor = { path = "../rten-tensor", version = "0.16.0" }
 lexopt = "0.3.0"
 
+[dev-dependencies]
+rten-testing = { path = "../rten-testing" }
+
 [features]
 # Use AVX-512 instructions if available. Requires nightly Rust for AVX-512 intrinsics.
 avx512 = ["rten/avx512"]

--- a/rten-cli/src/dim_size.rs
+++ b/rten-cli/src/dim_size.rs
@@ -127,10 +127,13 @@ impl std::error::Error for ParseError {}
 
 #[cfg(test)]
 mod tests {
+    use rten_testing::TestCases;
+
     use super::{DimSize, ParseError, ParseErrorKind};
 
     #[test]
     fn test_parse() {
+        #[derive(Debug)]
         struct Case<'a> {
             spec: &'a str,
             expected: Result<DimSize, ParseError>,
@@ -167,10 +170,10 @@ mod tests {
             },
         ];
 
-        for Case { spec, expected } in cases {
+        cases.test_each(|Case { spec, expected }| {
             let dim_size = DimSize::parse(&spec);
-            assert_eq!(dim_size, expected);
-        }
+            assert_eq!(dim_size, *expected);
+        })
     }
 
     #[test]

--- a/rten-generate/Cargo.toml
+++ b/rten-generate/Cargo.toml
@@ -15,6 +15,9 @@ rten = { path = "../", version = "0.16.0" }
 rten-text = { path = "../rten-text", version = "0.16.0", optional = true }
 rten-tensor = { path = "../rten-tensor", version = "0.16.0" }
 
+[dev-dependencies]
+rten-testing = { path = "../rten-testing" }
+
 [features]
 # Enable text decoding using tokenizers from rten-text
 text-decoder = ["dep:rten-text"]

--- a/rten-generate/src/sampler.rs
+++ b/rten-generate/src/sampler.rs
@@ -124,6 +124,7 @@ fn multinomial(rng: &mut fastrand::Rng, probs: NdTensorView<f32, 1>) -> Option<u
 mod tests {
     use rten_tensor::prelude::*;
     use rten_tensor::NdTensor;
+    use rten_testing::TestCases;
 
     use super::{ArgMaxSampler, Sampler, TopKSampler};
 
@@ -140,6 +141,7 @@ mod tests {
 
     #[test]
     fn test_topk_sampler() {
+        #[derive(Debug)]
         struct Case<'a> {
             k: usize,
             temperature: f32,
@@ -173,12 +175,13 @@ mod tests {
             },
         ];
 
-        for Case {
-            k,
-            temperature,
-            expected_counts: expected,
-        } in cases
-        {
+        cases.test_each(|case| {
+            let &Case {
+                k,
+                temperature,
+                expected_counts: expected,
+            } = case;
+
             let rng = fastrand::Rng::with_seed(1234);
 
             let logits = NdTensor::arange(0., 10., None);
@@ -206,6 +209,6 @@ mod tests {
             // For the top K tokens the distribution should be in proportion to
             // their probabilities.
             assert_eq!(counts[logits.size(vocab_dim) - k..], *expected);
-        }
+        })
     }
 }

--- a/rten-imageproc/Cargo.toml
+++ b/rten-imageproc/Cargo.toml
@@ -15,6 +15,7 @@ serde = { workspace = true, features = ["derive"], optional = true }
 
 [dev-dependencies]
 rten-bench = { path = "../rten-bench" }
+rten-testing = { path = "../rten-testing" }
 
 [lib]
 crate-type = ["lib"]

--- a/rten-imageproc/src/shapes.rs
+++ b/rten-imageproc/src/shapes.rs
@@ -1154,6 +1154,7 @@ impl ExactSizeIterator for PolygonsIter<'_> {}
 mod tests {
     use rten_tensor::test_util::ApproxEq;
     use rten_tensor::{MatrixLayout, NdTensor};
+    use rten_testing::TestCases;
 
     use crate::tests::{points_from_coords, points_from_n_coords};
     use crate::Vec2;
@@ -1174,6 +1175,7 @@ mod tests {
 
     #[test]
     fn test_line_distance() {
+        #[derive(Debug)]
         struct Case {
             start: Point,
             end: Point,
@@ -1234,7 +1236,7 @@ mod tests {
             },
         ];
 
-        for case in cases {
+        cases.test_each(|case| {
             let line = Line::from_endpoints(case.start, case.end);
             let dist = line.distance(case.point);
             assert!(
@@ -1246,7 +1248,7 @@ mod tests {
                 dist,
                 case.dist
             );
-        }
+        });
     }
 
     #[test]
@@ -1272,6 +1274,7 @@ mod tests {
 
     #[test]
     fn test_line_rightwards() {
+        #[derive(Debug)]
         struct Case {
             input: Line,
             right: Line,
@@ -1286,9 +1289,9 @@ mod tests {
                 right: Line::from_endpoints(Point::from_yx(0, 0), Point::from_yx(5, 5)),
             },
         ];
-        for case in cases {
+        cases.test_each(|case| {
             assert_eq!(case.input.rightwards(), case.right);
-        }
+        })
     }
 
     /// Create a line from [y1, x1, y2, x2] coordinates.
@@ -1301,6 +1304,7 @@ mod tests {
 
     #[test]
     fn test_line_intersects() {
+        #[derive(Debug)]
         struct Case {
             a: Line,
             b: Line,
@@ -1357,12 +1361,12 @@ mod tests {
             },
         ];
 
-        for case in cases {
+        cases.test_each(|case| {
             assert_eq!(case.a.intersects(case.b), case.expected);
 
             // `intersects` should be commutative.
             assert_eq!(case.b.intersects(case.a), case.expected);
-        }
+        })
     }
 
     #[test]
@@ -1379,6 +1383,7 @@ mod tests {
 
     #[test]
     fn test_line_overlap() {
+        #[derive(Debug)]
         struct Case {
             a: (i32, i32),
             b: (i32, i32),
@@ -1412,7 +1417,7 @@ mod tests {
             },
         ];
 
-        for case in cases {
+        cases.test_each(|case| {
             // Horizontal lines
             let a = Line::from_endpoints(Point::from_yx(0, case.a.0), Point::from_yx(0, case.a.1));
             let b = Line::from_endpoints(Point::from_yx(0, case.b.0), Point::from_yx(0, case.b.1));
@@ -1424,11 +1429,12 @@ mod tests {
             let b = Line::from_endpoints(Point::from_yx(case.b.0, 0), Point::from_yx(case.b.1, 0));
             assert_eq!(a.vertical_overlap(b), case.overlap);
             assert_eq!(b.vertical_overlap(a), case.overlap);
-        }
+        })
     }
 
     #[test]
     fn test_line_width_height() {
+        #[derive(Debug)]
         struct Case {
             line: Line,
             width: i32,
@@ -1448,14 +1454,15 @@ mod tests {
             },
         ];
 
-        for case in cases {
+        cases.test_each(|case| {
             assert_eq!(case.line.width(), case.width);
             assert_eq!(case.line.height(), case.height);
-        }
+        })
     }
 
     #[test]
     fn test_line_y_for_x_and_x_for_y() {
+        #[derive(Debug)]
         struct Case {
             line: Line,
 
@@ -1498,8 +1505,8 @@ mod tests {
             },
         ];
 
-        for case in cases {
-            for (x, expected_y) in case.points {
+        cases.test_each(|case| {
+            for &(x, expected_y) in &case.points {
                 assert_eq!(case.line.to_f32().y_for_x(x), expected_y);
                 if let Some(y) = expected_y {
                     assert_eq!(
@@ -1512,7 +1519,7 @@ mod tests {
                     );
                 }
             }
-        }
+        })
     }
 
     #[test]
@@ -1528,6 +1535,7 @@ mod tests {
 
     #[test]
     fn test_polygon_contains_pixel() {
+        #[derive(Debug)]
         struct Case {
             poly: Polygon,
         }
@@ -1561,7 +1569,7 @@ mod tests {
             },
         ];
 
-        for case in cases {
+        cases.test_each(|case| {
             // Create two grids that are slightly larger than the max X + Y
             // coordinates.
             let grid_size = case
@@ -1595,11 +1603,12 @@ mod tests {
                     assert_eq!(fill_grid[[y, x]], contains_pixel_grid[[y, x]]);
                 }
             }
-        }
+        })
     }
 
     #[test]
     fn test_polygon_is_simple() {
+        #[derive(Debug)]
         struct Case {
             poly: Polygon,
             simple: bool,
@@ -1618,13 +1627,12 @@ mod tests {
             },
         ];
 
-        for case in cases {
-            assert_eq!(case.poly.is_simple(), case.simple)
-        }
+        cases.test_each(|case| assert_eq!(case.poly.is_simple(), case.simple))
     }
 
     #[test]
     fn test_polygon_fill_iter() {
+        #[derive(Debug)]
         struct Case {
             vertices: Vec<Point>,
             filled: Vec<Point>,
@@ -1671,15 +1679,16 @@ mod tests {
             },
         ];
 
-        for case in cases {
+        cases.test_each(|case| {
             let poly = Polygon::new(&case.vertices);
             let filled: Vec<_> = poly.fill_iter().collect();
             assert_eq!(filled, case.filled);
-        }
+        })
     }
 
     #[test]
     fn test_rect_clamp() {
+        #[derive(Debug)]
         struct Case {
             rect: Rect,
             boundary: Rect,
@@ -1699,9 +1708,9 @@ mod tests {
             },
         ];
 
-        for case in cases {
+        cases.test_each(|case| {
             assert_eq!(case.rect.clamp(case.boundary), case.expected);
-        }
+        })
     }
 
     #[test]
@@ -1728,6 +1737,7 @@ mod tests {
 
     #[test]
     fn test_rotated_rect_contains() {
+        #[derive(Debug)]
         struct Case {
             rrect: RotatedRect,
         }
@@ -1747,7 +1757,9 @@ mod tests {
             },
         ];
 
-        for Case { rrect: r } in cases {
+        cases.test_each(|case| {
+            let &Case { rrect: r } = case;
+
             assert!(r.contains(r.center()));
 
             // Test points slightly inside.
@@ -1759,7 +1771,7 @@ mod tests {
             for c in r.expanded(1e-5, 1e-5).corners() {
                 assert!(!r.contains(c));
             }
-        }
+        })
     }
 
     #[test]
@@ -1788,6 +1800,7 @@ mod tests {
 
     #[test]
     fn test_rotated_rect_intersects() {
+        #[derive(Debug)]
         struct Case {
             a: RotatedRect,
             b: RotatedRect,
@@ -1823,7 +1836,7 @@ mod tests {
             },
         ];
 
-        for case in cases {
+        cases.test_each(|case| {
             assert_eq!(
                 case.a.bounding_rect().intersects(case.b.bounding_rect()),
                 case.bounding_rect_intersects
@@ -1831,7 +1844,7 @@ mod tests {
             assert_eq!(case.a.intersects(&case.b), case.intersects);
             // `intersects` should be transitive
             assert_eq!(case.b.intersects(&case.a), case.intersects);
-        }
+        })
     }
 
     #[test]

--- a/rten-tensor/Cargo.toml
+++ b/rten-tensor/Cargo.toml
@@ -14,6 +14,7 @@ serde = { workspace = true, optional = true }
 smallvec = { version = "1.10.0", features=["union", "const_generics", "const_new"] }
 
 [dev-dependencies]
+rten-testing = { path = "../rten-testing" }
 serde_json = { workspace = true }
 
 [lib]

--- a/rten-tensor/src/copy.rs
+++ b/rten-tensor/src/copy.rs
@@ -453,6 +453,8 @@ fn copy_range_into_slice_inner<T: Clone>(
 
 #[cfg(test)]
 mod tests {
+    use rten_testing::TestCases;
+
     use super::{copy_into, copy_into_slice, copy_into_uninit, copy_range_into_slice};
     use crate::rng::XorShiftRng;
     use crate::{AsView, Layout, NdTensor, SliceItem, Tensor, TensorView};
@@ -536,6 +538,7 @@ mod tests {
 
     #[test]
     fn test_copy_range_into_slice() {
+        #[derive(Debug)]
         struct Case<'a> {
             tensor: Tensor<i32>,
             range: &'a [SliceItem],
@@ -568,12 +571,13 @@ mod tests {
             },
         ];
 
-        for Case {
-            tensor,
-            range,
-            expected,
-        } in cases
-        {
+        cases.test_each(|case| {
+            let Case {
+                tensor,
+                range,
+                expected,
+            } = case;
+
             let dest_len = expected.len();
             let mut dest = Vec::with_capacity(dest_len);
 
@@ -588,8 +592,8 @@ mod tests {
                 dest.set_len(dest_len);
             }
 
-            assert_eq!(dest, expected);
-        }
+            assert_eq!(dest, *expected);
+        })
     }
 
     #[test]

--- a/rten-tensor/src/impl_debug.rs
+++ b/rten-tensor/src/impl_debug.rs
@@ -20,6 +20,7 @@ impl<T: Debug> Debug for Entry<T> {
 }
 
 /// Configuration for debug formatting of a tensor.
+#[derive(Clone, Debug)]
 struct FormatOptions {
     /// Maximum number of columns to print before eliding.
     pub max_columns: usize,
@@ -161,11 +162,14 @@ where
 
 #[cfg(test)]
 mod tests {
+    use rten_testing::TestCases;
+
     use super::{FormatOptions, FormatTensor};
     use crate::Tensor;
 
     #[test]
     fn test_debug() {
+        #[derive(Clone, Debug)]
         struct Case<'a> {
             tensor: Tensor,
             opts: FormatOptions,
@@ -266,14 +270,9 @@ mod tests {
             },
         ];
 
-        for Case {
-            tensor,
-            opts,
-            expected,
-        } in cases
-        {
-            let debug_str = format!("{:?}", FormatTensor::new(&tensor, opts));
-            assert_eq!(debug_str, expected);
-        }
+        cases.test_each_clone(|case| {
+            let debug_str = format!("{:?}", FormatTensor::new(&case.tensor, case.opts));
+            assert_eq!(debug_str, case.expected);
+        })
     }
 }

--- a/rten-tensor/src/impl_serialize.rs
+++ b/rten-tensor/src/impl_serialize.rs
@@ -119,10 +119,13 @@ where
 
 #[cfg(test)]
 mod tests {
+    use rten_testing::TestCases;
+
     use crate::{NdTensor, Tensor};
 
     #[test]
     fn test_deserialize_serialize_dynamic_rank() {
+        #[derive(Debug)]
         struct Case<'a> {
             json: &'a str,
             expected: Result<Tensor<f32>, String>,
@@ -161,12 +164,14 @@ mod tests {
             },
         ];
 
-        for Case { json, expected } in cases {
+        cases.test_each(|case| {
+            let Case { json, expected } = case;
+
             let actual: Result<Tensor<f32>, String> =
                 serde_json::from_str(&json).map_err(|e| e.to_string());
             match (actual, expected) {
                 (Ok(actual), Ok(expected)) => {
-                    assert_eq!(actual, expected);
+                    assert_eq!(actual, *expected);
 
                     // Verify that serializing the result produces the original
                     // JSON.
@@ -175,18 +180,19 @@ mod tests {
                     assert_eq!(actual_json, expected_json);
                 }
                 (Err(actual_err), Err(expected_err)) => assert!(
-                    actual_err.contains(&expected_err),
+                    actual_err.contains(expected_err),
                     "expected \"{}\" to contain \"{}\"",
                     actual_err,
                     expected_err
                 ),
-                (actual, expected) => assert_eq!(actual, expected),
+                (actual, expected) => assert_eq!(actual, *expected),
             }
-        }
+        })
     }
 
     #[test]
     fn test_deserialize_serialize_static_rank() {
+        #[derive(Debug)]
         struct Case<'a> {
             json: &'a str,
             expected: Result<NdTensor<f32, 2>, String>,
@@ -203,13 +209,15 @@ mod tests {
             },
         ];
 
-        for Case { json, expected } in cases {
+        cases.test_each(|case| {
+            let Case { json, expected } = case;
+
             let actual: Result<NdTensor<f32, 2>, String> =
                 serde_json::from_str(&json).map_err(|e| e.to_string());
 
             match (actual, expected) {
                 (Ok(actual), Ok(expected)) => {
-                    assert_eq!(actual, expected);
+                    assert_eq!(actual, *expected);
 
                     // Verify that serializing the result produces the original
                     // JSON.
@@ -218,13 +226,13 @@ mod tests {
                     assert_eq!(actual_json, expected_json);
                 }
                 (Err(actual_err), Err(expected_err)) => assert!(
-                    actual_err.contains(&expected_err),
+                    actual_err.contains(expected_err),
                     "expected \"{}\" to contain \"{}\"",
                     actual_err,
                     expected_err
                 ),
-                (actual, expected) => assert_eq!(actual, expected),
+                (actual, expected) => assert_eq!(actual, *expected),
             }
-        }
+        })
     }
 }

--- a/rten-tensor/src/overlap.rs
+++ b/rten-tensor/src/overlap.rs
@@ -71,10 +71,13 @@ pub fn may_have_internal_overlap(shape: &[usize], strides: &[usize]) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use rten_testing::TestCases;
+
     use super::is_contiguous;
 
     #[test]
     fn test_is_contiguous() {
+        #[derive(Debug)]
         struct Case<'a> {
             shape: &'a [usize],
             strides: &'a [usize],
@@ -153,13 +156,8 @@ mod tests {
             },
         ];
 
-        for Case {
-            shape,
-            strides,
-            contiguous,
-        } in cases
-        {
-            assert_eq!(is_contiguous(shape, strides), contiguous);
-        }
+        cases.test_each(|case| {
+            assert_eq!(is_contiguous(case.shape, case.strides), case.contiguous);
+        })
     }
 }

--- a/rten-tensor/src/slice_range.rs
+++ b/rten-tensor/src/slice_range.rs
@@ -506,6 +506,8 @@ impl std::iter::FusedIterator for IndexRangeIter {}
 
 #[cfg(test)]
 mod tests {
+    use rten_testing::TestCases;
+
     use super::{IntoSliceItems, SliceItem, SliceRange};
 
     #[test]
@@ -540,6 +542,7 @@ mod tests {
 
     #[test]
     fn test_index_range() {
+        #[derive(Debug)]
         struct Case {
             range: SliceItem,
             dim_size: usize,
@@ -631,24 +634,26 @@ mod tests {
             },
         ];
 
-        for Case {
-            range,
-            dim_size,
-            indices,
-        } in cases
-        {
-            let mut index_iter = range.index_range(dim_size).into_iter();
+        cases.test_each(|case| {
+            let Case {
+                range,
+                dim_size,
+                indices,
+            } = case;
+
+            let mut index_iter = range.index_range(*dim_size).into_iter();
             let size_hint = index_iter.size_hint();
             let index_vec: Vec<_> = index_iter.by_ref().collect();
 
             assert_eq!(size_hint, (index_vec.len(), Some(index_vec.len())));
-            assert_eq!(index_vec, indices);
+            assert_eq!(index_vec, *indices);
             assert_eq!(index_iter.size_hint(), (0, Some(0)));
-        }
+        })
     }
 
     #[test]
     fn test_index_range_steps() {
+        #[derive(Debug)]
         struct Case {
             range: SliceRange,
             dim_size: usize,
@@ -682,14 +687,9 @@ mod tests {
             },
         ];
 
-        for Case {
-            range,
-            dim_size,
-            steps,
-        } in cases
-        {
-            assert_eq!(range.index_range(dim_size).steps(), steps);
-        }
+        cases.test_each(|case| {
+            assert_eq!(case.range.index_range(case.dim_size).steps(), case.steps);
+        })
     }
 
     #[test]

--- a/rten-testing/Cargo.toml
+++ b/rten-testing/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "rten-testing"
+version = "0.1.0"
+edition = "2021"
+authors = ["Robert Knight"]
+description = "Testing utilities for use in RTen development"
+license = "MIT OR Apache-2.0"
+homepage = "https://github.com/robertknight/rten"
+repository = "https://github.com/robertknight/rten"
+
+[package.metadata.release]
+release = false
+
+[lib]
+crate-type = ["lib"]

--- a/rten-testing/README.md
+++ b/rten-testing/README.md
@@ -1,0 +1,1 @@
+Internal testing utilities used in RTen development.

--- a/rten-testing/src/lib.rs
+++ b/rten-testing/src/lib.rs
@@ -1,0 +1,250 @@
+//! Internal testing utilities for the rten crates.
+
+use std::fmt::Debug;
+use std::panic::{RefUnwindSafe, UnwindSafe};
+
+/// Utility for creating parametrized (aka. table-driven) tests.
+///
+/// To create a table driven test:
+///
+/// 1. Import the `TestCases` trait
+/// 2. Create a struct, conventionally named `Case`, that contains the data
+///    for a single test case. This struct must implement `Debug`.
+/// 3. Create a collection of `Case` instances (eg. an array or Vec),
+///    conventionally named `cases`.
+/// 4. Call `cases.test_each`, passing the test function as a closure
+///
+/// `test_each` will run all of the test cases and catch any panics. If all
+/// cases succeed (ie. run without panicking), `test_each` will return.
+/// Otherwise it will panic with a message that includes the count and debug
+/// representations of failing test cases.
+///
+/// ## Example
+///
+/// ```
+/// use rten_testing::TestCases;
+///
+/// // Add #[test] attribute
+/// fn test_multiply() {
+///   #[derive(Debug)]
+///   struct Case {
+///     a: i32,
+///     b: i32,
+///     expected: i32,
+///   }
+///
+///   let cases = [
+///     Case { a: 3, b: 5, expected: 15 },
+///   ];
+///
+///   cases.test_each(|&Case { a, b, expected }| {
+///     assert_eq!(a * b, expected);
+///   });
+/// }
+/// # test_multiply();
+/// ```
+///
+/// ## Passing cases by reference vs. value
+///
+/// `test_each` passes the test case to the function by reference, so that it
+/// can capture a debug representation of the case in the event of a panic.  If
+/// passing by reference causes difficulties, `test_each_clone` or
+/// `test_each_value` can be used instead, at the cost of some extra runtime
+/// overhead.
+///
+/// ## Unwind safety
+///
+/// Both test cases and the test function are required to be
+/// [unwind safe](https://doc.rust-lang.org/std/panic/fn.catch_unwind.html).
+///
+/// Practically this means that the test case items and any values _captured_
+/// by the test function closure must not contain interior mutability. Values
+/// created and used _within_ the test function can contain interior mutability
+/// however.
+///
+/// If some fields in a test case are not unwind safe, this can be handled in
+/// several ways:
+///
+///  - Replace the field value by a simpler unwind-safe type. For example instead of
+///    having a field that contains a `ComplexFoo`, use a field that describes
+///    how to create the `ComplexFoo`, and create it within the test function.
+///  - Wrap the field with [`AssertUnwindSafe`](std::panic::AssertUnwindSafe)
+///
+/// If the test function captures values that are not unwind safe, the simplest
+/// solution is usually to move the value into the test function. If this is
+/// problematic, `AssertUnwindSafe` can be used to wrap the value.
+pub trait TestCases {
+    /// The data for a single test case.
+    type Case;
+
+    /// Call test function `test` with each test case in `self`, catching any panics.
+    ///
+    /// After all cases have been evaluated, return if no panics occurred or
+    /// panic with details of failing cases otherwise.
+    fn test_each(self, test: impl Fn(&Self::Case) + RefUnwindSafe)
+    where
+        Self::Case: Debug + RefUnwindSafe;
+
+    /// Variant of [`test_each`](TestCases::test_each) which passes a clone
+    /// of each test case to the test function, rather than a reference.
+    ///
+    /// This is useful for tests where working with an owned test case is
+    /// more convenient than working with a reference, and the cost of cloning
+    /// is low.
+    fn test_each_clone(self, test: impl Fn(Self::Case) + RefUnwindSafe)
+    where
+        Self::Case: Debug + Clone + UnwindSafe;
+
+    /// Variant of [`test_each`](TestCases::test_each) which passes test cases
+    /// to the test function by value.
+    ///
+    /// To support printing a debug representation of the case in the event
+    /// of an error, each test case is formatted to a string before the test
+    /// function is called. This adds a small amount of overhead compared to
+    /// [`test_each`](TestCases::test_each).
+    fn test_each_value(self, test: impl Fn(Self::Case) + RefUnwindSafe)
+    where
+        Self::Case: Debug + UnwindSafe;
+}
+
+impl<I: IntoIterator> TestCases for I {
+    type Case = I::Item;
+
+    fn test_each(self, test: impl Fn(&I::Item) + RefUnwindSafe)
+    where
+        Self::Case: Debug + RefUnwindSafe,
+    {
+        let mut failures = Vec::new();
+        for case in self {
+            if std::panic::catch_unwind(|| {
+                test(&case);
+            })
+            .is_err()
+            {
+                failures.push(case);
+            }
+        }
+        assert_eq!(
+            failures.len(),
+            0,
+            "{} test cases failed: {:?}",
+            failures.len(),
+            failures
+        );
+    }
+
+    fn test_each_clone(self, test: impl Fn(I::Item) + RefUnwindSafe)
+    where
+        Self::Case: Clone + Debug + UnwindSafe,
+    {
+        let mut failures = Vec::new();
+        for case in self {
+            let value = case.clone();
+            let test = &test;
+
+            if std::panic::catch_unwind(move || {
+                test(value);
+            })
+            .is_err()
+            {
+                failures.push(case);
+            }
+        }
+        assert_eq!(
+            failures.len(),
+            0,
+            "{} test cases failed: {:?}",
+            failures.len(),
+            failures
+        );
+    }
+
+    fn test_each_value(self, test: impl Fn(I::Item) + RefUnwindSafe)
+    where
+        Self::Case: Debug + UnwindSafe,
+    {
+        let mut failures = Vec::new();
+        for case in self {
+            let test = &test;
+            let case_str = format!("{:?}", case);
+
+            if std::panic::catch_unwind(move || {
+                test(case);
+            })
+            .is_err()
+            {
+                failures.push(case_str);
+            }
+        }
+        assert_eq!(
+            failures.len(),
+            0,
+            "{} test cases failed: {:?}",
+            failures.len(),
+            failures
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TestCases;
+
+    #[test]
+    fn test_test_cases_success() {
+        #[derive(Clone, Debug)]
+        struct Case {
+            x: i32,
+        }
+
+        let cases = [Case { x: 1 }, Case { x: 2 }];
+        cases.clone().test_each(|case| _ = case.x);
+        cases.clone().test_each_clone(|case| _ = case.x);
+        cases.clone().test_each_value(|case| _ = case.x);
+    }
+
+    #[test]
+    #[should_panic(expected = "2 test cases failed")]
+    fn test_test_each_failure() {
+        #[derive(Debug)]
+        struct Case {
+            x: i32,
+        }
+
+        let cases = [Case { x: 1 }, Case { x: 2 }];
+        cases.test_each(|case| {
+            _ = case.x;
+            panic!("oh no");
+        })
+    }
+
+    #[test]
+    #[should_panic(expected = "2 test cases failed")]
+    fn test_test_each_clone_failure() {
+        #[derive(Clone, Debug)]
+        struct Case {
+            x: i32,
+        }
+
+        let cases = [Case { x: 1 }, Case { x: 2 }];
+        cases.test_each_clone(|case| {
+            _ = case.x;
+            panic!("oh no");
+        })
+    }
+
+    #[test]
+    #[should_panic(expected = "2 test cases failed")]
+    fn test_test_each_value_failure() {
+        #[derive(Debug)]
+        struct Case {
+            x: i32,
+        }
+
+        let cases = [Case { x: 1 }, Case { x: 2 }];
+        cases.test_each_value(|case| {
+            _ = case.x;
+            panic!("oh no");
+        })
+    }
+}

--- a/rten-text/Cargo.toml
+++ b/rten-text/Cargo.toml
@@ -18,3 +18,6 @@ unicode_categories = "0.1.1"
 unicode-normalization = "0.1.22"
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
+
+[dev-dependencies]
+rten-testing = { path = "../rten-testing" }

--- a/rten-text/src/split.rs
+++ b/rten-text/src/split.rs
@@ -153,10 +153,13 @@ impl<'a> SplitExt<'a> for &'a str {
 
 #[cfg(test)]
 mod tests {
+    use rten_testing::TestCases;
+
     use super::{SliceExt, SplitExt};
 
     #[test]
     fn test_chunks_overlap() {
+        #[derive(Debug)]
         struct Case<'a> {
             input: &'a [i32],
             chunk_size: usize,
@@ -202,16 +205,16 @@ mod tests {
             },
         ];
 
-        for Case {
-            input,
-            chunk_size,
-            overlap,
-            expected,
-        } in cases
-        {
+        cases.test_each(|case| {
+            let &Case {
+                input,
+                chunk_size,
+                overlap,
+                expected,
+            } = case;
             let chunks: Vec<_> = input.chunks_with_overlap(chunk_size, overlap).collect();
             assert_eq!(chunks, expected);
-        }
+        })
     }
 
     #[test]
@@ -225,6 +228,7 @@ mod tests {
 
     #[test]
     fn test_split_keep_delimeters() {
+        #[derive(Debug)]
         struct Case<'a> {
             text: &'a str,
             expected: &'a [&'a str],
@@ -256,12 +260,14 @@ mod tests {
             },
         ];
 
-        for Case { text, expected } in cases {
+        cases.test_each(|case| {
+            let &Case { text, expected } = case;
+
             let words_and_puncs: Vec<_> = text
                 .split_whitespace()
                 .flat_map(|s| s.split_keep_delimeters(|c| c.is_ascii_punctuation()))
                 .collect();
             assert_eq!(words_and_puncs, expected,);
-        }
+        })
     }
 }

--- a/src/header.rs
+++ b/src/header.rs
@@ -162,6 +162,8 @@ impl Error for HeaderError {}
 
 #[cfg(test)]
 mod tests {
+    use rten_testing::TestCases;
+
     use super::{Header, HeaderError};
 
     #[test]
@@ -183,6 +185,7 @@ mod tests {
 
     #[test]
     fn test_invalid_header() {
+        #[derive(Debug)]
         struct Case {
             buf: Vec<u8>,
             expected: HeaderError,
@@ -242,9 +245,9 @@ mod tests {
             },
         ];
 
-        for Case { buf, expected } in cases {
-            let result = Header::from_buf(&buf);
-            assert_eq!(result, Err(expected));
-        }
+        cases.test_each(|Case { buf, expected }| {
+            let result = Header::from_buf(buf);
+            assert_eq!(result.as_ref(), Err(expected));
+        })
     }
 }

--- a/src/ops/einsum.rs
+++ b/src/ops/einsum.rs
@@ -700,6 +700,7 @@ fn einsum_path(expr: &EinsumExpr, broadcast_ndim: u8) -> Vec<EinsumStep> {
 mod tests {
     use rten_tensor::prelude::*;
     use rten_tensor::{Tensor, TensorView};
+    use rten_testing::TestCases;
 
     use super::{einsum_path, EinsumExpr, EinsumInput, EinsumStep, EinsumTerm};
     use crate::ops::tests::new_pool;
@@ -707,6 +708,7 @@ mod tests {
 
     #[test]
     fn test_einsum() {
+        #[derive(Debug)]
         struct Case<'a> {
             equation: &'a str,
             inputs: Vec<TensorView<'a>>,
@@ -714,7 +716,6 @@ mod tests {
         }
 
         let pool = new_pool();
-
         let vec_a = Tensor::arange(1., 10., None);
         let vec_b = Tensor::arange(1., 5., None);
 
@@ -1042,19 +1043,21 @@ mod tests {
             },
         ];
 
-        for Case {
-            equation,
-            inputs,
-            expected,
-        } in cases
-        {
+        cases.test_each(|case| {
+            let Case {
+                equation,
+                inputs,
+                expected,
+            } = case;
+
+            let pool = new_pool();
             let output = einsum(&pool, inputs.as_slice(), equation);
             assert_eq!(
-                output, expected,
+                &output, expected,
                 "result mismatch for equation {}",
                 equation
             );
-        }
+        });
     }
 
     #[test]

--- a/src/ops/pad.rs
+++ b/src/ops/pad.rs
@@ -203,6 +203,7 @@ mod tests {
     use rten_tensor::prelude::*;
     use rten_tensor::test_util::expect_equal;
     use rten_tensor::{NdTensor, Tensor};
+    use rten_testing::TestCases;
 
     use crate::ops::tests::new_pool;
     use crate::ops::{pad, OpError, Operator, Pad, PadMode};
@@ -281,6 +282,7 @@ mod tests {
 
     #[test]
     fn test_pad_reflect() -> Result<(), Box<dyn Error>> {
+        #[derive(Debug)]
         struct Case {
             input: Tensor,
             pads: NdTensor<i32, 1>,
@@ -372,22 +374,22 @@ mod tests {
             },
         ];
 
-        let pool = new_pool();
+        cases.test_each(|case| {
+            let Case {
+                input,
+                pads,
+                expected,
+            } = case;
 
-        for Case {
-            input,
-            pads,
-            expected,
-        } in cases
-        {
+            let pool = new_pool();
             let result = pad(&pool, input.view(), &pads.view(), PadMode::Reflect, 0.);
             match (result, expected) {
                 (Ok(result), Ok(expected)) => {
-                    expect_equal(&result, &expected)?;
+                    expect_equal(&result, &expected).unwrap();
                 }
-                (result, expected) => assert_eq!(result, expected),
+                (result, expected) => assert_eq!(&result, expected),
             }
-        }
+        });
 
         Ok(())
     }

--- a/src/ops/pooling.rs
+++ b/src/ops/pooling.rs
@@ -406,6 +406,7 @@ mod tests {
     use rten_tensor::prelude::*;
     use rten_tensor::test_util::expect_equal;
     use rten_tensor::Tensor;
+    use rten_testing::TestCases;
 
     use super::calc_output_size_and_padding;
     use crate::ops::tests::expect_eq_1e4;
@@ -667,6 +668,7 @@ mod tests {
 
     #[test]
     fn test_calc_output_size_and_padding() {
+        #[derive(Debug)]
         struct Case {
             in_size: (usize, usize),
             kernel_size: (usize, usize),
@@ -772,25 +774,26 @@ mod tests {
             },
         ];
 
-        for Case {
-            in_size,
-            kernel_size,
-            dilations,
-            strides,
-            padding,
-            expected,
-        } in cases
-        {
+        cases.test_each(|case| {
+            let Case {
+                in_size,
+                kernel_size,
+                dilations,
+                strides,
+                padding,
+                expected,
+            } = case;
+
             assert_eq!(
-                calc_output_size_and_padding(
-                    in_size,
-                    kernel_size,
-                    strides,
-                    padding,
-                    Some(dilations),
+                &calc_output_size_and_padding(
+                    *in_size,
+                    *kernel_size,
+                    *strides,
+                    padding.clone(),
+                    Some(*dilations),
                 ),
                 expected
             );
-        }
+        })
     }
 }

--- a/src/ops/random.rs
+++ b/src/ops/random.rs
@@ -143,6 +143,7 @@ mod tests {
 
     use rten_tensor::prelude::*;
     use rten_tensor::Tensor;
+    use rten_testing::TestCases;
 
     use crate::ops::operators::{FloatOperators, Operators};
     use crate::ops::tests::{new_pool, run_op};
@@ -152,6 +153,7 @@ mod tests {
 
     #[test]
     fn test_random_uniform() {
+        #[derive(Clone, Debug)]
         struct Case {
             low: f32,
             high: f32,
@@ -189,15 +191,14 @@ mod tests {
             },
         ];
 
-        let pool = new_pool();
-
-        for Case {
+        cases.test_each_clone(|Case {
             low,
             high,
             shape,
             seed,
-        } in cases
+        }|
         {
+            let pool = new_pool();
             let op = RandomUniform {
                 low,
                 high,
@@ -250,7 +251,7 @@ mod tests {
             } else {
                 assert_ne!(output, output_2);
             }
-        }
+        })
     }
 
     #[test]

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -818,6 +818,7 @@ mod tests {
     use std::sync::Arc;
 
     use rten_tensor::Tensor;
+    use rten_testing::TestCases;
 
     use super::{GraphOptimizer, OptimizeError};
     use crate::constant_storage::{ArcSlice, ArcTensorView, ConstantStorage};
@@ -1142,13 +1143,14 @@ mod tests {
 
     #[test]
     fn test_fuse_layer_norm() {
+        #[derive(Debug)]
         struct Case {
             with_bias: bool,
         }
 
         let cases = [Case { with_bias: true }, Case { with_bias: false }];
 
-        for Case { with_bias } in cases {
+        cases.test_each(|&Case { with_bias }| {
             let graph = layer_norm_graph(with_bias);
             let graph = optimize_graph(graph).unwrap();
             let (_, op) = graph.get_source_node(graph.output_ids()[0]).unwrap();
@@ -1158,7 +1160,7 @@ mod tests {
             assert_eq!(layer_norm.epsilon, Some(1e-6));
             let bias_input = op.input_ids().get(2).copied().flatten();
             assert_eq!(bias_input.is_some(), with_bias);
-        }
+        })
     }
 
     #[test]


### PR DESCRIPTION
A widely used pattern in the rten codebase is to create table-driven tests using code like:

```rs
#[test]
fn test_foo() {
  struct Case {
    param_a: i32,
    param_b: usize,
  }

  for Case { param_a, param_b } in cases {
    // Test case
  }
}
```

This works well, except that:

- The test stops running at the first failing case
- In the event of a failure, nothing in the log output indicates which case failed

This PR introduces a `TestCases` trait in a new internal rten-testing library which addresses these two issues. To vet the API, many (but not all) existing parametrized tests are converted to use the new API.