### PR TITLE
Convert Exp and operations using it to safe SIMD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ miri:
 # nightly Rust.
 .PHONY: test
 test:
-	cargo test --workspace --features mmap,random,text-decoder,serde
+	cargo test --no-fail-fast --workspace --features mmap,random,text-decoder,serde
 
 .PHONY: wasm
 wasm:

--- a/rten-simd/src/safe/arch/aarch64.rs
+++ b/rten-simd/src/safe/arch/aarch64.rs
@@ -1,9 +1,9 @@
 use std::arch::aarch64::{
-    float32x4_t, int32x4_t, uint32x4_t, vaddq_f32, vaddq_s32, vbslq_f32, vbslq_s32, vceqq_f32,
-    vceqq_s32, vcgeq_f32, vcgeq_s32, vcgtq_f32, vcgtq_s32, vcleq_f32, vcleq_s32, vcltq_f32,
-    vcltq_s32, vcvtq_s32_f32, vdivq_f32, vdupq_n_f32, vdupq_n_s32, vfmaq_f32, vld1q_f32, vld1q_s32,
-    vld1q_u32, vmaxq_f32, vminq_f32, vmulq_f32, vmulq_s32, vnegq_f32, vnegq_s32, vshlq_n_s32,
-    vst1q_f32, vst1q_s32, vsubq_f32, vsubq_s32,
+    float32x4_t, int32x4_t, uint32x4_t, vabsq_f32, vaddq_f32, vaddq_s32, vbslq_f32, vbslq_s32,
+    vceqq_f32, vceqq_s32, vcgeq_f32, vcgeq_s32, vcgtq_f32, vcgtq_s32, vcleq_f32, vcleq_s32,
+    vcltq_f32, vcltq_s32, vcvtq_s32_f32, vdivq_f32, vdupq_n_f32, vdupq_n_s32, vfmaq_f32, vld1q_f32,
+    vld1q_s32, vld1q_u32, vmaxq_f32, vminq_f32, vmulq_f32, vmulq_s32, vnegq_f32, vnegq_s32,
+    vshlq_n_s32, vst1q_f32, vst1q_s32, vsubq_f32, vsubq_s32,
 };
 use std::mem::transmute;
 
