### PR TITLE
Support i8 -> i16 -> i32 extension in new SIMD API

### DIFF
--- a/rten-simd/src/safe.rs
+++ b/rten-simd/src/safe.rs
@@ -155,7 +155,9 @@ pub mod isa {
 
 pub use dispatch::{SimdOp, SimdUnaryOp};
 pub use iter::{Iter, SimdIterable};
-pub use vec::{Elem, FloatOps, Isa, Mask, MaskOps, NarrowSaturate, NumOps, SignedIntOps, Simd};
+pub use vec::{
+    Elem, Extend, FloatOps, Isa, Mask, MaskOps, NarrowSaturate, NumOps, SignedIntOps, Simd,
+};
 pub use writer::SliceWriter;
 
 #[cfg(test)]


### PR DESCRIPTION
This will replace uses of `load_extend_i8` in the old API. The new APIs are more efficient as they always expand one whole vec to two (1x 8-bit -> 2x 16-bit -> 4x 32-bit) whereas the previous API expanded 1/4 of an 8-bit vec to 1x 32-bit.