### PR TITLE
Add SIMD ops for i32 -> i16 and i16 -> u8 saturating narrow, port `Quantize` op to new SIMD API

### DIFF
--- a/rten-simd/src/safe.rs
+++ b/rten-simd/src/safe.rs
@@ -155,7 +155,7 @@ pub mod isa {
 
 pub use dispatch::{SimdOp, SimdUnaryOp};
 pub use iter::{Iter, SimdIterable};
-pub use vec::{Elem, Isa, Mask, MaskOps, Simd, SimdFloatOps, SimdIntOps, SimdOps};
+pub use vec::{Elem, Isa, Mask, MaskOps, NarrowSaturate, Simd, SimdFloatOps, SimdIntOps, SimdOps};
 pub use writer::SliceWriter;
 
 #[cfg(test)]

--- a/rten-simd/src/safe/arch/wasm32.rs
+++ b/rten-simd/src/safe/arch/wasm32.rs
@@ -2,18 +2,18 @@ use std::arch::wasm32::{
     f32x4_abs, f32x4_add, f32x4_div, f32x4_eq, f32x4_extract_lane, f32x4_ge, f32x4_gt, f32x4_le,
     f32x4_lt, f32x4_max, f32x4_min, f32x4_mul, f32x4_nearest, f32x4_neg, f32x4_splat, f32x4_sub,
     i16x8_add, i16x8_eq, i16x8_extmul_high_i8x16, i16x8_extmul_low_i8x16, i16x8_ge, i16x8_gt,
-    i16x8_mul, i16x8_neg, i16x8_shl, i16x8_splat, i16x8_sub, i32x4_add, i32x4_eq, i32x4_ge,
-    i32x4_gt, i32x4_mul, i32x4_neg, i32x4_shl, i32x4_shuffle, i32x4_splat, i32x4_sub,
-    i32x4_trunc_sat_f32x4, i8x16_add, i8x16_eq, i8x16_ge, i8x16_gt, i8x16_neg, i8x16_shl,
-    i8x16_shuffle, i8x16_splat, i8x16_sub, u16x8_add, u16x8_eq, u16x8_extmul_high_u8x16,
+    i16x8_mul, i16x8_narrow_i32x4, i16x8_neg, i16x8_shl, i16x8_splat, i16x8_sub, i32x4_add,
+    i32x4_eq, i32x4_ge, i32x4_gt, i32x4_mul, i32x4_neg, i32x4_shl, i32x4_shuffle, i32x4_splat,
+    i32x4_sub, i32x4_trunc_sat_f32x4, i8x16_add, i8x16_eq, i8x16_ge, i8x16_gt, i8x16_neg,
+    i8x16_shl, i8x16_shuffle, i8x16_splat, i8x16_sub, u16x8_add, u16x8_eq, u16x8_extmul_high_u8x16,
     u16x8_extmul_low_u8x16, u16x8_ge, u16x8_gt, u16x8_mul, u16x8_splat, u16x8_sub, u8x16_add,
-    u8x16_eq, u8x16_ge, u8x16_gt, u8x16_shuffle, u8x16_splat, u8x16_sub, v128, v128_and,
-    v128_bitselect, v128_load, v128_store,
+    u8x16_eq, u8x16_ge, u8x16_gt, u8x16_narrow_i16x8, u8x16_shuffle, u8x16_splat, u8x16_sub, v128,
+    v128_and, v128_bitselect, v128_load, v128_store,
 };
 use std::mem::transmute;
 
 use super::{lanes, simd_type};
-use crate::safe::{Isa, Mask, MaskOps, Simd, SimdFloatOps, SimdIntOps, SimdOps};
+use crate::safe::{Isa, Mask, MaskOps, NarrowSaturate, Simd, SimdFloatOps, SimdIntOps, SimdOps};
 
 simd_type!(F32x4, v128, f32, M32, Wasm32Isa);
 simd_type!(I32x4, v128, i32, M32, Wasm32Isa);
@@ -48,11 +48,11 @@ unsafe impl Isa for Wasm32Isa {
         self
     }
 
-    fn i32(self) -> impl SimdIntOps<Self::I32> {
+    fn i32(self) -> impl SimdIntOps<Self::I32> + NarrowSaturate<Self::I32, Self::I16> {
         self
     }
 
-    fn i16(self) -> impl SimdIntOps<Self::I16> {
+    fn i16(self) -> impl SimdIntOps<Self::I16> + NarrowSaturate<Self::I16, Self::U8> {
         self
     }
 
@@ -296,6 +296,13 @@ impl SimdIntOps<I32x4> for Wasm32Isa {
     }
 }
 
+impl NarrowSaturate<I32x4, I16x8> for Wasm32Isa {
+    #[inline]
+    fn narrow_saturate(self, low: I32x4, high: I32x4) -> I16x8 {
+        I16x8(i16x8_narrow_i32x4(low.0, high.0))
+    }
+}
+
 unsafe impl SimdOps<I16x8> for Wasm32Isa {
     simd_ops_common!(I16x8, M16, i16);
 
@@ -344,6 +351,13 @@ impl SimdIntOps<I16x8> for Wasm32Isa {
     #[inline]
     fn shift_left<const SHIFT: i32>(self, x: I16x8) -> I16x8 {
         I16x8(i16x8_shl(x.0, SHIFT as u32))
+    }
+}
+
+impl NarrowSaturate<I16x8, U8x16> for Wasm32Isa {
+    #[inline]
+    fn narrow_saturate(self, low: I16x8, high: I16x8) -> U8x16 {
+        U8x16(u8x16_narrow_i16x8(low.0, high.0))
     }
 }
 

--- a/rten-simd/src/safe/vec.rs
+++ b/rten-simd/src/safe/vec.rs
@@ -186,10 +186,10 @@ pub unsafe trait Isa: Copy {
     fn f32(self) -> impl SimdFloatOps<Self::F32, Int = Self::I32>;
 
     /// Operations on SIMD vectors with `i32` elements.
-    fn i32(self) -> impl SimdIntOps<Self::I32>;
+    fn i32(self) -> impl SimdIntOps<Self::I32> + NarrowSaturate<Self::I32, Self::I16>;
 
     /// Operations on SIMD vectors with `i16` elements.
-    fn i16(self) -> impl SimdIntOps<Self::I16>;
+    fn i16(self) -> impl SimdIntOps<Self::I16> + NarrowSaturate<Self::I16, Self::U8>;
 
     /// Operations on SIMD vectors with `i8` elements.
     fn i8(self) -> impl SimdIntOps<Self::I8>;
@@ -526,12 +526,24 @@ pub(crate) trait Narrow<S: Simd> {
     fn narrow_truncate(self, low: S, high: S) -> Self::Output;
 }
 
+/// Narrow lanes to one with half the bit-width, using saturation.
+///
+/// Conceptually, this converts each element from `S1::Elem` to `S2::Elem` using
+/// `x.clamp(S2::Elem::MIN as S1::Elem, S2::Elem::MAX as S1::Elem) as S2::Elem`.
+pub trait NarrowSaturate<S1: Simd, S2: Simd> {
+    /// Narrow each lane in a pair of vectors to one with half the bit-width.
+    ///
+    /// Returns a vector containing the concatenation of the narrowed lanes
+    /// from `low` followed by the narrowed lanes from `high`.
+    fn narrow_saturate(self, low: S1, high: S1) -> S2;
+}
+
 #[cfg(test)]
 mod tests {
     use super::WrappingAdd;
     use crate::safe::{
-        assert_simd_eq, test_simd_op, Isa, Mask, MaskOps, Simd, SimdFloatOps, SimdIntOps, SimdOp,
-        SimdOps,
+        assert_simd_eq, test_simd_op, Isa, Mask, MaskOps, NarrowSaturate, Simd, SimdFloatOps,
+        SimdIntOps, SimdOp, SimdOps,
     };
 
     // Generate tests for operations available on all numeric types.
@@ -1002,6 +1014,32 @@ mod tests {
     fn test_mask_ops_i8() {
         test_mask_ops!(i8);
     }
+
+    macro_rules! test_narrow_saturate {
+        ($test_name:ident, $src:ident, $dest:ident) => {
+            #[test]
+            fn $test_name() {
+                test_simd_op!(isa, {
+                    let ops = isa.$src();
+
+                    let src: Vec<$src> = (0..ops.len() * 2).map(|x| x as $src).collect();
+                    let expected: Vec<$dest> = src
+                        .iter()
+                        .map(|&x| x.clamp($dest::MIN as $src, $dest::MAX as $src) as $dest)
+                        .collect();
+
+                    let x_low = ops.load(&src[..ops.len()]);
+                    let x_high = ops.load(&src[ops.len()..]);
+                    let y = ops.narrow_saturate(x_low, x_high);
+
+                    assert_eq!(y.to_array().as_ref(), expected);
+                });
+            }
+        };
+    }
+
+    test_narrow_saturate!(test_narrow_i32_i16, i32, i16);
+    test_narrow_saturate!(test_narrow_u16_u8, i16, u8);
 
     #[test]
     fn test_reinterpret_cast() {

--- a/rten-simd/src/safe/vec.rs
+++ b/rten-simd/src/safe/vec.rs
@@ -303,6 +303,12 @@ pub unsafe trait SimdOps<S: Simd>: Copy {
         self.select(x, y, self.ge(x, y))
     }
 
+    /// Clamp values in `x` to minimum and maximum values from corresponding
+    /// lanes in `min` and `max`.
+    fn clamp(self, x: S, min: S, max: S) -> S {
+        self.min(self.max(x, min), max)
+    }
+
     /// Create a new vector with all lanes set to `x`.
     fn splat(self, x: S::Elem) -> S;
 
@@ -663,6 +669,31 @@ mod tests {
                         let expected = ops.splat(((2. * 3.) + 4.) as $elem);
 
                         assert_simd_eq!(actual, expected);
+                    })
+                }
+
+                #[test]
+                fn test_min_max() {
+                    test_simd_op!(isa, {
+                        let ops = isa.$elem();
+
+                        let x = ops.splat(3 as $elem);
+
+                        // Min
+                        let y_min = ops.min(x, ops.splat(2 as $elem));
+                        let y_min_2 = ops.min(ops.splat(2 as $elem), x);
+                        assert_simd_eq!(y_min, y_min_2);
+                        assert_simd_eq!(y_min, ops.splat(2 as $elem));
+
+                        // Max
+                        let y_max = ops.max(x, ops.splat(4 as $elem));
+                        let y_max_2 = ops.max(ops.splat(4 as $elem), x);
+                        assert_simd_eq!(y_max, y_max_2);
+                        assert_simd_eq!(y_max, ops.splat(4 as $elem));
+
+                        // Clamp
+                        let y_clamped = ops.clamp(x, ops.splat(0 as $elem), ops.splat(4 as $elem));
+                        assert_simd_eq!(y_clamped, ops.splat(3 as $elem));
                     })
                 }
 

--- a/rten-vecmath/src/quantize.rs
+++ b/rten-vecmath/src/quantize.rs
@@ -1,7 +1,6 @@
-use std::mem::{transmute, MaybeUninit};
+use std::mem::MaybeUninit;
 
-use rten_simd::dispatch::SimdOp;
-use rten_simd::{Simd, SimdFloat, SimdInt};
+use rten_simd::safe::{Isa, NarrowSaturate, SimdFloatOps, SimdOp, SimdOps, SliceWriter};
 
 /// Quantize a slice of `f32` elements to 8-bit integers using the formula:
 ///
@@ -39,46 +38,46 @@ impl<'d> SimdOp for Quantize<'_, 'd, u8> {
     type Output = &'d mut [u8];
 
     #[inline(always)]
-    unsafe fn eval<S: SimdFloat>(self) -> Self::Output {
-        let mut n = self.src.len();
-        let mut src_ptr = self.src.as_ptr();
-        let mut dest_ptr = self.dest.as_mut_ptr();
+    fn eval<I: Isa>(self, isa: I) -> Self::Output {
+        let src_ops = isa.f32();
+        let i32_ops = isa.i32();
 
-        let zp_vec = S::Int::splat(self.zero_point as i32);
-        let scale_vec = S::splat(self.inv_scale);
-        let v_len = S::len();
+        let zp_vec = i32_ops.splat(self.zero_point as i32);
+        let scale_vec = src_ops.splat(self.inv_scale);
+        let f32_v_len = src_ops.len();
 
-        while n >= v_len {
-            let q = S::load(src_ptr)
-                .mul(scale_vec)
-                .to_int_round()
-                .add(zp_vec)
-                .saturating_cast_u8();
-            q.store(dest_ptr as *mut u8);
+        // Generate one vector of u8 elements in each iteration by quantizing
+        // 4 vectors of f32 elements.
+        let mut src_chunks = self.src.chunks_exact(f32_v_len * 4);
+        let mut dest_writer = SliceWriter::new(self.dest);
 
-            src_ptr = src_ptr.add(v_len);
-            dest_ptr = dest_ptr.add(v_len);
-            n -= v_len;
+        for src_chunk in src_chunks.by_ref() {
+            let src = src_ops.load_many::<4>(src_chunk);
+            let quant_i32 = src.map(|x| {
+                let y = src_ops.mul(x, scale_vec);
+                let y = src_ops.to_int_round(y);
+                i32_ops.add(y, zp_vec)
+            });
+            let quant_i16_low = i32_ops.narrow_saturate(quant_i32[0], quant_i32[1]);
+            let quant_i16_high = i32_ops.narrow_saturate(quant_i32[2], quant_i32[3]);
+            let quant_u8 = isa.i16().narrow_saturate(quant_i16_low, quant_i16_high);
+            dest_writer.write_vec(isa.u8(), quant_u8);
         }
 
-        while n > 0 {
-            let x = *src_ptr;
-            let y = (x * self.inv_scale).round_ties_even() as i32;
+        // Quantize tail elements.
+        for src in src_chunks.remainder() {
+            let y = (src * self.inv_scale).round_ties_even() as i32;
             let y = (y + self.zero_point as i32).clamp(0, u8::MAX as i32);
-            dest_ptr.write(MaybeUninit::new(y as u8));
-
-            src_ptr = src_ptr.add(1);
-            dest_ptr = dest_ptr.add(1);
-            n -= 1;
+            dest_writer.write_scalar(y as u8);
         }
 
-        transmute::<&mut [MaybeUninit<u8>], &mut [u8]>(self.dest)
+        dest_writer.into_mut_slice()
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use rten_simd::dispatch::SimdOp;
+    use rten_simd::safe::{Isa, SimdOp, SimdOps};
 
     use super::Quantize;
 
@@ -91,13 +90,25 @@ mod tests {
             .collect()
     }
 
+    /// Return number of u8 lanes supported in a SIMD vector.
+    fn u8_vec_len() -> usize {
+        struct U8VecLen {}
+        impl SimdOp for U8VecLen {
+            type Output = usize;
+            fn eval<I: Isa>(self, isa: I) -> usize {
+                isa.u8().len()
+            }
+        }
+        U8VecLen {}.dispatch()
+    }
+
     #[test]
     fn test_quantize() {
         let mut rng = fastrand::Rng::with_seed(1234);
 
-        // Larger than max SIMD vector length, not a multiple of one, so we have
-        // a tail.
-        let len = 17;
+        // Larger than max u8 SIMD vector length, and not an exact multiple, so
+        // we have a tail.
+        let len = u8_vec_len() + 1;
         let src: Vec<f32> = std::iter::from_fn(|| Some(rng.f32())).take(len).collect();
         let inv_scale = 5.2;
         let zero_point = 10;

--- a/src/ops/quantize.rs
+++ b/src/ops/quantize.rs
@@ -1,7 +1,6 @@
 use std::mem::MaybeUninit;
 
-use rten_simd::dispatch::SimdOp as UnsafeSimdOp;
-use rten_simd::safe::SimdOp as SafeSimdOp;
+use rten_simd::safe::SimdOp;
 use rten_tensor::prelude::*;
 use rten_tensor::{AssumeInit, NdTensor, NdTensorView, Scalar, Tensor, TensorView};
 use rten_vecmath as vecmath;


### PR DESCRIPTION
Add a `NarrowSaturate` trait in the new SIMD API which narrows two input vectors with saturation and concatenates the results to form a full narrowed vector. Implement this for i32 -> i16 and i16 -> u8 narrowing, then use the new operations to port the `Quantize` op to the new SIMD API, with no `unsafe`.

This particular combination of narrowings was used because it maps directly to intrinsics in all platforms, especially AVX2 and wasm32 which have only a limited set of narrowing operations.

The new vectorized `Quantize` op is more efficient than the old one because it generates one u8 SIMD vector from 4x f32 vectors in each iteration, whereas the previous one converted one f32 vector to 1/4 of a u8 vector in each iteration.

There is also a commit that adds tests for `SimdOps::{min, max}` and a `clamp` operation. These were used in an earlier iteration of the ported `Quantize` op but ended up not being needed. Nevertheless, it is useful to have both the tests and `clamp`.

**TODO:**

- [x] Shuffle outputs in AVX2 / AVX512 to deal with the intrinsics operating on 128-bit blocks of the input