@@ -177,6 +177,11 @@ impl SimdFloatOps<float32x4_t> for ArmNeonIsa {
     #[inline]
     fn neg(self, x: float32x4_t) -> float32x4_t {
         unsafe { vnegq_f32(x) }
+    }
+
+    #[inline]
+    fn abs(self, x: float32x4_t) -> float32x4_t {
+        unsafe { vabsq_f32(x) }
     }
 
     #[inline]

--- a/rten-simd/src/safe/arch/generic.rs
+++ b/rten-simd/src/safe/arch/generic.rs
@@ -196,6 +196,12 @@ impl SimdFloatOps<F32x4> for GenericIsa {
     }
 
     #[inline]
+    fn abs(self, x: F32x4) -> F32x4 {
+        let xs = array::from_fn(|i| x.0[i].abs());
+        F32x4(xs)
+    }
+
+    #[inline]
     fn to_int_trunc(self, x: F32x4) -> Self::Int {
         let xs = array::from_fn(|i| x.0[i] as i32);
         I32x4(xs)

--- a/rten-simd/src/safe/arch/wasm32.rs
+++ b/rten-simd/src/safe/arch/wasm32.rs
@@ -1,7 +1,7 @@
 use std::arch::wasm32::{
-    f32x4_add, f32x4_div, f32x4_eq, f32x4_ge, f32x4_gt, f32x4_le, f32x4_lt, f32x4_max, f32x4_min,
-    f32x4_mul, f32x4_neg, f32x4_splat, f32x4_sub, i32x4_add, i32x4_eq, i32x4_ge, i32x4_gt,
-    i32x4_le, i32x4_lt, i32x4_mul, i32x4_neg, i32x4_shl, i32x4_splat, i32x4_sub,
+    f32x4_abs, f32x4_add, f32x4_div, f32x4_eq, f32x4_ge, f32x4_gt, f32x4_le, f32x4_lt, f32x4_max,
+    f32x4_min, f32x4_mul, f32x4_neg, f32x4_splat, f32x4_sub, i32x4_add, i32x4_eq, i32x4_ge,
+    i32x4_gt, i32x4_le, i32x4_lt, i32x4_mul, i32x4_neg, i32x4_shl, i32x4_splat, i32x4_sub,
     i32x4_trunc_sat_f32x4, v128, v128_bitselect, v128_load, v128_store,
 };
 use std::mem::transmute;
@@ -183,6 +183,11 @@ impl SimdFloatOps<F32x4> for Wasm32Isa {
     #[inline]
     fn neg(self, x: F32x4) -> F32x4 {
         F32x4(f32x4_neg(x.0))
+    }
+
+    #[inline]
+    fn abs(self, x: F32x4) -> F32x4 {
+        F32x4(f32x4_abs(x.0))
     }
 
     #[inline]

--- a/rten-simd/src/safe/arch/x86_64.rs
+++ b/rten-simd/src/safe/arch/x86_64.rs
@@ -1,7 +1,7 @@
 use std::arch::x86_64::{
-    __m256, __m256i, _mm256_add_epi32, _mm256_add_ps, _mm256_blendv_epi8, _mm256_blendv_ps,
-    _mm256_cmp_ps, _mm256_cmpeq_epi32, _mm256_cmpgt_epi32, _mm256_cvttps_epi32, _mm256_div_ps,
-    _mm256_fmadd_ps, _mm256_loadu_ps, _mm256_loadu_si256, _mm256_maskload_epi32,
+    __m256, __m256i, _mm256_add_epi32, _mm256_add_ps, _mm256_andnot_ps, _mm256_blendv_epi8,
+    _mm256_blendv_ps, _mm256_cmp_ps, _mm256_cmpeq_epi32, _mm256_cmpgt_epi32, _mm256_cvttps_epi32,
+    _mm256_div_ps, _mm256_fmadd_ps, _mm256_loadu_ps, _mm256_loadu_si256, _mm256_maskload_epi32,
     _mm256_maskload_ps, _mm256_maskstore_epi32, _mm256_maskstore_ps, _mm256_max_ps, _mm256_min_ps,
     _mm256_mul_ps, _mm256_mullo_epi32, _mm256_or_si256, _mm256_set1_epi32, _mm256_set1_ps,
     _mm256_setzero_si256, _mm256_slli_epi32, _mm256_storeu_ps, _mm256_storeu_si256,
@@ -153,6 +153,11 @@ impl SimdFloatOps<__m256> for Avx2Isa {
     #[inline]
     fn div(self, x: __m256, y: __m256) -> __m256 {
         unsafe { _mm256_div_ps(x, y) }
+    }
+
+    #[inline]
+    fn abs(self, x: __m256) -> __m256 {
+        unsafe { _mm256_andnot_ps(_mm256_set1_ps(-0.0), x) }
     }
 
     #[inline]

--- a/rten-simd/src/safe/dispatch.rs
+++ b/rten-simd/src/safe/dispatch.rs
@@ -123,6 +123,18 @@ pub trait SimdUnaryOp<T: Elem> {
         let wrapped_op = SimdMapOp::wrap(input.into(), self);
         dispatch(wrapped_op);
     }
+
+    /// Apply this operation to a single element.
+    #[allow(private_bounds)]
+    fn scalar_eval(&self, x: T) -> T
+    where
+        Self: Sized,
+        for<'a> SimdMapOp<'a, T, Self>: SimdOp,
+    {
+        let mut array = [x];
+        self.map_mut(&mut array);
+        array[0]
+    }
 }
 
 /// SIMD operation which applies a unary operator `Op` to all elements in

--- a/rten-vecmath/src/lib.rs
+++ b/rten-vecmath/src/lib.rs
@@ -28,7 +28,7 @@
 //! ```
 //! use std::mem::MaybeUninit;
 //!
-//! use rten_simd::dispatch::SimdUnaryOp;
+//! use rten_simd::safe::SimdUnaryOp;
 //! use rten_vecmath::Erf;
 //!
 //! // Apply the error function to each element of `data`.
@@ -45,7 +45,7 @@
 //! ### Applying softmax in place
 //!
 //! ```
-//! use rten_simd::dispatch::SimdOp;
+//! use rten_simd::safe::SimdOp;
 //! use rten_vecmath::Softmax;
 //!
 //! let mut data = [1., 0.5, 2.0];
@@ -58,7 +58,7 @@
 //! buffer. The softmax operation returns the initialized slice.
 //!
 //! ```
-//! use rten_simd::dispatch::SimdOp;
+//! use rten_simd::safe::SimdOp;
 //! use rten_vecmath::Softmax;
 //!
 //! let data = [1., 0.5, 2.0];

--- a/src/ops/norm.rs
+++ b/src/ops/norm.rs
@@ -1,8 +1,7 @@
 use std::mem::MaybeUninit;
 
 use rayon::prelude::*;
-use rten_simd::dispatch::SimdOp as UnsafeSimdOp;
-use rten_simd::safe::SimdOp as SafeSimdOp;
+use rten_simd::safe::SimdOp;
 use rten_tensor::prelude::*;
 use rten_tensor::{NdTensorView, Tensor, TensorView};
 use rten_vecmath as vecmath;

--- a/src/ops/unary_elementwise.rs
+++ b/src/ops/unary_elementwise.rs
@@ -4,7 +4,7 @@ use std::any::Any;
 use std::fmt::Debug;
 use std::mem::MaybeUninit;
 
-use rten_simd::dispatch::SimdUnaryOp;
+use rten_simd::safe::SimdUnaryOp;
 use rten_tensor::prelude::*;
 use rten_tensor::{Tensor, TensorView, TensorViewMut};
 use rten_vecmath as vecmath;


### PR DESCRIPTION
Convert the exponential (`Exp`) operation implementation to use the new portable SIMD API introduced in https://github.com/robertknight/rten/pull/604, as well as other operations built on top of it (Swish, Silu, Sigmoid, Gelu, Erf, Sigmoid, Tanh, Softmax).

In the process also add a few general SIMD operations (abs, reciprocal, poly_eval, fold_splat) that were missing from the new SIMD API.