### PR TITLE
Support u16 vectors in new SIMD API

### DIFF
--- a/rten-simd/src/safe/arch/aarch64.rs
+++ b/rten-simd/src/safe/arch/aarch64.rs
@@ -1,14 +1,15 @@
 use std::arch::aarch64::{
     float32x4_t, int16x8_t, int32x4_t, int8x16_t, uint16x8_t, uint32x4_t, uint8x16_t, vabsq_f32,
-    vaddq_f32, vaddq_s16, vaddq_s32, vaddq_s8, vaddvq_f32, vandq_u16, vandq_u32, vandq_u8,
-    vbslq_f32, vbslq_s16, vbslq_s32, vbslq_s8, vceqq_f32, vceqq_s16, vceqq_s32, vceqq_s8,
-    vcgeq_f32, vcgeq_s16, vcgeq_s32, vcgeq_s8, vcgtq_f32, vcgtq_s16, vcgtq_s32, vcgtq_s8,
-    vcleq_f32, vcleq_s16, vcleq_s8, vcltq_f32, vcltq_s16, vcltq_s8, vcvtnq_s32_f32, vcvtq_s32_f32,
-    vdivq_f32, vdupq_n_f32, vdupq_n_s16, vdupq_n_s32, vdupq_n_s8, vfmaq_f32, vld1q_f32, vld1q_s16,
-    vld1q_s32, vld1q_s8, vld1q_u16, vld1q_u32, vld1q_u8, vmaxq_f32, vminq_f32, vmulq_f32,
-    vmulq_s16, vmulq_s32, vmulq_s8, vnegq_f32, vnegq_s16, vnegq_s32, vnegq_s8, vshlq_n_s16,
-    vshlq_n_s32, vshlq_n_s8, vst1q_f32, vst1q_s16, vst1q_s32, vst1q_s8, vsubq_f32, vsubq_s16,
-    vsubq_s32, vsubq_s8,
+    vaddq_f32, vaddq_s16, vaddq_s32, vaddq_s8, vaddq_u16, vaddvq_f32, vandq_u16, vandq_u32,
+    vandq_u8, vbslq_f32, vbslq_s16, vbslq_s32, vbslq_s8, vbslq_u16, vceqq_f32, vceqq_s16,
+    vceqq_s32, vceqq_s8, vceqq_u16, vcgeq_f32, vcgeq_s16, vcgeq_s32, vcgeq_s8, vcgeq_u16,
+    vcgtq_f32, vcgtq_s16, vcgtq_s32, vcgtq_s8, vcgtq_u16, vcleq_f32, vcleq_s16, vcleq_s8,
+    vcleq_u16, vcltq_f32, vcltq_s16, vcltq_s8, vcltq_u16, vcvtnq_s32_f32, vcvtq_s32_f32, vdivq_f32,
+    vdupq_n_f32, vdupq_n_s16, vdupq_n_s32, vdupq_n_s8, vdupq_n_u16, vfmaq_f32, vld1q_f32,
+    vld1q_s16, vld1q_s32, vld1q_s8, vld1q_u16, vld1q_u32, vld1q_u8, vmaxq_f32, vminq_f32,
+    vmulq_f32, vmulq_s16, vmulq_s32, vmulq_s8, vmulq_u16, vnegq_f32, vnegq_s16, vnegq_s32,
+    vnegq_s8, vshlq_n_s16, vshlq_n_s32, vshlq_n_s8, vst1q_f32, vst1q_s16, vst1q_s32, vst1q_s8,
+    vst1q_u16, vsubq_f32, vsubq_s16, vsubq_s32, vsubq_s8, vsubq_u16,
 };
 use std::mem::transmute;
 
@@ -31,6 +32,7 @@ unsafe impl Isa for ArmNeonIsa {
     type I32 = int32x4_t;
     type I16 = int16x8_t;
     type I8 = int8x16_t;
+    type U16 = uint16x8_t;
     type Bits = int32x4_t;
 
     fn f32(self) -> impl SimdFloatOps<Self::F32, Int = Self::I32> {
@@ -46,6 +48,10 @@ unsafe impl Isa for ArmNeonIsa {
     }
 
     fn i8(self) -> impl SimdIntOps<Self::I8> {
+        self
+    }
+
+    fn u16(self) -> impl SimdOps<Self::U16> {
         self
     }
 }
@@ -452,6 +458,76 @@ impl SimdIntOps<int8x16_t> for ArmNeonIsa {
     }
 }
 
