### PR TITLE
Replace PtrLen/MutPtrLen with SrcDest for vectorized op inputs/outputs

### DIFF
--- a/rten-vecmath/src/min_max.rs
+++ b/rten-vecmath/src/min_max.rs
@@ -19,7 +19,7 @@ impl SimdOp for MinMax<'_> {
     #[inline(always)]
     unsafe fn eval<S: SimdFloat>(self) -> Self::Output {
         let [vec_min, vec_max] = simd_fold_array(
-            self.input.into(),
+            self.input,
             [S::splat(f32::MAX), S::splat(f32::MIN)],
             #[inline(always)]
             |[min, max], x| [x.min(min), x.max(max)],

--- a/rten-vecmath/src/sum.rs
+++ b/rten-vecmath/src/sum.rs
@@ -24,7 +24,7 @@ impl SimdOp for Sum<'_> {
     #[inline(always)]
     unsafe fn eval<S: SimdFloat>(self) -> Self::Output {
         let vec_sum = simd_fold(
-            self.input.into(),
+            self.input,
             S::zero(),
             #[inline(always)]
             |sum, x| sum.add(x),
@@ -56,7 +56,7 @@ impl SimdOp for SumSquare<'_> {
     #[inline(always)]
     unsafe fn eval<S: SimdFloat>(self) -> Self::Output {
         let vec_sum = simd_fold(
-            self.input.into(),
+            self.input,
             S::zero(),
             #[inline(always)]
             |sum, x| x.mul_add(x, sum),
@@ -88,7 +88,7 @@ impl SimdOp for SumSquareSub<'_> {
     unsafe fn eval<S: SimdFloat>(self) -> Self::Output {
         let offset_vec = S::splat(self.offset);
         let vec_sum = simd_fold(
-            self.input.into(),
+            self.input,
             S::zero(),
             #[inline(always)]
             |sum, x| {


### PR DESCRIPTION
Vectorized operations can operate either in-place on a single mutable slice, or a pair of source and destination slices where the destination is uninitialized. To handle both cases with the same implementation, slice-like types without the aliasing guarantees were used. Replace this with a `SrcDest` type which models the possible cases better in the type system and is a step towards reducing unsafety in vectorized ops.

Part of https://github.com/robertknight/rten/issues/549.