### PR TITLE
Rename safe SIMD traits

### DIFF
--- a/rten-simd/src/safe.rs
+++ b/rten-simd/src/safe.rs
@@ -20,7 +20,7 @@
 //! evaluates it on a vector of floats:
 //!
 //! ```
-//! use rten_simd::safe::{Isa, SimdOp, SimdOps};
+//! use rten_simd::safe::{Isa, SimdOp, NumOps};
 //! use rten_simd::safe::functional::simd_map;
 //!
 //! struct Square<'a> {
@@ -79,12 +79,12 @@
 //!
 //! An instance of the [`Isa`] trait is passed to the operation when it is
 //! evaluated. The type of ISA will depend on the selected instruction set.  The
-//! ISA provides access to different implementations of the [`SimdOps`] trait
+//! ISA provides access to different implementations of the [`NumOps`] trait
 //! and sub-traits. These in turn provide operations on SIMD vectors with
-//! different data types. The [`SimdOps`] trait provides operations that are
-//! available on all SIMD vectors. The sub-traits [`SimdFloatOps`] and
-//! [`SimdIntOps`] provide operations that are only available on SIMD vectors
-//! with float and integer elements respectively.
+//! different data types. The [`NumOps`] trait provides operations that are
+//! available on all SIMD vectors. The sub-traits [`FloatOps`] and
+//! [`SignedIntOps`] provide operations that are only available on SIMD vectors
+//! with float and signed integer elements respectively.
 //!
 //! ## Applying SIMD operations to slices
 //!
