### PR TITLE
Use separate types for masks and SIMD vectors in wasm32 and generic ISAs

### DIFF
--- a/rten-simd/src/safe/arch/generic.rs
+++ b/rten-simd/src/safe/arch/generic.rs
@@ -6,21 +6,24 @@ use crate::safe::{Isa, Mask, MaskOps, Simd, SimdFloatOps, SimdIntOps, SimdOps};
 // Size of SIMD vector in 32-bit lanes.
 const LEN_X32: usize = 4;
 
-#[repr(align(16))]
-#[derive(Copy, Clone, Debug)]
-pub struct F32x4([f32; LEN_X32]);
+macro_rules! simd_type {
+    ($simd:ident, $elem:ty, $len:expr) => {
+        #[repr(align(16))]
+        #[derive(Copy, Clone, Debug)]
+        pub struct $simd([$elem; $len]);
+    };
+}
 
-#[repr(align(16))]
-#[derive(Copy, Clone, Debug)]
-pub struct I32x4([i32; LEN_X32]);
+// Define SIMD vector types.
+simd_type!(F32x4, f32, LEN_X32);
+simd_type!(I32x4, i32, LEN_X32);
+simd_type!(I16x8, i16, LEN_X32 * 2);
+simd_type!(I8x16, i8, LEN_X32 * 4);
 
