### PR TITLE
Convert more table-driven tests to use `TestCases` utility

### DIFF
--- a/src/gemm/packing.rs
+++ b/src/gemm/packing.rs
@@ -293,12 +293,14 @@ impl Default for PackingBuffer {
 
 #[cfg(test)]
 mod tests {
+    use rten_testing::TestCases;
     use std::mem::MaybeUninit;
 
     use super::{PackedLayout, PackingBuffer};
 
     #[test]
     fn test_packing_buffer() {
+        #[derive(Clone, Debug)]
         struct Case {
             size: usize,
             align: usize,
@@ -311,12 +313,13 @@ mod tests {
             panel_stride: 64,
         }];
 
-        for Case {
-            size,
-            align,
-            panel_stride,
-        } in cases
-        {
+        cases.test_each_clone(|case| {
+            let Case {
+                size,
+                align,
+                panel_stride,
+            } = case;
+
             let mut buf = PackingBuffer::new();
             assert_eq!(buf.as_bytes().len(), 0);
 
@@ -331,6 +334,6 @@ mod tests {
             }
 
             assert_eq!(buf.as_bytes().len(), layout.size());
-        }
+        })
     }
 }

--- a/src/ops/convert.rs
+++ b/src/ops/convert.rs
@@ -81,15 +81,15 @@ impl Operator for Cast {
 
 #[cfg(test)]
 mod tests {
-    use std::error::Error;
-
     use rten_tensor::Tensor;
+    use rten_testing::TestCases;
 
     use crate::ops::tests::new_pool;
     use crate::ops::{Cast, DataType, Operator, Output};
 
     #[test]
-    fn test_cast() -> Result<(), Box<dyn Error>> {
+    fn test_cast() {
+        #[derive(Debug)]
         struct Case {
             input: Output,
             dtype: DataType,
@@ -152,18 +152,11 @@ mod tests {
             },
         ];
 
-        let pool = new_pool();
-        for Case {
-            input,
-            dtype,
-            expected,
-        } in cases
-        {
-            let cast_op = Cast { to: dtype };
-            let result = cast_op.run(&pool, (&input).into()).unwrap().remove(0);
-            assert_eq!(result, expected);
-        }
-
-        Ok(())
+        cases.test_each(|case| {
+            let pool = new_pool();
+            let cast_op = Cast { to: case.dtype };
+            let result = cast_op.run(&pool, (&case.input).into()).unwrap().remove(0);
+            assert_eq!(result, case.expected);
+        })
     }
 }

--- a/src/ops/einsum.rs
+++ b/src/ops/einsum.rs
@@ -1062,6 +1062,7 @@ mod tests {
 
     #[test]
     fn test_einsum_path() {
+        #[derive(Debug)]
         struct Case<'a> {
             equation: &'a str,
             broadcast_ndim: u8,
@@ -1157,14 +1158,9 @@ mod tests {
             },
         ];
 
-        for Case {
-            equation,
-            path,
-            broadcast_ndim,
-        } in cases
-        {
-            let expr = EinsumExpr::parse(equation).unwrap();
-            assert_eq!(einsum_path(&expr, broadcast_ndim), path);
-        }
+        cases.test_each(|case| {
+            let expr = EinsumExpr::parse(case.equation).unwrap();
+            assert_eq!(einsum_path(&expr, case.broadcast_ndim), case.path);
+        })
     }
 }

--- a/src/ops/generate.rs
+++ b/src/ops/generate.rs
@@ -153,6 +153,7 @@ impl Operator for Range {
 mod tests {
     use rten_tensor::prelude::*;
     use rten_tensor::Tensor;
+    use rten_testing::TestCases;
 
     use crate::ops::tests::new_pool;
     use crate::ops::{onehot, range, ConstantOfShape, OpError, Operator, Scalar};
@@ -178,6 +179,7 @@ mod tests {
 
     #[test]
     fn test_onehot() {
+        #[derive(Debug)]
         struct Case {
             classes: Tensor<i32>,
             axis: isize,
@@ -247,19 +249,18 @@ mod tests {
             },
         ];
 
-        let pool = new_pool();
-        for Case {
-            classes,
-            axis,
-            depth,
-            on_value,
-            off_value,
-            expected,
-        } in cases
-        {
-            let result = onehot(&pool, classes.view(), axis, depth, on_value, off_value);
-            assert_eq!(result, expected);
-        }
+        cases.test_each(|case| {
+            let pool = new_pool();
+            let result = onehot(
+                &pool,
+                case.classes.view(),
+                case.axis,
+                case.depth,
+                case.on_value,
+                case.off_value,
+            );
+            assert_eq!(result, case.expected);
+        })
     }
 
     #[test]

--- a/src/ops/random.rs
+++ b/src/ops/random.rs
@@ -139,8 +139,6 @@ impl Operator for RandomNormalLike {
 
 #[cfg(test)]
 mod tests {
-    use std::error::Error;
-
     use rten_tensor::prelude::*;
     use rten_tensor::Tensor;
     use rten_testing::TestCases;
@@ -267,7 +265,8 @@ mod tests {
     }
 
     #[test]
-    fn test_random_normal() -> Result<(), Box<dyn Error>> {
+    fn test_random_normal() {
+        #[derive(Clone, Debug)]
         struct Case {
             mean: f32,
             scale: f32,
@@ -299,13 +298,14 @@ mod tests {
             },
         ];
 
-        for Case {
-            mean,
-            scale,
-            shape,
-            seed,
-        } in cases
-        {
+        cases.test_each_clone(|case| {
+            let Case {
+                mean,
+                scale,
+                shape,
+                seed,
+            } = case;
+
             let op = RandomNormal {
                 mean,
                 scale,
@@ -317,7 +317,8 @@ mod tests {
 
             // Test that outputs have expected distribution.
             let mean = output
-                .reduce_mean(None, false /* keep_dims */)?
+                .reduce_mean(None, false /* keep_dims */)
+                .unwrap()
                 .item()
                 .copied()
                 .unwrap();
@@ -330,7 +331,8 @@ mod tests {
 
             let var: f32 = output
                 .map(|x| (x - mean) * (x - mean))
-                .reduce_sum(None, false /* keep_dims */)?
+                .reduce_sum(None, false /* keep_dims */)
+                .unwrap()
                 .item()
                 .unwrap()
                 / output.len() as f32;
@@ -346,9 +348,7 @@ mod tests {
             } else {
                 assert_ne!(output, output_2);
             }
-        }
-
-        Ok(())
+        })
     }
 
     #[test]

--- a/src/ops/trilu.rs
+++ b/src/ops/trilu.rs
@@ -57,12 +57,14 @@ impl Operator for Trilu {
 mod tests {
     use rten_tensor::prelude::*;
     use rten_tensor::Tensor;
+    use rten_testing::TestCases;
 
     use crate::ops::tests::new_pool;
     use crate::ops::{trilu, OpError};
 
     #[test]
     fn test_trilu() {
+        #[derive(Debug)]
         struct Case {
             input: Tensor<i32>,
             expected: Tensor<i32>,
@@ -146,17 +148,11 @@ mod tests {
             },
         ];
 
-        let pool = new_pool();
-        for Case {
-            input,
-            expected,
-            upper,
-            k,
-        } in cases
-        {
-            let result = trilu(&pool, input.view(), k, upper).unwrap();
-            assert_eq!(result, expected);
-        }
+        cases.test_each(|case| {
+            let pool = new_pool();
+            let result = trilu(&pool, case.input.view(), case.k, case.upper).unwrap();
+            assert_eq!(result, case.expected);
+        })
     }
 
     #[test]


### PR DESCRIPTION
Continue the refactoring started in https://github.com/robertknight/rten/pull/594.