@@ -155,7 +155,7 @@ pub mod isa {
 
 pub use dispatch::{SimdOp, SimdUnaryOp};
 pub use iter::{Iter, SimdIterable};
-pub use vec::{Elem, Isa, Mask, MaskOps, NarrowSaturate, Simd, SimdFloatOps, SimdIntOps, SimdOps};
+pub use vec::{Elem, FloatOps, Isa, Mask, MaskOps, NarrowSaturate, NumOps, SignedIntOps, Simd};
 pub use writer::SliceWriter;
 
 #[cfg(test)]
@@ -176,7 +176,7 @@ pub(crate) use assert_simd_eq;
 #[cfg(test)]
 mod tests {
     use super::functional::simd_map;
-    use super::{Isa, SimdOp, SimdOps};
+    use super::{Isa, NumOps, SimdOp};
 
     #[test]
     fn test_simd_f32_op() {

--- a/rten-simd/src/safe/arch/x86_64/avx2.rs
+++ b/rten-simd/src/safe/arch/x86_64/avx2.rs
@@ -21,7 +21,7 @@ use std::mem::transmute;
 
 use super::super::{lanes, simd_type};
 use crate::safe::vec::{Extend, Narrow};
-use crate::safe::{Isa, Mask, MaskOps, NarrowSaturate, Simd, SimdFloatOps, SimdIntOps, SimdOps};
+use crate::safe::{FloatOps, Isa, Mask, MaskOps, NarrowSaturate, NumOps, SignedIntOps, Simd};
 
 simd_type!(F32x8, __m256, f32, F32x8, Avx2Isa);
 simd_type!(I32x8, __m256i, i32, I32x8, Avx2Isa);
@@ -55,27 +55,27 @@ unsafe impl Isa for Avx2Isa {
     type U16 = U16x16;
     type Bits = I32x8;
 
-    fn f32(self) -> impl SimdFloatOps<Self::F32, Int = Self::I32> {
+    fn f32(self) -> impl FloatOps<Self::F32, Int = Self::I32> {
         self
     }
 
-    fn i32(self) -> impl SimdIntOps<Self::I32> + NarrowSaturate<Self::I32, Self::I16> {
+    fn i32(self) -> impl SignedIntOps<Self::I32> + NarrowSaturate<Self::I32, Self::I16> {
         self
     }
 
-    fn i16(self) -> impl SimdIntOps<Self::I16> + NarrowSaturate<Self::I16, Self::U8> {
+    fn i16(self) -> impl SignedIntOps<Self::I16> + NarrowSaturate<Self::I16, Self::U8> {
         self
     }
 
-    fn i8(self) -> impl SimdIntOps<Self::I8> {
+    fn i8(self) -> impl SignedIntOps<Self::I8> {
         self
     }
 
-    fn u8(self) -> impl SimdOps<Self::U8> {
+    fn u8(self) -> impl NumOps<Self::U8> {
         self
     }
 
-    fn u16(self) -> impl SimdOps<Self::U16> {
+    fn u16(self) -> impl NumOps<Self::U16> {
         self
     }
 }
@@ -104,7 +104,7 @@ macro_rules! simd_ops_common {
     };
 }
 
-unsafe impl SimdOps<F32x8> for Avx2Isa {
+unsafe impl NumOps<F32x8> for Avx2Isa {
     simd_ops_common!(F32x8, F32x8);
 
     #[inline]
@@ -216,7 +216,7 @@ unsafe impl SimdOps<F32x8> for Avx2Isa {
     }
 }
 
-impl SimdFloatOps<F32x8> for Avx2Isa {
+impl FloatOps<F32x8> for Avx2Isa {
     type Int = <Self as Isa>::I32;
 
     #[inline]
@@ -245,7 +245,7 @@ impl SimdFloatOps<F32x8> for Avx2Isa {
     }
 }
 
-unsafe impl SimdOps<I32x8> for Avx2Isa {
+unsafe impl NumOps<I32x8> for Avx2Isa {
     simd_ops_common!(I32x8, I32x8);
 
     #[inline]
@@ -316,7 +316,7 @@ unsafe impl SimdOps<I32x8> for Avx2Isa {
     }
 }
 
-impl SimdIntOps<I32x8> for Avx2Isa {
+impl SignedIntOps<I32x8> for Avx2Isa {
     #[inline]
     fn neg(self, x: I32x8) -> I32x8 {
         unsafe { _mm256_sub_epi32(_mm256_setzero_si256(), x.0) }.into()
@@ -348,7 +348,7 @@ impl NarrowSaturate<I32x8, I16x16> for Avx2Isa {
     }
 }
 
-unsafe impl SimdOps<I16x16> for Avx2Isa {
+unsafe impl NumOps<I16x16> for Avx2Isa {
     simd_ops_common!(I16x16, I16x16);
 
     #[inline]
@@ -441,7 +441,7 @@ unsafe impl SimdOps<I16x16> for Avx2Isa {
     }
 }
 
-impl SimdIntOps<I16x16> for Avx2Isa {
+impl SignedIntOps<I16x16> for Avx2Isa {
     #[inline]
     fn neg(self, x: I16x16) -> I16x16 {
         unsafe { _mm256_sub_epi16(_mm256_setzero_si256(), x.0) }.into()
@@ -468,7 +468,7 @@ impl NarrowSaturate<I16x16, U8x32> for Avx2Isa {
     }
 }
 
-unsafe impl SimdOps<I8x32> for Avx2Isa {
+unsafe impl NumOps<I8x32> for Avx2Isa {
     simd_ops_common!(I8x32, I8x32);
 
     #[inline]
@@ -567,7 +567,7 @@ unsafe impl SimdOps<I8x32> for Avx2Isa {
     }
 }
 
-impl SimdIntOps<I8x32> for Avx2Isa {
+impl SignedIntOps<I8x32> for Avx2Isa {
     #[inline]
     fn neg(self, x: I8x32) -> I8x32 {
         unsafe { _mm256_sub_epi8(_mm256_setzero_si256(), x.0) }.into()
@@ -585,7 +585,7 @@ impl SimdIntOps<I8x32> for Avx2Isa {
     }
 }
 
-unsafe impl SimdOps<U8x32> for Avx2Isa {
+unsafe impl NumOps<U8x32> for Avx2Isa {
     simd_ops_common!(U8x32, I8x32);
 
     #[inline]
@@ -693,7 +693,7 @@ unsafe impl SimdOps<U8x32> for Avx2Isa {
     }
 }
 
-unsafe impl SimdOps<U16x16> for Avx2Isa {
+unsafe impl NumOps<U16x16> for Avx2Isa {
     simd_ops_common!(U16x16, I16x16);
 
     #[inline]

--- a/rten-simd/src/safe/arch/x86_64/avx512.rs
+++ b/rten-simd/src/safe/arch/x86_64/avx512.rs
@@ -22,7 +22,7 @@ use std::mem::transmute;
 
 use super::super::{lanes, simd_type};
 use crate::safe::vec::{Extend, Narrow};
-use crate::safe::{Isa, Mask, MaskOps, NarrowSaturate, Simd, SimdFloatOps, SimdIntOps, SimdOps};
+use crate::safe::{FloatOps, Isa, Mask, MaskOps, NarrowSaturate, NumOps, SignedIntOps, Simd};
 
 simd_type!(F32x16, __m512, f32, __mmask16, Avx512Isa);
 simd_type!(I32x16, __m512i, i32, __mmask16, Avx512Isa);
@@ -56,27 +56,27 @@ unsafe impl Isa for Avx512Isa {
     type U16 = U16x32;
     type Bits = I32x16;
 
-    fn f32(self) -> impl SimdFloatOps<Self::F32, Int = Self::I32> {
+    fn f32(self) -> impl FloatOps<Self::F32, Int = Self::I32> {
         self
     }
 
-    fn i32(self) -> impl SimdIntOps<Self::I32> + NarrowSaturate<Self::I32, Self::I16> {
+    fn i32(self) -> impl SignedIntOps<Self::I32> + NarrowSaturate<Self::I32, Self::I16> {
         self
     }
 
-    fn i16(self) -> impl SimdIntOps<Self::I16> + NarrowSaturate<Self::I16, Self::U8> {
+    fn i16(self) -> impl SignedIntOps<Self::I16> + NarrowSaturate<Self::I16, Self::U8> {
         self
     }
 
-    fn i8(self) -> impl SimdIntOps<Self::I8> {
+    fn i8(self) -> impl SignedIntOps<Self::I8> {
         self
     }
 
-    fn u8(self) -> impl SimdOps<Self::U8> {
+    fn u8(self) -> impl NumOps<Self::U8> {
         self
     }
 
-    fn u16(self) -> impl SimdOps<Self::U16> {
+    fn u16(self) -> impl NumOps<Self::U16> {
         self
     }
 }
@@ -114,7 +114,7 @@ macro_rules! simd_ops_common {
     };
 }
 
-unsafe impl SimdOps<F32x16> for Avx512Isa {
+unsafe impl NumOps<F32x16> for Avx512Isa {
     simd_ops_common!(F32x16, __mmask16);
 
     #[inline]
@@ -208,7 +208,7 @@ unsafe impl SimdOps<F32x16> for Avx512Isa {
     }
 }
 
-impl SimdFloatOps<F32x16> for Avx512Isa {
+impl FloatOps<F32x16> for Avx512Isa {
     type Int = <Self as Isa>::I32;
 
     #[inline]
@@ -237,7 +237,7 @@ impl SimdFloatOps<F32x16> for Avx512Isa {
     }
 }
 
-unsafe impl SimdOps<I32x16> for Avx512Isa {
+unsafe impl NumOps<I32x16> for Avx512Isa {
     simd_ops_common!(I32x16, __mmask16);
 
     #[inline]
@@ -301,7 +301,7 @@ unsafe impl SimdOps<I32x16> for Avx512Isa {
     }
 }
 
-impl SimdIntOps<I32x16> for Avx512Isa {
+impl SignedIntOps<I32x16> for Avx512Isa {
     #[inline]
     fn neg(self, x: I32x16) -> I32x16 {
         unsafe { _mm512_sub_epi32(_mm512_setzero_si512(), x.0) }.into()
@@ -330,7 +330,7 @@ impl NarrowSaturate<I32x16, I16x32> for Avx512Isa {
     }
 }
 
-unsafe impl SimdOps<I16x32> for Avx512Isa {
+unsafe impl NumOps<I16x32> for Avx512Isa {
     simd_ops_common!(I16x32, __mmask32);
 
     #[inline]
@@ -394,7 +394,7 @@ unsafe impl SimdOps<I16x32> for Avx512Isa {
     }
 }
 
-impl SimdIntOps<I16x32> for Avx512Isa {
+impl SignedIntOps<I16x32> for Avx512Isa {
     #[inline]
     fn neg(self, x: I16x32) -> I16x32 {
         unsafe { _mm512_sub_epi16(_mm512_setzero_si512(), x.0) }.into()
@@ -423,7 +423,7 @@ impl NarrowSaturate<I16x32, U8x64> for Avx512Isa {
     }
 }
 
-unsafe impl SimdOps<I8x64> for Avx512Isa {
+unsafe impl NumOps<I8x64> for Avx512Isa {
     simd_ops_common!(I8x64, __mmask64);
 
     #[inline]
@@ -494,7 +494,7 @@ unsafe impl SimdOps<I8x64> for Avx512Isa {
     }
 }
 
-impl SimdIntOps<I8x64> for Avx512Isa {
+impl SignedIntOps<I8x64> for Avx512Isa {
     #[inline]
     fn neg(self, x: I8x64) -> I8x64 {
         unsafe { _mm512_sub_epi8(_mm512_setzero_si512(), x.0) }.into()
@@ -514,7 +514,7 @@ impl SimdIntOps<I8x64> for Avx512Isa {
     }
 }
 
-unsafe impl SimdOps<U8x64> for Avx512Isa {
+unsafe impl NumOps<U8x64> for Avx512Isa {
     simd_ops_common!(U8x64, __mmask64);
 
     #[inline]
@@ -647,7 +647,7 @@ impl Narrow<U16x32> for Avx512Isa {
     }
 }
 
-unsafe impl SimdOps<U16x32> for Avx512Isa {
+unsafe impl NumOps<U16x32> for Avx512Isa {
     simd_ops_common!(U16x32, __mmask32);
 
     #[inline]

--- a/rten-simd/src/safe/dispatch.rs
+++ b/rten-simd/src/safe/dispatch.rs
@@ -84,7 +84,7 @@ pub trait SimdUnaryOp<T: Elem> {
     /// the specific type used by the ISA:
     ///
     /// ```
-    /// use rten_simd::safe::{Isa, Simd, SimdFloatOps, SimdOps, SimdUnaryOp};
+    /// use rten_simd::safe::{Isa, Simd, FloatOps, NumOps, SimdUnaryOp};
     ///
     /// struct Reciprocal {}
     ///
@@ -214,7 +214,7 @@ pub(crate) use test_simd_op;
 #[cfg(test)]
 mod tests {
     use super::SimdUnaryOp;
-    use crate::safe::{Isa, Simd, SimdFloatOps, SimdOps};
+    use crate::safe::{FloatOps, Isa, NumOps, Simd};
 
     #[test]
     fn test_unary_float_op() {

--- a/rten-simd/src/safe/functional.rs
+++ b/rten-simd/src/safe/functional.rs
@@ -1,6 +1,6 @@
 //! Vectorized higher-order operations (map, fold etc.)
 
-use super::{Simd, SimdOps};
+use super::{NumOps, Simd};
 use crate::span::SrcDest;
 
 /// Transform a slice by applying a vectorized map function to its elements.
@@ -11,7 +11,7 @@ use crate::span::SrcDest;
 /// The map function must have the same input and output type.
 #[inline(always)]
 pub fn simd_map<'src, 'dst, S: Simd, Op: FnMut(S) -> S>(
-    ops: impl SimdOps<S>,
+    ops: impl NumOps<S>,
     src_dest: impl Into<SrcDest<'src, 'dst, S::Elem>>,
     mut op: Op,
 ) -> &'dst mut [S::Elem]
@@ -50,7 +50,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::safe::{Isa, SimdOp, SimdOps};
+    use crate::safe::{Isa, NumOps, SimdOp};
 
     use super::simd_map;
 

--- a/rten-simd/src/safe/writer.rs
+++ b/rten-simd/src/safe/writer.rs
@@ -1,6 +1,6 @@
 use std::mem::{transmute, MaybeUninit};
 
-use super::{Simd, SimdOps};
+use super::{NumOps, Simd};
 
 /// Utility for incrementally filling an uninitialized slice, one SIMD vector
 /// at a time.
@@ -19,7 +19,7 @@ impl<'a, T> SliceWriter<'a, T> {
     /// of SIMD vector `xs`.
     ///
     /// Panics if the slice does not have space for `ops.len()` elements.
-    pub fn write_vec<S: Simd<Elem = T>>(&mut self, ops: impl SimdOps<S>, xs: S) {
+    pub fn write_vec<S: Simd<Elem = T>>(&mut self, ops: impl NumOps<S>, xs: S) {
         let written = ops.store_uninit(xs, &mut self.buf[self.n_init..]);
         self.n_init += written.len();
     }
@@ -45,7 +45,7 @@ impl<'a, T> SliceWriter<'a, T> {
 mod tests {
     use std::mem::MaybeUninit;
 
-    use crate::safe::{Isa, SimdOp, SimdOps, SliceWriter};
+    use crate::safe::{Isa, NumOps, SimdOp, SliceWriter};
 
     #[test]
     fn test_slice_writer() {

--- a/rten-vecmath/src/erf.rs
+++ b/rten-vecmath/src/erf.rs
@@ -4,7 +4,7 @@
 
 use std::f32::consts::SQRT_2;
 
-use rten_simd::safe::{Isa, Simd, SimdFloatOps, SimdOps, SimdUnaryOp};
+use rten_simd::safe::{FloatOps, Isa, NumOps, Simd, SimdUnaryOp};
 
 use crate::Exp;
 

--- a/rten-vecmath/src/exp.rs
+++ b/rten-vecmath/src/exp.rs
@@ -2,7 +2,7 @@
 
 #![allow(clippy::excessive_precision)]
 
-use rten_simd::safe::{Isa, Simd, SimdFloatOps, SimdIntOps, SimdOps, SimdUnaryOp};
+use rten_simd::safe::{FloatOps, Isa, NumOps, SignedIntOps, Simd, SimdUnaryOp};
 
 const INV_LOG2: f32 = std::f32::consts::LOG2_E; // aka. 1 / ln2
 const ROUNDING_MAGIC: f32 = 12582912.; // 0x3 << 22

--- a/rten-vecmath/src/min_max.rs
+++ b/rten-vecmath/src/min_max.rs
@@ -1,4 +1,4 @@
-use rten_simd::safe::{Isa, Simd, SimdIterable, SimdOp, SimdOps};
+use rten_simd::safe::{Isa, NumOps, Simd, SimdIterable, SimdOp};
 
 /// Compute the minimum and maximum values in a slice of floats.
 pub struct MinMax<'a> {

--- a/rten-vecmath/src/normalize.rs
+++ b/rten-vecmath/src/normalize.rs
@@ -1,7 +1,7 @@
 use std::mem::MaybeUninit;
 
 use rten_simd::safe::functional::simd_map;
-use rten_simd::safe::{Isa, SimdIterable, SimdOp, SimdOps};
+use rten_simd::safe::{Isa, NumOps, SimdIterable, SimdOp};
 use rten_simd::span::SrcDest;
 
 /// Normalize the mean and variance of elements in a slice.

--- a/rten-vecmath/src/quantize.rs
+++ b/rten-vecmath/src/quantize.rs
@@ -1,6 +1,6 @@
 use std::mem::MaybeUninit;
 
-use rten_simd::safe::{Isa, NarrowSaturate, SimdFloatOps, SimdOp, SimdOps, SliceWriter};
+use rten_simd::safe::{FloatOps, Isa, NarrowSaturate, NumOps, SimdOp, SliceWriter};
 
 /// Quantize a slice of `f32` elements to 8-bit integers using the formula:
 ///
@@ -77,7 +77,7 @@ impl<'d> SimdOp for Quantize<'_, 'd, u8> {
 
 #[cfg(test)]
 mod tests {
-    use rten_simd::safe::{Isa, SimdOp, SimdOps};
+    use rten_simd::safe::{Isa, NumOps, SimdOp};
 
     use super::Quantize;
 

--- a/rten-vecmath/src/softmax.rs
+++ b/rten-vecmath/src/softmax.rs
@@ -1,7 +1,7 @@
 use std::mem::MaybeUninit;
 
 use rten_simd::safe::functional::simd_map;
-use rten_simd::safe::{Isa, SimdFloatOps, SimdIterable, SimdOp, SimdOps, SimdUnaryOp};
+use rten_simd::safe::{FloatOps, Isa, NumOps, SimdIterable, SimdOp, SimdUnaryOp};
 use rten_simd::span::SrcDest;
 
 use crate::Exp;

--- a/rten-vecmath/src/sum.rs
+++ b/rten-vecmath/src/sum.rs
@@ -1,4 +1,4 @@
-use rten_simd::safe::{Isa, Simd, SimdIterable, SimdOp, SimdOps};
+use rten_simd::safe::{Isa, NumOps, Simd, SimdIterable, SimdOp};
 
 /// Computes the sum of a sequence of numbers.
 ///

--- a/rten-vecmath/src/tanh.rs
+++ b/rten-vecmath/src/tanh.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::excessive_precision)]
 
-use rten_simd::safe::{Isa, Simd, SimdFloatOps, SimdOps, SimdUnaryOp};
+use rten_simd::safe::{FloatOps, Isa, NumOps, Simd, SimdUnaryOp};
 
 use crate::Exp;
 

--- a/src/gemm/im2col.rs
+++ b/src/gemm/im2col.rs
@@ -1,7 +1,7 @@
 use std::mem::MaybeUninit;
 use std::ops::Range;
 
-use rten_simd::safe::{Isa, Mask, MaskOps, Simd, SimdOps};
+use rten_simd::safe::{Isa, Mask, MaskOps, NumOps, Simd};
 use rten_tensor::{NdTensorView, Storage};
 
 use super::packing::int8::shift_cast_i8_u8;

--- a/src/gemm/kernels/simd_generic.rs
+++ b/src/gemm/kernels/simd_generic.rs
@@ -1,6 +1,6 @@
 use std::mem::MaybeUninit;
 
-use rten_simd::safe::{Isa, SimdOps};
+use rten_simd::safe::{Isa, NumOps};
 use rten_simd::SimdInt;
 use rten_tensor::{Matrix, MatrixLayout, Storage};
 


### PR DESCRIPTION
Rename the SIMD operation traits to make the names more distinctive at a glance and avoid them all having the same `Simd*` prefix:

 `SimdOps` -> `NumOps`
 `SimdFloatOps` -> `FloatOps`
 `SimdIntOps` -> `SignedIntOps`