### PR TITLE
Add trait for mask operations in new SIMD API

### DIFF
--- a/rten-simd/src/safe.rs
+++ b/rten-simd/src/safe.rs
@@ -126,7 +126,7 @@ mod vec;
 
 pub use dispatch::{SimdOp, SimdUnaryOp};
 pub use iter::{Iter, SimdIterable};
-pub use vec::{Elem, Isa, Mask, Simd, SimdFloatOps, SimdIntOps, SimdOps};
+pub use vec::{Elem, Isa, Mask, MaskOps, Simd, SimdFloatOps, SimdIntOps, SimdOps};
 
 #[cfg(test)]
 pub(crate) use dispatch::test_simd_op;

--- a/rten-simd/src/safe/arch/aarch64.rs
+++ b/rten-simd/src/safe/arch/aarch64.rs
@@ -1,13 +1,13 @@
 use std::arch::aarch64::{
-    float32x4_t, int32x4_t, uint32x4_t, vabsq_f32, vaddq_f32, vaddq_s32, vbslq_f32, vbslq_s32,
-    vceqq_f32, vceqq_s32, vcgeq_f32, vcgeq_s32, vcgtq_f32, vcgtq_s32, vcleq_f32, vcleq_s32,
-    vcltq_f32, vcltq_s32, vcvtq_s32_f32, vdivq_f32, vdupq_n_f32, vdupq_n_s32, vfmaq_f32, vld1q_f32,
-    vld1q_s32, vld1q_u32, vmaxq_f32, vminq_f32, vmulq_f32, vmulq_s32, vnegq_f32, vnegq_s32,
-    vshlq_n_s32, vst1q_f32, vst1q_s32, vsubq_f32, vsubq_s32,
+    float32x4_t, int32x4_t, uint32x4_t, vabsq_f32, vaddq_f32, vaddq_s32, vandq_u32, vbslq_f32,
+    vbslq_s32, vceqq_f32, vceqq_s32, vcgeq_f32, vcgeq_s32, vcgtq_f32, vcgtq_s32, vcleq_f32,
+    vcleq_s32, vcltq_f32, vcltq_s32, vcvtq_s32_f32, vdivq_f32, vdupq_n_f32, vdupq_n_s32, vfmaq_f32,
+    vld1q_f32, vld1q_s32, vld1q_u32, vmaxq_f32, vminq_f32, vmulq_f32, vmulq_s32, vnegq_f32,
+    vnegq_s32, vshlq_n_s32, vst1q_f32, vst1q_s32, vsubq_f32, vsubq_s32,
 };
 use std::mem::transmute;
 
-use crate::safe::{Isa, Mask, Simd, SimdFloatOps, SimdIntOps, SimdOps};
+use crate::safe::{Isa, Mask, MaskOps, Simd, SimdFloatOps, SimdIntOps, SimdOps};
 
 #[derive(Copy, Clone)]
 pub struct ArmNeonIsa {
@@ -78,6 +78,11 @@ macro_rules! simd_ops_x32_common {
                     *ptr.add(i) = x_array[i];
                 }
             }
+        }
+
+        #[inline]
+        fn mask_ops(self) -> impl MaskOps<uint32x4_t> {
+            self
         }
     };
 }
@@ -303,6 +308,13 @@ macro_rules! simd_x32_common {
             unsafe { transmute::<Self, Self::Array>(self) }
         }
     };
+}
+
+unsafe impl MaskOps<uint32x4_t> for ArmNeonIsa {
+    #[inline]
+    fn and(self, x: uint32x4_t, y: uint32x4_t) -> uint32x4_t {
+        unsafe { vandq_u32(x, y) }
+    }
 }
 
 impl Simd for float32x4_t {

--- a/rten-simd/src/safe/arch/wasm32.rs
+++ b/rten-simd/src/safe/arch/wasm32.rs
@@ -2,11 +2,11 @@ use std::arch::wasm32::{
     f32x4_abs, f32x4_add, f32x4_div, f32x4_eq, f32x4_ge, f32x4_gt, f32x4_le, f32x4_lt, f32x4_max,
     f32x4_min, f32x4_mul, f32x4_neg, f32x4_splat, f32x4_sub, i32x4_add, i32x4_eq, i32x4_ge,
     i32x4_gt, i32x4_le, i32x4_lt, i32x4_mul, i32x4_neg, i32x4_shl, i32x4_splat, i32x4_sub,
-    i32x4_trunc_sat_f32x4, v128, v128_bitselect, v128_load, v128_store,
+    i32x4_trunc_sat_f32x4, v128, v128_and, v128_bitselect, v128_load, v128_store,
 };
 use std::mem::transmute;
 
-use crate::safe::{Isa, Mask, Simd, SimdFloatOps, SimdIntOps, SimdOps};
+use crate::safe::{Isa, Mask, MaskOps, Simd, SimdFloatOps, SimdIntOps, SimdOps};
 
 #[derive(Copy, Clone, Debug)]
 #[repr(transparent)]
@@ -45,6 +45,11 @@ unsafe impl Isa for Wasm32Isa {
 
 macro_rules! simd_ops_x32_common {
     ($simd:ty) => {
+        #[inline]
+        fn mask_ops(self) -> impl MaskOps<v128> {
+            self
+        }
+
         #[inline]
         fn len(self) -> usize {
             4
@@ -279,6 +284,13 @@ impl Mask for v128 {
     fn to_array(self) -> Self::Array {
         let array = unsafe { transmute::<Self, [i32; 4]>(self) };
         std::array::from_fn(|i| array[i] != 0)
+    }
+}
+
+unsafe impl MaskOps<v128> for Wasm32Isa {
+    #[inline]
+    fn and(self, x: v128, y: v128) -> v128 {
+        v128_and(x, y)
     }
 }
 


### PR DESCRIPTION
This works similarly to the `SimdOps` trait and sub-traits, but provides operations on masks. The only initial method is `and`, which is needed for im2col.

This change was extracted from https://github.com/robertknight/rten/pull/607.