### PR TITLE
Add `ExtendInit` utility for updating length of destination buffers for vectorized ops

### DIFF
--- a/rten-vecmath/src/extend_init.rs
+++ b/rten-vecmath/src/extend_init.rs
@@ -1,0 +1,85 @@
+use std::mem::MaybeUninit;
+
+/// Extend a buffer by incrementally initializing spare capacity.
+///
+/// This is implemented for [`Vec<T>`], where it provides a safe API to
+/// initialize the spare capacity returned by
+/// [`spare_capacity_mut`](Vec::spare_capacity_mut).
+pub trait ExtendInit {
+    /// Element type in the buffer.
+    type Elem;
+
+    /// Extend the buffer by initializing a portion of the buffer's spare
+    /// capacity.
+    ///
+    /// The function `f` is passed the uninitialized portion of the buffer and
+    /// should return the portion that it has initialized. `extend_init` can
+    /// be called many times, until the entire buffer has been initialized.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `f` returns a slice that is not a prefix of the slice that
+    /// was passed to it.
+    fn extend_init<F: Fn(&mut [MaybeUninit<Self::Elem>]) -> &[Self::Elem]>(&mut self, f: F);
+}
+
+impl<T> ExtendInit for Vec<T> {
+    type Elem = T;
+
+    fn extend_init<F: Fn(&mut [MaybeUninit<Self::Elem>]) -> &[Self::Elem]>(&mut self, f: F) {
+        let cap = self.spare_capacity_mut();
+        let cap_ptr = cap.as_ptr();
+        let cap_len = cap.len();
+
+        let initialized = f(cap);
+        assert_eq!(
+            initialized.as_ptr(),
+            cap_ptr as *const T,
+            "returned slice must be a prefix of the input"
+        );
+        assert!(
+            initialized.len() <= cap_len,
+            "initialized slice length {} is longer than input {}",
+            initialized.len(),
+            cap_len
+        );
+        let n_init = initialized.len();
+
+        // Safety: `n_init` elements from the spare capacity have been initialized.
+        unsafe { self.set_len(self.len() + n_init) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::mem::MaybeUninit;
+
+    use super::ExtendInit;
+
+    // Implementation of `MaybeUninit::fill` from nightly Rust.
+    fn fill<T: Copy>(xs: &mut [MaybeUninit<T>], value: T) -> &mut [T] {
+        for x in xs.iter_mut() {
+            x.write(value);
+        }
+        unsafe { std::mem::transmute::<&mut [MaybeUninit<T>], &mut [T]>(xs) }
+    }
+
+    #[test]
+    fn test_extend_init() {
+        let mut vec = Vec::with_capacity(7);
+
+        vec.extend_init(|uninit| {
+            assert_eq!(uninit.len(), 7);
+            fill(&mut uninit[..3], 1.)
+        });
+        assert_eq!(vec.len(), 3);
+        assert_eq!(vec, &[1., 1., 1.]);
+
+        vec.extend_init(|uninit| {
+            assert_eq!(uninit.len(), 4);
+            fill(uninit, 2.)
+        });
+        assert_eq!(vec.len(), 7);
+        assert_eq!(vec, &[1., 1., 1., 2., 2., 2., 2.]);
+    }
+}

--- a/rten-vecmath/src/lib.rs
+++ b/rten-vecmath/src/lib.rs
@@ -96,6 +96,8 @@ mod ulp;
 #[cfg(test)]
 mod testing;
 
+mod extend_init;
+
 // Unary functions.
 pub use erf::{Erf, Gelu};
 pub use exp::{Exp, Sigmoid, Silu, Swish};
@@ -107,3 +109,6 @@ pub use min_max::MinMax;
 pub use normalize::{Normalize, NormalizeOptions};
 pub use softmax::Softmax;
 pub use sum::{Sum, SumSquare, SumSquareSub};
+
+// Utilities
+pub use extend_init::ExtendInit;


### PR DESCRIPTION
The non-in-place vectorized ops in rten-vecmath take uninitialized output slices so that the caller has the freedom choose how/where the buffer is allocated and avoid the overhead of zeroing a slice that the operation is going to initialize anyway. This means that the caller has to use an unsafe `Vec::set_len` call or similar afterwards to update the length of the buffer.

Add an `ExtendInit` trait in rten-vecmath which handles this for the common case of filling a `Vec` with the result of a vectorized operation, and convert a couple of operations in the rten crate to use it.

A limitation of the initial design is that it doesn't support the case where multiple threads are initializing separate chunks of the buffer in parallel. Solving that is left as a future exercise.