### PR TITLE
Support u8 vectors in new SIMD API

### DIFF
--- a/rten-simd/src/safe/arch/aarch64.rs
+++ b/rten-simd/src/safe/arch/aarch64.rs
@@ -1,15 +1,16 @@
 use std::arch::aarch64::{
     float32x4_t, int16x8_t, int32x4_t, int8x16_t, uint16x8_t, uint32x4_t, uint8x16_t, vabsq_f32,
-    vaddq_f32, vaddq_s16, vaddq_s32, vaddq_s8, vaddq_u16, vaddvq_f32, vandq_u16, vandq_u32,
-    vandq_u8, vbslq_f32, vbslq_s16, vbslq_s32, vbslq_s8, vbslq_u16, vceqq_f32, vceqq_s16,
-    vceqq_s32, vceqq_s8, vceqq_u16, vcgeq_f32, vcgeq_s16, vcgeq_s32, vcgeq_s8, vcgeq_u16,
-    vcgtq_f32, vcgtq_s16, vcgtq_s32, vcgtq_s8, vcgtq_u16, vcleq_f32, vcleq_s16, vcleq_s8,
-    vcleq_u16, vcltq_f32, vcltq_s16, vcltq_s8, vcltq_u16, vcvtnq_s32_f32, vcvtq_s32_f32, vdivq_f32,
-    vdupq_n_f32, vdupq_n_s16, vdupq_n_s32, vdupq_n_s8, vdupq_n_u16, vfmaq_f32, vld1q_f32,
-    vld1q_s16, vld1q_s32, vld1q_s8, vld1q_u16, vld1q_u32, vld1q_u8, vmaxq_f32, vminq_f32,
-    vmulq_f32, vmulq_s16, vmulq_s32, vmulq_s8, vmulq_u16, vnegq_f32, vnegq_s16, vnegq_s32,
-    vnegq_s8, vshlq_n_s16, vshlq_n_s32, vshlq_n_s8, vst1q_f32, vst1q_s16, vst1q_s32, vst1q_s8,
-    vst1q_u16, vsubq_f32, vsubq_s16, vsubq_s32, vsubq_s8, vsubq_u16,
+    vaddq_f32, vaddq_s16, vaddq_s32, vaddq_s8, vaddq_u16, vaddq_u8, vaddvq_f32, vandq_u16,
+    vandq_u32, vandq_u8, vbslq_f32, vbslq_s16, vbslq_s32, vbslq_s8, vbslq_u16, vbslq_u8, vceqq_f32,
+    vceqq_s16, vceqq_s32, vceqq_s8, vceqq_u16, vceqq_u8, vcgeq_f32, vcgeq_s16, vcgeq_s32, vcgeq_s8,
+    vcgeq_u16, vcgeq_u8, vcgtq_f32, vcgtq_s16, vcgtq_s32, vcgtq_s8, vcgtq_u16, vcgtq_u8, vcleq_f32,
+    vcleq_s16, vcleq_s8, vcleq_u16, vcleq_u8, vcltq_f32, vcltq_s16, vcltq_s8, vcltq_u16, vcltq_u8,
+    vcvtnq_s32_f32, vcvtq_s32_f32, vdivq_f32, vdupq_n_f32, vdupq_n_s16, vdupq_n_s32, vdupq_n_s8,
+    vdupq_n_u16, vdupq_n_u8, vfmaq_f32, vld1q_f32, vld1q_s16, vld1q_s32, vld1q_s8, vld1q_u16,
+    vld1q_u32, vld1q_u8, vmaxq_f32, vminq_f32, vmulq_f32, vmulq_s16, vmulq_s32, vmulq_s8,
+    vmulq_u16, vmulq_u8, vnegq_f32, vnegq_s16, vnegq_s32, vnegq_s8, vshlq_n_s16, vshlq_n_s32,
+    vshlq_n_s8, vst1q_f32, vst1q_s16, vst1q_s32, vst1q_s8, vst1q_u16, vst1q_u8, vsubq_f32,
+    vsubq_s16, vsubq_s32, vsubq_s8, vsubq_u16, vsubq_u8,
 };
 use std::mem::transmute;
 
@@ -32,6 +33,7 @@ unsafe impl Isa for ArmNeonIsa {
     type I32 = int32x4_t;
     type I16 = int16x8_t;
     type I8 = int8x16_t;
+    type U8 = uint8x16_t;
     type U16 = uint16x8_t;
     type Bits = int32x4_t;
 
@@ -48,6 +50,10 @@ unsafe impl Isa for ArmNeonIsa {
     }
 
     fn i8(self) -> impl SimdIntOps<Self::I8> {
+        self
+    }
+
+    fn u8(self) -> impl SimdOps<Self::U8> {
         self
     }
 
@@ -458,6 +464,76 @@ impl SimdIntOps<int8x16_t> for ArmNeonIsa {
     }
 }
 