-#[repr(align(16))]
-#[derive(Copy, Clone, Debug)]
-pub struct I16x8([i16; LEN_X32 * 2]);
-
-#[repr(align(16))]
-#[derive(Copy, Clone, Debug)]
-pub struct I8x16([i8; LEN_X32 * 4]);
+// Define mask vector types. `Mn` is a mask for a vector with n-bit lanes.
+simd_type!(M32, i32, LEN_X32);
+simd_type!(M16, i16, LEN_X32 * 2);
+simd_type!(M8, i8, LEN_X32 * 4);
 
 #[derive(Copy, Clone)]
 pub struct GenericIsa {
@@ -195,7 +198,7 @@ macro_rules! simd_ops_common {
 }
 
 unsafe impl SimdOps<F32x4> for GenericIsa {
-    simd_ops_common!(F32x4, f32, 4, I32x4);
+    simd_ops_common!(F32x4, f32, 4, M32);
 }
 
 impl SimdFloatOps<F32x4> for GenericIsa {
@@ -254,9 +257,9 @@ macro_rules! impl_simd_int_ops {
     };
 }
 
-impl_simd_int_ops!(I32x4, i32, 4, I32x4);
-impl_simd_int_ops!(I16x8, i16, 8, I16x8);
-impl_simd_int_ops!(I8x16, i8, 16, I8x16);
+impl_simd_int_ops!(I32x4, i32, 4, M32);
+impl_simd_int_ops!(I16x8, i16, 8, M16);
+impl_simd_int_ops!(I8x16, i8, 16, M8);
 
 macro_rules! impl_mask {
     ($mask:ident, $len:expr) => {
@@ -280,9 +283,9 @@ macro_rules! impl_mask {
     };
 }
 
-impl_mask!(I32x4, LEN_X32);
-impl_mask!(I16x8, LEN_X32 * 2);
-impl_mask!(I8x16, LEN_X32 * 4);
+impl_mask!(M32, LEN_X32);
+impl_mask!(M16, LEN_X32 * 2);
+impl_mask!(M8, LEN_X32 * 4);
 
 macro_rules! impl_simd {
     ($simd:ty, $elem:ty, $mask:ty, $len:expr) => {
@@ -312,7 +315,7 @@ macro_rules! impl_simd {
     };
 }
 
-impl_simd!(F32x4, f32, I32x4, 4);
-impl_simd!(I32x4, i32, I32x4, 4);
-impl_simd!(I16x8, i16, I16x8, 8);
-impl_simd!(I8x16, i8, I8x16, 16);
+impl_simd!(F32x4, f32, M32, 4);
+impl_simd!(I32x4, i32, M32, 4);
+impl_simd!(I16x8, i16, M16, 8);
+impl_simd!(I8x16, i8, M8, 16);

--- a/rten-simd/src/safe/arch/wasm32.rs
+++ b/rten-simd/src/safe/arch/wasm32.rs
@@ -12,10 +12,10 @@ use std::mem::transmute;
 use super::{lanes, simd_type};
 use crate::safe::{Isa, Mask, MaskOps, Simd, SimdFloatOps, SimdIntOps, SimdOps};
 
-simd_type!(F32x4, v128, f32, I32x4, Wasm32Isa);
-simd_type!(I32x4, v128, i32, I32x4, Wasm32Isa);
-simd_type!(I16x8, v128, i16, I16x8, Wasm32Isa);
-simd_type!(I8x16, v128, i8, I8x16, Wasm32Isa);
+simd_type!(F32x4, v128, f32, M32, Wasm32Isa);
+simd_type!(I32x4, v128, i32, M32, Wasm32Isa);
+simd_type!(I16x8, v128, i16, M16, Wasm32Isa);
+simd_type!(I8x16, v128, i8, M8, Wasm32Isa);
 
 #[derive(Copy, Clone)]
 pub struct Wasm32Isa {
@@ -119,7 +119,7 @@ macro_rules! simd_ops_common {
 }
 
 unsafe impl SimdOps<F32x4> for Wasm32Isa {
-    simd_ops_common!(F32x4, I32x4, i32);
+    simd_ops_common!(F32x4, M32, i32);
 
     #[inline]
     fn add(self, x: F32x4, y: F32x4) -> F32x4 {
@@ -149,28 +149,28 @@ unsafe impl SimdOps<F32x4> for Wasm32Isa {
     }
 
     #[inline]
-    fn lt(self, x: F32x4, y: F32x4) -> I32x4 {
-        I32x4(f32x4_lt(x.0, y.0))
+    fn lt(self, x: F32x4, y: F32x4) -> M32 {
+        M32(f32x4_lt(x.0, y.0))
     }
 
     #[inline]
-    fn le(self, x: F32x4, y: F32x4) -> I32x4 {
-        I32x4(f32x4_le(x.0, y.0))
+    fn le(self, x: F32x4, y: F32x4) -> M32 {
+        M32(f32x4_le(x.0, y.0))
     }
 
     #[inline]
-    fn eq(self, x: F32x4, y: F32x4) -> I32x4 {
-        I32x4(f32x4_eq(x.0, y.0))
+    fn eq(self, x: F32x4, y: F32x4) -> M32 {
+        M32(f32x4_eq(x.0, y.0))
     }
 
     #[inline]
-    fn ge(self, x: F32x4, y: F32x4) -> I32x4 {
-        I32x4(f32x4_ge(x.0, y.0))
+    fn ge(self, x: F32x4, y: F32x4) -> M32 {
+        M32(f32x4_ge(x.0, y.0))
     }
 
     #[inline]
-    fn gt(self, x: F32x4, y: F32x4) -> I32x4 {
-        I32x4(f32x4_gt(x.0, y.0))
+    fn gt(self, x: F32x4, y: F32x4) -> M32 {
+        M32(f32x4_gt(x.0, y.0))
     }
 
     #[inline]
@@ -231,7 +231,7 @@ impl SimdFloatOps<F32x4> for Wasm32Isa {
 }
 
 unsafe impl SimdOps<I32x4> for Wasm32Isa {
-    simd_ops_common!(I32x4, I32x4, i32);
+    simd_ops_common!(I32x4, M32, i32);
 
     #[inline]
     fn add(self, x: I32x4, y: I32x4) -> I32x4 {
@@ -254,18 +254,18 @@ unsafe impl SimdOps<I32x4> for Wasm32Isa {
     }
 
     #[inline]
-    fn eq(self, x: I32x4, y: I32x4) -> I32x4 {
-        I32x4(i32x4_eq(x.0, y.0))
+    fn eq(self, x: I32x4, y: I32x4) -> M32 {
+        M32(i32x4_eq(x.0, y.0))
     }
 
     #[inline]
-    fn ge(self, x: I32x4, y: I32x4) -> I32x4 {
-        I32x4(i32x4_ge(x.0, y.0))
+    fn ge(self, x: I32x4, y: I32x4) -> M32 {
+        M32(i32x4_ge(x.0, y.0))
     }
 
     #[inline]
-    fn gt(self, x: I32x4, y: I32x4) -> I32x4 {
-        I32x4(i32x4_gt(x.0, y.0))
+    fn gt(self, x: I32x4, y: I32x4) -> M32 {
+        M32(i32x4_gt(x.0, y.0))
     }
 }
 
@@ -282,7 +282,7 @@ impl SimdIntOps<I32x4> for Wasm32Isa {
 }
 
 unsafe impl SimdOps<I16x8> for Wasm32Isa {
-    simd_ops_common!(I16x8, I16x8, i16);
+    simd_ops_common!(I16x8, M16, i16);
 
     #[inline]
     fn add(self, x: I16x8, y: I16x8) -> I16x8 {
@@ -305,18 +305,18 @@ unsafe impl SimdOps<I16x8> for Wasm32Isa {
     }
 
     #[inline]
-    fn eq(self, x: I16x8, y: I16x8) -> I16x8 {
-        I16x8(i16x8_eq(x.0, y.0))
+    fn eq(self, x: I16x8, y: I16x8) -> M16 {
+        M16(i16x8_eq(x.0, y.0))
     }
 
     #[inline]
-    fn ge(self, x: I16x8, y: I16x8) -> I16x8 {
-        I16x8(i16x8_ge(x.0, y.0))
+    fn ge(self, x: I16x8, y: I16x8) -> M16 {
+        M16(i16x8_ge(x.0, y.0))
     }
 
     #[inline]
-    fn gt(self, x: I16x8, y: I16x8) -> I16x8 {
-        I16x8(i16x8_gt(x.0, y.0))
+    fn gt(self, x: I16x8, y: I16x8) -> M16 {
+        M16(i16x8_gt(x.0, y.0))
     }
 }
 
@@ -333,7 +333,7 @@ impl SimdIntOps<I16x8> for Wasm32Isa {
 }
 
 unsafe impl SimdOps<I8x16> for Wasm32Isa {
-    simd_ops_common!(I8x16, I8x16, i8);
+    simd_ops_common!(I8x16, M8, i8);
 
     #[inline]
     fn add(self, x: I8x16, y: I8x16) -> I8x16 {
@@ -365,18 +365,18 @@ unsafe impl SimdOps<I8x16> for Wasm32Isa {
     }
 
     #[inline]
-    fn eq(self, x: I8x16, y: I8x16) -> I8x16 {
-        I8x16(i8x16_eq(x.0, y.0))
+    fn eq(self, x: I8x16, y: I8x16) -> M8 {
+        M8(i8x16_eq(x.0, y.0))
     }
 
     #[inline]
-    fn ge(self, x: I8x16, y: I8x16) -> I8x16 {
-        I8x16(i8x16_ge(x.0, y.0))
+    fn ge(self, x: I8x16, y: I8x16) -> M8 {
+        M8(i8x16_ge(x.0, y.0))
     }
 
     #[inline]
-    fn gt(self, x: I8x16, y: I8x16) -> I8x16 {
-        I8x16(i8x16_gt(x.0, y.0))
+    fn gt(self, x: I8x16, y: I8x16) -> M8 {
+        M8(i8x16_gt(x.0, y.0))
     }
 }
 
@@ -394,6 +394,10 @@ impl SimdIntOps<I8x16> for Wasm32Isa {
 
 macro_rules! mask_type {
     ($mask:ident, $elem:ty, $len: expr) => {
+        #[derive(Copy, Clone, Debug)]
+        #[repr(transparent)]
+        pub struct $mask(v128);
+
         impl Mask for $mask {
             type Array = [bool; $len];
 
@@ -413,6 +417,7 @@ macro_rules! mask_type {
     };
 }
 
-mask_type!(I32x4, i32, 4);
-mask_type!(I16x8, i16, 8);
-mask_type!(I8x16, i8, 16);
+// Define mask vector types. `Mn` is a mask for a vector with n-bit lanes.
+mask_type!(M32, i32, 4);
+mask_type!(M16, i16, 8);
+mask_type!(M8, i8, 16);


### PR DESCRIPTION
This makes method signatures for mask-using/returning methods easier to follow. It will also make it easier to potentially use a smaller uint type as the representation for masks in future.