### PR TITLE
Introduce safe SIMD API, port some simple vectorized operations to use it

### DIFF
--- a/rten-simd/src/lib.rs
+++ b/rten-simd/src/lib.rs
@@ -35,6 +35,8 @@ pub mod isa_detection;
 pub mod span;
 mod vec;
 
+pub mod safe;
+
 pub use vec::{vec_count, Simd, SimdFloat, SimdInt, SimdMask};
 
 #[cfg(feature = "avx512")]

--- a/rten-simd/src/safe.rs
+++ b/rten-simd/src/safe.rs
@@ -1,0 +1,166 @@
+//! Portable SIMD library.
+//!
+//! _This module contains a new portable SIMD API which is in development. The
+//! focus is to revise the API to reduce the amount of unsafe code needed when
+//! using it._
+//!
+//! rten-simd is a library for defining operations that are accelerated using
+//! [SIMD](https://en.wikipedia.org/wiki/Single_instruction,_multiple_data)
+//! instructions such as AVX2, Arm Neon or WebAssembly SIMD. These operations
+//! can be defined once and then evaluated using the preferred instruction set
+//! at runtime, depending on the platform and available CPU instructions.
+//!
+//! The design is inspired by Google's
+//! [Highway](https://github.com/google/highway) library for C++ and the
+//! [pulp](https://docs.rs/pulp/latest/pulp/) crate.
+//!
+//! ## Example
+//!
+//! This code defines an operation which squares each value in a slice and
+//! evaluates it on a vector of floats:
+//!
+//! ```
+//! use rten_simd::safe::{Isa, SimdOp, SimdOps};
+//! use rten_simd::safe::functional::simd_map;
+//!
+//! struct Square<'a> {
+//!     xs: &'a mut [f32],
+//! }
+//!
+//! impl<'a> SimdOp for Square<'a> {
+//!     type Output = &'a mut [f32];
+//!
+//!     #[inline(always)]
+//!     fn eval<I: Isa>(self, isa: I) -> Self::Output {
+//!         let ops = isa.f32();
+//!         simd_map(ops, self.xs, |x| ops.mul(x, x))
+//!     }
+//! }
+//!
+//! let mut buf: Vec<_> = (0..32).map(|x| x as f32).collect();
+//! let expected: Vec<_> = buf.iter().map(|x| *x * *x).collect();
+//! let squared = Square { xs: &mut buf }.dispatch();
+//! assert_eq!(squared, &expected);
+//! ```
+//!
+//! The above may use AVX2 on an x86 system, Arm Neon on aarch64 and WASM SIMD
+//! on wasm32. In the `simd_map` callback, `x` is the SIMD vector for the chosen
+//! instruction set.
+//!
+//! This example shows the basic steps to define a vectorized operation:
+//!
+//! 1. Create a struct containing the operation's parameters.
+//! 2. Implement the [`SimdOp`] trait for the struct to define how to evaluate
+//!    the operation.
+//! 3. Call [`SimdOp::dispatch`] to select the preferred SIMD instruction set and
+//!    evaluate the operation using it.
+//!
+//! ## Separation of SIMD vector types and operations
+//!
+//! SIMD vectors are effectively arrays (like `[T; N]`) with a specific
+//! alignment. A SIMD vector type can be created whether or not the associated
+//! instructions are supported on the system.
+//!
+//! Performing a SIMD operation however requires the caller to first ensure that
+//! the instructions are supported on the current system. To enforce this,
+//! operations are separated from the vector type, and types providing access to
+//! SIMD operations ([`Isa`]) can only be instantiated if the instruction set is
+//! supported.
+//!
+//! ## Key traits
+//!
+//! The [`SimdOp`] trait defines an _operation_ which can be vectorized using
+//! different SIMD instruction sets.
+//!
+//! An instance of the [`Isa`] trait is passed to the operation when it is
+//! evaluated. This instance provides access to different implementations of
+//! the [`SimdOps`] trait and sub-traits, which provide operations on SIMD
+//! vectors with different data types. The [`SimdOps`] trait provides operations
+//! that are available on all SIMD vectors. The sub-traits [`SimdFloatOps`]
+//! and [`SimdIntOps`] provide operations that are only available on SIMD
+//! vectors with float and integer elements respectively.
+//!
+//! ## Applying SIMD operations to slices
+//!
+//! SIMD operations are usually applied to a slice of elements. To assist this,
+//! the [`SimdIterable`] trait provides a way to iterate over SIMD vector-sized
+//! chunks of a slice.
+//!
+//! The [`functional`] module provides utilities for defining vectorized
+//! transforms on slices (eg. [`simd_map`](functional::simd_map)).
+mod arch;
+mod dispatch;
+pub mod functional;
+mod iter;
+mod vec;
+
+pub use dispatch::{SimdOp, SimdUnaryOp};
+pub use iter::{Iter, SimdIterable};
+pub use vec::{Elem, Isa, Mask, Simd, SimdFloatOps, SimdIntOps, SimdOps};
+
+#[cfg(test)]
+pub(crate) use dispatch::test_simd_op;
+
+/// Test that two [`Simd`] vectors are equal according to a [`PartialEq`]
+/// comparison of their array representations.
+#[cfg(test)]
+macro_rules! assert_simd_eq {
+    ($x:expr, $y:expr) => {
+        assert_eq!($x.to_array(), $y.to_array());
+    };
+}
+
+#[cfg(test)]
+pub(crate) use assert_simd_eq;
+
+#[cfg(test)]
+mod tests {
+    use super::functional::simd_map;
+    use super::{Isa, SimdOp, SimdOps};
+
+    #[test]
+    fn test_simd_f32_op() {
+        struct Square<'a> {
+            xs: &'a mut [f32],
+        }
+
+        impl<'a> SimdOp for Square<'a> {
+            type Output = &'a mut [f32];
+
+            fn eval<I: Isa>(self, isa: I) -> Self::Output {
+                let ops = isa.f32();
+                simd_map(ops, self.xs, |x| ops.mul(x, x))
+            }
+        }
+
+        let mut buf: Vec<_> = (0..32).map(|x| x as f32).collect();
+        let expected: Vec<_> = buf.iter().map(|x| *x * *x).collect();
+
+        let squared = Square { xs: &mut buf }.dispatch();
+
+        assert_eq!(squared, &expected);
+    }
+
+    #[test]
+    fn test_simd_i32_op() {
+        struct Square<'a> {
+            xs: &'a mut [i32],
+        }
+
+        impl<'a> SimdOp for Square<'a> {
+            type Output = &'a mut [i32];
+
+            fn eval<I: Isa>(self, isa: I) -> Self::Output {
+                let ops = isa.i32();
+                simd_map(ops, self.xs, |x| ops.mul(x, x))
+            }
+        }
+
+        let mut buf: Vec<_> = (0..32).collect();
+        let expected: Vec<_> = buf.iter().map(|x| *x * *x).collect();
+
+        let squared = Square { xs: &mut buf }.dispatch();
+
+        assert_eq!(squared, &expected);
+    }
+}

--- a/rten-simd/src/safe/arch.rs
+++ b/rten-simd/src/safe/arch.rs
@@ -1,0 +1,11 @@
+#[cfg(target_arch = "aarch64")]
+pub mod aarch64;
+
+#[cfg(target_arch = "x86_64")]
+pub mod x86_64;
+
+#[cfg(target_arch = "wasm32")]
+#[cfg(target_feature = "simd128")]
+pub mod wasm32;
+
+pub mod generic;

