### PR TITLE
Convert int8 im2col to new SIMD API

### DIFF
--- a/rten-simd/src/safe/vec.rs
+++ b/rten-simd/src/safe/vec.rs
@@ -24,6 +24,7 @@ impl Elem for i32 {
 /// Implementations are obtained via [`SimdOps::mask_ops`].
 pub trait Mask: Copy + Debug {
     type Array: AsRef<[bool]>
+        + Copy
         + Debug
         + IntoIterator<Item = bool>
         + PartialEq<Self::Array>
@@ -48,10 +49,12 @@ pub trait Mask: Copy + Debug {
 pub trait Simd: Copy + Debug {
     /// Representation of this vector as a `[Self::Elem; N]` array.
     type Array: AsRef<[Self::Elem]>
+        + Copy
         + Debug
         + IntoIterator<Item = Self::Elem>
         + PartialEq<Self::Array>
-        + std::ops::Index<usize, Output = Self::Elem>;
+        + std::ops::Index<usize, Output = Self::Elem>
+        + std::ops::IndexMut<usize, Output = Self::Elem>;
 
     /// Type of data held in each SIMD lane.
     type Elem: Elem;

--- a/src/gemm/kernels/wasm.rs
+++ b/src/gemm/kernels/wasm.rs
@@ -180,7 +180,7 @@ unsafe impl Kernel<f32, f32, f32> for WasmKernel {
 }
 
 pub struct WasmInt8Kernel {
-    _private: (),
+    isa: Wasm32Isa,
 }
 
 impl WasmInt8Kernel {
@@ -190,7 +190,7 @@ impl WasmInt8Kernel {
 
 unsafe impl Kernel<u8, i8, i32> for WasmInt8Kernel {
     fn new() -> Option<Self> {
-        Some(WasmInt8Kernel { _private: () })
+        Wasm32Isa::new().map(|isa| WasmInt8Kernel { isa })
     }
 
     fn name(&self) -> &'static str {
@@ -261,11 +261,7 @@ unsafe impl Kernel<u8, i8, i32> for WasmInt8Kernel {
         cols: Range<usize>,
     ) {
         const NR_REGS: usize = vec_count::<v128f>(WasmInt8Kernel::NR).unwrap();
-
-        // Safety: WASM SIMD is supported.
-        unsafe {
-            image.pack_block_i8_dot_cast_u8::<v128i, NR_REGS>(out, rows, cols);
-        }
+        image.pack_block_i8_dot_cast_u8::<_, NR_REGS>(self.isa, out, rows, cols);
     }
 
     unsafe fn kernel(


### PR DESCRIPTION
Convert the im2col implementation for int8 GEMM kernels to the new SIMD API. This allows for much more limited use of `unsafe`.

Part of https://github.com/robertknight/rten/issues/549.