### PR TITLE
Add APIs for initializing slices with SIMD vector stores

### DIFF
--- a/rten-simd/src/safe.rs
+++ b/rten-simd/src/safe.rs
@@ -95,6 +95,10 @@
 //! The [`functional`] module provides utilities for defining vectorized
 //! transforms on slices (eg. [`simd_map`](functional::simd_map)).
 //!
+//! The [`SliceWriter`] utility provides a way to incrementally initialize the
+//! contents of a slice with the results of SIMD operations, by writing one
+//! SIMD vector at a time.
+//!
 //! ## The importance of inlining
 //!
 //! In the above example `#[inline(always)]` attributes are applied to ensure
@@ -123,6 +127,7 @@ mod dispatch;
 pub mod functional;
 mod iter;
 mod vec;
+mod writer;
 
 /// Target-specific [`Isa`] implementations.
 ///
@@ -151,6 +156,7 @@ pub mod isa {
 pub use dispatch::{SimdOp, SimdUnaryOp};
 pub use iter::{Iter, SimdIterable};
 pub use vec::{Elem, Isa, Mask, MaskOps, Simd, SimdFloatOps, SimdIntOps, SimdOps};
+pub use writer::SliceWriter;
 
 #[cfg(test)]
 pub(crate) use dispatch::test_simd_op;

--- a/rten-simd/src/safe/writer.rs
+++ b/rten-simd/src/safe/writer.rs
@@ -1,0 +1,92 @@
+use std::mem::{transmute, MaybeUninit};
+
+use super::{Simd, SimdOps};
+
+/// Utility for incrementally filling an uninitialized slice, one SIMD vector
+/// at a time.
+pub struct SliceWriter<'a, T> {
+    buf: &'a mut [MaybeUninit<T>],
+    n_init: usize,
+}
+
+impl<'a, T> SliceWriter<'a, T> {
+    /// Create a writer which initializes elements of `buf`.
+    pub fn new(buf: &'a mut [MaybeUninit<T>]) -> Self {
+        SliceWriter { buf, n_init: 0 }
+    }
+
+    /// Initialize the next `ops.len()` elements of the slice from the contents
+    /// of SIMD vector `xs`.
+    ///
+    /// Panics if the slice does not have space for `ops.len()` elements.
+    pub fn write_vec<S: Simd<Elem = T>>(&mut self, ops: impl SimdOps<S>, xs: S) {
+        let written = ops.store_uninit(xs, &mut self.buf[self.n_init..]);
+        self.n_init += written.len();
+    }
+
+    /// Initialize the next element of the slice from `x`.
+    ///
+    /// Panics if the slice does not have space for writing any more elements.
+    pub fn write_scalar(&mut self, x: T) {
+        self.buf[self.n_init].write(x);
+        self.n_init += 1;
+    }
+
+    /// Finish writing the slice and return the initialized portion.
+    pub fn into_mut_slice(self) -> &'a mut [T] {
+        let init = &mut self.buf[0..self.n_init];
+
+        // Safety: All elements in `init` have been initialized.
+        unsafe { transmute::<&mut [MaybeUninit<T>], &mut [T]>(init) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::mem::MaybeUninit;
+
+    use crate::safe::{Isa, SimdOp, SimdOps, SliceWriter};
+
+    #[test]
+    fn test_slice_writer() {
+        struct MemCopy<'src, 'dest> {
+            src: &'src [f32],
+            dest: &'dest mut [MaybeUninit<f32>],
+        }
+
+        impl<'src, 'dest> SimdOp for MemCopy<'src, 'dest> {
+            type Output = &'dest mut [f32];
+
+            fn eval<I: Isa>(self, isa: I) -> &'dest mut [f32] {
+                let ops = isa.f32();
+
+                let mut src_chunks = self.src.chunks_exact(ops.len());
+                let mut dest_writer = SliceWriter::new(self.dest);
+
+                for chunk in src_chunks.by_ref() {
+                    let xs = ops.load(chunk);
+                    dest_writer.write_vec(ops, xs);
+                }
+
+                for x in src_chunks.remainder() {
+                    dest_writer.write_scalar(*x);
+                }
+
+                dest_writer.into_mut_slice()
+            }
+        }
+
+        // Length which should cover the vectorized body and tail cases for
+        // every ISA.
+        let len = 17;
+        let src: Vec<_> = (0..len).map(|x| x as f32).collect();
+        let mut dest = Vec::with_capacity(src.len());
+
+        let copied = MemCopy {
+            src: &src,
+            dest: dest.spare_capacity_mut(),
+        }
+        .dispatch();
+        assert_eq!(copied, src);
+    }
+}


### PR DESCRIPTION
Add additional APIs for loading and storing SIMD vectors. These will be useful in porting the `Quantize` operation to the new SIMD API:

- `SimdOps::load_many` loads N SIMD vectors from `N * v_len` consecutive elements of a slice, with only one bounds check
- `SimdOps::store_uninit` writes a `Simd<Elem=T>` vector to a `MaybeUninit<T>` slice and returns the initializes sub-slice
- `SliceWriter` is a utility for incrementally initializing a slice using vectorized stores