### PR TITLE
Port int8 GEMM to new SIMD API

### DIFF
--- a/rten-simd/src/safe/arch.rs
+++ b/rten-simd/src/safe/arch.rs
@@ -21,9 +21,14 @@ const fn lanes<S: Simd>() -> usize {
 #[allow(unused_macros)] // Not used on some platforms
 macro_rules! simd_type {
     ($type:ident, $inner:ty, $elem:ty, $mask:ty, $isa:ty) => {
+        // The platform intrinsic is exposed as a public field so that
+        // downstream crates can implement custom SIMD operations. It might be
+        // better to support an `Into` conversion from the wrapper to the
+        // platform type instead?
+
         #[derive(Copy, Clone, Debug)]
         #[repr(transparent)]
-        pub struct $type($inner);
+        pub struct $type(pub $inner);
 
         impl From<$inner> for $type {
             fn from(val: $inner) -> Self {

--- a/src/gemm/kernels/generic.rs
+++ b/src/gemm/kernels/generic.rs
@@ -1,8 +1,7 @@
 use std::mem::MaybeUninit;
 use std::ops::Range;
 
-use rten_simd::safe::isa::GenericIsa;
-use rten_simd::vec_count;
+use rten_simd::safe::{isa::GenericIsa, Isa};
 use rten_tensor::{Matrix, MatrixLayout};
 
 use super::simd_generic::{simd_gemv, GemmDispatch};
@@ -26,6 +25,8 @@ impl GenericKernel {
     // that.
     const NR: usize = 4;
 }
+
+const X32_LANES: usize = size_of::<<GenericIsa as Isa>::I32>() / size_of::<i32>();
 
 // Safety - Base kernel is always supported
 unsafe impl Kernel<f32, f32, f32> for GenericKernel {
@@ -99,7 +100,7 @@ unsafe impl Kernel<f32, f32, f32> for GenericKernel {
         rows: Range<usize>,
         cols: Range<usize>,
     ) {
-        const NR_REGS: usize = vec_count::<f32>(GenericKernel::NR).unwrap();
+        const NR_REGS: usize = GenericKernel::NR / X32_LANES;
 
         // Safety: Scalar "SIMD" types are always supported
         let out = cast_pod_mut_slice(out).unwrap();


### PR DESCRIPTION
Port int8 matrix multiplication and matrix-vector multiplication to the new SIMD API.

The `simd_int8_gemm` and `simd_int8_gemv` functions are still marked as `unsafe` at this stage, but this is a step towards more narrowly scoped use of `unsafe` in future.

**TODO:**

- [x] Verify performance is not regressed on Arm
- [x] ... on AVX-2
- [x] ... on AVX-512 (see https://github.com/robertknight/rten/pull/629)
- [ ] ... on WASM