--- a/rten-simd/src/safe/arch/aarch64.rs
+++ b/rten-simd/src/safe/arch/aarch64.rs
@@ -1,0 +1,313 @@
+use std::arch::aarch64::{
+    float32x4_t, int32x4_t, uint32x4_t, vaddq_f32, vaddq_s32, vbslq_f32, vbslq_s32, vceqq_f32,
+    vceqq_s32, vcgeq_f32, vcgeq_s32, vcgtq_f32, vcgtq_s32, vcleq_f32, vcleq_s32, vcltq_f32,
+    vcltq_s32, vcvtq_s32_f32, vdivq_f32, vdupq_n_f32, vdupq_n_s32, vfmaq_f32, vld1q_f32, vld1q_s32,
+    vld1q_u32, vmaxq_f32, vminq_f32, vmulq_f32, vmulq_s32, vnegq_f32, vnegq_s32, vshlq_n_s32,
+    vst1q_f32, vst1q_s32, vsubq_f32, vsubq_s32,
+};
+use std::mem::transmute;
+
+use crate::safe::{Isa, Mask, Simd, SimdFloatOps, SimdIntOps, SimdOps};
+
+#[derive(Copy, Clone)]
+pub struct ArmNeonIsa {
+    _private: (),
+}
+
+impl ArmNeonIsa {
+    pub fn new() -> Option<Self> {
+        Some(ArmNeonIsa { _private: () })
+    }
+}
+
+// Safety: Neon is supported, as it is a required feature of aarch64.
+unsafe impl Isa for ArmNeonIsa {
+    type F32 = float32x4_t;
+    type I32 = int32x4_t;
+    type Bits = int32x4_t;
+
+    fn f32(self) -> impl SimdFloatOps<Self::F32, Int = Self::I32> {
+        self
+    }
+
+    fn i32(self) -> impl SimdIntOps<Self::I32> {
+        self
+    }
+}
+
+macro_rules! simd_ops_x32_common {
+    ($simd:ty) => {
+        #[inline]
+        fn len(self) -> usize {
+            4
+        }
+
+        #[inline]
+        fn first_n_mask(self, n: usize) -> uint32x4_t {
+            let mask: [u32; 4] = std::array::from_fn(|i| if i < n { u32::MAX } else { 0 });
+            unsafe { vld1q_u32(mask.as_ptr()) }
+        }
+
+        #[inline]
+        unsafe fn load_ptr_mask(
+            self,
+            ptr: *const <$simd as Simd>::Elem,
+            mask: uint32x4_t,
+        ) -> $simd {
+            let mask_array = mask.to_array();
+            let mut vec = <Self as SimdOps<$simd>>::zero(self).to_array();
+            for i in 0..mask_array.len() {
+                if mask_array[i] {
+                    vec[i] = *ptr.add(i);
+                }
+            }
+            self.load_ptr(vec.as_ref().as_ptr())
+        }
+
+        #[inline]
+        unsafe fn store_ptr_mask(
+            self,
+            x: $simd,
+            ptr: *mut <$simd as Simd>::Elem,
+            mask: <$simd as Simd>::Mask,
+        ) {
+            let mask_array = mask.to_array();
+            let x_array = x.to_array();
+            for i in 0..<Self as SimdOps<$simd>>::len(self) {
+                if mask_array[i] {
+                    *ptr.add(i) = x_array[i];
+                }
+            }
+        }
+    };
+}
+
+unsafe impl SimdOps<float32x4_t> for ArmNeonIsa {
+    simd_ops_x32_common!(float32x4_t);
+
+    #[inline]
+    fn add(self, x: float32x4_t, y: float32x4_t) -> float32x4_t {
+        unsafe { vaddq_f32(x, y) }
+    }
+
+    #[inline]
+    fn sub(self, x: float32x4_t, y: float32x4_t) -> float32x4_t {
+        unsafe { vsubq_f32(x, y) }
+    }
+
+    #[inline]
+    fn mul(self, x: float32x4_t, y: float32x4_t) -> float32x4_t {
+        unsafe { vmulq_f32(x, y) }
+    }
+
+    #[inline]
+    fn mul_add(self, a: float32x4_t, b: float32x4_t, c: float32x4_t) -> float32x4_t {
+        unsafe { vfmaq_f32(c, a, b) }
+    }
+
+    #[inline]
+    fn lt(self, x: float32x4_t, y: float32x4_t) -> uint32x4_t {
+        unsafe { vcltq_f32(x, y) }
+    }
+
+    #[inline]
+    fn le(self, x: float32x4_t, y: float32x4_t) -> uint32x4_t {
+        unsafe { vcleq_f32(x, y) }
+    }
+
+    #[inline]
+    fn eq(self, x: float32x4_t, y: float32x4_t) -> uint32x4_t {
+        unsafe { vceqq_f32(x, y) }
+    }
+
+    #[inline]
+    fn ge(self, x: float32x4_t, y: float32x4_t) -> uint32x4_t {
+        unsafe { vcgeq_f32(x, y) }
+    }
+
+    #[inline]
+    fn gt(self, x: float32x4_t, y: float32x4_t) -> uint32x4_t {
+        unsafe { vcgtq_f32(x, y) }
+    }
+
+    #[inline]
+    fn min(self, x: float32x4_t, y: float32x4_t) -> float32x4_t {
+        unsafe { vminq_f32(x, y) }
+    }
+
+    #[inline]
+    fn max(self, x: float32x4_t, y: float32x4_t) -> float32x4_t {
+        unsafe { vmaxq_f32(x, y) }
+    }
+
+    #[inline]
+    fn splat(self, x: f32) -> float32x4_t {
+        unsafe { vdupq_n_f32(x) }
+    }
+
+    #[inline]
+    unsafe fn load_ptr(self, ptr: *const f32) -> float32x4_t {
+        unsafe { vld1q_f32(ptr) }
+    }
+
+    #[inline]
+    fn select(
+        self,
+        x: float32x4_t,
+        y: float32x4_t,
+        mask: <float32x4_t as Simd>::Mask,
+    ) -> float32x4_t {
+        unsafe { vbslq_f32(mask, x, y) }
+    }
+
+    #[inline]
+    unsafe fn store_ptr(self, x: float32x4_t, ptr: *mut f32) {
+        unsafe { vst1q_f32(ptr, x) }
+    }
+}
+
+impl SimdFloatOps<float32x4_t> for ArmNeonIsa {
+    type Int = <Self as Isa>::I32;
+
+    #[inline]
+    fn div(self, x: float32x4_t, y: float32x4_t) -> float32x4_t {
+        unsafe { vdivq_f32(x, y) }
+    }
+
+    #[inline]
+    fn neg(self, x: float32x4_t) -> float32x4_t {
+        unsafe { vnegq_f32(x) }
+    }
+
+    #[inline]
+    fn to_int_trunc(self, x: float32x4_t) -> Self::Int {
+        unsafe { vcvtq_s32_f32(x) }
+    }
+}
+
+unsafe impl SimdOps<int32x4_t> for ArmNeonIsa {
+    simd_ops_x32_common!(int32x4_t);
+
+    #[inline]
+    fn add(self, x: int32x4_t, y: int32x4_t) -> int32x4_t {
+        unsafe { vaddq_s32(x, y) }
+    }
+
+    #[inline]
+    fn sub(self, x: int32x4_t, y: int32x4_t) -> int32x4_t {
+        unsafe { vsubq_s32(x, y) }
+    }
+
+    #[inline]
+    fn mul(self, x: int32x4_t, y: int32x4_t) -> int32x4_t {
+        unsafe { vmulq_s32(x, y) }
+    }
+
+    #[inline]
+    fn splat(self, x: i32) -> int32x4_t {
+        unsafe { vdupq_n_s32(x) }
+    }
+
+    #[inline]
+    fn lt(self, x: int32x4_t, y: int32x4_t) -> uint32x4_t {
+        unsafe { vcltq_s32(x, y) }
+    }
+
+    #[inline]
+    fn le(self, x: int32x4_t, y: int32x4_t) -> uint32x4_t {
+        unsafe { vcleq_s32(x, y) }
+    }
+
+    #[inline]
+    fn eq(self, x: int32x4_t, y: int32x4_t) -> uint32x4_t {
+        unsafe { vceqq_s32(x, y) }
+    }
+
+    #[inline]
+    fn ge(self, x: int32x4_t, y: int32x4_t) -> uint32x4_t {
+        unsafe { vcgeq_s32(x, y) }
+    }
+
+    #[inline]
+    fn gt(self, x: int32x4_t, y: int32x4_t) -> uint32x4_t {
+        unsafe { vcgtq_s32(x, y) }
+    }
+
+    #[inline]
+    unsafe fn load_ptr(self, ptr: *const i32) -> int32x4_t {
+        unsafe { vld1q_s32(ptr) }
+    }
+
+    #[inline]
+    fn select(self, x: int32x4_t, y: int32x4_t, mask: <int32x4_t as Simd>::Mask) -> int32x4_t {
+        unsafe { vbslq_s32(mask, x, y) }
+    }
+
+    #[inline]
+    unsafe fn store_ptr(self, x: int32x4_t, ptr: *mut i32) {
+        unsafe { vst1q_s32(ptr, x) }
+    }
+}
+
+impl SimdIntOps<int32x4_t> for ArmNeonIsa {
+    #[inline]
+    fn neg(self, x: int32x4_t) -> int32x4_t {
+        unsafe { vnegq_s32(x) }
+    }
+
+    #[inline]
+    fn shift_left<const SHIFT: i32>(self, x: int32x4_t) -> int32x4_t {
+        unsafe { vshlq_n_s32::<SHIFT>(x) }
+    }
+}
+
+impl Mask for uint32x4_t {
+    type Array = [bool; 4];
+
+    #[inline]
+    fn to_array(self) -> Self::Array {
+        let array = unsafe { transmute::<Self, [u32; 4]>(self) };
+        std::array::from_fn(|i| array[i] != 0)
+    }
+}
+
+macro_rules! simd_x32_common {
+    () => {
+        type Array = [Self::Elem; 4];
+        type Mask = uint32x4_t;
+        type Isa = ArmNeonIsa;
+
+        #[inline]
+        fn to_bits(self) -> <Self::Isa as Isa>::Bits {
+            #[allow(clippy::useless_transmute)]
+            unsafe {
+                transmute::<Self, int32x4_t>(self)
+            }
+        }
+
+        #[inline]
+        fn from_bits(bits: <Self::Isa as Isa>::Bits) -> Self {
+            #[allow(clippy::useless_transmute)]
+            unsafe {
+                transmute::<int32x4_t, Self>(bits)
+            }
+        }
+
+        #[inline]
+        fn to_array(self) -> Self::Array {
+            unsafe { transmute::<Self, Self::Array>(self) }
+        }
+    };
+}
+
+impl Simd for float32x4_t {
+    type Elem = f32;
+
+    simd_x32_common!();
+}
+
+impl Simd for int32x4_t {
+    type Elem = i32;
+
+    simd_x32_common!();
+}

--- a/rten-simd/src/safe/arch/generic.rs
+++ b/rten-simd/src/safe/arch/generic.rs
@@ -1,0 +1,273 @@
+use std::array;
+use std::mem::transmute;
+
+const LEN: usize = 4;
+
+#[repr(align(16))]
+#[derive(Copy, Clone, Debug)]
+pub struct I32x4([i32; LEN]);
+
+#[repr(align(16))]
+#[derive(Copy, Clone, Debug)]
+pub struct F32x4([f32; LEN]);
+
+use crate::safe::{Isa, Mask, Simd, SimdFloatOps, SimdIntOps, SimdOps};
+
+#[derive(Copy, Clone)]
+pub struct GenericIsa {
+    _private: (),
+}
+
+impl GenericIsa {
+    pub fn new() -> Self {
+        GenericIsa { _private: () }
+    }
+}
+
+// Safety: Instructions used by generic ISA are always supported.
+unsafe impl Isa for GenericIsa {
+    type F32 = F32x4;
+    type I32 = I32x4;
+    type Bits = I32x4;
+
+    fn f32(self) -> impl SimdFloatOps<Self::F32, Int = Self::I32> {
+        self
+    }
+
+    fn i32(self) -> impl SimdIntOps<Self::I32> {
+        self
+    }
+}
+
+macro_rules! simd_ops_x32_common {
+    ($simd:ident, $elem:ty) => {
+        #[inline]
+        fn len(self) -> usize {
+            LEN
+        }
+
+        #[inline]
+        fn first_n_mask(self, n: usize) -> <$simd as Simd>::Mask {
+            let mask: [i32; LEN] = std::array::from_fn(|i| if i < n { -1 } else { 0 });
+            I32x4(mask)
+        }
+
+        #[inline]
+        unsafe fn load_ptr_mask(
+            self,
+            ptr: *const <$simd as Simd>::Elem,
+            mask: <$simd as Simd>::Mask,
+        ) -> $simd {
+            let mask_array = mask.0;
+            let mut vec = <Self as SimdOps<$simd>>::zero(self).0;
+            for i in 0..mask_array.len() {
+                if mask_array[i] != 0 {
+                    vec[i] = *ptr.add(i);
+                }
+            }
+            self.load_ptr(vec.as_ref().as_ptr())
+        }
+
+        #[inline]
+        unsafe fn store_ptr_mask(
+            self,
+            x: $simd,
+            ptr: *mut <$simd as Simd>::Elem,
+            mask: <$simd as Simd>::Mask,
+        ) {
+            let mask_array = mask.0;
+            let x_array = x.0;
+            for i in 0..<Self as SimdOps<$simd>>::len(self) {
+                if mask_array[i] != 0 {
+                    *ptr.add(i) = x_array[i];
+                }
+            }
+        }
+
+        #[inline]
+        fn add(self, x: $simd, y: $simd) -> $simd {
+            let xs = array::from_fn(|i| x.0[i] + y.0[i]);
+            $simd(xs)
+        }
+
+        #[inline]
+        fn sub(self, x: $simd, y: $simd) -> $simd {
+            let xs = array::from_fn(|i| x.0[i] - y.0[i]);
+            $simd(xs)
+        }
+
+        #[inline]
+        fn mul(self, x: $simd, y: $simd) -> $simd {
+            let xs = array::from_fn(|i| x.0[i] * y.0[i]);
+            $simd(xs)
+        }
+
+        #[inline]
+        fn mul_add(self, a: $simd, b: $simd, c: $simd) -> $simd {
+            let xs = array::from_fn(|i| a.0[i] * b.0[i] + c.0[i]);
+            $simd(xs)
+        }
+
+        #[inline]
+        fn lt(self, x: $simd, y: $simd) -> I32x4 {
+            let xs = array::from_fn(|i| if x.0[i] < y.0[i] { -1 } else { 0 });
+            I32x4(xs)
+        }
+
+        #[inline]
+        fn le(self, x: $simd, y: $simd) -> I32x4 {
+            let xs = array::from_fn(|i| if x.0[i] <= y.0[i] { -1 } else { 0 });
+            I32x4(xs)
+        }
+
+        #[inline]
+        fn eq(self, x: $simd, y: $simd) -> I32x4 {
+            let xs = array::from_fn(|i| if x.0[i] == y.0[i] { -1 } else { 0 });
+            I32x4(xs)
+        }
+
+        #[inline]
+        fn ge(self, x: $simd, y: $simd) -> I32x4 {
+            let xs = array::from_fn(|i| if x.0[i] >= y.0[i] { -1 } else { 0 });
+            I32x4(xs)
+        }
+
+        #[inline]
+        fn gt(self, x: $simd, y: $simd) -> I32x4 {
+            let xs = array::from_fn(|i| if x.0[i] > y.0[i] { -1 } else { 0 });
+            I32x4(xs)
+        }
+
+        #[inline]
+        fn min(self, x: $simd, y: $simd) -> $simd {
+            let xs = array::from_fn(|i| x.0[i].min(y.0[i]));
+            $simd(xs)
+        }
+
+        #[inline]
+        fn max(self, x: $simd, y: $simd) -> $simd {
+            let xs = array::from_fn(|i| x.0[i].max(y.0[i]));
+            $simd(xs)
+        }
+
+        #[inline]
+        fn splat(self, x: $elem) -> $simd {
+            $simd([x; LEN])
+        }
+
+        #[inline]
+        unsafe fn load_ptr(self, ptr: *const $elem) -> $simd {
+            let xs = array::from_fn(|i| *ptr.add(i));
+            $simd(xs)
+        }
+
+        #[inline]
+        fn select(self, x: $simd, y: $simd, mask: <$simd as Simd>::Mask) -> $simd {
+            let xs = array::from_fn(|i| if mask.0[i] != 0 { x.0[i] } else { y.0[i] });
+            $simd(xs)
+        }
+
+        #[inline]
+        unsafe fn store_ptr(self, x: $simd, ptr: *mut $elem) {
+            for i in 0..LEN {
+                *ptr.add(i) = x.0[i];
+            }
+        }
+    };
+}
+
+unsafe impl SimdOps<F32x4> for GenericIsa {
+    simd_ops_x32_common!(F32x4, f32);
+}
+
+impl SimdFloatOps<F32x4> for GenericIsa {
+    type Int = <Self as Isa>::I32;
+
+    #[inline]
+    fn div(self, x: F32x4, y: F32x4) -> F32x4 {
+        let xs = array::from_fn(|i| x.0[i] / y.0[i]);
+        F32x4(xs)
+    }
+
+    #[inline]
+    fn neg(self, x: F32x4) -> F32x4 {
+        let xs = array::from_fn(|i| -x.0[i]);
+        F32x4(xs)
+    }
+
+    #[inline]
+    fn to_int_trunc(self, x: F32x4) -> Self::Int {
+        let xs = array::from_fn(|i| x.0[i] as i32);
+        I32x4(xs)
+    }
+}
+
+unsafe impl SimdOps<I32x4> for GenericIsa {
+    simd_ops_x32_common!(I32x4, i32);
+}
+
+impl SimdIntOps<I32x4> for GenericIsa {
+    #[inline]
+    fn neg(self, x: I32x4) -> I32x4 {
+        let xs = array::from_fn(|i| -x.0[i]);
+        I32x4(xs)
+    }
+
+    #[inline]
+    fn shift_left<const SHIFT: i32>(self, x: I32x4) -> I32x4 {
+        let xs = array::from_fn(|i| x.0[i] << SHIFT);
+        I32x4(xs)
+    }
+}
+
+impl Mask for I32x4 {
+    type Array = [bool; LEN];
+
+    #[inline]
+    fn to_array(self) -> Self::Array {
+        let array = self.0;
+        std::array::from_fn(|i| array[i] != 0)
+    }
+}
+
+macro_rules! simd_x32_common {
+    ($simd:ty, $elem:ty) => {
+        type Array = [$elem; LEN];
+        type Mask = I32x4;
+        type Isa = GenericIsa;
+
+        #[inline]
+        fn to_bits(self) -> <Self::Isa as Isa>::Bits {
+            #[allow(clippy::useless_transmute)]
+            I32x4(unsafe { transmute::<[$elem; LEN], [i32; LEN]>(self.0) })
+        }
+
+        #[inline]
+        fn from_bits(bits: <Self::Isa as Isa>::Bits) -> Self {
+            #[allow(clippy::useless_transmute)]
+            Self(unsafe { transmute::<[i32; LEN], [$elem; LEN]>(bits.0) })
+        }
+    };
+}
+
+impl Simd for F32x4 {
+    type Elem = f32;
+
+    simd_x32_common!(F32x4, f32);
+
+    #[inline]
+    fn to_array(self) -> Self::Array {
+        self.0
+    }
+}
+
+impl Simd for I32x4 {
+    type Elem = i32;
+
+    simd_x32_common!(I32x4, i32);
+
+    #[inline]
+    fn to_array(self) -> Self::Array {
+        self.0
+    }
+}