+unsafe impl SimdOps<uint8x16_t> for ArmNeonIsa {
+    simd_ops_common!(uint8x16_t, uint8x16_t);
+
+    #[inline]
+    fn add(self, x: uint8x16_t, y: uint8x16_t) -> uint8x16_t {
+        unsafe { vaddq_u8(x, y) }
+    }
+
+    #[inline]
+    fn sub(self, x: uint8x16_t, y: uint8x16_t) -> uint8x16_t {
+        unsafe { vsubq_u8(x, y) }
+    }
+
+    #[inline]
+    fn mul(self, x: uint8x16_t, y: uint8x16_t) -> uint8x16_t {
+        unsafe { vmulq_u8(x, y) }
+    }
+
+    #[inline]
+    fn splat(self, x: u8) -> uint8x16_t {
+        unsafe { vdupq_n_u8(x) }
+    }
+
+    #[inline]
+    fn lt(self, x: uint8x16_t, y: uint8x16_t) -> uint8x16_t {
+        unsafe { vcltq_u8(x, y) }
+    }
+
+    #[inline]
+    fn le(self, x: uint8x16_t, y: uint8x16_t) -> uint8x16_t {
+        unsafe { vcleq_u8(x, y) }
+    }
+
+    #[inline]
+    fn eq(self, x: uint8x16_t, y: uint8x16_t) -> uint8x16_t {
+        unsafe { vceqq_u8(x, y) }
+    }
+
+    #[inline]
+    fn ge(self, x: uint8x16_t, y: uint8x16_t) -> uint8x16_t {
+        unsafe { vcgeq_u8(x, y) }
+    }
+
+    #[inline]
+    fn gt(self, x: uint8x16_t, y: uint8x16_t) -> uint8x16_t {
+        unsafe { vcgtq_u8(x, y) }
+    }
+
+    #[inline]
+    unsafe fn load_ptr(self, ptr: *const u8) -> uint8x16_t {
+        unsafe { vld1q_u8(ptr) }
+    }
+
+    #[inline]
+    fn first_n_mask(self, n: usize) -> uint8x16_t {
+        let mask: [u8; 16] = std::array::from_fn(|i| if i < n { u8::MAX } else { 0 });
+        unsafe { vld1q_u8(mask.as_ptr()) }
+    }
+
+    #[inline]
+    fn select(self, x: uint8x16_t, y: uint8x16_t, mask: <uint8x16_t as Simd>::Mask) -> uint8x16_t {
+        unsafe { vbslq_u8(mask, x, y) }
+    }
+
+    #[inline]
+    unsafe fn store_ptr(self, x: uint8x16_t, ptr: *mut u8) {
+        unsafe { vst1q_u8(ptr, x) }
+    }
+}
+
 unsafe impl SimdOps<uint16x8_t> for ArmNeonIsa {
     simd_ops_common!(uint16x8_t, uint16x8_t);
 
@@ -610,4 +686,5 @@ impl_simd!(float32x4_t, f32, 4, uint32x4_t);
 impl_simd!(int32x4_t, i32, 4, uint32x4_t);
 impl_simd!(int16x8_t, i16, 8, uint16x8_t);
 impl_simd!(int8x16_t, i8, 16, uint8x16_t);
+impl_simd!(uint8x16_t, u8, 16, uint8x16_t);
 impl_simd!(uint16x8_t, u16, 8, uint16x8_t);

--- a/rten-simd/src/safe/arch/generic.rs
+++ b/rten-simd/src/safe/arch/generic.rs
@@ -19,6 +19,7 @@ simd_type!(F32x4, f32, LEN_X32);
 simd_type!(I32x4, i32, LEN_X32);
 simd_type!(I16x8, i16, LEN_X32 * 2);
 simd_type!(I8x16, i8, LEN_X32 * 4);
+simd_type!(U8x16, u8, LEN_X32 * 4);
 simd_type!(U16x8, u16, LEN_X32 * 2);
 
 // Define mask vector types. `Mn` is a mask for a vector with n-bit lanes.
@@ -49,6 +50,7 @@ unsafe impl Isa for GenericIsa {
     type I32 = I32x4;
     type I16 = I16x8;
     type I8 = I8x16;
+    type U8 = U8x16;
     type U16 = U16x8;
     type Bits = I32x4;
 
@@ -65,6 +67,10 @@ unsafe impl Isa for GenericIsa {
     }
 
     fn i8(self) -> impl SimdIntOps<Self::I8> {
+        self
+    }
+
+    fn u8(self) -> impl SimdOps<Self::U8> {
         self
     }
 
@@ -274,6 +280,7 @@ macro_rules! impl_simd_unsigned_int_ops {
         }
     };
 }
