### PR TITLE
Support i8 vectors in new SIMD API

### DIFF
--- a/rten-simd/src/safe/arch/aarch64.rs
+++ b/rten-simd/src/safe/arch/aarch64.rs
@@ -1,12 +1,14 @@
 use std::arch::aarch64::{
-    float32x4_t, int16x8_t, int32x4_t, uint16x8_t, uint32x4_t, vabsq_f32, vaddq_f32, vaddq_s16,
-    vaddq_s32, vaddvq_f32, vandq_u16, vandq_u32, vbslq_f32, vbslq_s16, vbslq_s32, vceqq_f32,
-    vceqq_s16, vceqq_s32, vcgeq_f32, vcgeq_s16, vcgeq_s32, vcgtq_f32, vcgtq_s16, vcgtq_s32,
-    vcleq_f32, vcleq_s16, vcltq_f32, vcltq_s16, vcvtnq_s32_f32, vcvtq_s32_f32, vdivq_f32,
-    vdupq_n_f32, vdupq_n_s16, vdupq_n_s32, vfmaq_f32, vld1q_f32, vld1q_s16, vld1q_s32, vld1q_u16,
-    vld1q_u32, vmaxq_f32, vminq_f32, vmulq_f32, vmulq_s16, vmulq_s32, vnegq_f32, vnegq_s16,
-    vnegq_s32, vshlq_n_s16, vshlq_n_s32, vst1q_f32, vst1q_s16, vst1q_s32, vsubq_f32, vsubq_s16,
-    vsubq_s32,
+    float32x4_t, int16x8_t, int32x4_t, int8x16_t, uint16x8_t, uint32x4_t, uint8x16_t, vabsq_f32,
+    vaddq_f32, vaddq_s16, vaddq_s32, vaddq_s8, vaddvq_f32, vandq_u16, vandq_u32, vandq_u8,
+    vbslq_f32, vbslq_s16, vbslq_s32, vbslq_s8, vceqq_f32, vceqq_s16, vceqq_s32, vceqq_s8,
+    vcgeq_f32, vcgeq_s16, vcgeq_s32, vcgeq_s8, vcgtq_f32, vcgtq_s16, vcgtq_s32, vcgtq_s8,
+    vcleq_f32, vcleq_s16, vcleq_s8, vcltq_f32, vcltq_s16, vcltq_s8, vcvtnq_s32_f32, vcvtq_s32_f32,
+    vdivq_f32, vdupq_n_f32, vdupq_n_s16, vdupq_n_s32, vdupq_n_s8, vfmaq_f32, vld1q_f32, vld1q_s16,
+    vld1q_s32, vld1q_s8, vld1q_u16, vld1q_u32, vld1q_u8, vmaxq_f32, vminq_f32, vmulq_f32,
+    vmulq_s16, vmulq_s32, vmulq_s8, vnegq_f32, vnegq_s16, vnegq_s32, vnegq_s8, vshlq_n_s16,
+    vshlq_n_s32, vshlq_n_s8, vst1q_f32, vst1q_s16, vst1q_s32, vst1q_s8, vsubq_f32, vsubq_s16,
+    vsubq_s32, vsubq_s8,
 };
 use std::mem::transmute;
 
@@ -28,6 +30,7 @@ unsafe impl Isa for ArmNeonIsa {
     type F32 = float32x4_t;
     type I32 = int32x4_t;
     type I16 = int16x8_t;
+    type I8 = int8x16_t;
     type Bits = int32x4_t;
 
     fn f32(self) -> impl SimdFloatOps<Self::F32, Int = Self::I32> {
@@ -39,6 +42,10 @@ unsafe impl Isa for ArmNeonIsa {
     }
 
     fn i16(self) -> impl SimdIntOps<Self::I16> {
+        self
+    }
+
+    fn i8(self) -> impl SimdIntOps<Self::I8> {
         self
     }
 }
@@ -363,6 +370,88 @@ impl SimdIntOps<int16x8_t> for ArmNeonIsa {
     }
 }
 
