### PR TITLE
Enable AVX-512BW and AVX-512DQ target features in AVX-512 dispatch

### DIFF
--- a/rten-simd/src/isa_detection.rs
+++ b/rten-simd/src/isa_detection.rs
@@ -20,6 +20,7 @@ pub mod macos {
             // avx512f, as that is implied if the extensions are supported.
             sysctl_bool(c"hw.optional.avx512vl").unwrap_or(false)
                 && sysctl_bool(c"hw.optional.avx512bw").unwrap_or(false)
+                && sysctl_bool(c"hw.optional.avx512dq").unwrap_or(false)
         })
     }
 
@@ -79,6 +80,7 @@ pub mod macos {
 ///  - AVX512F
 ///  - AVX512VL
 ///  - AVX512BW
+///  - AVX512DQ
 ///
 /// These features are available on Skylake (2016) and later.
 /// See <https://en.wikipedia.org/wiki/Advanced_Vector_Extensions#AVX-512_CPU_compatibility_table>.
@@ -90,6 +92,7 @@ pub fn is_avx512_supported() -> bool {
     if is_x86_feature_detected!("avx512f")
         && is_x86_feature_detected!("avx512vl")
         && is_x86_feature_detected!("avx512bw")
+        && is_x86_feature_detected!("avx512dq")
     {
         true
     } else {

--- a/rten-simd/src/safe/dispatch.rs
+++ b/rten-simd/src/safe/dispatch.rs
@@ -35,8 +35,11 @@ pub fn dispatch<Op: SimdOp>(op: Op) -> Op::Output {
     {
         #[cfg(feature = "avx512")]
         {
+            // The target features enabled here must match those tested for by `Avx512Isa::new`.
             #[target_feature(enable = "avx512f")]
             #[target_feature(enable = "avx512vl")]
+            #[target_feature(enable = "avx512bw")]
+            #[target_feature(enable = "avx512dq")]
             unsafe fn dispatch_avx512<Op: SimdOp>(isa: impl Isa, op: Op) -> Op::Output {
                 op.eval(isa)
             }
@@ -49,6 +52,7 @@ pub fn dispatch<Op: SimdOp>(op: Op) -> Op::Output {
             }
         }
 
+        // The target features enabled here must match those tested for by `Avx2Isa::new`.
         #[target_feature(enable = "avx2")]
         #[target_feature(enable = "avx")]
         #[target_feature(enable = "fma")]


### PR DESCRIPTION
 - AVX-512BW was tested for in `Avx512Isa::new`, but not enabled when dispatching. This resulted in intrinsics using these extensions not being inlined.

 - AVX-512DQ is used by `_mm512_xor_ps`, but this feature was not tested for and the target feature wasn't enabled, so this intrinsic did not get inlined.

According to [^1] all CPUs that support the BW extension also support DQ, so this doesn't change which systems can use AVX-512.

[^1]: https://en.wikipedia.org/wiki/Advanced_Vector_Extensions#AVX-512_CPU_compatibility_table