### PR TITLE
Make SIMD vector length a runtime rather than compile-time constant

### DIFF
--- a/rten-simd/src/arch/aarch64.rs
+++ b/rten-simd/src/arch/aarch64.rs
@@ -34,7 +34,7 @@ impl SimdMask for uint32x4_t {
 }
 
 impl Simd for int32x4_t {
-    const LEN: usize = 4;
+    const LEN: Option<usize> = Some(4);
 
     type Array = [i32; 4];
     type Elem = i32;
@@ -192,7 +192,7 @@ impl SimdInt for int32x4_t {
 }
 
 impl Simd for float32x4_t {
-    const LEN: usize = 4;
+    const LEN: Option<usize> = Some(4);
 
     type Array = [f32; 4];
     type Elem = f32;
@@ -294,7 +294,7 @@ impl SimdFloat for float32x4_t {
 
     #[inline]
     unsafe fn gather_mask(src: *const f32, offsets: Self::Int, mask: Self::Mask) -> Self {
-        super::simd_gather_mask::<_, _, _, { Self::LEN }>(src, offsets, mask)
+        super::simd_gather_mask::<_, _, _, { Self::LEN.unwrap() }>(src, offsets, mask)
     }
 
     #[inline]

--- a/rten-simd/src/arch/array.rs
+++ b/rten-simd/src/arch/array.rs
@@ -25,7 +25,7 @@ macro_rules! impl_simd_for_array {
         where
             [bool; N]: Default,
         {
-            const LEN: usize = N;
+            const LEN: Option<usize> = Some(N);
 
             type Array = Self;
             type Elem = $type;
@@ -48,7 +48,7 @@ macro_rules! impl_simd_for_array {
 
             #[inline]
             unsafe fn store(self, ptr: *mut $type) {
-                for i in 0..Self::LEN {
+                for i in 0..N {
                     ptr.add(i).write(self[i]);
                 }
             }

--- a/rten-simd/src/arch/scalar.rs
+++ b/rten-simd/src/arch/scalar.rs
@@ -24,7 +24,7 @@ impl SimdMask for bool {
 macro_rules! impl_simd {
     ($type:ty) => {
         impl Simd for $type {
-            const LEN: usize = 1;
+            const LEN: Option<usize> = Some(1);
 
             type Array = [$type; 1];
             type Elem = $type;

--- a/rten-simd/src/arch/wasm.rs
+++ b/rten-simd/src/arch/wasm.rs
@@ -49,7 +49,7 @@ impl SimdMask for v128i {
 }
 
 impl Simd for v128i {
-    const LEN: usize = 4;
+    const LEN: Option<usize> = Some(4);
 
     type Array = [i32; 4];
     type Elem = i32;
@@ -220,7 +220,7 @@ impl SimdInt for v128i {
 }
 
 impl Simd for v128f {
-    const LEN: usize = 4;
+    const LEN: Option<usize> = Some(4);
 
     type Array = [f32; 4];
     type Elem = f32;
@@ -329,7 +329,7 @@ impl SimdFloat for v128f {
 
     #[inline]
     unsafe fn gather_mask(src: *const f32, offsets: Self::Int, mask: Self::Mask) -> Self {
-        super::simd_gather_mask::<_, _, _, { Self::LEN }>(src, offsets, mask)
+        super::simd_gather_mask::<_, _, _, { Self::LEN.unwrap() }>(src, offsets, mask)
     }
 
     #[inline]

--- a/rten-simd/src/arch/x86_64.rs
+++ b/rten-simd/src/arch/x86_64.rs
@@ -47,7 +47,7 @@ impl SimdMask for __m256i {
 }
 
 impl Simd for __m256i {
-    const LEN: usize = 8;
+    const LEN: Option<usize> = Some(8);
 
     type Array = [i32; 8];
     type Elem = i32;
@@ -243,7 +243,7 @@ impl SimdInt for __m256i {
 }
 
 impl Simd for __m256 {
-    const LEN: usize = 8;
+    const LEN: Option<usize> = Some(8);
 
     type Array = [f32; 8];
     type Elem = f32;
@@ -383,7 +383,7 @@ impl SimdFloat for __m256 {
         // same extent, so using an emulated gather may not pay off there.
         //
         // See https://www.intel.com/content/www/us/en/developer/articles/technical/software-security-guidance/technical-documentation/gather-data-sampling.html
-        super::simd_gather_mask::<_, _, _, { Self::LEN }>(src, offsets, mask)
+        super::simd_gather_mask::<_, _, _, { Self::LEN.unwrap() }>(src, offsets, mask)
     }
 
     #[inline]
@@ -448,7 +448,7 @@ impl SimdMask for __mmask16 {
 
 #[cfg(feature = "avx512")]
 impl Simd for __m512i {
-    const LEN: usize = 16;
+    const LEN: Option<usize> = Some(16);
 
     type Array = [i32; 16];
     type Elem = i32;
@@ -631,7 +631,7 @@ impl SimdInt for __m512i {
 
 #[cfg(feature = "avx512")]
 impl Simd for __m512 {
-    const LEN: usize = 16;
+    const LEN: Option<usize> = Some(16);
 
     type Array = [f32; 16];
     type Elem = f32;

--- a/rten-vecmath/src/normalize.rs
+++ b/rten-vecmath/src/normalize.rs
@@ -105,8 +105,9 @@ impl<'a> SimdOp for Normalize<'a> {
         let const_scale_vec = S::splat(scale);
         let const_bias_vec = S::splat(bias);
         let pre_scale_bias_vec = S::splat(pre_scale_bias);
+        let v_len = S::len();
 
-        while n >= S::LEN {
+        while n >= v_len {
             let scale_vec = scale_ptr
                 .map(|s| S::load(s))
                 .unwrap_or(one)
@@ -120,12 +121,12 @@ impl<'a> SimdOp for Normalize<'a> {
                 .mul_add(scale_vec, bias_vec);
             y.store(out_ptr as *mut f32);
 
-            in_ptr = in_ptr.add(S::LEN);
-            out_ptr = out_ptr.add(S::LEN);
-            scale_ptr = scale_ptr.map(|s| s.add(S::LEN));
-            bias_ptr = bias_ptr.map(|b| b.add(S::LEN));
+            in_ptr = in_ptr.add(v_len);
+            out_ptr = out_ptr.add(v_len);
+            scale_ptr = scale_ptr.map(|s| s.add(v_len));
+            bias_ptr = bias_ptr.map(|b| b.add(v_len));
 
-            n -= S::LEN;
+            n -= v_len;
         }
 
         if n > 0 {

--- a/rten-vecmath/src/quantize.rs
+++ b/rten-vecmath/src/quantize.rs
@@ -46,8 +46,9 @@ impl<'d> SimdOp for Quantize<'_, 'd, u8> {
 
         let zp_vec = S::Int::splat(self.zero_point as i32);
         let scale_vec = S::splat(self.inv_scale);
+        let v_len = S::len();
 
-        while n >= S::LEN {
+        while n >= v_len {
             let q = S::load(src_ptr)
                 .mul(scale_vec)
                 .to_int_round()
@@ -55,9 +56,9 @@ impl<'d> SimdOp for Quantize<'_, 'd, u8> {
                 .saturating_cast_u8();
             q.store(dest_ptr as *mut u8);
 
-            src_ptr = src_ptr.add(S::LEN);
-            dest_ptr = dest_ptr.add(S::LEN);
-            n -= S::LEN;
+            src_ptr = src_ptr.add(v_len);
+            dest_ptr = dest_ptr.add(v_len);
+            n -= v_len;
         }
 
         while n > 0 {

--- a/rten-vecmath/src/softmax.rs
+++ b/rten-vecmath/src/softmax.rs
@@ -64,7 +64,7 @@ impl<'a> SimdOp for Softmax<'a> {
         );
 
         // Undo the last update to `exp_sum` for unused lanes.
-        let remainder = dest.len() % S::LEN;
+        let remainder = dest.len() % S::len();
         if remainder != 0 {
             let remainder_mask = S::Mask::first_n(remainder);
             exp_sum = prev_exp_sum.blend(exp_sum, remainder_mask);

--- a/src/gemm/kernels/aarch64.rs
+++ b/src/gemm/kernels/aarch64.rs
@@ -91,7 +91,7 @@ unsafe impl Kernel<f32, f32, f32> for ArmNeonKernel {
         rows: Range<usize>,
         cols: Range<usize>,
     ) {
-        const NR_REGS: usize = vec_count::<float32x4_t>(ArmNeonKernel::NR);
+        const NR_REGS: usize = vec_count::<float32x4_t>(ArmNeonKernel::NR).unwrap();
 
         // Safety: Arm Neon instructions are supported
         let out = cast_pod_mut_slice(out).unwrap();
@@ -116,7 +116,7 @@ unsafe impl Kernel<f32, f32, f32> for ArmNeonKernel {
     ) {
         const MR: usize = ArmNeonKernel::MR;
         const NR: usize = ArmNeonKernel::NR;
-        const NR_REGS: usize = vec_count::<float32x4_t>(NR);
+        const NR_REGS: usize = vec_count::<float32x4_t>(NR).unwrap();
 
         let b = cast_pod_slice(b).unwrap();
 
@@ -243,7 +243,7 @@ macro_rules! impl_arm_int8_common {
             cols: Range<usize>,
         ) {
             // Safety: Arm Neon is supported
-            const NR_REGS: usize = vec_count::<int32x4_t>(<$self_type>::NR);
+            const NR_REGS: usize = vec_count::<int32x4_t>(<$self_type>::NR).unwrap();
             unsafe { image.pack_block_i8_dot_cast_u8::<int32x4_t, NR_REGS>(out, rows, cols) }
         }
     };
@@ -298,7 +298,7 @@ unsafe impl Kernel<u8, i8, i32> for ArmInt8DotKernel {
         let (a_data, a_row_sums) = packing::int8::extract_packed_a::<{ Self::MR }>(a_data);
         let (b, b_col_sums) = packing::int8::extract_packed_b::<{ Self::NR }>(b);
 
-        const NR_REGS: usize = vec_count::<int32x4_t>(ArmInt8DotKernel::NR);
+        const NR_REGS: usize = vec_count::<int32x4_t>(ArmInt8DotKernel::NR).unwrap();
         simd_int8_gemm::<_, { Self::MR }, { Self::NR }, NR_REGS>(
             tile_ptr,
             tile_row_stride,
@@ -395,7 +395,7 @@ unsafe impl Kernel<u8, i8, i32> for ArmInt8Kernel {
         let (a_data, a_row_sums) = packing::int8::extract_packed_a::<{ Self::MR }>(a_data);
         let (b, b_col_sums) = packing::int8::extract_packed_b::<{ Self::NR }>(b);
 
-        const NR_REGS: usize = vec_count::<int32x4_t>(ArmInt8Kernel::NR);
+        const NR_REGS: usize = vec_count::<int32x4_t>(ArmInt8Kernel::NR).unwrap();
         simd_int8_gemm::<_, { Self::MR }, { Self::NR }, NR_REGS>(
             tile_ptr,
             tile_row_stride,

--- a/src/gemm/kernels/generic.rs
+++ b/src/gemm/kernels/generic.rs
@@ -96,7 +96,7 @@ unsafe impl Kernel<f32, f32, f32> for GenericKernel {
         rows: Range<usize>,
         cols: Range<usize>,
     ) {
-        const NR_REGS: usize = vec_count::<f32>(GenericKernel::NR);
+        const NR_REGS: usize = vec_count::<f32>(GenericKernel::NR).unwrap();
 
         // Safety: Scalar "SIMD" types are always supported
         let out = cast_pod_mut_slice(out).unwrap();
@@ -121,7 +121,7 @@ unsafe impl Kernel<f32, f32, f32> for GenericKernel {
     ) {
         const MR: usize = GenericKernel::MR;
         const NR: usize = GenericKernel::NR;
-        const NR_REGS: usize = vec_count::<f32>(NR);
+        const NR_REGS: usize = vec_count::<f32>(NR).unwrap();
 
         let b = cast_pod_slice(b).unwrap();
         let mut tmp_tile = TempTile::<f32, MR, NR>::new();
@@ -250,7 +250,7 @@ unsafe impl Kernel<u8, i8, i32> for GenericKernel {
         rows: Range<usize>,
         cols: Range<usize>,
     ) {
-        const NR_REGS: usize = vec_count::<f32>(GenericKernel::NR);
+        const NR_REGS: usize = vec_count::<f32>(GenericKernel::NR).unwrap();
 
         // Safety: Scalar "SIMD" types are always supported
         let out = cast_pod_mut_slice(out).unwrap();

--- a/src/gemm/kernels/wasm.rs
+++ b/src/gemm/kernels/wasm.rs
@@ -95,7 +95,7 @@ unsafe impl Kernel<f32, f32, f32> for WasmKernel {
         rows: Range<usize>,
         cols: Range<usize>,
     ) {
-        const NR_REGS: usize = vec_count::<v128f>(WasmKernel::NR);
+        const NR_REGS: usize = vec_count::<v128f>(WasmKernel::NR).unwrap();
 
         // Safety: WASM SIMD types are supported
         let out = cast_pod_mut_slice(out).unwrap();
@@ -120,7 +120,7 @@ unsafe impl Kernel<f32, f32, f32> for WasmKernel {
     ) {
         const MR: usize = WasmKernel::MR;
         const NR: usize = WasmKernel::NR;
-        const NR_REGS: usize = vec_count::<v128f>(NR);
+        const NR_REGS: usize = vec_count::<v128f>(NR).unwrap();
 
         let b = cast_pod_slice(b).unwrap();
         let mut tmp_tile = TempTile::<f32, MR, NR>::new();
@@ -261,7 +261,7 @@ unsafe impl Kernel<u8, i8, i32> for WasmInt8Kernel {
         rows: Range<usize>,
         cols: Range<usize>,
     ) {
-        const NR_REGS: usize = vec_count::<v128f>(WasmInt8Kernel::NR);
+        const NR_REGS: usize = vec_count::<v128f>(WasmInt8Kernel::NR).unwrap();
 
         // Safety: WASM SIMD is supported.
         unsafe {
@@ -293,7 +293,7 @@ unsafe impl Kernel<u8, i8, i32> for WasmInt8Kernel {
         let (a_data, a_row_sums) = packing::int8::extract_packed_a::<{ Self::MR }>(a_data);
         let (b, b_col_sums) = packing::int8::extract_packed_b::<{ Self::NR }>(b);
 
-        const NR_REGS: usize = vec_count::<v128f>(WasmInt8Kernel::NR);
+        const NR_REGS: usize = vec_count::<v128f>(WasmInt8Kernel::NR).unwrap();
         simd_int8_gemm::<_, { Self::MR }, { Self::NR }, NR_REGS>(
             tile_ptr,
             tile_row_stride,

--- a/src/gemm/kernels/x86_64.rs
+++ b/src/gemm/kernels/x86_64.rs
@@ -145,7 +145,7 @@ unsafe impl Kernel<f32, f32, f32> for FmaKernel {
         rows: Range<usize>,
         cols: Range<usize>,
     ) {
-        const NR_REGS: usize = vec_count::<__m256i>(FmaKernel::NR);
+        const NR_REGS: usize = vec_count::<__m256i>(FmaKernel::NR).unwrap();
 
         // Safety: Kernel can only be constructed if AVX is supported
         let out = cast_pod_mut_slice(out).unwrap();
@@ -172,7 +172,7 @@ unsafe impl Kernel<f32, f32, f32> for FmaKernel {
     ) {
         const MR: usize = FmaKernel::MR;
         const NR: usize = FmaKernel::NR;
-        const NR_REGS: usize = vec_count::<__m256>(NR);
+        const NR_REGS: usize = vec_count::<__m256>(NR).unwrap();
 
         let b = cast_pod_slice(b).unwrap();
 
@@ -353,7 +353,7 @@ unsafe impl Kernel<f32, f32, f32> for Avx512Kernel {
         rows: Range<usize>,
         cols: Range<usize>,
     ) {
-        const NR_REGS: usize = vec_count::<__m512i>(Avx512Kernel::NR);
+        const NR_REGS: usize = vec_count::<__m512i>(Avx512Kernel::NR).unwrap();
 
         // Safety: Kernel can only be constructed if AVX-512 is supported.
         let out = cast_pod_mut_slice(out).unwrap();
@@ -380,7 +380,7 @@ unsafe impl Kernel<f32, f32, f32> for Avx512Kernel {
     ) {
         const MR: usize = Avx512Kernel::MR;
         const NR: usize = Avx512Kernel::NR;
-        const NR_REGS: usize = vec_count::<__m512>(NR);
+        const NR_REGS: usize = vec_count::<__m512>(NR).unwrap();
 
         let b = cast_pod_slice(b).unwrap();
 
@@ -545,7 +545,7 @@ unsafe impl Kernel<u8, i8, i32> for Avx2Int8Kernel {
             rows: Range<usize>,
             cols: Range<usize>,
         ) {
-            const NR_REGS: usize = vec_count::<__m256i>(Avx2Int8Kernel::NR);
+            const NR_REGS: usize = vec_count::<__m256i>(Avx2Int8Kernel::NR).unwrap();
 
             let out = cast_pod_mut_slice(out).unwrap();
             image.pack_block_i8_dot::<__m256i, NR_REGS>(out, rows, cols);
@@ -581,7 +581,7 @@ unsafe impl Kernel<u8, i8, i32> for Avx2Int8Kernel {
         let (a_data, a_row_sums) = packing::int8::extract_packed_a::<{ Self::MR }>(a_data);
         let (b, b_col_sums) = packing::int8::extract_packed_b::<{ Self::NR }>(b);
 
-        const NR_REGS: usize = vec_count::<__m256i>(Avx2Int8Kernel::NR);
+        const NR_REGS: usize = vec_count::<__m256i>(Avx2Int8Kernel::NR).unwrap();
         simd_int8_gemm::<_, { Self::MR }, { Self::NR }, NR_REGS>(
             tile_ptr,
             tile_row_stride,
@@ -753,7 +753,7 @@ unsafe impl Kernel<u8, i8, i32> for Avx512Int8Kernel {
             rows: Range<usize>,
             cols: Range<usize>,
         ) {
-            const NR_REGS: usize = vec_count::<__m512i>(Avx512Int8Kernel::NR);
+            const NR_REGS: usize = vec_count::<__m512i>(Avx512Int8Kernel::NR).unwrap();
 
             let out = cast_pod_mut_slice(out).unwrap();
             image.pack_block_i8_dot::<__m512i, NR_REGS>(out, rows, cols);
@@ -790,7 +790,7 @@ unsafe impl Kernel<u8, i8, i32> for Avx512Int8Kernel {
         let (a_data, a_row_sums) = packing::int8::extract_packed_a::<{ Self::MR }>(a_data);
         let (b, b_col_sums) = packing::int8::extract_packed_b::<{ Self::NR }>(b);
 
-        const NR_REGS: usize = vec_count::<__m512i>(Avx512Int8Kernel::NR);
+        const NR_REGS: usize = vec_count::<__m512i>(Avx512Int8Kernel::NR).unwrap();
         if self.have_vnni {
             simd_int8_gemm::<_, { Self::MR }, { Self::NR }, NR_REGS>(
                 tile_ptr,


### PR DESCRIPTION
Make `Simd::LEN` an `Option<usize>` to represent the possibility that the vector length is unknown at compile time, but a fixed size at runtime, and add a `Simd::len` method which returns either the compile or runtime-constant size.

Runtime-determined SIMD vector types (eg. Arm SVE, RVV) are not currently supported in Rust, but the expectation is that they will be eventually [^1]. This change is made in the hope that it will make it easier to support such types in future.

[^1]: https://github.com/davidtwco/rfcs/blob/sized-hierarchy/text/3729-sized-hierarchy.md