### PR TITLE
Convert more table-driven tests to use `TestCases`

### DIFF
--- a/rten-imageproc/src/contours.rs
+++ b/rten-imageproc/src/contours.rs
@@ -235,6 +235,7 @@ pub fn find_contours(mask: NdTensorView<bool, 2>, mode: RetrievalMode) -> Polygo
 mod tests {
     use rten_tensor::prelude::*;
     use rten_tensor::NdTensor;
+    use rten_testing::TestCases;
 
     use crate::tests::border_points;
     use crate::{fill_rect, stroke_rect, Point, Rect};
@@ -243,6 +244,7 @@ mod tests {
 
     #[test]
     fn test_find_contours_in_empty_mask() {
+        #[derive(Debug)]
         struct Case {
             size: [usize; 2],
         }
@@ -253,15 +255,16 @@ mod tests {
             Case { size: [10, 10] },
         ];
 
-        for case in cases {
+        cases.test_each(|case| {
             let mask = NdTensor::zeros(case.size);
             let contours = find_contours(mask.view(), RetrievalMode::List);
             assert_eq!(contours.len(), 0);
-        }
+        })
     }
 
     #[test]
     fn test_find_contours_single_rect() {
+        #[derive(Debug)]
         struct Case {
             rect: Rect,
         }
@@ -270,7 +273,7 @@ mod tests {
             rect: Rect::from_tlbr(5, 5, 10, 10),
         }];
 
-        for case in cases {
+        cases.test_each(|case| {
             let mut mask = NdTensor::zeros([20, 20]);
             fill_rect(mask.view_mut(), case.rect, true);
 
@@ -279,7 +282,7 @@ mod tests {
             assert_eq!(contours.len(), 1);
             let border = contours.iter().next().unwrap();
             assert_eq!(border, border_points(case.rect, false /* omit_corners */));
-        }
+        })
     }
 
     #[test]

--- a/rten-imageproc/src/drawing.rs
+++ b/rten-imageproc/src/drawing.rs
@@ -478,6 +478,7 @@ impl<'a, T: Copy + Default> Painter<'a, T> {
 mod tests {
     use rten_tensor::prelude::*;
     use rten_tensor::{MatrixLayout, NdTensor, NdTensorView};
+    use rten_testing::TestCases;
 
     use crate::tests::print_grid;
     use crate::{BoundingRect, Painter, Point, Polygon, Rect};
@@ -525,6 +526,7 @@ mod tests {
 
     #[test]
     fn test_draw_polygon() {
+        #[derive(Debug)]
         struct Case {
             points: &'static [[i32; 2]],
             expected: NdTensor<i32, 2>,
@@ -566,7 +568,7 @@ mod tests {
             },
         ];
 
-        for case in cases {
+        cases.test_each(|case| {
             let points: Vec<_> = case
                 .points
                 .iter()
@@ -576,7 +578,7 @@ mod tests {
             let mut image = NdTensor::zeros(case.expected.shape());
             draw_polygon(image.view_mut(), &points, 1, 1 /* width */);
             compare_images(image.view(), case.expected.view());
-        }
+        })
     }
 
     #[test]

--- a/rten-imageproc/src/poly_algos.rs
+++ b/rten-imageproc/src/poly_algos.rs
@@ -223,12 +223,15 @@ pub fn min_area_rect(points: &[PointF]) -> Option<RotatedRect> {
 
 #[cfg(test)]
 mod tests {
+    use rten_testing::TestCases;
+
     use super::{convex_hull, min_area_rect, simplify_polygon, simplify_polyline};
     use crate::tests::{border_points, points_from_coords};
     use crate::{BoundingRect, Point, PointF, Polygon, Rect};
 
     #[test]
     fn test_convex_hull() {
+        #[derive(Debug)]
         struct Case {
             points: &'static [[f32; 2]],
             hull: &'static [[f32; 2]],
@@ -288,18 +291,19 @@ mod tests {
             },
         ];
 
-        for case in cases {
+        cases.test_each(|case| {
             let points = points_from_coords(case.points);
             let expected_hull = points_from_coords(case.hull);
 
             let hull = convex_hull(&points);
 
             assert_eq!(hull, expected_hull);
-        }
+        })
     }
 
     #[test]
     fn test_min_area_rect() {
+        #[derive(Debug)]
         struct Case {
             points: Vec<PointF>,
         }
@@ -329,10 +333,10 @@ mod tests {
             Case { points: Vec::new() },
         ];
 
-        for case in cases {
+        cases.test_each(|case| {
             let Some(min_rect) = min_area_rect(&case.points) else {
                 assert!(case.points.is_empty());
-                continue;
+                return;
             };
 
             // Rotated rect should never be larger than axis-aligned bounding rect.
@@ -364,11 +368,12 @@ mod tests {
                 max_dist,
                 threshold
             );
-        }
+        })
     }
 
     #[test]
     fn test_simplify_polyline() {
+        #[derive(Debug)]
         struct Case {
             poly: Vec<PointF>,
             epsilon: f32,
@@ -423,14 +428,15 @@ mod tests {
             },
         ];
 
-        for case in cases {
+        cases.test_each(|case| {
             let simplified = simplify_polyline(&case.poly, case.epsilon);
             assert_eq!(&simplified, &case.simplified);
-        }
+        })
     }
 
     #[test]
     fn test_simplify_polygon() {
+        #[derive(Debug)]
         struct Case {
             poly: Vec<PointF>,
             epsilon: f32,
@@ -451,9 +457,9 @@ mod tests {
                 .collect(),
         }];
 
-        for case in cases {
+        cases.test_each(|case| {
             let simplified = simplify_polygon(&case.poly, case.epsilon);
             assert_eq!(&simplified, &case.simplified);
-        }
+        })
     }
 }

--- a/rten-imageproc/src/shapes.rs
+++ b/rten-imageproc/src/shapes.rs
@@ -1253,6 +1253,7 @@ mod tests {
 
     #[test]
     fn test_line_downwards() {
+        #[derive(Debug)]
         struct Case {
             input: Line,
             down: Line,
@@ -1267,9 +1268,9 @@ mod tests {
                 down: Line::from_endpoints(Point::from_yx(0, 0), Point::from_yx(5, 5)),
             },
         ];
-        for case in cases {
+        cases.test_each(|case| {
             assert_eq!(case.input.downwards(), case.down);
-        }
+        })
     }
 
     #[test]

--- a/src/gemm.rs
+++ b/src/gemm.rs
@@ -1803,9 +1803,8 @@ mod tests {
     }
 
     #[test]
-    fn test_gemm_prepack() -> Result<(), Box<dyn Error>> {
-        let mut rng = XorShiftRng::new(1234);
-
+    fn test_gemm_prepack() {
+        #[derive(Clone, Debug)]
         struct Case {
             m: usize,
             n: usize,
@@ -1832,8 +1831,10 @@ mod tests {
             },
         ];
 
-        for case in cases {
+        cases.test_each_clone(|case| {
             let Case { m, n, k } = case;
+
+            let mut rng = XorShiftRng::new(1234);
             let a = NdTensor::rand([m, k], &mut rng);
             let b = NdTensor::rand([k, n], &mut rng);
 
@@ -1877,10 +1878,8 @@ mod tests {
             )
             .unwrap();
 
-            expect_equal(&result, &expected)?;
-        }
-
-        Ok(())
+            expect_equal(&result, &expected).unwrap();
+        })
     }
 
     // Simplified version of the im2col builder used by convolution code.

--- a/src/ops/binary_elementwise.rs
+++ b/src/ops/binary_elementwise.rs
@@ -895,6 +895,7 @@ mod tests {
     use rten_tensor::prelude::*;
     use rten_tensor::test_util::expect_equal;
     use rten_tensor::Tensor;
+    use rten_testing::TestCases;
 
     use super::fast_broadcast_cycles_repeats;
     use crate::ops::tests::new_pool;
@@ -1346,7 +1347,8 @@ mod tests {
     }
 
     #[test]
-    fn test_pow() -> Result<(), Box<dyn Error>> {
+    fn test_pow() {
+        #[derive(Debug)]
         struct Case {
             a: Tensor<f32>,
             b: Tensor<f32>,
@@ -1380,20 +1382,18 @@ mod tests {
             },
         ];
 
-        let pool = new_pool();
+        cases.test_each(|case| {
+            let pool = new_pool();
 
-        for case in cases {
             // Copying variant
             let result = pow(&pool, case.a.view(), case.b.view()).unwrap();
-            expect_equal(&result, &case.expected)?;
+            expect_equal(&result, &case.expected).unwrap();
 
             // In-place variant
             let mut a = case.a.clone();
             pow_in_place(a.view_mut(), case.b.view());
-            expect_equal(&a, &case.expected)?;
-        }
-
-        Ok(())
+            expect_equal(&a, &case.expected).unwrap();
+        })
     }
 
     #[test]

--- a/src/ops/layout.rs
+++ b/src/ops/layout.rs
@@ -633,6 +633,7 @@ mod tests {
     use rten_tensor::rng::XorShiftRng;
     use rten_tensor::test_util::expect_equal;
     use rten_tensor::{NdTensor, Tensor};
+    use rten_testing::TestCases;
 
     use super::{depth_to_space, DepthToSpaceMode};
     use crate::ops::layout::{
@@ -644,6 +645,7 @@ mod tests {
 
     #[test]
     fn test_depth_to_space() {
+        #[derive(Debug)]
         struct Case {
             input: NdTensor<f32, 4>,
             block_size: u32,
@@ -702,17 +704,11 @@ mod tests {
             },
         ];
 
-        let pool = new_pool();
-        for Case {
-            input,
-            block_size,
-            mode,
-            expected,
-        } in cases
-        {
-            let result = depth_to_space(&pool, input.as_dyn(), block_size, mode);
-            assert_eq!(result, expected);
-        }
+        cases.test_each(|case| {
+            let pool = new_pool();
+            let result = depth_to_space(&pool, case.input.as_dyn(), case.block_size, case.mode);
+            assert_eq!(result, case.expected);
+        })
     }
 
     #[test]
@@ -778,8 +774,7 @@ mod tests {
 
     #[test]
     fn test_flatten() {
-        let pool = new_pool();
-
+        #[derive(Debug)]
         struct Case {
             shape: Vec<usize>,
             axis: isize,
@@ -838,16 +833,13 @@ mod tests {
             },
         ];
 
-        for Case {
-            shape,
-            axis,
-            expected,
-        } in cases
-        {
-            let input = Tensor::<f32>::zeros(shape.as_slice());
-            let result = flatten(&pool, input.view(), axis).map(|tensor| tensor.shape().to_vec());
-            assert_eq!(result, expected);
-        }
+        cases.test_each(|case| {
+            let pool = new_pool();
+            let input = Tensor::<f32>::zeros(case.shape.as_slice());
+            let result =
+                flatten(&pool, input.view(), case.axis).map(|tensor| tensor.shape().to_vec());
+            assert_eq!(result, case.expected);
+        })
     }
 
     #[test]

--- a/src/ops/pooling.rs
+++ b/src/ops/pooling.rs
@@ -414,7 +414,7 @@ mod tests {
     use crate::ops::{average_pool, global_average_pool, max_pool, OpError, Padding};
 
     #[test]
-    fn test_average_pool() -> Result<(), Box<dyn Error>> {
+    fn test_average_pool() {
         let input = Tensor::from_data(
             &[1, 1, 4, 4],
             vec![
@@ -425,6 +425,7 @@ mod tests {
             ],
         );
 
+        #[derive(Debug)]
         struct Case {
             kernel_size: [usize; 2],
             strides: [usize; 2],
@@ -478,8 +479,8 @@ mod tests {
             },
         ];
 
-        let pool = new_pool();
-        for case in cases {
+        cases.test_each(|case| {
+            let pool = new_pool();
             let result = average_pool(
                 &pool,
                 input.view(),
@@ -489,10 +490,8 @@ mod tests {
                 false, /* count_include_pad */
             )
             .unwrap();
-            expect_equal(&result, &case.expected)?;
-        }
-
-        Ok(())
+            expect_equal(&result, &case.expected).unwrap();
+        })
     }
 
     #[test]
@@ -566,7 +565,7 @@ mod tests {
     }
 
     #[test]
-    fn test_max_pool() -> Result<(), Box<dyn Error>> {
+    fn test_max_pool() {
         let input = Tensor::from_data(
             &[1, 1, 4, 4],
             vec![
@@ -577,6 +576,7 @@ mod tests {
             ],
         );
 
+        #[derive(Debug)]
         struct Case {
             kernel_size: [usize; 2],
             strides: [usize; 2],
@@ -629,8 +629,8 @@ mod tests {
             },
         ];
 
-        let pool = new_pool();
-        for case in cases {
+        cases.test_each(|case| {
+            let pool = new_pool();
             let result = max_pool(
                 &pool,
                 input.view(),
@@ -639,10 +639,8 @@ mod tests {
                 [0, 0, 0, 0].into(),
             )
             .unwrap();
-            expect_equal(&result, &case.expected)?;
-        }
-
-        Ok(())
+            expect_equal(&result, &case.expected).unwrap();
+        })
     }
 
     #[test]

--- a/src/ops/slice.rs
+++ b/src/ops/slice.rs
@@ -168,6 +168,7 @@ mod tests {
     use rten_tensor::rng::XorShiftRng;
     use rten_tensor::test_util::expect_equal;
     use rten_tensor::Tensor;
+    use rten_testing::TestCases;
 
     use crate::ops::tests::new_pool;
     use crate::ops::{slice, slice_in_place};
@@ -449,6 +450,7 @@ mod tests {
     fn test_slice_with_step() {
         let input = from_slice(&[1, 2, 3, 4, 5]);
 
+        #[derive(Debug)]
         struct Case<'a> {
             start: i32,
             end: i32,
@@ -492,8 +494,8 @@ mod tests {
             },
         ];
 
-        let pool = new_pool();
-        for case in cases {
+        cases.test_each(|case| {
+            let pool = new_pool();
             let starts = &[case.start];
             let ends = &[case.end];
             let axes = &[0];
@@ -512,6 +514,6 @@ mod tests {
                 sliced,
                 Tensor::from_data(case.expected_shape, case.expected_elements.to_vec())
             );
-        }
+        })
     }
 }

--- a/src/ops/variadic_elementwise.rs
+++ b/src/ops/variadic_elementwise.rs
@@ -150,6 +150,7 @@ mod tests {
     use rten_tensor::prelude::*;
     use rten_tensor::test_util::eq_with_nans;
     use rten_tensor::{Tensor, TensorView};
+    use rten_testing::TestCases;
 
     use crate::ops::tests::new_pool;
     use crate::ops::{max, mean, min, sum, Input, InputList, Max, Min, OpError, Operator, Sum};
@@ -165,6 +166,7 @@ mod tests {
     // other elementwise reductions share most of the implementation.
     #[test]
     fn test_max() {
+        #[derive(Debug)]
         struct Case {
             inputs: Vec<Tensor>,
             expected: Result<Tensor, OpError>,
@@ -226,15 +228,15 @@ mod tests {
             },
         ];
 
-        let pool = new_pool();
-        for case in cases {
+        cases.test_each(|case| {
+            let pool = new_pool();
             let views: Vec<_> = case.inputs.iter().map(|t| t.view()).collect();
             let result = max(&pool, &views);
-            match (result, case.expected) {
+            match (&result, &case.expected) {
                 (Ok(result), Ok(expected)) => assert!(eq_with_nans(result.view(), expected.view())),
                 (result, expected) => assert_eq!(result, expected),
             }
-        }
+        });
 
         // Test the `Max` Operator impl
         let a = Tensor::from([1., 2., 7., 8.]);


### PR DESCRIPTION
This (almost) finishes the work started in https://github.com/robertknight/rten/pull/594.