### PR TITLE
Use separate lifetimes for source and destination of vectorized ops

### DIFF
--- a/rten-simd/src/dispatch.rs
+++ b/rten-simd/src/dispatch.rs
@@ -163,19 +163,19 @@ pub trait SimdUnaryOp {
 
 /// SIMD operation which applies a unary operator `Op` to all elements in
 /// an input buffer using [`simd_map`].
-pub struct SimdMapOp<'a, Op: SimdUnaryOp> {
-    src_dest: SrcDest<'a, f32>,
-    op: &'a Op,
+pub struct SimdMapOp<'src, 'dst, 'op, Op: SimdUnaryOp> {
+    src_dest: SrcDest<'src, 'dst, f32>,
+    op: &'op Op,
 }
 
-impl<'a, Op: SimdUnaryOp> SimdMapOp<'a, Op> {
-    pub fn wrap(src_dest: SrcDest<'a, f32>, op: &'a Op) -> SimdMapOp<'a, Op> {
+impl<'src, 'dst, 'op, Op: SimdUnaryOp> SimdMapOp<'src, 'dst, 'op, Op> {
+    pub fn wrap(src_dest: SrcDest<'src, 'dst, f32>, op: &'op Op) -> Self {
         SimdMapOp { src_dest, op }
     }
 }
 
-impl<'a, Op: SimdUnaryOp> SimdOp for SimdMapOp<'a, Op> {
-    type Output = &'a mut [f32];
+impl<'dst, Op: SimdUnaryOp> SimdOp for SimdMapOp<'_, 'dst, '_, Op> {
+    type Output = &'dst mut [f32];
 
     #[inline(always)]
     unsafe fn eval<S: SimdFloat>(self) -> Self::Output {

--- a/rten-simd/src/functional.rs
+++ b/rten-simd/src/functional.rs
@@ -18,10 +18,10 @@ use crate::{Simd, SimdMask};
 /// The caller must ensure that `S` is a supported SIMD vector type on the
 /// current system.
 #[inline(always)]
-pub unsafe fn simd_map<S: Simd, Op: FnMut(S) -> S>(
-    mut src_dest: SrcDest<S::Elem>,
+pub unsafe fn simd_map<'dst, S: Simd, Op: FnMut(S) -> S>(
+    mut src_dest: SrcDest<'_, 'dst, S::Elem>,
     mut op: Op,
-) -> &mut [S::Elem] {
+) -> &'dst mut [S::Elem] {
     let (mut in_ptr, mut out_ptr, mut n) = src_dest.src_dest_ptr();
 
     let v_len = S::len();

--- a/rten-simd/src/safe/functional.rs
+++ b/rten-simd/src/safe/functional.rs
@@ -10,11 +10,14 @@ use crate::span::SrcDest;
 ///
 /// The map function must have the same input and output type.
 #[inline(always)]
-pub fn simd_map<'a, S: Simd, Op: FnMut(S) -> S>(
+pub fn simd_map<'src, 'dst, S: Simd, Op: FnMut(S) -> S>(
     ops: impl SimdOps<S>,
-    src_dest: impl Into<SrcDest<'a, S::Elem>>,
+    src_dest: impl Into<SrcDest<'src, 'dst, S::Elem>>,
     mut op: Op,
-) -> &'a mut [S::Elem] {
+) -> &'dst mut [S::Elem]
+where
+    S::Elem: 'static,
+{
     let mut src_dest = src_dest.into();
     let (mut in_ptr, mut out_ptr, mut n) = src_dest.src_dest_ptr();
 

--- a/rten-vecmath/src/softmax.rs
+++ b/rten-vecmath/src/softmax.rs
@@ -13,30 +13,33 @@ use crate::Exp;
 /// and <https://arxiv.org/abs/2001.04438>.
 ///
 /// [softmax]: <https://en.wikipedia.org/wiki/Softmax_function>
-pub struct Softmax<'a> {
-    src_dest: SrcDest<'a, f32>,
+pub struct Softmax<'src, 'dst> {
+    src_dest: SrcDest<'src, 'dst, f32>,
 }
 
-impl<'a> Softmax<'a> {
+impl<'src, 'dst> Softmax<'src, 'dst> {
     /// Construct a softmax operation which reads `input` and writes to to
     /// `output`.
-    pub fn new(input: &'a [f32], output: &'a mut [MaybeUninit<f32>]) -> Self {
+    pub fn new(input: &'src [f32], output: &'dst mut [MaybeUninit<f32>]) -> Self {
         Softmax {
             src_dest: (input, output).into(),
         }
     }
 
     /// Construct a softmax operation which updates `input` in place.
-    pub fn new_mut(input: &'a mut [f32]) -> Self {
+    pub fn new_mut(input: &'dst mut [f32]) -> Self
+    where
+        'dst: 'src,
+    {
         Softmax {
             src_dest: input.into(),
         }
     }
 }
 
-impl<'a> SimdOp for Softmax<'a> {
+impl<'dst> SimdOp for Softmax<'_, 'dst> {
     /// The normalized elements.
-    type Output = &'a mut [f32];
+    type Output = &'dst mut [f32];
 
     #[inline(always)]
     fn eval<I: Isa>(self, isa: I) -> Self::Output {


### PR DESCRIPTION
Use separate lifetimes for the source and destination buffers of vectorized ops, so that the compiler can understand that the source buffer is no borrowed after an operation is dispatched.

This change is an enabler for creating a safe API to update the length of a `Vec` after writing to the uninitialized portion.