--- a/rten-simd/src/safe/arch/wasm32.rs
+++ b/rten-simd/src/safe/arch/wasm32.rs
@@ -1,0 +1,324 @@
+use std::arch::wasm32::{
+    f32x4_add, f32x4_div, f32x4_eq, f32x4_ge, f32x4_gt, f32x4_le, f32x4_lt, f32x4_max, f32x4_min,
+    f32x4_mul, f32x4_neg, f32x4_splat, f32x4_sub, i32x4_add, i32x4_eq, i32x4_ge, i32x4_gt,
+    i32x4_le, i32x4_lt, i32x4_mul, i32x4_neg, i32x4_shl, i32x4_splat, i32x4_sub,
+    i32x4_trunc_sat_f32x4, v128, v128_bitselect, v128_load, v128_store,
+};
+use std::mem::transmute;
+
+use crate::safe::{Isa, Mask, Simd, SimdFloatOps, SimdIntOps, SimdOps};
+
+#[derive(Copy, Clone, Debug)]
+#[repr(transparent)]
+pub struct I32x4(v128);
+
+#[derive(Copy, Clone, Debug)]
+#[repr(transparent)]
+pub struct F32x4(v128);
+
+#[derive(Copy, Clone)]
+pub struct Wasm32Isa {
+    _private: (),
+}
+
+impl Wasm32Isa {
+    pub fn new() -> Option<Self> {
+        Some(Wasm32Isa { _private: () })
+    }
+}
+
+// Safety: This module is only compiled if WASM SIMD is enabled at compile
+// time, hence this module can treat SIMD as always-available.
+unsafe impl Isa for Wasm32Isa {
+    type F32 = F32x4;
+    type I32 = I32x4;
+    type Bits = I32x4;
+
+    fn f32(self) -> impl SimdFloatOps<Self::F32, Int = Self::I32> {
+        self
+    }
+
+    fn i32(self) -> impl SimdIntOps<Self::I32> {
+        self
+    }
+}
+
+macro_rules! simd_ops_x32_common {
+    ($simd:ty) => {
+        #[inline]
+        fn len(self) -> usize {
+            4
+        }
+
+        #[inline]
+        fn first_n_mask(self, n: usize) -> v128 {
+            let mask: [i32; 4] = std::array::from_fn(|i| if i < n { -1 } else { 0 });
+            unsafe { v128_load(mask.as_ptr() as *const v128) }
+        }
+
+        #[inline]
+        unsafe fn load_ptr_mask(self, ptr: *const <$simd as Simd>::Elem, mask: v128) -> $simd {
+            let mask_array = Mask::to_array(mask);
+            let mut vec = Simd::to_array(<Self as SimdOps<$simd>>::zero(self));
+            for i in 0..mask_array.len() {
+                if mask_array[i] {
+                    vec[i] = *ptr.add(i);
+                }
+            }
+            self.load_ptr(vec.as_ref().as_ptr())
+        }
+
+        #[inline]
+        unsafe fn store_ptr_mask(
+            self,
+            x: $simd,
+            ptr: *mut <$simd as Simd>::Elem,
+            mask: <$simd as Simd>::Mask,
+        ) {
+            let mask_array = Mask::to_array(mask);
+            let x_array = Simd::to_array(x);
+            for i in 0..<Self as SimdOps<$simd>>::len(self) {
+                if mask_array[i] {
+                    *ptr.add(i) = x_array[i];
+                }
+            }
+        }
+    };
+}
+
+unsafe impl SimdOps<F32x4> for Wasm32Isa {
+    simd_ops_x32_common!(F32x4);
+
+    #[inline]
+    fn add(self, x: F32x4, y: F32x4) -> F32x4 {
+        F32x4(f32x4_add(x.0, y.0))
+    }
+
+    #[inline]
+    fn sub(self, x: F32x4, y: F32x4) -> F32x4 {
+        F32x4(f32x4_sub(x.0, y.0))
+    }
+
+    #[inline]
+    fn mul(self, x: F32x4, y: F32x4) -> F32x4 {
+        F32x4(f32x4_mul(x.0, y.0))
+    }
+
+    #[inline]
+    fn mul_add(self, a: F32x4, b: F32x4, c: F32x4) -> F32x4 {
+        #[cfg(target_feature = "relaxed-simd")]
+        {
+            F32x4(f32x4_relaxed_madd(a.0, b.0, c.0))
+        }
+        #[cfg(not(target_feature = "relaxed-simd"))]
+        {
+            F32x4(f32x4_add(f32x4_mul(a.0, b.0), c.0))
+        }
+    }
+
+    #[inline]
+    fn lt(self, x: F32x4, y: F32x4) -> v128 {
+        f32x4_lt(x.0, y.0)
+    }
+
+    #[inline]
+    fn le(self, x: F32x4, y: F32x4) -> v128 {
+        f32x4_le(x.0, y.0)
+    }
+
+    #[inline]
+    fn eq(self, x: F32x4, y: F32x4) -> v128 {
+        f32x4_eq(x.0, y.0)
+    }
+
+    #[inline]
+    fn ge(self, x: F32x4, y: F32x4) -> v128 {
+        f32x4_ge(x.0, y.0)
+    }
+
+    #[inline]
+    fn gt(self, x: F32x4, y: F32x4) -> v128 {
+        f32x4_gt(x.0, y.0)
+    }
+
+    #[inline]
+    fn min(self, x: F32x4, y: F32x4) -> F32x4 {
+        F32x4(f32x4_min(x.0, y.0))
+    }
+
+    #[inline]
+    fn max(self, x: F32x4, y: F32x4) -> F32x4 {
+        F32x4(f32x4_max(x.0, y.0))
+    }
+
+    #[inline]
+    fn splat(self, x: f32) -> F32x4 {
+        F32x4(f32x4_splat(x))
+    }
+
+    #[inline]
+    unsafe fn load_ptr(self, ptr: *const f32) -> F32x4 {
+        F32x4(unsafe { v128_load(ptr as *const v128) })
+    }
+
+    #[inline]
+    fn select(self, x: F32x4, y: F32x4, mask: <F32x4 as Simd>::Mask) -> F32x4 {
+        F32x4(v128_bitselect(x.0, y.0, mask))
+    }
+
+    #[inline]
+    unsafe fn store_ptr(self, x: F32x4, ptr: *mut f32) {
+        unsafe { v128_store(ptr as *mut v128, x.0) }
+    }
+}
+
+impl SimdFloatOps<F32x4> for Wasm32Isa {
+    type Int = <Self as Isa>::I32;
+
+    #[inline]
+    fn div(self, x: F32x4, y: F32x4) -> F32x4 {
+        F32x4(f32x4_div(x.0, y.0))
+    }
+
+    #[inline]
+    fn neg(self, x: F32x4) -> F32x4 {
+        F32x4(f32x4_neg(x.0))
+    }
+
+    #[inline]
+    fn to_int_trunc(self, x: F32x4) -> Self::Int {
+        I32x4(i32x4_trunc_sat_f32x4(x.0))
+    }
+}
+
+unsafe impl SimdOps<I32x4> for Wasm32Isa {
+    simd_ops_x32_common!(I32x4);
+
+    #[inline]
+    fn add(self, x: I32x4, y: I32x4) -> I32x4 {
+        I32x4(i32x4_add(x.0, y.0))
+    }
+
+    #[inline]
+    fn sub(self, x: I32x4, y: I32x4) -> I32x4 {
+        I32x4(i32x4_sub(x.0, y.0))
+    }
+
+    #[inline]
+    fn mul(self, x: I32x4, y: I32x4) -> I32x4 {
+        I32x4(i32x4_mul(x.0, y.0))
+    }
+
+    #[inline]
+    fn splat(self, x: i32) -> I32x4 {
+        I32x4(i32x4_splat(x))
+    }
+
+    #[inline]
+    fn lt(self, x: I32x4, y: I32x4) -> v128 {
+        i32x4_lt(x.0, y.0)
+    }
+
+    #[inline]
+    fn le(self, x: I32x4, y: I32x4) -> v128 {
+        i32x4_le(x.0, y.0)
+    }
+
+    #[inline]
+    fn eq(self, x: I32x4, y: I32x4) -> v128 {
+        i32x4_eq(x.0, y.0)
+    }
+
+    #[inline]
+    fn ge(self, x: I32x4, y: I32x4) -> v128 {
+        i32x4_ge(x.0, y.0)
+    }
+
+    #[inline]
+    fn gt(self, x: I32x4, y: I32x4) -> v128 {
+        i32x4_gt(x.0, y.0)
+    }
+
+    #[inline]
+    unsafe fn load_ptr(self, ptr: *const i32) -> I32x4 {
+        I32x4(unsafe { v128_load(ptr as *const v128) })
+    }
+
+    #[inline]
+    fn select(self, x: I32x4, y: I32x4, mask: <I32x4 as Simd>::Mask) -> I32x4 {
+        I32x4(v128_bitselect(x.0, y.0, mask))
+    }
+
+    #[inline]
+    unsafe fn store_ptr(self, x: I32x4, ptr: *mut i32) {
+        unsafe { v128_store(ptr as *mut v128, x.0) }
+    }
+}
+
+impl SimdIntOps<I32x4> for Wasm32Isa {
+    #[inline]
+    fn neg(self, x: I32x4) -> I32x4 {
+        I32x4(i32x4_neg(x.0))
+    }
+
+    #[inline]
+    fn shift_left<const SHIFT: i32>(self, x: I32x4) -> I32x4 {
+        I32x4(i32x4_shl(x.0, SHIFT as u32))
+    }
+}
+
+impl Mask for v128 {
+    type Array = [bool; 4];
+
+    #[inline]
+    fn to_array(self) -> Self::Array {
+        let array = unsafe { transmute::<Self, [i32; 4]>(self) };
+        std::array::from_fn(|i| array[i] != 0)
+    }
+}
+
+macro_rules! simd_x32_common {
+    () => {
+        type Array = [Self::Elem; 4];
+        type Mask = v128;
+        type Isa = Wasm32Isa;
+
+        #[inline]
+        fn to_bits(self) -> <Self::Isa as Isa>::Bits {
+            #[allow(clippy::useless_transmute)]
+            unsafe {
+                transmute::<Self, I32x4>(self)
+            }
+        }
+
+        #[inline]
+        fn from_bits(bits: <Self::Isa as Isa>::Bits) -> Self {
+            #[allow(clippy::useless_transmute)]
+            unsafe {
+                transmute::<I32x4, Self>(bits)
+            }
+        }
+    };
+}
+
+impl Simd for F32x4 {
+    type Elem = f32;
+
+    simd_x32_common!();
+
+    #[inline]
+    fn to_array(self) -> Self::Array {
+        unsafe { transmute::<v128, Self::Array>(self.0) }
+    }
+}
+
+impl Simd for I32x4 {
+    type Elem = i32;
+
+    simd_x32_common!();
+
+    #[inline]
+    fn to_array(self) -> Self::Array {
+        unsafe { transmute::<v128, [i32; 4]>(self.0) }
+    }
+}