+unsafe impl SimdOps<uint16x8_t> for ArmNeonIsa {
+    simd_ops_common!(uint16x8_t, uint16x8_t);
+
+    #[inline]
+    fn add(self, x: uint16x8_t, y: uint16x8_t) -> uint16x8_t {
+        unsafe { vaddq_u16(x, y) }
+    }
+
+    #[inline]
+    fn sub(self, x: uint16x8_t, y: uint16x8_t) -> uint16x8_t {
+        unsafe { vsubq_u16(x, y) }
+    }
+
+    #[inline]
+    fn mul(self, x: uint16x8_t, y: uint16x8_t) -> uint16x8_t {
+        unsafe { vmulq_u16(x, y) }
+    }
+
+    #[inline]
+    fn splat(self, x: u16) -> uint16x8_t {
+        unsafe { vdupq_n_u16(x) }
+    }
+
+    #[inline]
+    fn lt(self, x: uint16x8_t, y: uint16x8_t) -> uint16x8_t {
+        unsafe { vcltq_u16(x, y) }
+    }
+
+    #[inline]
+    fn le(self, x: uint16x8_t, y: uint16x8_t) -> uint16x8_t {
+        unsafe { vcleq_u16(x, y) }
+    }
+
+    #[inline]
+    fn eq(self, x: uint16x8_t, y: uint16x8_t) -> uint16x8_t {
+        unsafe { vceqq_u16(x, y) }
+    }
+
+    #[inline]
+    fn ge(self, x: uint16x8_t, y: uint16x8_t) -> uint16x8_t {
+        unsafe { vcgeq_u16(x, y) }
+    }
+
+    #[inline]
+    fn gt(self, x: uint16x8_t, y: uint16x8_t) -> uint16x8_t {
+        unsafe { vcgtq_u16(x, y) }
+    }
+
+    #[inline]
+    unsafe fn load_ptr(self, ptr: *const u16) -> uint16x8_t {
+        unsafe { vld1q_u16(ptr) }
+    }
+
+    #[inline]
+    fn first_n_mask(self, n: usize) -> uint16x8_t {
+        let mask: [u16; 8] = std::array::from_fn(|i| if i < n { u16::MAX } else { 0 });
+        unsafe { vld1q_u16(mask.as_ptr()) }
+    }
+
+    #[inline]
+    fn select(self, x: uint16x8_t, y: uint16x8_t, mask: <uint16x8_t as Simd>::Mask) -> uint16x8_t {
+        unsafe { vbslq_u16(mask, x, y) }
+    }
+
+    #[inline]
+    unsafe fn store_ptr(self, x: uint16x8_t, ptr: *mut u16) {
+        unsafe { vst1q_u16(ptr, x) }
+    }
+}
+
 macro_rules! impl_mask {
     ($mask:ty, $elem:ty, $len:expr) => {
         impl Mask for $mask {
@@ -534,3 +610,4 @@ impl_simd!(float32x4_t, f32, 4, uint32x4_t);
 impl_simd!(int32x4_t, i32, 4, uint32x4_t);
 impl_simd!(int16x8_t, i16, 8, uint16x8_t);
 impl_simd!(int8x16_t, i8, 16, uint8x16_t);
+impl_simd!(uint16x8_t, u16, 8, uint16x8_t);

--- a/rten-simd/src/safe/arch/generic.rs
+++ b/rten-simd/src/safe/arch/generic.rs
@@ -19,6 +19,7 @@ simd_type!(F32x4, f32, LEN_X32);
 simd_type!(I32x4, i32, LEN_X32);
 simd_type!(I16x8, i16, LEN_X32 * 2);
 simd_type!(I8x16, i8, LEN_X32 * 4);
+simd_type!(U16x8, u16, LEN_X32 * 2);
 
 // Define mask vector types. `Mn` is a mask for a vector with n-bit lanes.
 simd_type!(M32, i32, LEN_X32);
@@ -48,6 +49,7 @@ unsafe impl Isa for GenericIsa {
     type I32 = I32x4;
     type I16 = I16x8;
     type I8 = I8x16;
+    type U16 = U16x8;
     type Bits = I32x4;
 
     fn f32(self) -> impl SimdFloatOps<Self::F32, Int = Self::I32> {
@@ -63,6 +65,10 @@ unsafe impl Isa for GenericIsa {
     }
 
     fn i8(self) -> impl SimdIntOps<Self::I8> {
+        self
+    }
+
+    fn u16(self) -> impl SimdOps<Self::U16> {
         self
     }
 }
@@ -235,7 +241,7 @@ impl SimdFloatOps<F32x4> for GenericIsa {
     }
 }
 
-macro_rules! impl_simd_int_ops {
+macro_rules! impl_simd_signed_int_ops {
     ($simd:ident, $elem:ty, $len:expr, $mask:ident) => {
         unsafe impl SimdOps<$simd> for GenericIsa {
             simd_ops_common!($simd, $elem, $len, $mask);
@@ -257,9 +263,18 @@ macro_rules! impl_simd_int_ops {
     };
 }
 
-impl_simd_int_ops!(I32x4, i32, 4, M32);
-impl_simd_int_ops!(I16x8, i16, 8, M16);
-impl_simd_int_ops!(I8x16, i8, 16, M8);
+impl_simd_signed_int_ops!(I32x4, i32, 4, M32);
+impl_simd_signed_int_ops!(I16x8, i16, 8, M16);
+impl_simd_signed_int_ops!(I8x16, i8, 16, M8);
+
+macro_rules! impl_simd_unsigned_int_ops {
+    ($simd:ident, $elem:ty, $len:expr, $mask:ident) => {
+        unsafe impl SimdOps<$simd> for GenericIsa {
+            simd_ops_common!($simd, $elem, $len, $mask);
+        }
+    };
+}
+impl_simd_unsigned_int_ops!(U16x8, u16, 8, M16);
 
 macro_rules! impl_mask {
     ($mask:ident, $len:expr) => {
@@ -319,3 +334,4 @@ impl_simd!(F32x4, f32, M32, 4);
 impl_simd!(I32x4, i32, M32, 4);
 impl_simd!(I16x8, i16, M16, 8);
 impl_simd!(I8x16, i8, M8, 16);
+impl_simd!(U16x8, u16, M16, 8);


### PR DESCRIPTION
For x64 there aren't specific intrinsics for operations on u16 values in many cases, but we rely on the fact that the i16 operations work. This is either because the operation only cares about the lane width (splat, select etc.) or that it works the same for signed/unsigned in two's complement (add, sub, low half of multiplication).

**TODO:**

- [x] Implement `gt` for AVX2 for u16 (AVX2 lacks a comparison operation for u16, so values need to be shifted to signed first)