### PR TITLE
Implement i8 and i16 interleave in new SIMD API

### DIFF
--- a/rten-simd/src/safe.rs
+++ b/rten-simd/src/safe.rs
@@ -156,7 +156,8 @@ pub mod isa {
 pub use dispatch::{SimdOp, SimdUnaryOp};
 pub use iter::{Iter, SimdIterable};
 pub use vec::{
-    Elem, Extend, FloatOps, Isa, Mask, MaskOps, NarrowSaturate, NumOps, SignedIntOps, Simd,
+    Elem, Extend, FloatOps, Interleave, Isa, Mask, MaskOps, NarrowSaturate, NumOps, SignedIntOps,
+    Simd,
 };
 pub use writer::SliceWriter;
 


### PR DESCRIPTION
This replaces the `zip_{lo, hi}_{i8, i16}` methods in the old SIMD API.