### PR TITLE
Replace `Simd:blend` with `Simd::select`

### DIFF
--- a/rten-simd/src/arch.rs
+++ b/rten-simd/src/arch.rs
@@ -41,10 +41,10 @@ unsafe fn simd_gather_mask<
     // Set offset to zero where masked out. `src` is required to point to
     // a non-empty buffer, so index zero can be loaded as a dummy. This avoids
     // an unpredictable branch.
-    let offsets = SI::zero().blend(offsets, mask);
+    let offsets = offsets.select(SI::zero(), mask);
     let mut offset_array = [0; LEN];
     offsets.store(offset_array.as_mut_ptr());
 
     let values: [S::Elem; LEN] = std::array::from_fn(|i| *src.add(offset_array[i] as usize));
-    S::zero().blend(S::load(values.as_ptr()), mask)
+    S::load(values.as_ptr()).select(S::zero(), mask)
 }

--- a/rten-simd/src/arch/aarch64.rs
+++ b/rten-simd/src/arch/aarch64.rs
@@ -51,8 +51,8 @@ impl Simd for int32x4_t {
     }
 
     #[inline]
-    unsafe fn blend(self, other: Self, mask: Self::Mask) -> Self {
-        vbslq_s32(mask, other, self)
+    unsafe fn select(self, other: Self, mask: Self::Mask) -> Self {
+        vbslq_s32(mask, self, other)
     }
 
     #[inline]
@@ -204,8 +204,8 @@ impl Simd for float32x4_t {
     }
 
     #[inline]
-    unsafe fn blend(self, other: Self, mask: Self::Mask) -> Self {
-        vbslq_f32(mask, other, self)
+    unsafe fn select(self, other: Self, mask: Self::Mask) -> Self {
+        vbslq_f32(mask, self, other)
     }
 
     #[inline]

--- a/rten-simd/src/arch/array.rs
+++ b/rten-simd/src/arch/array.rs
@@ -32,8 +32,8 @@ macro_rules! impl_simd_for_array {
             type Mask = [bool; N];
 
             #[inline]
-            unsafe fn blend(self, rhs: Self, mask: Self::Mask) -> Self {
-                std::array::from_fn(|i| if !mask[i] { self[i] } else { rhs[i] })
+            unsafe fn select(self, rhs: Self, mask: Self::Mask) -> Self {
+                std::array::from_fn(|i| if mask[i] { self[i] } else { rhs[i] })
             }
 
             #[inline]

--- a/rten-simd/src/arch/scalar.rs
+++ b/rten-simd/src/arch/scalar.rs
@@ -31,8 +31,8 @@ macro_rules! impl_simd {
             type Mask = bool;
 
             #[inline]
-            unsafe fn blend(self, other: Self, mask: Self::Mask) -> Self {
-                if !mask {
+            unsafe fn select(self, other: Self, mask: Self::Mask) -> Self {
+                if mask {
                     self
                 } else {
                     other

--- a/rten-simd/src/arch/wasm.rs
+++ b/rten-simd/src/arch/wasm.rs
@@ -61,8 +61,8 @@ impl Simd for v128i {
     }
 
     #[inline]
-    unsafe fn blend(self, other: Self, mask: Self::Mask) -> Self {
-        Self(v128_bitselect(other.0, self.0, mask.0))
+    unsafe fn select(self, other: Self, mask: Self::Mask) -> Self {
+        Self(v128_bitselect(self.0, other.0, mask.0))
     }
 
     #[inline]
@@ -232,8 +232,8 @@ impl Simd for v128f {
     }
 
     #[inline]
-    unsafe fn blend(self, rhs: Self, mask: Self::Mask) -> Self {
-        Self(v128_bitselect(rhs.0, self.0, mask.0))
+    unsafe fn select(self, rhs: Self, mask: Self::Mask) -> Self {
+        Self(v128_bitselect(self.0, rhs.0, mask.0))
     }
 
     #[inline]

--- a/rten-simd/src/arch/x86_64.rs
+++ b/rten-simd/src/arch/x86_64.rs
@@ -55,8 +55,8 @@ impl Simd for __m256i {
 
     #[inline]
     #[target_feature(enable = "avx2")]
-    unsafe fn blend(self, other: Self, mask: Self::Mask) -> Self {
-        _mm256_blendv_epi8(self, other, mask)
+    unsafe fn select(self, other: Self, mask: Self::Mask) -> Self {
+        _mm256_blendv_epi8(other, self, mask)
     }
 
     #[inline]
@@ -251,8 +251,8 @@ impl Simd for __m256 {
 
     #[inline]
     #[target_feature(enable = "avx2")]
-    unsafe fn blend(self, rhs: Self, mask: Self::Mask) -> Self {
-        _mm256_blendv_ps(self, rhs, transmute::<__m256i, __m256>(mask))
+    unsafe fn select(self, rhs: Self, mask: Self::Mask) -> Self {
+        _mm256_blendv_ps(rhs, self, transmute::<__m256i, __m256>(mask))
     }
 
     #[inline]
@@ -468,8 +468,8 @@ impl Simd for __m512i {
 
     #[inline]
     #[target_feature(enable = "avx512f")]
-    unsafe fn blend(self, other: Self, mask: Self::Mask) -> Self {
-        _mm512_mask_blend_epi32(mask, self, other)
+    unsafe fn select(self, other: Self, mask: Self::Mask) -> Self {
+        _mm512_mask_blend_epi32(mask, other, self)
     }
 
     #[inline]
@@ -645,8 +645,8 @@ impl Simd for __m512 {
 
     #[inline]
     #[target_feature(enable = "avx512f")]
-    unsafe fn blend(self, rhs: Self, mask: Self::Mask) -> Self {
-        _mm512_mask_blend_ps(mask, self, rhs)
+    unsafe fn select(self, rhs: Self, mask: Self::Mask) -> Self {
+        _mm512_mask_blend_ps(mask, rhs, self)
     }
 
     #[inline]

--- a/rten-simd/src/functional.rs
+++ b/rten-simd/src/functional.rs
@@ -74,7 +74,7 @@ pub unsafe fn simd_fold<S: Simd, Op: Fn(S, S) -> S>(
         let x = S::load_partial(x_ptr, n);
         let prev_accum = accum;
         let new_accum = simd_op(accum, x);
-        accum = prev_accum.blend(new_accum, n_mask);
+        accum = new_accum.select(prev_accum, n_mask);
     }
 
     accum
@@ -111,7 +111,7 @@ pub unsafe fn simd_fold_array<S: Simd, const N: usize, Op: Fn([S; N], S) -> [S; 
         let new_accum = simd_op(accum, x);
 
         for i in 0..N {
-            accum[i] = prev_accum[i].blend(new_accum[i], n_mask);
+            accum[i] = new_accum[i].select(prev_accum[i], n_mask);
         }
     }
 

--- a/rten-simd/src/vec.rs
+++ b/rten-simd/src/vec.rs
@@ -77,11 +77,11 @@ pub trait Simd: Copy {
         Self::LEN.unwrap()
     }
 
-    /// Combine elements of `self` and `rhs` according to a mask.
+    /// Combine elements of `self` and `other` according to a mask.
     ///
-    /// For each lane, if the mask value is zero, return the element from
+    /// For each lane, if the mask value is one, return the element from
     /// `self`, otherwise return the value from `other`.
-    unsafe fn blend(self, other: Self, mask: Self::Mask) -> Self;
+    unsafe fn select(self, other: Self, mask: Self::Mask) -> Self;
 
     /// Broadcast `val` to all elements in a new vector.
     ///

--- a/rten-vecmath/src/erf.rs
+++ b/rten-vecmath/src/erf.rs
@@ -25,7 +25,7 @@ impl SimdUnaryOp for Erf {
         let neg_mask = x.lt(S::zero());
 
         // x = x.abs()
-        let x = x.blend(x.neg(), neg_mask);
+        let x = x.neg().select(x, neg_mask);
 
         let p = S::splat(0.3275911);
 
@@ -49,7 +49,7 @@ impl SimdUnaryOp for Erf {
 
         // Approximation is valid only for x >= 0. For negative values approximation
         // can be computed as -erf(-x).
-        y.blend(y.neg(), neg_mask)
+        y.neg().select(y, neg_mask)
     }
 }
 

--- a/rten-vecmath/src/exp.rs
+++ b/rten-vecmath/src/exp.rs
@@ -104,7 +104,7 @@ impl SimdUnaryOp for Exp {
         let x7f = S::Int::splat(0x7f000000);
         #[allow(overflowing_literals)]
         let x83 = S::Int::splat(0x83000000);
-        let ia = x83.blend(S::Int::zero(), ia);
+        let ia = S::Int::zero().select(x83, ia);
         let is = ia.add(x7f);
 
         let it = k.shl::<23>();
@@ -118,8 +118,8 @@ impl SimdUnaryOp for Exp {
         // Handle overflow and underflow when `x.abs() >= 104.`
         let overflow_mask = x.ge(S::splat(104.0));
         let underflow_mask = x.le(S::splat(-104.0));
-        let r = r.blend(S::splat(f32::INFINITY), overflow_mask);
-        r.blend(S::zero(), underflow_mask)
+        let r = S::splat(f32::INFINITY).select(r, overflow_mask);
+        S::zero().select(r, underflow_mask)
     }
 }
 

--- a/rten-vecmath/src/softmax.rs
+++ b/rten-vecmath/src/softmax.rs
@@ -67,7 +67,7 @@ impl<'a> SimdOp for Softmax<'a> {
         let remainder = dest.len() % S::len();
         if remainder != 0 {
             let remainder_mask = S::Mask::first_n(remainder);
-            exp_sum = prev_exp_sum.blend(exp_sum, remainder_mask);
+            exp_sum = exp_sum.select(prev_exp_sum, remainder_mask);
         }
 
         // *x /= exp_sum

--- a/rten-vecmath/src/tanh.rs
+++ b/rten-vecmath/src/tanh.rs
@@ -53,12 +53,12 @@ impl SimdUnaryOp for Tanh {
         let y_medium = exp_2x_m1.div(exp_2x_p1);
 
         // Select output to use depending on |x|.
-        let y = y_medium.blend(S::one(), x_cutoff);
-        let y = y.blend(y_small, x_small);
-        let y = y.blend(abs_x, x_tiny);
+        let y = S::one().select(y_medium, x_cutoff);
+        let y = y_small.select(y, x_small);
+        let y = abs_x.select(y, x_tiny);
 
         // Flip sign if input was negative.
-        y.blend(y.neg(), x_negative)
+        y.neg().select(y, x_negative)
     }
 }
 

--- a/src/gemm/im2col.rs
+++ b/src/gemm/im2col.rs
@@ -173,7 +173,7 @@ impl<T: Copy + Default> Im2Col<'_, T> {
 
                     // Set offsets to zero for padding elements. We require
                     // this offset is always valid.
-                    let offsets_array = zero.blend(offsets, pad_mask).to_array();
+                    let offsets_array = offsets.select(zero, pad_mask).to_array();
                     let pad_mask_array = pad_mask.to_array();
 
                     // Gather elements and store in packing buffer.
@@ -301,7 +301,7 @@ impl Im2Col<'_, i8> {
 
                         // Set offsets to zero for padding elements. We require
                         // this offset is always valid.
-                        let offsets_array = zero.blend(offsets, pad_mask).to_array();
+                        let offsets_array = offsets.select(zero, pad_mask).to_array();
 
                         for idx in 0..S::len() {
                             let out_ptr =


### PR DESCRIPTION
`Simd::select` has the same function but the opposite operand order.

The operand order and naming used by `blend` align with the x86-64 intrinsics. The order and naming used by `select` aligns more closely with the Arm, wasm32 and Rust `std::simd` functions, and to me feels more intuitive.