--- a/rten-simd/src/safe/arch/x86_64.rs
+++ b/rten-simd/src/safe/arch/x86_64.rs
@@ -1,0 +1,309 @@
+use std::arch::x86_64::{
+    __m256, __m256i, _mm256_add_epi32, _mm256_add_ps, _mm256_blendv_epi8, _mm256_blendv_ps,
+    _mm256_cmp_ps, _mm256_cmpeq_epi32, _mm256_cmpgt_epi32, _mm256_cvttps_epi32, _mm256_div_ps,
+    _mm256_fmadd_ps, _mm256_loadu_ps, _mm256_loadu_si256, _mm256_maskload_epi32,
+    _mm256_maskload_ps, _mm256_maskstore_epi32, _mm256_maskstore_ps, _mm256_max_ps, _mm256_min_ps,
+    _mm256_mul_ps, _mm256_mullo_epi32, _mm256_or_si256, _mm256_set1_epi32, _mm256_set1_ps,
+    _mm256_setzero_si256, _mm256_slli_epi32, _mm256_storeu_ps, _mm256_storeu_si256,
+    _mm256_sub_epi32, _mm256_sub_ps, _mm256_xor_ps, _CMP_EQ_OQ, _CMP_GE_OQ, _CMP_GT_OQ, _CMP_LE_OQ,
+    _CMP_LT_OQ,
+};
+use std::is_x86_feature_detected;
+use std::mem::transmute;
+
+use crate::safe::{Isa, Mask, Simd, SimdFloatOps, SimdIntOps, SimdOps};
+
+#[derive(Copy, Clone)]
+pub struct Avx2Isa {
+    _private: (),
+}
+
+impl Avx2Isa {
+    pub fn new() -> Option<Self> {
+        if is_x86_feature_detected!("avx2") && is_x86_feature_detected!("fma") {
+            Some(Avx2Isa { _private: () })
+        } else {
+            None
+        }
+    }
+}
+
+// Safety: AVX2 is supported as `Avx2Isa::new` checks this.
+unsafe impl Isa for Avx2Isa {
+    type F32 = __m256;
+    type I32 = __m256i;
+    type Bits = __m256i;
+
+    fn f32(self) -> impl SimdFloatOps<Self::F32, Int = Self::I32> {
+        self
+    }
+
+    fn i32(self) -> impl SimdIntOps<Self::I32> {
+        self
+    }
+}
+
+macro_rules! simd_ops_x32_common {
+    ($simd:ty) => {
+        #[inline]
+        fn len(self) -> usize {
+            8
+        }
+
+        #[inline]
+        fn first_n_mask(self, n: usize) -> __m256i {
+            let mask: [i32; 8] = std::array::from_fn(|i| if i < n { -1 } else { 0 });
+            unsafe { _mm256_loadu_si256(mask.as_ptr() as *const __m256i) }
+        }
+    };
+}
+
+unsafe impl SimdOps<__m256> for Avx2Isa {
+    simd_ops_x32_common!(__m256);
+
+    #[inline]
+    fn add(self, x: __m256, y: __m256) -> __m256 {
+        unsafe { _mm256_add_ps(x, y) }
+    }
+
+    #[inline]
+    fn sub(self, x: __m256, y: __m256) -> __m256 {
+        unsafe { _mm256_sub_ps(x, y) }
+    }
+
+    #[inline]
+    fn mul(self, x: __m256, y: __m256) -> __m256 {
+        unsafe { _mm256_mul_ps(x, y) }
+    }
+
+    #[inline]
+    fn mul_add(self, a: __m256, b: __m256, c: __m256) -> __m256 {
+        unsafe { _mm256_fmadd_ps(a, b, c) }
+    }
+
+    #[inline]
+    fn lt(self, x: __m256, y: __m256) -> __m256i {
+        unsafe { transmute(_mm256_cmp_ps(x, y, _CMP_LT_OQ)) }
+    }
+
+    #[inline]
+    fn le(self, x: __m256, y: __m256) -> __m256i {
+        unsafe { transmute(_mm256_cmp_ps(x, y, _CMP_LE_OQ)) }
+    }
+
+    #[inline]
+    fn eq(self, x: __m256, y: __m256) -> __m256i {
+        unsafe { transmute(_mm256_cmp_ps(x, y, _CMP_EQ_OQ)) }
+    }
+
+    #[inline]
+    fn ge(self, x: __m256, y: __m256) -> __m256i {
+        unsafe { transmute(_mm256_cmp_ps(x, y, _CMP_GE_OQ)) }
+    }
+
+    #[inline]
+    fn gt(self, x: __m256, y: __m256) -> __m256i {
+        unsafe { transmute(_mm256_cmp_ps(x, y, _CMP_GT_OQ)) }
+    }
+
+    #[inline]
+    fn min(self, x: __m256, y: __m256) -> __m256 {
+        unsafe { _mm256_min_ps(x, y) }
+    }
+
+    #[inline]
+    fn max(self, x: __m256, y: __m256) -> __m256 {
+        unsafe { _mm256_max_ps(x, y) }
+    }
+
+    #[inline]
+    fn splat(self, x: f32) -> __m256 {
+        unsafe { _mm256_set1_ps(x) }
+    }
+
+    #[inline]
+    unsafe fn load_ptr(self, ptr: *const f32) -> __m256 {
+        unsafe { _mm256_loadu_ps(ptr) }
+    }
+
+    #[inline]
+    fn select(self, x: __m256, y: __m256, mask: <__m256 as Simd>::Mask) -> __m256 {
+        unsafe { _mm256_blendv_ps(y, x, transmute::<__m256i, __m256>(mask)) }
+    }
+
+    #[inline]
+    unsafe fn load_ptr_mask(self, ptr: *const f32, mask: __m256i) -> __m256 {
+        unsafe { _mm256_maskload_ps(ptr, mask) }
+    }
+
+    #[inline]
+    unsafe fn store_ptr_mask(self, x: __m256, ptr: *mut f32, mask: __m256i) {
+        unsafe { _mm256_maskstore_ps(ptr, mask, x) }
+    }
+
+    #[inline]
+    unsafe fn store_ptr(self, x: __m256, ptr: *mut f32) {
+        unsafe { _mm256_storeu_ps(ptr, x) }
+    }
+}
+
+impl SimdFloatOps<__m256> for Avx2Isa {
+    type Int = <Self as Isa>::I32;
+
+    #[inline]
+    fn div(self, x: __m256, y: __m256) -> __m256 {
+        unsafe { _mm256_div_ps(x, y) }
+    }
+
+    #[inline]
+    fn neg(self, x: __m256) -> __m256 {
+        unsafe { _mm256_xor_ps(x, _mm256_set1_ps(-0.0)) }
+    }
+
+    #[inline]
+    fn to_int_trunc(self, x: __m256) -> Self::Int {
+        unsafe { _mm256_cvttps_epi32(x) }
+    }
+}
+
+unsafe impl SimdOps<__m256i> for Avx2Isa {
+    simd_ops_x32_common!(__m256i);
+
+    #[inline]
+    fn add(self, x: __m256i, y: __m256i) -> __m256i {
+        unsafe { _mm256_add_epi32(x, y) }
+    }
+
+    #[inline]
+    fn sub(self, x: __m256i, y: __m256i) -> __m256i {
+        unsafe { _mm256_sub_epi32(x, y) }
+    }
+
+    #[inline]
+    fn mul(self, x: __m256i, y: __m256i) -> __m256i {
+        unsafe { _mm256_mullo_epi32(x, y) }
+    }
+
+    #[inline]
+    fn splat(self, x: i32) -> __m256i {
+        unsafe { _mm256_set1_epi32(x) }
+    }
+
+    #[inline]
+    fn lt(self, x: __m256i, y: __m256i) -> __m256i {
+        unsafe { _mm256_cmpgt_epi32(y, x) }
+    }
+
+    #[inline]
+    fn le(self, x: __m256i, y: __m256i) -> __m256i {
+        unsafe { _mm256_or_si256(_mm256_cmpgt_epi32(y, x), _mm256_cmpeq_epi32(x, y)) }
+    }
+
+    #[inline]
+    fn eq(self, x: __m256i, y: __m256i) -> __m256i {
+        unsafe { _mm256_cmpeq_epi32(x, y) }
+    }
+
+    #[inline]
+    fn ge(self, x: __m256i, y: __m256i) -> __m256i {
+        unsafe { _mm256_or_si256(_mm256_cmpgt_epi32(x, y), _mm256_cmpeq_epi32(x, y)) }
+    }
+
+    #[inline]
+    fn gt(self, x: __m256i, y: __m256i) -> __m256i {
+        unsafe { _mm256_cmpgt_epi32(x, y) }
+    }
+
+    #[inline]
+    unsafe fn load_ptr(self, ptr: *const i32) -> __m256i {
+        unsafe { _mm256_loadu_si256(ptr as *const __m256i) }
+    }
+
+    #[inline]
+    fn select(self, x: __m256i, y: __m256i, mask: <__m256i as Simd>::Mask) -> __m256i {
+        unsafe { _mm256_blendv_epi8(y, x, mask) }
+    }
+
+    #[inline]
+    unsafe fn store_ptr(self, x: __m256i, ptr: *mut i32) {
+        unsafe { _mm256_storeu_si256(ptr as *mut __m256i, x) }
+    }
+
+    #[inline]
+    unsafe fn load_ptr_mask(self, ptr: *const i32, mask: __m256i) -> __m256i {
+        unsafe { _mm256_maskload_epi32(ptr, mask) }
+    }
+
+    #[inline]
+    unsafe fn store_ptr_mask(self, x: __m256i, ptr: *mut i32, mask: __m256i) {
+        unsafe { _mm256_maskstore_epi32(ptr, mask, x) }
+    }
+}
+
+impl SimdIntOps<__m256i> for Avx2Isa {
+    #[inline]
+    fn neg(self, x: __m256i) -> __m256i {
+        unsafe { _mm256_sub_epi32(_mm256_setzero_si256(), x) }
+    }
+
+    #[inline]
+    fn shift_left<const SHIFT: i32>(self, x: __m256i) -> __m256i {
+        unsafe { _mm256_slli_epi32(x, SHIFT) }
+    }
+}
+
+impl Mask for __m256i {
+    type Array = [bool; 8];
+
+    #[inline]
+    fn to_array(self) -> Self::Array {
+        let array = unsafe { transmute::<Self, [i32; 8]>(self) };
+        std::array::from_fn(|i| array[i] != 0)
+    }
+}
+
+macro_rules! simd_x32_common {
+    () => {
+        type Array = [Self::Elem; 8];
+        type Mask = __m256i;
+        type Isa = Avx2Isa;
+
+        #[inline]
+        fn to_bits(self) -> <Self::Isa as Isa>::Bits {
+            #[allow(clippy::useless_transmute)]
+            unsafe {
+                transmute::<Self, __m256i>(self)
+            }
+        }
+
+        #[inline]
+        fn from_bits(bits: <Self::Isa as Isa>::Bits) -> Self {
+            #[allow(clippy::useless_transmute)]
+            unsafe {
+                transmute::<__m256i, Self>(bits)
+            }
+        }
+    };
+}
+
+impl Simd for __m256 {
+    type Elem = f32;
+
+    simd_x32_common!();
+
+    #[inline]
+    fn to_array(self) -> Self::Array {
+        unsafe { transmute::<__m256, Self::Array>(self) }
+    }
+}
+
+impl Simd for __m256i {
+    type Elem = i32;
+
+    simd_x32_common!();
+
+    #[inline]
+    fn to_array(self) -> Self::Array {
+        unsafe { transmute::<__m256i, [i32; 8]>(self) }
+    }
+}

