### PR TITLE
Use stronger typing for `SimdUnaryOp` argument

### DIFF
--- a/rten-simd/src/safe/vec.rs
+++ b/rten-simd/src/safe/vec.rs
@@ -71,6 +71,18 @@ pub trait Simd: Copy + Debug {
         T::from_bits(self.to_bits())
     }
 
+    /// Cast this vector to another with the same ISA and element type.
+    ///
+    /// This cast is a no-op which doesn't generate any code. It is needed in
+    /// some cases to downcast a `Simd` type to one of an `Isa`s associated
+    /// types, or vice-versa.
+    fn same_cast<T>(self) -> T
+    where
+        T: Simd<Elem = Self::Elem, Isa = Self::Isa>,
+    {
+        T::from_bits(self.to_bits())
+    }
+
     /// Convert `self` to a SIMD array.
     ///
     /// This is a cheap transmute in most cases, since SIMD vectors usually

--- a/rten-vecmath/src/erf.rs
+++ b/rten-vecmath/src/erf.rs
@@ -20,9 +20,9 @@ pub struct Erf {}
 
 impl SimdUnaryOp<f32> for Erf {
     #[inline(always)]
-    fn eval<I: Isa>(&self, isa: I, x: I::Bits) -> I::Bits {
+    fn eval<I: Isa, S: Simd<Elem = f32, Isa = I>>(&self, isa: I, x: S) -> S {
         let ops = isa.f32();
-        let x = I::F32::from_bits(x);
+        let x = x.same_cast();
 
         let neg_mask = ops.lt(x, ops.zero());
 
@@ -51,7 +51,7 @@ impl SimdUnaryOp<f32> for Erf {
 
         // Approximation is valid only for x >= 0. For negative values approximation
         // can be computed as -erf(-x).
-        ops.select(ops.neg(y), y, neg_mask).to_bits()
+        ops.select(ops.neg(y), y, neg_mask).same_cast()
     }
 }
 
@@ -63,15 +63,15 @@ pub struct Gelu {}
 
 impl SimdUnaryOp<f32> for Gelu {
     #[inline(always)]
-    fn eval<I: Isa>(&self, isa: I, x: I::Bits) -> I::Bits {
+    fn eval<I: Isa, S: Simd<Elem = f32, Isa = I>>(&self, isa: I, x: S) -> S {
         let ops = isa.f32();
-        let x = I::F32::from_bits(x);
+        let x = x.same_cast();
 
         let half_x = ops.mul(x, ops.splat(0.5));
         let sqrt_2_rcp = ops.splat(SQRT_2_RCP);
         let y = ops.mul(x, sqrt_2_rcp);
         let y = ops.add(Erf::apply(isa, y), ops.splat(1.0));
-        ops.mul(half_x, y).to_bits()
+        ops.mul(half_x, y).same_cast()
     }
 }
 

--- a/rten-vecmath/src/tanh.rs
+++ b/rten-vecmath/src/tanh.rs
@@ -9,9 +9,9 @@ pub struct Tanh {}
 
 impl SimdUnaryOp<f32> for Tanh {
     #[inline(always)]
-    fn eval<I: Isa>(&self, isa: I, x: I::Bits) -> I::Bits {
+    fn eval<I: Isa, S: Simd<Elem = f32, Isa = I>>(&self, isa: I, x: S) -> S {
         let ops = isa.f32();
-        let x = I::F32::from_bits(x);
+        let x = x.same_cast();
 
         let x_negative = ops.le(x, ops.zero());
         let abs_x = ops.abs(x);
@@ -60,7 +60,7 @@ impl SimdUnaryOp<f32> for Tanh {
         let y = ops.select(abs_x, y, x_tiny);
 
         // Flip sign if input was negative.
-        ops.select(ops.neg(y), y, x_negative).to_bits()
+        ops.select(ops.neg(y), y, x_negative).same_cast()
     }
 }
 


### PR DESCRIPTION
Revise signature of `SimdUnaryOp::eval` so that it specifies the element type in the SIMD vector. Casting between the generic type and the concrete type used by the ISA is still required, but is now safer as the cast prevents accidental changing of the element type.

A bonus is that it now becomes slightly easier to implement an operation for different element types via a macro, as only the element type needs to varied for each impl in many cases.