+impl_simd_unsigned_int_ops!(U8x16, u8, 16, M8);
 impl_simd_unsigned_int_ops!(U16x8, u16, 8, M16);
 
 macro_rules! impl_mask {
@@ -334,4 +341,5 @@ impl_simd!(F32x4, f32, M32, 4);
 impl_simd!(I32x4, i32, M32, 4);
 impl_simd!(I16x8, i16, M16, 8);
 impl_simd!(I8x16, i8, M8, 16);
+impl_simd!(U8x16, u8, M8, 16);
 impl_simd!(U16x8, u16, M16, 8);

--- a/rten-simd/src/safe/vec.rs
+++ b/rten-simd/src/safe/vec.rs
@@ -649,7 +649,7 @@ mod tests {
     test_num_ops!(num_ops_u8, u8);
     test_num_ops!(num_ops_u16, u16);
 
-    // Test that i8 multiply truncates result as expected.
+    // Test that x8 multiply truncates result as expected.
     #[test]
     fn test_i8_mul_truncate() {
         test_simd_op!(isa, {
@@ -657,6 +657,23 @@ mod tests {
 
             let x = 17i8;
             let y = 19i8;
+
+            let x_vec = ops.splat(x);
+            let y_vec = ops.splat(y);
+            let expected = ops.splat(x.wrapping_mul(y));
+            let actual = ops.mul(x_vec, y_vec);
+
+            assert_simd_eq!(actual, expected);
+        })
+    }
+
+    #[test]
+    fn test_u8_mul_truncate() {
+        test_simd_op!(isa, {
+            let ops = isa.u8();
+
+            let x = 17u8;
+            let y = 19u8;
 
             let x_vec = ops.splat(x);
             let y_vec = ops.splat(y);
@@ -809,6 +826,17 @@ mod tests {
             let ops = isa.u16();
             let x = ops.splat(i16::MAX as u16);
             let y = ops.splat(i16::MAX as u16 + 1);
+            assert!(ops.gt(y, x).all_true());
+            assert!(ops.ge(y, x).all_true());
+        });
+    }
+
+    #[test]
+    fn test_cmp_gt_ge_u8() {
+        test_simd_op!(isa, {
+            let ops = isa.u8();
+            let x = ops.splat(i8::MAX as u8);
+            let y = ops.splat(i8::MAX as u8 + 1);
             assert!(ops.gt(y, x).all_true());
             assert!(ops.ge(y, x).all_true());
         });

--- a/rten-simd/src/safe/vec.rs
+++ b/rten-simd/src/safe/vec.rs
@@ -175,6 +175,9 @@ pub unsafe trait Isa: Copy {
     /// SIMD vector with `i8` elements.
     type I8: Simd<Elem = i8, Isa = Self>;
 
+    /// SIMD vector with `u8` elements.
+    type U8: Simd<Elem = u8, Isa = Self>;
+
     /// SIMD vector with `u16` elements.
     type U16: Simd<Elem = u16, Isa = Self>;
 
@@ -189,6 +192,9 @@ pub unsafe trait Isa: Copy {
 
     /// Operations on SIMD vectors with `i8` elements.
     fn i8(self) -> impl SimdIntOps<Self::I8>;
+
+    /// Operations on SIMD vectors with `u8` elements.
+    fn u8(self) -> impl SimdOps<Self::U8>;
 
     /// Operations on SIMD vectors with `u16` elements.
     fn u16(self) -> impl SimdOps<Self::U16>;
@@ -640,6 +646,7 @@ mod tests {
     test_num_ops!(num_ops_i32, i32);
     test_num_ops!(num_ops_i16, i16);
     test_num_ops!(num_ops_i8, i8);
+    test_num_ops!(num_ops_u8, u8);
     test_num_ops!(num_ops_u16, u16);
 
     // Test that i8 multiply truncates result as expected.

--- a/rten-simd/src/safe/vec.rs
+++ b/rten-simd/src/safe/vec.rs
@@ -786,6 +786,35 @@ mod tests {
                     })
                 }
 
+                // Add / Sub / Mul with a negative argument.
+                #[test]
+                fn test_bin_ops_neg() {
+                    test_simd_op!(isa, {
+                        let ops = isa.$elem();
+
+                        let a = -2 as $elem;
+                        let b = 3 as $elem;
+
+                        let x = ops.splat(a);
+                        let y = ops.splat(b);
+
+                        // Add
+                        let expected = ops.splat(a + b);
+                        let actual = ops.add(x, y);
+                        assert_simd_eq!(actual, expected);
+
+                        // Sub
+                        let expected = ops.splat(b - a);
+                        let actual = ops.sub(y, x);
+                        assert_simd_eq!(actual, expected);
+
+                        // Mul
+                        let expected = ops.splat(a * b);
+                        let actual = ops.mul(x, y);
+                        assert_simd_eq!(actual, expected);
+                    })
+                }
+
                 #[test]
                 fn test_shl() {
                     test_simd_op!(isa, {


### PR DESCRIPTION
This completes basic SIMD support for all the types involved in int8 quantization. There is additional work to do to support narrowing vectors and converting between signed and unsigned.