--- a/rten-simd/src/safe/dispatch.rs
+++ b/rten-simd/src/safe/dispatch.rs
@@ -1,0 +1,224 @@
+use std::mem::MaybeUninit;
+
+use super::functional::simd_map;
+use super::{Elem, Isa, Simd};
+use crate::span::SrcDest;
+
+/// A vectorized operation which can be instantiated for different instruction
+/// sets.
+pub trait SimdOp {
+    type Output;
+
+    /// Evaluate the operation using the given instruction set.
+    fn eval<I: Isa>(self, isa: I) -> Self::Output;
+
+    /// Dispatch this operation using the preferred ISA for the current platform.
+    fn dispatch(self) -> Self::Output
+    where
+        Self: Sized,
+    {
+        dispatch(self)
+    }
+}
+
+/// Invoke a SIMD operation using the preferred ISA for the current system.
+///
+/// This function will check the available SIMD instruction sets and then
+/// dispatch to [`SimdOp::eval`], passing the selected [`Isa`].
+pub fn dispatch<Op: SimdOp>(op: Op) -> Op::Output {
+    #[cfg(target_arch = "aarch64")]
+    if let Some(isa) = super::arch::aarch64::ArmNeonIsa::new() {
+        return op.eval(isa);
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    {
+        #[target_feature(enable = "avx2")]
+        #[target_feature(enable = "avx")]
+        #[target_feature(enable = "fma")]
+        unsafe fn dispatch_avx2<Op: SimdOp>(isa: impl Isa, op: Op) -> Op::Output {
+            op.eval(isa)
+        }
+
+        if let Some(isa) = super::arch::x86_64::Avx2Isa::new() {
+            // Safety: AVX2 is supported
+            unsafe {
+                return dispatch_avx2(isa, op);
+            }
+        }
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    #[cfg(target_feature = "simd128")]
+    {
+        if let Some(isa) = super::arch::wasm32::Wasm32Isa::new() {
+            return op.eval(isa);
+        }
+    }
+
+    let isa = super::arch::generic::GenericIsa::new();
+    op.eval(isa)
+}
+
+/// Convenience trait for defining vectorized unary operations.
+pub trait SimdUnaryOp<T: Elem> {
+    /// Evaluate the unary function on the elements in `x`.
+    ///
+    /// `eval` is passed an untyped SIMD vector. This can be cast to the
+    /// specific type expected by the operation.
+    ///
+    /// ```
+    /// use rten_simd::safe::{Isa, Simd, SimdFloatOps, SimdOps, SimdUnaryOp};
+    ///
+    /// struct Reciprocal {}
+    ///
+    /// impl SimdUnaryOp<f32> for Reciprocal {
+    ///     fn eval<I: Isa>(&self, isa: I, x: I::Bits) -> I::Bits {
+    ///         let ops = isa.f32();
+    ///         let x = ops.from_bits(x);
+    ///         let reciprocal = ops.div(ops.one(), x);
+    ///         reciprocal.to_bits()
+    ///     }
+    /// }
+    /// ```
+    fn eval<I: Isa>(&self, isa: I, x: I::Bits) -> I::Bits;
+
+    /// Evaluate the unary function on elements in `x`.
+    ///
+    /// This is a shorthand for `Self::default().eval(x)`. It is mainly useful
+    /// when one vectorized operation needs to call another as part of its
+    /// implementation.
+    #[inline(always)]
+    fn apply<I: Isa, S: Simd<Elem = T, Isa = I>>(isa: I, x: S) -> S
+    where
+        Self: Default,
+    {
+        S::from_bits(Self::default().eval(isa, x.to_bits()))
+    }
+
+    /// Apply this function to a slice.
+    ///
+    /// This reads elements from `input` in SIMD vector-sized chunks, applies
+    /// the operation and writes the results to `output`.
+    #[allow(private_bounds)]
+    fn map(&self, input: &[T], output: &mut [MaybeUninit<T>])
+    where
+        Self: Sized,
+        for<'a> SimdMapOp<'a, T, Self>: SimdOp,
+    {
+        let wrapped_op = SimdMapOp::wrap((input, output).into(), self);
+        dispatch(wrapped_op);
+    }
+
+    /// Apply a vectorized unary function to a mutable slice.
+    ///
+    /// This is similar to [`map`](SimdUnaryOp::map) but reads and writes
+    /// to the same slice.
+    #[allow(private_bounds)]
+    fn map_mut(&self, input: &mut [T])
+    where
+        Self: Sized,
+        for<'a> SimdMapOp<'a, T, Self>: SimdOp,
+    {
+        let wrapped_op = SimdMapOp::wrap(input.into(), self);
+        dispatch(wrapped_op);
+    }
+}
+
+/// SIMD operation which applies a unary operator `Op` to all elements in
+/// an input buffer using [`simd_map`].
+struct SimdMapOp<'a, T: Elem, Op: SimdUnaryOp<T>> {
+    src_dest: SrcDest<'a, T>,
+    op: &'a Op,
+}
+
+impl<'a, T: Elem, Op: SimdUnaryOp<T>> SimdMapOp<'a, T, Op> {
+    pub fn wrap(src_dest: SrcDest<'a, T>, op: &'a Op) -> Self {
+        SimdMapOp { src_dest, op }
+    }
+}
+
+macro_rules! impl_simd_map_op {
+    ($type:ident, $cap_type:ident) => {
+        impl<'a, Op: SimdUnaryOp<$type>> SimdOp for SimdMapOp<'a, $type, Op> {
+            type Output = &'a mut [$type];
+
+            #[inline(always)]
+            fn eval<I: Isa>(self, isa: I) -> Self::Output {
+                simd_map(
+                    isa.$type(),
+                    self.src_dest,
+                    #[inline(always)]
+                    |x| I::$cap_type::from_bits(self.op.eval(isa, x.to_bits())),
+                )
+            }
+        }
+    };
+}
+
+impl_simd_map_op!(f32, F32);
+impl_simd_map_op!(i32, I32);
+
+/// Convenience macro for defining and evaluating a SIMD operation.
+#[cfg(test)]
+macro_rules! test_simd_op {
+    ($isa:ident, $op:block) => {{
+        struct TestOp {}
+
+        impl SimdOp for TestOp {
+            type Output = ();
+
+            fn eval<I: Isa>(self, $isa: I) {
+                $op
+            }
+        }
+
+        TestOp {}.dispatch()
+    }};
+}
+
+#[cfg(test)]
+pub(crate) use test_simd_op;
+
+#[cfg(test)]
+mod tests {
+    use super::SimdUnaryOp;
+    use crate::safe::{Isa, Simd, SimdFloatOps, SimdOps};
+
+    #[test]
+    fn test_unary_float_op() {
+        struct Reciprocal {}
+
+        impl SimdUnaryOp<f32> for Reciprocal {
+            fn eval<I: Isa>(&self, isa: I, x: I::Bits) -> I::Bits {
+                let ops = isa.f32();
+                let x = ops.from_bits(x);
+                let y = ops.div(ops.one(), x);
+                y.to_bits()
+            }
+        }
+
+        let mut buf = [1., 2., 3., 4.];
+        Reciprocal {}.map_mut(&mut buf);
+
+        assert_eq!(buf, [1., 1. / 2., 1. / 3., 1. / 4.]);
+    }
+
+    #[test]
+    fn test_unary_int_op() {
+        struct Double {}
+
+        impl SimdUnaryOp<i32> for Double {
+            fn eval<I: Isa>(&self, isa: I, x: I::Bits) -> I::Bits {
+                let ops = isa.i32();
+                let x = ops.from_bits(x);
+                ops.add(x, x).to_bits()
+            }
+        }
+
+        let mut buf = [1, 2, 3, 4];
+        Double {}.map_mut(&mut buf);
+
+        assert_eq!(buf, [2, 4, 6, 8]);
+    }
+}

--- a/rten-simd/src/safe/functional.rs
+++ b/rten-simd/src/safe/functional.rs
@@ -1,0 +1,79 @@
+//! Vectorized higher-order operations (map, fold etc.)
+
+use super::{Simd, SimdOps};
+use crate::span::SrcDest;
+
+/// Transform a slice by applying a vectorized map function to its elements.
+///
+/// If the slice is not a multiple of the vector length, the final call to
+/// `op` will use a vector padded with zeros.
+///
+/// The map function must have the same input and output type.
+#[inline(always)]
+pub fn simd_map<'a, S: Simd, Op: FnMut(S) -> S>(
+    ops: impl SimdOps<S>,
+    src_dest: impl Into<SrcDest<'a, S::Elem>>,
+    mut op: Op,
+) -> &'a mut [S::Elem] {
+    let mut src_dest = src_dest.into();
+    let (mut in_ptr, mut out_ptr, mut n) = src_dest.src_dest_ptr();
+
+    let v_len = ops.len();
+    while n >= v_len {
+        // Safety: `in_ptr` points at >= `v_len` elements.
+        let x = unsafe { ops.load_ptr(in_ptr) };
+        let y = op(x);
+        unsafe { ops.store_ptr(y, out_ptr as *mut S::Elem) };
+
+        n -= v_len;
+        unsafe {
+            in_ptr = in_ptr.add(v_len);
+            out_ptr = out_ptr.add(v_len);
+        }
+    }
+
+    if n > 0 {
+        let mask = ops.first_n_mask(n);
+        let x = unsafe { ops.load_ptr_mask(in_ptr, mask) };
+        let y = op(x);
+        unsafe {
+            ops.store_ptr_mask(y, out_ptr as *mut S::Elem, mask);
+        }
+    }
+
+    // Safety: All elements in `src_dest` have been initialized.
+    unsafe { src_dest.dest_assume_init() }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::safe::{Isa, SimdOp, SimdOps};
+
+    use super::simd_map;
+
+    // f32 vector length, chosen to exercise main and tail loops for all ISAs.
+    const TEST_LEN: usize = 18;
+
+    #[test]
+    fn test_simd_map() {
+        struct Square<'a> {
+            xs: &'a mut [f32],
+        }
+
+        impl<'a> SimdOp for Square<'a> {
+            type Output = &'a mut [f32];
+
+            fn eval<I: Isa>(self, isa: I) -> Self::Output {
+                let ops = isa.f32();
+                simd_map(ops, self.xs, |x| ops.mul(x, x))
+            }
+        }
+
+        let mut buf: Vec<_> = (0..TEST_LEN).map(|x| x as f32).collect();
+        let expected: Vec<_> = buf.iter().map(|x| *x * *x).collect();
+
+        let squared = Square { xs: &mut buf }.dispatch();
+
+        assert_eq!(squared, &expected);
+    }
+}

