### PR TITLE
Add safe load/store methods in new SIMD API

### DIFF
--- a/rten-simd/src/safe/iter.rs
+++ b/rten-simd/src/safe/iter.rs
@@ -112,13 +112,7 @@ impl<'a, S: Simd, O: SimdOps<S>> Iter<'a, S, O> {
     pub fn tail(&self) -> Option<(S, S::Mask)> {
         let n = self.xs.len();
         if n > 0 {
-            let mask = self.ops.first_n_mask(n);
-
-            // Safety: `xs.add(i)` points to a valid element for all enabled
-            // mask lanes.
-            let x = unsafe { self.ops.load_ptr_mask(self.xs.as_ptr(), mask) };
-
-            Some((x, mask))
+            Some(self.ops.load_pad(self.xs))
         } else {
             None
         }

--- a/src/gemm/im2col.rs
+++ b/src/gemm/im2col.rs
@@ -136,12 +136,10 @@ impl<T: Copy + Default> Im2Col<'_, T> {
         let mut out_offset = 0;
 
         for start_col in (0..col_y_offsets.len()).step_by(ops.len() * NR_REGS) {
-            let col_y_offset: [I::I32; NR_REGS] = std::array::from_fn(|i| unsafe {
-                ops.load_ptr(col_y_offsets.as_ptr().add(start_col + ops.len() * i))
-            });
-            let col_x_offset: [I::I32; NR_REGS] = std::array::from_fn(|i| unsafe {
-                ops.load_ptr(col_x_offsets.as_ptr().add(start_col + ops.len() * i))
-            });
+            let col_y_offset: [I::I32; NR_REGS] =
+                std::array::from_fn(|i| ops.load(&col_y_offsets[start_col + ops.len() * i..]));
+            let col_x_offset: [I::I32; NR_REGS] =
+                std::array::from_fn(|i| ops.load(&col_x_offsets[start_col + ops.len() * i..]));
             let max_x_offset = ops.splat(self.max_x_offset);
             let max_y_offset = ops.splat(self.max_y_offset);
 
@@ -279,12 +277,10 @@ impl Im2Col<'_, i8> {
         let mut out_offset = 0;
 
         for start_col in cols.step_by(ops.len() * NR_REGS) {
-            let col_y_offset: [I::I32; NR_REGS] = std::array::from_fn(|i| unsafe {
-                ops.load_ptr(col_y_offsets.get_unchecked(start_col + i * ops.len()))
-            });
-            let col_x_offset: [I::I32; NR_REGS] = std::array::from_fn(|i| unsafe {
-                ops.load_ptr(col_x_offsets.get_unchecked(start_col + i * ops.len()))
-            });
+            let col_y_offset: [I::I32; NR_REGS] =
+                std::array::from_fn(|i| ops.load(&col_y_offsets[start_col + i * ops.len()..]));
+            let col_x_offset: [I::I32; NR_REGS] =
+                std::array::from_fn(|i| ops.load(&col_x_offsets[start_col + i * ops.len()..]));
             let zero = ops.zero();
 
             let mut col_sums = [ops.zero().to_array(); NR_REGS];


### PR DESCRIPTION
Add `SimdOps::{load, load_pad, store}` methods for loading/storing from a slice with length checks, as opposed to the existing unsafe `load_ptr`, `store_ptr` methods.

The safe methods are preferred in contexts where the length check cost is tolerable.