+unsafe impl SimdOps<int8x16_t> for ArmNeonIsa {
+    simd_ops_common!(int8x16_t, uint8x16_t);
+
+    #[inline]
+    fn add(self, x: int8x16_t, y: int8x16_t) -> int8x16_t {
+        unsafe { vaddq_s8(x, y) }
+    }
+
+    #[inline]
+    fn sub(self, x: int8x16_t, y: int8x16_t) -> int8x16_t {
+        unsafe { vsubq_s8(x, y) }
+    }
+
+    #[inline]
+    fn mul(self, x: int8x16_t, y: int8x16_t) -> int8x16_t {
+        unsafe { vmulq_s8(x, y) }
+    }
+
+    #[inline]
+    fn splat(self, x: i8) -> int8x16_t {
+        unsafe { vdupq_n_s8(x) }
+    }
+
+    #[inline]
+    fn lt(self, x: int8x16_t, y: int8x16_t) -> uint8x16_t {
+        unsafe { vcltq_s8(x, y) }
+    }
+
+    #[inline]
+    fn le(self, x: int8x16_t, y: int8x16_t) -> uint8x16_t {
+        unsafe { vcleq_s8(x, y) }
+    }
+
+    #[inline]
+    fn eq(self, x: int8x16_t, y: int8x16_t) -> uint8x16_t {
+        unsafe { vceqq_s8(x, y) }
+    }
+
+    #[inline]
+    fn ge(self, x: int8x16_t, y: int8x16_t) -> uint8x16_t {
+        unsafe { vcgeq_s8(x, y) }
+    }
+
+    #[inline]
+    fn gt(self, x: int8x16_t, y: int8x16_t) -> uint8x16_t {
+        unsafe { vcgtq_s8(x, y) }
+    }
+
+    #[inline]
+    unsafe fn load_ptr(self, ptr: *const i8) -> int8x16_t {
+        unsafe { vld1q_s8(ptr) }
+    }
+
+    #[inline]
+    fn first_n_mask(self, n: usize) -> uint8x16_t {
+        let mask: [u8; 16] = std::array::from_fn(|i| if i < n { u8::MAX } else { 0 });
+        unsafe { vld1q_u8(mask.as_ptr()) }
+    }
+
+    #[inline]
+    fn select(self, x: int8x16_t, y: int8x16_t, mask: <int8x16_t as Simd>::Mask) -> int8x16_t {
+        unsafe { vbslq_s8(mask, x, y) }
+    }
+
+    #[inline]
+    unsafe fn store_ptr(self, x: int8x16_t, ptr: *mut i8) {
+        unsafe { vst1q_s8(ptr, x) }
+    }
+}
+
+impl SimdIntOps<int8x16_t> for ArmNeonIsa {
+    #[inline]
+    fn neg(self, x: int8x16_t) -> int8x16_t {
+        unsafe { vnegq_s8(x) }
+    }
+
+    #[inline]
+    fn shift_left<const SHIFT: i32>(self, x: int8x16_t) -> int8x16_t {
+        unsafe { vshlq_n_s8::<SHIFT>(x) }
+    }
+}
+
 macro_rules! impl_mask {
     ($mask:ty, $elem:ty, $len:expr) => {
         impl Mask for $mask {
@@ -379,6 +468,7 @@ macro_rules! impl_mask {
 
 impl_mask!(uint32x4_t, u32, 4);
 impl_mask!(uint16x8_t, u16, 8);
+impl_mask!(uint8x16_t, u8, 16);
 
 unsafe impl MaskOps<uint32x4_t> for ArmNeonIsa {
     #[inline]
@@ -391,6 +481,13 @@ unsafe impl MaskOps<uint16x8_t> for ArmNeonIsa {
     #[inline]
     fn and(self, x: uint16x8_t, y: uint16x8_t) -> uint16x8_t {
         unsafe { vandq_u16(x, y) }
+    }
+}
+
+unsafe impl MaskOps<uint8x16_t> for ArmNeonIsa {
+    #[inline]
+    fn and(self, x: uint8x16_t, y: uint8x16_t) -> uint8x16_t {
+        unsafe { vandq_u8(x, y) }
     }
 }
 
@@ -436,3 +533,4 @@ macro_rules! impl_simd {
 impl_simd!(float32x4_t, f32, 4, uint32x4_t);
 impl_simd!(int32x4_t, i32, 4, uint32x4_t);
 impl_simd!(int16x8_t, i16, 8, uint16x8_t);
+impl_simd!(int8x16_t, i8, 16, uint8x16_t);

--- a/rten-simd/src/safe/arch/generic.rs
+++ b/rten-simd/src/safe/arch/generic.rs
@@ -18,6 +18,10 @@ pub struct I32x4([i32; LEN_X32]);
 #[derive(Copy, Clone, Debug)]
 pub struct I16x8([i16; LEN_X32 * 2]);
 
+#[repr(align(16))]
+#[derive(Copy, Clone, Debug)]
+pub struct I8x16([i8; LEN_X32 * 4]);
+
 #[derive(Copy, Clone)]
 pub struct GenericIsa {
     _private: (),
@@ -40,6 +44,7 @@ unsafe impl Isa for GenericIsa {
     type F32 = F32x4;
     type I32 = I32x4;
     type I16 = I16x8;
+    type I8 = I8x16;
     type Bits = I32x4;
 
     fn f32(self) -> impl SimdFloatOps<Self::F32, Int = Self::I32> {
@@ -51,6 +56,10 @@ unsafe impl Isa for GenericIsa {
     }
 
     fn i16(self) -> impl SimdIntOps<Self::I16> {
+        self
+    }
+
+    fn i8(self) -> impl SimdIntOps<Self::I8> {
         self
     }
 }
@@ -247,6 +256,7 @@ macro_rules! impl_simd_int_ops {
 
 impl_simd_int_ops!(I32x4, i32, 4, I32x4);
 impl_simd_int_ops!(I16x8, i16, 8, I16x8);
+impl_simd_int_ops!(I8x16, i8, 16, I8x16);
 
 macro_rules! impl_mask {
     ($mask:ident, $len:expr) => {
@@ -272,6 +282,7 @@ macro_rules! impl_mask {
 
 impl_mask!(I32x4, LEN_X32);
 impl_mask!(I16x8, LEN_X32 * 2);
+impl_mask!(I8x16, LEN_X32 * 4);
 
 macro_rules! impl_simd {
     ($simd:ty, $elem:ty, $mask:ty, $len:expr) => {
@@ -304,3 +315,4 @@ macro_rules! impl_simd {
 impl_simd!(F32x4, f32, I32x4, 4);
 impl_simd!(I32x4, i32, I32x4, 4);
 impl_simd!(I16x8, i16, I16x8, 8);
+impl_simd!(I8x16, i8, I8x16, 16);

--- a/rten-simd/src/safe/arch/x86_64/avx2.rs
+++ b/rten-simd/src/safe/arch/x86_64/avx2.rs
@@ -1,26 +1,31 @@
 use std::arch::x86_64::{
-    __m256, __m256i, _mm256_add_epi16, _mm256_add_epi32, _mm256_add_ps, _mm256_and_ps,
-    _mm256_and_si256, _mm256_andnot_ps, _mm256_blendv_epi8, _mm256_blendv_ps,
-    _mm256_castps256_ps128, _mm256_cmp_ps, _mm256_cmpeq_epi16, _mm256_cmpeq_epi32,
-    _mm256_cmpgt_epi16, _mm256_cmpgt_epi32, _mm256_cvtps_epi32, _mm256_cvttps_epi32, _mm256_div_ps,
-    _mm256_extractf128_ps, _mm256_fmadd_ps, _mm256_loadu_ps, _mm256_loadu_si256,
-    _mm256_maskload_epi32, _mm256_maskload_ps, _mm256_maskstore_epi32, _mm256_maskstore_ps,
-    _mm256_max_ps, _mm256_min_ps, _mm256_movemask_epi8, _mm256_mul_ps, _mm256_mullo_epi16,
-    _mm256_mullo_epi32, _mm256_or_si256, _mm256_set1_epi16, _mm256_set1_epi32, _mm256_set1_ps,
+    __m128i, __m256, __m256i, _mm256_add_epi16, _mm256_add_epi32, _mm256_add_epi8, _mm256_add_ps,
+    _mm256_and_ps, _mm256_and_si256, _mm256_andnot_ps, _mm256_blendv_epi8, _mm256_blendv_ps,
+    _mm256_castps256_ps128, _mm256_castsi256_si128, _mm256_cmp_ps, _mm256_cmpeq_epi16,
+    _mm256_cmpeq_epi32, _mm256_cmpeq_epi8, _mm256_cmpgt_epi16, _mm256_cmpgt_epi32,
+    _mm256_cmpgt_epi8, _mm256_cvtepi8_epi16, _mm256_cvtps_epi32, _mm256_cvttps_epi32,
+    _mm256_div_ps, _mm256_extractf128_ps, _mm256_extracti128_si256, _mm256_fmadd_ps,
+    _mm256_loadu_ps, _mm256_loadu_si256, _mm256_maskload_epi32, _mm256_maskload_ps,
+    _mm256_maskstore_epi32, _mm256_maskstore_ps, _mm256_max_ps, _mm256_min_ps,
+    _mm256_movemask_epi8, _mm256_mul_ps, _mm256_mullo_epi16, _mm256_mullo_epi32, _mm256_or_si256,
+    _mm256_set1_epi16, _mm256_set1_epi32, _mm256_set1_epi8, _mm256_set1_ps, _mm256_setr_m128i,
     _mm256_setzero_si256, _mm256_slli_epi16, _mm256_slli_epi32, _mm256_storeu_ps,
-    _mm256_storeu_si256, _mm256_sub_epi16, _mm256_sub_epi32, _mm256_sub_ps, _mm256_xor_ps,
-    _mm_add_ps, _mm_cvtss_f32, _mm_movehl_ps, _mm_prefetch, _mm_shuffle_ps, _CMP_EQ_OQ, _CMP_GE_OQ,
-    _CMP_GT_OQ, _CMP_LE_OQ, _CMP_LT_OQ, _MM_HINT_ET0, _MM_HINT_T0,
+    _mm256_storeu_si256, _mm256_sub_epi16, _mm256_sub_epi32, _mm256_sub_epi8, _mm256_sub_ps,
+    _mm256_xor_ps, _mm_add_ps, _mm_cvtss_f32, _mm_movehl_ps, _mm_prefetch, _mm_setr_epi8,
+    _mm_shuffle_epi8, _mm_shuffle_ps, _mm_unpacklo_epi64, _CMP_EQ_OQ, _CMP_GE_OQ, _CMP_GT_OQ,
+    _CMP_LE_OQ, _CMP_LT_OQ, _MM_HINT_ET0, _MM_HINT_T0,
 };
 use std::is_x86_feature_detected;
 use std::mem::transmute;
 
 use super::super::{lanes, simd_type};
+use crate::safe::vec::{Extend, Narrow};
 use crate::safe::{Isa, Mask, MaskOps, Simd, SimdFloatOps, SimdIntOps, SimdOps};
 
 simd_type!(F32x8, __m256, f32, F32x8, Avx2Isa);
 simd_type!(I32x8, __m256i, i32, I32x8, Avx2Isa);
 simd_type!(I16x16, __m256i, i16, I16x16, Avx2Isa);
+simd_type!(I8x32, __m256i, i8, I8x32, Avx2Isa);
 
 #[derive(Copy, Clone)]
 pub struct Avx2Isa {
@@ -42,6 +47,7 @@ unsafe impl Isa for Avx2Isa {
     type F32 = F32x8;
     type I32 = I32x8;
     type I16 = I16x16;
+    type I8 = I8x32;
     type Bits = I32x8;
 
     fn f32(self) -> impl SimdFloatOps<Self::F32, Int = Self::I32> {
@@ -53,6 +59,10 @@ unsafe impl Isa for Avx2Isa {
     }
 
     fn i16(self) -> impl SimdIntOps<Self::I16> {
+        self
+    }
+
+    fn i8(self) -> impl SimdIntOps<Self::I8> {
         self
     }
 }
@@ -335,17 +345,6 @@ unsafe impl SimdOps<I16x16> for Avx2Isa {
     }
 
     #[inline]
-    fn lt(self, x: I16x16, y: I16x16) -> I16x16 {
-        unsafe { _mm256_cmpgt_epi16(y.0, x.0) }.into()
-    }
-
-    #[inline]
-    fn le(self, x: I16x16, y: I16x16) -> I16x16 {
-        unsafe { _mm256_or_si256(_mm256_cmpgt_epi16(y.0, x.0), _mm256_cmpeq_epi16(x.0, y.0)) }
-            .into()
-    }
-
-    #[inline]
     fn eq(self, x: I16x16, y: I16x16) -> I16x16 {
         unsafe { _mm256_cmpeq_epi16(x.0, y.0) }.into()
     }
@@ -421,6 +420,123 @@ impl SimdIntOps<I16x16> for Avx2Isa {
     }
 }
 
+unsafe impl SimdOps<I8x32> for Avx2Isa {
+    simd_ops_common!(I8x32, I8x32);
+
+    #[inline]
+    fn first_n_mask(self, n: usize) -> I8x32 {
+        let mask: [i8; 32] = std::array::from_fn(|i| if i < n { -1 } else { 0 });
+        unsafe { _mm256_loadu_si256(mask.as_ptr() as *const __m256i) }.into()
+    }
+
+    #[inline]
+    fn add(self, x: I8x32, y: I8x32) -> I8x32 {
+        unsafe { _mm256_add_epi8(x.0, y.0) }.into()
+    }
+
+    #[inline]
+    fn sub(self, x: I8x32, y: I8x32) -> I8x32 {
+        unsafe { _mm256_sub_epi8(x.0, y.0) }.into()
+    }
+
+    #[inline]
+    fn mul(self, x: I8x32, y: I8x32) -> I8x32 {
+        let (x_lo, x_hi) = self.extend(x);
+        let (y_lo, y_hi) = self.extend(y);
+
+        let i16_ops = self.i16();
+        let prod_lo = i16_ops.mul(x_lo, y_lo);
+        let prod_hi = i16_ops.mul(x_hi, y_hi);
+
+        self.narrow_truncate(prod_lo, prod_hi)
+    }
+
+    #[inline]
+    fn splat(self, x: i8) -> I8x32 {
+        unsafe { _mm256_set1_epi8(x) }.into()
+    }
+
+    #[inline]
+    fn eq(self, x: I8x32, y: I8x32) -> I8x32 {
+        unsafe { _mm256_cmpeq_epi8(x.0, y.0) }.into()
+    }
+
+    #[inline]
+    fn ge(self, x: I8x32, y: I8x32) -> I8x32 {
+        unsafe { _mm256_or_si256(_mm256_cmpgt_epi8(x.0, y.0), _mm256_cmpeq_epi8(x.0, y.0)) }.into()
+    }
+
+    #[inline]
+    fn gt(self, x: I8x32, y: I8x32) -> I8x32 {
+        unsafe { _mm256_cmpgt_epi8(x.0, y.0) }.into()
+    }
+
+    #[inline]
+    unsafe fn load_ptr(self, ptr: *const i8) -> I8x32 {
+        unsafe { _mm256_loadu_si256(ptr as *const __m256i) }.into()
+    }
+
+    #[inline]
+    fn select(self, x: I8x32, y: I8x32, mask: <I8x32 as Simd>::Mask) -> I8x32 {
+        unsafe { _mm256_blendv_epi8(y.0, x.0, mask.0) }.into()
+    }
+
+    #[inline]
+    unsafe fn store_ptr(self, x: I8x32, ptr: *mut i8) {
+        unsafe { _mm256_storeu_si256(ptr as *mut __m256i, x.0) }
+    }
+
+    #[inline]
+    unsafe fn load_ptr_mask(self, ptr: *const i8, mask: I8x32) -> I8x32 {
+        // There is no native masked-load instruction for i8, so fall back to
+        // scalar loads.
+        let mask = _mm256_movemask_epi8(mask.0) as u32;
+        let xs: [i8; 32] = std::array::from_fn(|i| {
+            let mask_bit = mask & (1 << i);
+            if mask_bit != 0 {
+                // Safety: Caller promises that `ptr.add(i)` is valid if mask[i] is set.
+                unsafe { *ptr.add(i) }
+            } else {
+                0
+            }
+        });
+        self.load_ptr(xs.as_ptr())
+    }
+
+    #[inline]
+    unsafe fn store_ptr_mask(self, x: I8x32, ptr: *mut i8, mask: I8x32) {
+        // There is no native masked-store instruction for i8, so fall back to
+        // scalar store.
+        let xs = Simd::to_array(x);
+        let mask = _mm256_movemask_epi8(mask.0) as u32;
+        for i in 0..32 {
+            let mask_bit = mask & (1 << i);
+            if mask_bit != 0 {
+                // Safety: Caller promises that `ptr.add(i)` is valid if mask[i] is set.
+                unsafe { *ptr.add(i) = xs[i] }
+            }
+        }
+    }
+}
+
+impl SimdIntOps<I8x32> for Avx2Isa {
+    #[inline]
+    fn neg(self, x: I8x32) -> I8x32 {
+        unsafe { _mm256_sub_epi8(_mm256_setzero_si256(), x.0) }.into()
+    }
+
+    #[inline]
+    fn shift_left<const SHIFT: i32>(self, x: I8x32) -> I8x32 {
+        let (x_lo, x_hi) = self.extend(x);
+
+        let i16_ops = self.i16();
+        let y_lo = i16_ops.shift_left::<SHIFT>(x_lo);
+        let y_hi = i16_ops.shift_left::<SHIFT>(x_hi);
+
+        self.narrow_truncate(y_lo, y_hi)
+    }
+}
+
 macro_rules! impl_mask {
     ($mask:ty, $elem:ty) => {
         impl Mask for $mask {
@@ -438,6 +554,7 @@ macro_rules! impl_mask {
 impl_mask!(F32x8, f32);
 impl_mask!(I32x8, i32);
 impl_mask!(I16x16, i16);
+impl_mask!(I8x32, i8);
 
 macro_rules! impl_int_mask_ops {
     ($mask:ty) => {
@@ -451,10 +568,55 @@ macro_rules! impl_int_mask_ops {
 }
 impl_int_mask_ops!(I32x8);
 impl_int_mask_ops!(I16x16);
+impl_int_mask_ops!(I8x32);
 
 unsafe impl MaskOps<F32x8> for Avx2Isa {
     #[inline]
     fn and(self, x: F32x8, y: F32x8) -> F32x8 {
         unsafe { _mm256_and_ps(x.0, y.0) }.into()
+    }
+}
+
+impl Extend<I8x32> for Avx2Isa {
+    type Output = I16x16;
+
+    #[inline]
+    fn extend(self, x: I8x32) -> (Self::Output, Self::Output) {
+        let (low_i16, high_i16) = unsafe {
+            let low = _mm256_castsi256_si128(x.0);
+            let high = _mm256_extracti128_si256(x.0, 1);
+            (_mm256_cvtepi8_epi16(low), _mm256_cvtepi8_epi16(high))
+        };
+        (I16x16(low_i16), I16x16(high_i16))
+    }
+}
+
+/// Extract bytes at even indices.
+///
+/// Given an input with 16-bit lanes, this extracts truncated 8-bit values.
+#[inline]
+unsafe fn extract_even_bytes(vec: __m256i) -> __m128i {
+    let lo = _mm256_extracti128_si256(vec, 0);
+    let hi = _mm256_extracti128_si256(vec, 1);
+
+    // Shuffle mask that moves bytes at even indices into first half of output.
+    // For the second half set the high bit to zero the bytes.
+    let mask = _mm_setr_epi8(0, 2, 4, 6, 8, 10, 12, 14, -1, -1, -1, -1, -1, -1, -1, -1);
+
+    // Extract even bytes from each half, then concatenate.
+    let lo_even = _mm_shuffle_epi8(lo, mask);
+    let hi_even = _mm_shuffle_epi8(hi, mask);
+    _mm_unpacklo_epi64(lo_even, hi_even)
+}
+
+impl Narrow<I16x16> for Avx2Isa {
+    type Output = I8x32;
+
+    #[inline]
+    fn narrow_truncate(self, low: I16x16, high: I16x16) -> Self::Output {
+        let low_even = unsafe { extract_even_bytes(low.0) };
+        let high_even = unsafe { extract_even_bytes(high.0) };
+        let combined = unsafe { _mm256_setr_m128i(low_even, high_even) };
+        I8x32(combined)
     }
 }

--- a/rten-simd/src/safe/arch/x86_64/avx512.rs
+++ b/rten-simd/src/safe/arch/x86_64/avx512.rs
@@ -1,24 +1,30 @@
 use std::arch::x86_64::{
-    __m512, __m512i, __mmask16, __mmask32, _mm512_add_epi16, _mm512_add_epi32, _mm512_add_ps,
-    _mm512_andnot_ps, _mm512_cmp_epi16_mask, _mm512_cmp_epi32_mask, _mm512_cmp_ps_mask,
-    _mm512_cvtps_epi32, _mm512_cvttps_epi32, _mm512_div_ps, _mm512_fmadd_ps, _mm512_loadu_ps,
-    _mm512_loadu_si512, _mm512_mask_blend_epi16, _mm512_mask_blend_epi32, _mm512_mask_blend_ps,
-    _mm512_mask_loadu_epi16, _mm512_mask_loadu_epi32, _mm512_mask_loadu_ps,
-    _mm512_mask_storeu_epi16, _mm512_mask_storeu_epi32, _mm512_mask_storeu_ps, _mm512_max_ps,
-    _mm512_min_ps, _mm512_mul_ps, _mm512_mullo_epi16, _mm512_mullo_epi32, _mm512_reduce_add_ps,
-    _mm512_set1_epi16, _mm512_set1_epi32, _mm512_set1_ps, _mm512_setzero_si512, _mm512_sllv_epi16,
-    _mm512_sllv_epi32, _mm512_storeu_ps, _mm512_storeu_si512, _mm512_sub_epi16, _mm512_sub_epi32,
+    __m512, __m512i, __mmask16, __mmask32, __mmask64, _mm512_add_epi16, _mm512_add_epi32,
+    _mm512_add_epi8, _mm512_add_ps, _mm512_andnot_ps, _mm512_castsi256_si512,
+    _mm512_cmp_epi16_mask, _mm512_cmp_epi32_mask, _mm512_cmp_ps_mask, _mm512_cmpeq_epi8_mask,
+    _mm512_cmpge_epi8_mask, _mm512_cmpgt_epi8_mask, _mm512_cvtepi16_epi8, _mm512_cvtepi8_epi16,
+    _mm512_cvtps_epi32, _mm512_cvttps_epi32, _mm512_div_ps, _mm512_extracti64x4_epi64,
+    _mm512_fmadd_ps, _mm512_inserti64x4, _mm512_loadu_ps, _mm512_loadu_si512,
+    _mm512_mask_blend_epi16, _mm512_mask_blend_epi32, _mm512_mask_blend_epi8, _mm512_mask_blend_ps,
+    _mm512_mask_loadu_epi16, _mm512_mask_loadu_epi32, _mm512_mask_loadu_epi8, _mm512_mask_loadu_ps,
+    _mm512_mask_storeu_epi16, _mm512_mask_storeu_epi32, _mm512_mask_storeu_epi8,
+    _mm512_mask_storeu_ps, _mm512_max_ps, _mm512_min_ps, _mm512_mul_ps, _mm512_mullo_epi16,
+    _mm512_mullo_epi32, _mm512_reduce_add_ps, _mm512_set1_epi16, _mm512_set1_epi32,
+    _mm512_set1_epi8, _mm512_set1_ps, _mm512_setzero_si512, _mm512_sllv_epi16, _mm512_sllv_epi32,
+    _mm512_storeu_ps, _mm512_storeu_si512, _mm512_sub_epi16, _mm512_sub_epi32, _mm512_sub_epi8,
     _mm512_sub_ps, _mm512_xor_ps, _mm_prefetch, _CMP_EQ_OQ, _CMP_GE_OQ, _CMP_GT_OQ, _CMP_LE_OQ,
     _CMP_LT_OQ, _MM_CMPINT_EQ, _MM_CMPINT_NLE, _MM_CMPINT_NLT, _MM_HINT_ET0, _MM_HINT_T0,
 };
 use std::mem::transmute;
 
 use super::super::{lanes, simd_type};
+use crate::safe::vec::{Extend, Narrow};
 use crate::safe::{Isa, Mask, MaskOps, Simd, SimdFloatOps, SimdIntOps, SimdOps};
 
 simd_type!(F32x16, __m512, f32, __mmask16, Avx512Isa);
 simd_type!(I32x16, __m512i, i32, __mmask16, Avx512Isa);
 simd_type!(I16x32, __m512i, i16, __mmask32, Avx512Isa);
+simd_type!(I8x64, __m512i, i8, __mmask64, Avx512Isa);
 
 #[derive(Copy, Clone)]
 pub struct Avx512Isa {
@@ -40,6 +46,7 @@ unsafe impl Isa for Avx512Isa {
     type F32 = F32x16;
     type I32 = I32x16;
     type I16 = I16x32;
+    type I8 = I8x64;
     type Bits = I32x16;
 
     fn f32(self) -> impl SimdFloatOps<Self::F32, Int = Self::I32> {
@@ -51,6 +58,10 @@ unsafe impl Isa for Avx512Isa {
     }
 
     fn i16(self) -> impl SimdIntOps<Self::I16> {
+        self
+    }
+
+    fn i8(self) -> impl SimdIntOps<Self::I8> {
         self
     }
 }
@@ -365,6 +376,128 @@ impl SimdIntOps<I16x32> for Avx512Isa {
     }
 }
 
+unsafe impl SimdOps<I8x64> for Avx512Isa {
+    simd_ops_common!(I8x64, __mmask64);
+
+    #[inline]
+    fn add(self, x: I8x64, y: I8x64) -> I8x64 {
+        unsafe { _mm512_add_epi8(x.0, y.0) }.into()
+    }
+
+    #[inline]
+    fn sub(self, x: I8x64, y: I8x64) -> I8x64 {
+        unsafe { _mm512_sub_epi8(x.0, y.0) }.into()
+    }
+
+    #[inline]
+    fn mul(self, x: I8x64, y: I8x64) -> I8x64 {
+        let (x_lo, x_hi) = self.extend(x);
+        let (y_lo, y_hi) = self.extend(y);
+
+        let i16_ops = self.i16();
+        let prod_lo = i16_ops.mul(x_lo, y_lo);
+        let prod_hi = i16_ops.mul(x_hi, y_hi);
+
+        self.narrow_truncate(prod_lo, prod_hi)
+    }
+
+    #[inline]
+    fn splat(self, x: i8) -> I8x64 {
+        unsafe { _mm512_set1_epi8(x) }.into()
+    }
+
+    #[inline]
+    fn eq(self, x: I8x64, y: I8x64) -> __mmask64 {
+        unsafe { _mm512_cmpeq_epi8_mask(x.0, y.0) }
+    }
+
+    #[inline]
+    fn ge(self, x: I8x64, y: I8x64) -> __mmask64 {
+        unsafe { _mm512_cmpge_epi8_mask(x.0, y.0) }
+    }
+
+    #[inline]
+    fn gt(self, x: I8x64, y: I8x64) -> __mmask64 {
+        unsafe { _mm512_cmpgt_epi8_mask(x.0, y.0) }
+    }
+
+    #[inline]
+    unsafe fn load_ptr(self, ptr: *const i8) -> I8x64 {
+        unsafe { _mm512_loadu_si512(ptr as *const i32) }.into()
+    }
+
+    #[inline]
+    fn select(self, x: I8x64, y: I8x64, mask: <I8x64 as Simd>::Mask) -> I8x64 {
+        unsafe { _mm512_mask_blend_epi8(mask, y.0, x.0) }.into()
+    }
+
+    #[inline]
+    unsafe fn store_ptr(self, x: I8x64, ptr: *mut i8) {
+        unsafe { _mm512_storeu_si512(ptr as *mut __m512i, x.0) }
+    }
+
+    #[inline]
+    unsafe fn load_ptr_mask(self, ptr: *const i8, mask: __mmask64) -> I8x64 {
+        unsafe { _mm512_mask_loadu_epi8(_mm512_set1_epi8(0), mask, ptr) }.into()
+    }
+
+    #[inline]
+    unsafe fn store_ptr_mask(self, x: I8x64, ptr: *mut i8, mask: __mmask64) {
+        unsafe { _mm512_mask_storeu_epi8(ptr, mask, x.0) }
+    }
+}
+
+impl SimdIntOps<I8x64> for Avx512Isa {
+    #[inline]
+    fn neg(self, x: I8x64) -> I8x64 {
+        unsafe { _mm512_sub_epi8(_mm512_setzero_si512(), x.0) }.into()
+    }
+
+    #[inline]
+    fn shift_left<const SHIFT: i32>(self, x: I8x64) -> I8x64 {
+        let (x_lo, x_hi) = self.extend(x);
+
+        let i16_ops = self.i16();
+        let (y_lo, y_hi) = (
+            i16_ops.shift_left::<SHIFT>(x_lo),
+            i16_ops.shift_left::<SHIFT>(x_hi),
+        );
+
+        self.narrow_truncate(y_lo, y_hi)
+    }
+}
+
+impl Extend<I8x64> for Avx512Isa {
+    type Output = I16x32;
+
+    #[inline]
+    fn extend(self, x: I8x64) -> (I16x32, I16x32) {
+        let (lo, hi) = unsafe {
+            let lo = _mm512_extracti64x4_epi64(x.0, 0);
+            let lo = _mm512_cvtepi8_epi16(lo);
+
+            let hi = _mm512_extracti64x4_epi64(x.0, 1);
+            let hi = _mm512_cvtepi8_epi16(hi);
+            (lo, hi)
+        };
+        (I16x32(lo), I16x32(hi))
+    }
+}
+
+impl Narrow<I16x32> for Avx512Isa {
+    type Output = I8x64;
+
+    #[inline]
+    fn narrow_truncate(self, a: I16x32, b: I16x32) -> I8x64 {
+        let y = unsafe {
+            let lo_i8 = _mm512_cvtepi16_epi8(a.0);
+            let hi_i8 = _mm512_cvtepi16_epi8(b.0);
+            _mm512_inserti64x4(_mm512_castsi256_si512(lo_i8), hi_i8, 1)
+        };
+        I8x64(y)
+    }
+}
+
 macro_rules! impl_mask {
     ($mask:ty) => {
         impl Mask for $mask {
@@ -387,3 +520,4 @@ macro_rules! impl_mask {
 
 impl_mask!(__mmask16);
 impl_mask!(__mmask32);
+impl_mask!(__mmask64);


### PR DESCRIPTION
The code is mostly copied and adjusted from i16 support, except that some
platforms do not have i8 multiply or shift-left instructions, so an
extend-transform-narrow sequence is used.

The test for the `sum` method overflows under AVX2 and AVX-512 with i8 inputs.
To ensure consistency between platforms, the `sum` method has been redefined to
use wrapping addition.

**TODO:**

- [x] Use truncation when narrowing in i8 mul for AVX2
- [x] ... same for AVX512
- [x] ... same for wasm32
- [x] Check truncation behavior for `shift_left` for AVX512 especially (and other archs)