--- a/rten-simd/src/safe/iter.rs
+++ b/rten-simd/src/safe/iter.rs
@@ -1,0 +1,306 @@
+//! Tools for vectorized iteration over slices.
+
+use crate::safe::{Simd, SimdOps};
+
+/// Methods for creating vectorized iterators.
+pub trait SimdIterable {
+    /// Element type in the slice.
+    type Elem;
+
+    /// Iterate over SIMD-sized chunks of the input.
+    ///
+    /// If the input length is not divisble by the SIMD vector width, the
+    /// iterator yields only the full chunks. The tail is accessible via the
+    /// iterator's [`tail`](Iter::tail) method.
+    fn simd_iter<S: Simd<Elem = Self::Elem>, O: SimdOps<S>>(&self, ops: O) -> Iter<S, O>;
+
+    /// Iterate over SIMD-sized chunks of the input.
+    ///
+    /// If the input length is not divisble by the SIMD vector width, the final
+    /// chunk will be padded with zeros.
+    fn simd_iter_pad<S: Simd<Elem = Self::Elem>, O: SimdOps<S>>(
+        &self,
+        ops: O,
+    ) -> impl ExactSizeIterator<Item = S>;
+}
+
+impl<T> SimdIterable for [T] {
+    type Elem = T;
+
+    #[inline]
+    fn simd_iter<S: Simd<Elem = T>, O: SimdOps<S>>(&self, ops: O) -> Iter<S, O> {
+        Iter::new(ops, self)
+    }
+
+    #[inline]
+    fn simd_iter_pad<S: Simd<Elem = T>, O: SimdOps<S>>(
+        &self,
+        ops: O,
+    ) -> impl ExactSizeIterator<Item = S> {
+        IterPad::new(ops, self)
+    }
+}
+
+/// Iterator which yields chunks of a slice as a SIMD vector.
+///
+/// This type is created by [`SimdIterable::simd_iter`].
+pub struct Iter<'a, S: Simd, O: SimdOps<S>> {
+    ops: O,
+    xs: &'a [S::Elem],
+    n_full_chunks: usize,
+}
+
+impl<'a, S: Simd, O: SimdOps<S>> Iter<'a, S, O> {
+    #[inline]
+    fn new(ops: O, xs: &'a [S::Elem]) -> Self {
+        let n_full_chunks = xs.len() / ops.len();
+        Iter {
+            ops,
+            xs,
+            n_full_chunks,
+        }
+    }
+
+    /// Reduce an iterator to a single SIMD vector.
+    ///
+    /// This is like [`Iterator::fold`] but the `fold` function receives SIMD
+    /// vectors instead of single elements. If the iterator length is not a
+    /// multiple of the SIMD vector length, the final vector will be padded with
+    /// zeros.
+    #[inline]
+    pub fn fold<F: FnMut(S, S) -> S>(mut self, mut accum: S, mut fold: F) -> S {
+        for chunk in &mut self {
+            accum = fold(accum, chunk);
+        }
+
+        if let Some((tail, mask)) = self.tail() {
+            let new_accum = fold(accum, tail);
+            accum = self.ops.select(new_accum, accum, mask);
+        }
+
+        accum
+    }
+
+    /// Variant of [`fold`](Self::fold) that computes multiple accumulator
+    /// values in a single pass.
+    #[inline]
+    pub fn fold_n<const N: usize>(
+        mut self,
+        mut accum: [S; N],
+        mut fold: impl FnMut([S; N], S) -> [S; N],
+    ) -> [S; N] {
+        for chunk in &mut self {
+            accum = fold(accum, chunk);
+        }
+
+        if let Some((tail, mask)) = self.tail() {
+            let new_accum = fold(accum, tail);
+            for i in 0..N {
+                accum[i] = self.ops.select(new_accum[i], accum[i], mask);
+            }
+        }
+
+        accum
+    }
+
+    /// Return a SIMD vector and mask for the left-over elements in the
+    /// slice after iterating over all full SIMD chunks.
+    ///
+    /// Elements of the SIMD vector that correspond to positions where the mask
+    /// is false will be set to zero.
+    #[inline]
+    pub fn tail(&self) -> Option<(S, S::Mask)> {
+        let n = self.xs.len();
+        if n > 0 {
+            let mask = self.ops.first_n_mask(n);
+
+            // Safety: `xs.add(i)` points to a valid element for all enabled
+            // mask lanes.
+            let x = unsafe { self.ops.load_ptr_mask(self.xs.as_ptr(), mask) };
+
+            Some((x, mask))
+        } else {
+            None
+        }
+    }
+}
+
+impl<S: Simd, O: SimdOps<S>> Iterator for Iter<'_, S, O> {
+    type Item = S;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        let v_len = self.ops.len();
+        if let Some((chunk, tail)) = self.xs.split_at_checked(v_len) {
+            self.xs = tail;
+
+            // Safety: `chunk.as_ptr()` points to `v_len` elements.
+            let x = unsafe { self.ops.load_ptr(chunk.as_ptr()) };
+
+            Some(x)
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.n_full_chunks, Some(self.n_full_chunks))
+    }
+}
+
+impl<S: Simd, O: SimdOps<S>> ExactSizeIterator for Iter<'_, S, O> {}
+
+impl<S: Simd, O: SimdOps<S>> std::iter::FusedIterator for Iter<'_, S, O> {}
+
+/// Iterator which yields chunks of a slice as a SIMD vector.
+///
+/// This type is created by [`SimdIterable::simd_iter_pad`].
+pub struct IterPad<'a, S: Simd, O: SimdOps<S>> {
+    iter: Iter<'a, S, O>,
+    has_tail: bool,
+}
+
+impl<'a, S: Simd, O: SimdOps<S>> IterPad<'a, S, O> {
+    #[inline]
+    fn new(ops: O, xs: &'a [S::Elem]) -> Self {
+        let iter = Iter::new(ops, xs);
+        let has_tail = xs.len() % ops.len() != 0;
+        Self { iter, has_tail }
+    }
+}
+
+impl<S: Simd, O: SimdOps<S>> Iterator for IterPad<'_, S, O> {
+    type Item = S;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(chunk) = self.iter.next() {
+            Some(chunk)
+        } else if self.has_tail {
+            let (tail, _mask) = self.iter.tail().unwrap();
+            self.has_tail = false;
+            Some(tail)
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let n_tail = if self.has_tail { 1 } else { 0 };
+        let n_chunks = self.iter.len() + n_tail;
+        (n_chunks, Some(n_chunks))
+    }
+}
+
+impl<S: Simd, O: SimdOps<S>> ExactSizeIterator for IterPad<'_, S, O> {}
+
+impl<S: Simd, O: SimdOps<S>> std::iter::FusedIterator for IterPad<'_, S, O> {}
+
+#[cfg(test)]
+mod tests {
+    use super::SimdIterable;
+    use crate::safe::dispatch::test_simd_op;
+    use crate::safe::{Isa, Simd, SimdOp, SimdOps};
+
+    // f32 vector length, chosen to exercise main and tail loops for all ISAs.
+    const TEST_LEN: usize = 18;
+
+    #[test]
+    fn test_iter() {
+        test_simd_op!(isa, {
+            let buf: Vec<_> = (0..TEST_LEN).map(|x| x as f32).collect();
+            let chunks = buf.chunks_exact(isa.f32().len());
+
+            let iter = buf.simd_iter(isa.f32());
+            assert_eq!(iter.len(), chunks.len());
+
+            for (scalar_chunk, simd_chunk) in chunks.zip(iter) {
+                assert_eq!(simd_chunk.to_array().as_ref(), scalar_chunk);
+            }
+        });
+    }
+
+    #[test]
+    fn test_iter_pad() {
+        test_simd_op!(isa, {
+            let buf: Vec<_> = (0..TEST_LEN).map(|x| x as f32).collect();
+            let chunks = buf.chunks(isa.f32().len());
+
+            let iter = buf.simd_iter_pad(isa.f32());
+            assert_eq!(iter.len(), chunks.len());
+
+            for (scalar_chunk, simd_chunk) in chunks.zip(iter) {
+                let simd_elts = simd_chunk.to_array();
+                let simd_elts = simd_elts.as_ref();
+                assert_eq!(&simd_elts[..scalar_chunk.len()], scalar_chunk);
+                if simd_elts.len() > scalar_chunk.len() {
+                    assert!(&simd_elts[scalar_chunk.len()..].iter().all(|x| *x == 0.));
+                }
+            }
+        });
+    }
+
+    #[test]
+    fn test_fold() {
+        struct Sum<'a> {
+            xs: &'a [f32],
+        }
+
+        impl<'a> SimdOp for Sum<'a> {
+            type Output = f32;
+
+            fn eval<I: Isa>(self, isa: I) -> Self::Output {
+                let ops = isa.f32();
+                let vec_sum = self
+                    .xs
+                    .simd_iter(ops)
+                    .fold(ops.zero(), |sum, x| ops.add(sum, x));
+                vec_sum.to_array().into_iter().fold(0., |sum, x| sum + x)
+            }
+        }
+
+        let buf: Vec<_> = (0..TEST_LEN).map(|x| x as f32).collect();
+        let expected = (buf.len() as f32 * buf[buf.len() - 1]) / 2.;
+
+        let sum = Sum { xs: &buf }.dispatch();
+        assert_eq!(sum, expected);
+    }
+
+    #[test]
+    fn test_fold_n() {
+        struct MinMax<'a> {
+            xs: &'a [f32],
+        }
+
+        impl<'a> SimdOp for MinMax<'a> {
+            type Output = (f32, f32);
+
+            fn eval<I: Isa>(self, isa: I) -> Self::Output {
+                let ops = isa.f32();
+                let [vec_min, vec_max] = self.xs.simd_iter(ops).fold_n(
+                    [ops.splat(f32::MAX), ops.splat(f32::MIN)],
+                    |[min, max], x| [ops.min(min, x), ops.max(max, x)],
+                );
+                let min = vec_min
+                    .to_array()
+                    .into_iter()
+                    .reduce(|min, x| min.min(x))
+                    .unwrap();
+                let max = vec_max
+                    .to_array()
+                    .into_iter()
+                    .reduce(|max, x| max.max(x))
+                    .unwrap();
+                (min, max)
+            }
+        }
+
+        let buf: Vec<_> = (0..TEST_LEN).map(|x| x as f32).collect();
+
+        let (min, max) = MinMax { xs: &buf }.dispatch();
+        assert_eq!(min, 0. as f32);
+        assert_eq!(max, (TEST_LEN - 1) as f32);
+    }
+}

--- a/rten-simd/src/safe/vec.rs
+++ b/rten-simd/src/safe/vec.rs
@@ -1,0 +1,439 @@
+use std::fmt::Debug;
+
+/// Types used as elements (or _lanes_) of SIMD vectors.
+pub trait Elem: Copy + Default {
+    /// Return the 1 value of this type.
+    fn one() -> Self;
+}
+
+impl Elem for f32 {
+    fn one() -> Self {
+        1.
+    }
+}
+
+impl Elem for i32 {
+    fn one() -> Self {
+        1
+    }
+}
+
+/// Masks used or returned by SIMD operations.
+pub trait Mask: Copy {
+    type Array: AsRef<[bool]>;
+
+    /// Convert this mask to a bool array.
+    fn to_array(self) -> Self::Array;
+
+    /// Return true if all lanes in the mask are one.
+    fn all_true(self) -> bool {
+        self.to_array().as_ref().iter().all(|&x| x)
+    }
+
+    /// Return true if all lanes in the mask are false.
+    fn all_false(self) -> bool {
+        self.to_array().as_ref().iter().all(|&x| !x)
+    }
+}
+
+/// SIMD vector type.
+#[allow(clippy::len_without_is_empty)]
+pub trait Simd: Copy + Debug {
+    /// Representation of this vector as a `[Self::Elem; N]` array.
+    type Array: AsRef<[Self::Elem]>
+        + Debug
+        + IntoIterator<Item = Self::Elem>
+        + PartialEq<Self::Array>;
+
+    /// Type of data held in each SIMD lane.
+    type Elem: Elem;
+
+    /// Mask with the same number of elements as this vector.
+    type Mask: Mask;
+
+    /// The ISA associated with this SIMD vector.
+    type Isa: Isa;
+
+    /// Convert this SIMD vector to the common "bits" type used by all vectors
+    /// in this family.
+    fn to_bits(self) -> <Self::Isa as Isa>::Bits;
+
+    /// Convert this SIMD vector from the common "bits" type used by all vectors
+    /// in this family.
+    fn from_bits(bits: <Self::Isa as Isa>::Bits) -> Self;
+
+    /// Reinterpret the bits of this vector as another vector from the same
+    /// family.
+    fn reinterpret_cast<T>(self) -> T
+    where
+        T: Simd<Isa = Self::Isa>,
+    {
+        T::from_bits(self.to_bits())
+    }
+
+    /// Convert `self` to a SIMD array.
+    ///
+    /// This is a cheap transmute in most cases, since SIMD vectors usually
+    /// have the same layout as `[S::Elem; N]` but a greater alignment.
+    fn to_array(self) -> Self::Array;
+}
+
+/// Entry point for performing SIMD operations using a particular Instruction
+/// Set Architecture (ISA).
+///
+/// Implementations of this trait are types which can only be instantiated
+/// if the instruction set is available. They are usually zero-sized and thus
+/// free to copy.
+///
+/// # Safety
+///
+/// Implementations must ensure they can only be constructed if the
+/// instruction set is supported on the current system.
+pub unsafe trait Isa: Copy {
+    /// A SIMD vector of unspecified type which all vectors in this family can
+    /// be cast to/from.
+    type Bits: Simd;
+
+    /// SIMD vector type for this ISA with `f32` elements.
+    type F32: Simd<Elem = f32, Isa = Self>;
+
+    /// SIMD vector type for this ISA with `i32` elements.
+    type I32: Simd<Elem = i32, Isa = Self>;
+
+    /// Entry point for operations on SIMD vectors containing `f32` elements.
+    fn f32(self) -> impl SimdFloatOps<Self::F32, Int = Self::I32>;
+
+    /// Entry point for operations on SIMD vectors containing `i32` elements.
+    fn i32(self) -> impl SimdIntOps<Self::I32>;
+}
+
+/// Trait for SIMD operations on a particular vector type.
+///
+/// # Safety
+///
+/// Implementations must ensure they can only be constructed if the
+/// instruction set is supported on the current system.
+#[allow(clippy::len_without_is_empty)]
+pub unsafe trait SimdOps<S: Simd>: Copy {
+    /// Convert `x` to an untyped vector of the same width.
+    #[allow(clippy::wrong_self_convention)]
+    fn from_bits(self, x: <S::Isa as Isa>::Bits) -> S {
+        S::from_bits(x)
+    }
+
+    /// Return the number of elements in the vector.
+    fn len(self) -> usize;
+
+    /// Compute `x + y`.
+    fn add(self, x: S, y: S) -> S;
+
+    /// Compute `x - y`.
+    fn sub(self, x: S, y: S) -> S;
+
+    /// Compute `x * y`.
+    fn mul(self, x: S, y: S) -> S;
+
+    /// Create a new vector with all lanes set to zero.
+    fn zero(self) -> S {
+        self.splat(S::Elem::default())
+    }
+
+    /// Create a new vector with all lanes set to one.
+    fn one(self) -> S {
+        self.splat(S::Elem::one())
+    }
+
+    /// Compute `a * b + c`.
+    ///
+    /// This will use fused multiply-add instructions if available. For float
+    /// element types, this may use one or two roundings.
+    fn mul_add(self, a: S, b: S, c: S) -> S {
+        self.add(self.mul(a, b), c)
+    }
+
+    /// Return a mask indicating whether elements in `x` are less than `y`.
+    fn lt(self, x: S, y: S) -> S::Mask;
+
+    /// Return a mask indicating whether elements in `x` are less or equal to `y`.
+    fn le(self, x: S, y: S) -> S::Mask;
+
+    /// Return a mask indicating whether elements in `x` are equal to `y`.
+    fn eq(self, x: S, y: S) -> S::Mask;
+
+    /// Return a mask indicating whether elements in `x` are greater or equal to `y`.
+    fn ge(self, x: S, y: S) -> S::Mask;
+
+    /// Return a mask indicating whether elements in `x` are greater than `y`.
+    fn gt(self, x: S, y: S) -> S::Mask;
+
+    /// Return the minimum of `x` and `y` for each lane.
+    fn min(self, x: S, y: S) -> S {
+        self.select(x, y, self.le(x, y))
+    }
+
+    /// Return the maximum of `x` and `y` for each lane.
+    fn max(self, x: S, y: S) -> S {
+        self.select(x, y, self.ge(x, y))
+    }
+
+    /// Create a new vector with all lanes set to `x`.
+    fn splat(self, x: S::Elem) -> S;
+
+    /// Return a mask with the first `n` lanes set to true.
+    fn first_n_mask(self, n: usize) -> S::Mask;
+
+    /// Load vector of elements from `ptr`.
+    ///
+    /// `ptr` is not required to have any particular alignment.
+    ///
+    /// # Safety
+    ///
+    /// `ptr` must point to `self.len()` initialized elements of type `S::Elem`.
+    unsafe fn load_ptr(self, ptr: *const S::Elem) -> S;
+
+    /// Load vector elements from `ptr` using a mask.
+    ///
+    /// `ptr` is not required to have any particular alignment.
+    ///
+    /// # Safety
+    ///
+    /// For each mask position `i` which is true, `ptr.add(i)` must point to
+    /// an initialized element of type `S::Elem`.
+    unsafe fn load_ptr_mask(self, ptr: *const S::Elem, mask: S::Mask) -> S;
+
+    /// Select elements from `x` or `y` according to a mask.
+    ///
+    /// Elements are selected from `x` where the corresponding mask element
+    /// is one or `y` if zero.
+    fn select(self, x: S, y: S, mask: S::Mask) -> S;
+
+    /// Store the values in this vector to a memory location.
+    ///
+    /// # Safety
+    ///
+    /// `ptr` must point to `self.len()` elements.
+    unsafe fn store_ptr(self, x: S, ptr: *mut S::Elem);
+
+    /// Store the values in this vector to a memory location, where the
+    /// corresponding mask element is set.
+    ///
+    /// # Safety
+    ///
+    /// For each position `i` in the mask which is true, `ptr.add(i)` must point
+    /// to a valid element of type `Self::Elem`.
+    unsafe fn store_ptr_mask(self, x: S, ptr: *mut S::Elem, mask: S::Mask);
+}
+
+/// Extends [`SimdOps`] with operations available on SIMD vectors with float
+/// elements.
+pub trait SimdFloatOps<S: Simd>: SimdOps<S> {
+    /// Integer SIMD vector of the same bit-width as this vector.
+    type Int: Simd;
+
+    /// Compute x / y
+    fn div(self, x: S, y: S) -> S;
+
+    /// Compute `-x`
+    fn neg(self, x: S) -> S {
+        self.sub(self.zero(), x)
+    }
+
+    /// Convert each lane to an integer of the same width, rounding towards zero.
+    fn to_int_trunc(self, x: S) -> Self::Int;
+}
+
+/// Extends [`SimdOps`] with operations available on SIMD vectors with signed
+/// integer elements.
+pub trait SimdIntOps<S: Simd>: SimdOps<S> {
+    /// Shift each lane in `x` left by `SHIFT` bits.
+    fn shift_left<const SHIFT: i32>(self, x: S) -> S;
+
+    /// Return `-x`.
+    fn neg(self, x: S) -> S {
+        self.sub(self.zero(), x)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::safe::{
+        assert_simd_eq, test_simd_op, Isa, Mask, Simd, SimdFloatOps, SimdIntOps, SimdOp, SimdOps,
+    };
+
+    #[test]
+    fn test_bin_ops_f32() {
+        test_simd_op!(isa, {
+            let ops = isa.f32();
+
+            let x = ops.splat(1.);
+            let y = ops.splat(2.);
+
+            // Add
+            let expected = ops.splat(3.);
+            let actual = ops.add(x, y);
+            assert_simd_eq!(actual, expected);
+
+            // Sub
+            let expected = ops.splat(-1.);
+            let actual = ops.sub(x, y);
+            assert_simd_eq!(actual, expected);
+
+            // Mul
+            let expected = ops.splat(2.);
+            let actual = ops.mul(x, y);
+            assert_simd_eq!(actual, expected);
+
+            // Div
+            let expected = ops.splat(0.5);
+            let actual = ops.div(x, y);
+            assert_simd_eq!(actual, expected);
+        })
+    }
+
+    #[test]
+    fn test_mul_add_f32() {
+        test_simd_op!(isa, {
+            let ops = isa.f32();
+
+            let a = ops.splat(2.);
+            let b = ops.splat(3.);
+            let c = ops.splat(4.);
+
+            let actual = ops.mul_add(a, b, c);
+            let expected = ops.splat((2. * 3.) + 4.);
+
+            assert_simd_eq!(actual, expected);
+        })
+    }
+
+    #[test]
+    fn test_cmp_ops_f32() {
+        test_simd_op!(isa, {
+            let ops = isa.f32();
+
+            let x = ops.splat(1.);
+            let y = ops.splat(2.);
+
+            assert!(ops.eq(x, x).all_true());
+            assert!(ops.eq(x, y).all_false());
+            assert!(ops.le(x, x).all_true());
+            assert!(ops.le(x, y).all_true());
+            assert!(ops.le(y, x).all_false());
+            assert!(ops.ge(x, x).all_true());
+            assert!(ops.ge(x, y).all_false());
+            assert!(ops.gt(x, y).all_false());
+            assert!(ops.gt(y, x).all_true());
+        })
+    }
+
+    #[test]
+    fn test_unary_ops_f32() {
+        test_simd_op!(isa, {
+            let ops = isa.f32();
+
+            let x = ops.splat(3.);
+
+            // Neg
+            let expected = ops.splat(-3.);
+            let actual = ops.neg(x);
+            assert_simd_eq!(actual, expected);
+        })
+    }
+
+    #[test]
+    fn test_bin_ops_i32() {
+        test_simd_op!(isa, {
+            let ops = isa.i32();
+
+            let x = ops.splat(1);
+            let y = ops.splat(2);
+
+            // Add
+            let expected = ops.splat(3);
+            let actual = ops.add(x, y);
+            assert_simd_eq!(actual, expected);
+
+            // Sub
+            let expected = ops.splat(-1);
+            let actual = ops.sub(x, y);
+            assert_simd_eq!(actual, expected);
+
+            // Mul
+            let expected = ops.splat(2);
+            let actual = ops.mul(x, y);
+            assert_simd_eq!(actual, expected);
+        })
+    }
+
+    #[test]
+    fn test_cmp_ops_i32() {
+        test_simd_op!(isa, {
+            let ops = isa.i32();
+
+            let x = ops.splat(1);
+            let y = ops.splat(2);
+
+            assert!(ops.eq(x, x).all_true());
+            assert!(ops.eq(x, y).all_false());
+            assert!(ops.le(x, x).all_true());
+            assert!(ops.le(x, y).all_true());
+            assert!(ops.le(y, x).all_false());
+            assert!(ops.ge(x, x).all_true());
+            assert!(ops.ge(x, y).all_false());
+            assert!(ops.gt(x, y).all_false());
+            assert!(ops.gt(y, x).all_true());
+        })
+    }
+
+    #[test]
+    fn test_unary_ops_i32() {
+        test_simd_op!(isa, {
+            let ops = isa.i32();
+
+            let x = ops.splat(3);
+
+            // Add
+            let expected = ops.splat(-3);
+            let actual = ops.neg(x);
+            assert_simd_eq!(actual, expected);
+        })
+    }
+
+    #[test]
+    fn test_reinterpret_cast() {
+        test_simd_op!(isa, {
+            let x = 1.456f32;
+            let x_i32 = x.to_bits() as i32;
+
+            let x_vec = isa.f32().splat(x);
+            let y_vec: I::I32 = x_vec.reinterpret_cast();
+
+            let expected = isa.i32().splat(x_i32);
+            assert_simd_eq!(y_vec, expected);
+        })
+    }
+
+    #[test]
+    fn test_shl() {
+        test_simd_op!(isa, {
+            let ops = isa.i32();
+
+            let x = ops.splat(42);
+            let y = ops.shift_left::<1>(x);
+            let expected = isa.i32().splat(42 << 1);
+            assert_simd_eq!(y, expected);
+        })
+    }
+
+    #[test]
+    fn test_f32_to_i32_trunc() {
+        test_simd_op!(isa, {
+            let ops = isa.f32();
+
+            let x = ops.splat(12.345);
+            let y = ops.to_int_trunc(x);
+            let expected = isa.i32().splat(12);
+            assert_simd_eq!(y, expected);
+        })
+    }
+}

--- a/rten-vecmath/src/lib.rs
+++ b/rten-vecmath/src/lib.rs
@@ -74,7 +74,7 @@
 //! ### Computing the sum of a list of floats
 //!
 //! ```
-//! use rten_simd::dispatch::SimdOp;
+//! use rten_simd::safe::SimdOp;
 //! use rten_vecmath::Sum;
 //!
 //! let data = [1., 0.5, 2.0];

--- a/rten-vecmath/src/sum.rs
+++ b/rten-vecmath/src/sum.rs
@@ -96,6 +96,8 @@ impl SimdOp for SumSquareSub<'_> {
 
 #[cfg(test)]
 mod tests {
+    use crate::ulp::assert_ulp_diff_le;
+
     use super::{Sum, SumSquare, SumSquareSub};
     use rten_simd::safe::SimdOp;
 
@@ -106,25 +108,29 @@ mod tests {
     #[test]
     fn test_sum() {
         let xs: Vec<f32> = (0..LEN).map(|i| i as f32 * 0.1).collect();
-        let expected_sum: f32 = xs.iter().sum();
+        let expected_sum: f64 = xs.iter().map(|x| *x as f64).sum();
         let sum = Sum::new(&xs).dispatch();
-        assert_eq!(sum, expected_sum);
+        assert_ulp_diff_le!(sum, expected_sum as f32, 1.0);
     }
 
     #[test]
     fn test_sum_square() {
         let xs: Vec<f32> = (0..LEN).map(|i| i as f32 * 0.1).collect();
-        let expected_sum: f32 = xs.iter().copied().map(|x| x * x).sum();
+        let expected_sum: f64 = xs.iter().copied().map(|x| x as f64 * x as f64).sum();
         let sum = SumSquare::new(&xs).dispatch();
-        assert_eq!(sum, expected_sum);
+        assert_ulp_diff_le!(sum, expected_sum as f32, 2.0);
     }
 
     #[test]
     fn test_sum_square_sub() {
         let xs: Vec<f32> = (0..LEN).map(|i| i as f32 * 0.1).collect();
         let mean = xs.iter().sum::<f32>() / xs.len() as f32;
-        let expected_sum: f32 = xs.iter().copied().map(|x| (x - mean) * (x - mean)).sum();
+        let expected_sum: f64 = xs
+            .iter()
+            .copied()
+            .map(|x| (x as f64 - mean as f64) * (x as f64 - mean as f64))
+            .sum();
         let sum = SumSquareSub::new(&xs, mean).dispatch();
-        assert_eq!(sum, expected_sum);
+        assert_ulp_diff_le!(sum, expected_sum as f32, 2.0);
     }
 }

--- a/rten-vecmath/src/ulp.rs
+++ b/rten-vecmath/src/ulp.rs
@@ -36,6 +36,26 @@ impl Ulp for f32 {
     }
 }
 
+/// Assert that the difference between two values is less than or equal to a
+/// given number of [ULPs](Ulp).
+macro_rules! assert_ulp_diff_le {
+    ($actual:expr, $expected:expr, $max_diff:expr) => {{
+        use crate::ulp::Ulp;
+
+        let ulp_diff = ($actual).diff_ulps($expected);
+        assert!(
+            ulp_diff <= $max_diff,
+            "difference between {} and {} is {} ULPs which exceeds {}",
+            $actual,
+            $expected,
+            ulp_diff,
+            $max_diff
+        );
+    }};
+}
+
+pub(crate) use assert_ulp_diff_le;
+
 #[cfg(test)]
 mod tests {
     use super::Ulp;

--- a/src/ops/norm.rs
+++ b/src/ops/norm.rs
@@ -1,7 +1,8 @@
 use std::mem::MaybeUninit;
 
 use rayon::prelude::*;
-use rten_simd::dispatch::SimdOp;
+use rten_simd::dispatch::SimdOp as UnsafeSimdOp;
+use rten_simd::safe::SimdOp as SafeSimdOp;
 use rten_tensor::prelude::*;
 use rten_tensor::{NdTensorView, Tensor, TensorView};
 use rten_vecmath as vecmath;

--- a/src/ops/quantize.rs
+++ b/src/ops/quantize.rs
@@ -1,6 +1,7 @@
 use std::mem::MaybeUninit;
 
-use rten_simd::dispatch::SimdOp;
+use rten_simd::dispatch::SimdOp as UnsafeSimdOp;
+use rten_simd::safe::SimdOp as SafeSimdOp;
 use rten_tensor::prelude::*;
 use rten_tensor::{AssumeInit, NdTensor, NdTensorView, Scalar, Tensor, TensorView};
 use rten_vecmath as vecmath;

--- a/src/ops/reduce.rs
+++ b/src/ops/reduce.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 use std::cmp::Ordering;
 
-use rten_simd::dispatch::SimdOp;
+use rten_simd::safe::SimdOp;
 use rten_tensor;
 use rten_tensor::prelude::*;
 use rten_tensor::{NdTensor, NdTensorView, Tensor, TensorView};


### PR DESCRIPTION
This PR is the first step in addressing https://github.com/robertknight/rten/issues/549, which will significantly reduce the amount of unsafe code overall in rten.

It introduces a new API for the rten-simd portable SIMD library in `rten_simd::safe`, which allows defining SIMD operations using safe code, and ports some of the simpler vectorized operations in rten-vecmath (Sum, SumSquare, SumSquareSub, MinMax, Normalize) to use it.

The basic idea behind the API design is to separate SIMD data types (which can always be constructed) and operations (which require hardware support), and enforce that the types implementing the operations can only be constructed if the ISA is supported. This is similar to [pulp](https://docs.rs/pulp/latest/pulp/), which appears to be a Rust-ified version of [Highway](https://github.com/google/highway). One important difference is that the SIMD traits are designed in a way which makes it easier to reuse code for vectorized operations on different data types. To reduce the need for unsafe operations to load and store SIMD vectors, iterators and functional utilities (map, fold etc.) on slices are provided, which handle the load/store internally.

## Design notes

### Unified versus separate types for data and operations

An earlier version of this PR used a different design where operations were implemented as methods of the SIMD data types, similar to `std::simd`. This has several advantages compared to what is implemented here:

- Operations like add, sub, mul etc. can be implemented as implementations of `std::ops` traits, so you can use expressions like (`a * b + c`)
- Operations are methods on the SIMD vector so they can be chained. Chaining operations is less ergonomic with the design here (`ops.mul(x, ops.splat(2))` versus `ops.splat(2).mul(x)` or `ops.splat(2) * x`).

With such a design any operation that _constructs_ a SIMD vector needs to somehow enforce that the instruction set is supported.  This requires wrapping the built-in SIMD types (`__m256` etc.) with a newtype and then enforcing that constructing instances of the newtype requires some kind of proof that the ISA is supported. I did this earlier by moving all constructing operations to a separate trait. This made the overall set of traits more complex however.

### Support for scalable vectors

One of the reasons that Highway separates operations and data is because they want to support scalable vectors with a size that is unknown at compile time, and such compiler builtin types cannot be wrapped in classes in C++ in order to implement the operations as methods. In Rust it isn't completely settled yet what restrictions SVE types will have, but [it seems](https://rust-lang.zulipchat.com/#narrow/channel/257879-project-portable-simd/topic/Newtype.20pattern.20and.20SVE) that the newtype pattern is expected to work. If so, then both designs would work with all vector types.

**TODO:**

- [x] Review and revise documentation
- [x] Compare performance vs `main` on Arm
- [x] Compare performance vs `main` on x64