### PR TITLE
Parametrize `NumOps` by element type instead of SIMD type

### DIFF
--- a/rten-simd/src/arch/x86_64/avx512.rs
+++ b/rten-simd/src/arch/x86_64/avx512.rs
@@ -57,17 +57,19 @@ unsafe impl Isa for Avx512Isa {
     type U16 = U16x32;
     type Bits = I32x16;
 
-    fn f32(self) -> impl FloatOps<Self::F32, Int = Self::I32> {
+    fn f32(self) -> impl FloatOps<f32, Simd = Self::F32, Int = Self::I32> {
         self
     }
 
-    fn i32(self) -> impl SignedIntOps<Self::I32> + NarrowSaturate<Self::I32, Self::I16> {
+    fn i32(
+        self,
+    ) -> impl SignedIntOps<i32, Simd = Self::I32> + NarrowSaturate<Self::I32, Self::I16> {
         self
     }
 
     fn i16(
         self,
-    ) -> impl SignedIntOps<Self::I16>
+    ) -> impl SignedIntOps<i16, Simd = Self::I16>
            + NarrowSaturate<Self::I16, Self::U8>
            + Extend<Self::I16, Output = Self::I32>
            + Interleave<Self::I16> {
@@ -76,22 +78,25 @@ unsafe impl Isa for Avx512Isa {
 
     fn i8(
         self,
-    ) -> impl SignedIntOps<Self::I8> + Extend<Self::I8, Output = Self::I16> + Interleave<Self::I8>
-    {
+    ) -> impl SignedIntOps<i8, Simd = Self::I8>
+           + Extend<Self::I8, Output = Self::I16>
+           + Interleave<Self::I8> {
         self
     }
 
-    fn u8(self) -> impl NumOps<Self::U8> {
+    fn u8(self) -> impl NumOps<u8, Simd = Self::U8> {
         self
     }
 
-    fn u16(self) -> impl NumOps<Self::U16> {
+    fn u16(self) -> impl NumOps<u16, Simd = Self::U16> {
         self
     }
 }
 
 macro_rules! simd_ops_common {
     ($simd:ty, $mask:ty) => {
+        type Simd = $simd;
+
         #[inline]
         fn len(self) -> usize {
             lanes::<$simd>()
@@ -137,7 +142,7 @@ macro_rules! simd_int_ops_common {
     };
 }
 
-unsafe impl NumOps<F32x16> for Avx512Isa {
+unsafe impl NumOps<f32> for Avx512Isa {
     simd_ops_common!(F32x16, __mmask16);
 
     #[inline]
@@ -242,7 +247,7 @@ unsafe impl NumOps<F32x16> for Avx512Isa {
     }
 }
 
-impl FloatOps<F32x16> for Avx512Isa {
+impl FloatOps<f32> for Avx512Isa {
     type Int = <Self as Isa>::I32;
 
     #[inline]
@@ -271,7 +276,7 @@ impl FloatOps<F32x16> for Avx512Isa {
     }
 }
 
-unsafe impl NumOps<I32x16> for Avx512Isa {
+unsafe impl NumOps<i32> for Avx512Isa {
     simd_ops_common!(I32x16, __mmask16);
     simd_int_ops_common!(I32x16);
 
@@ -336,7 +341,7 @@ unsafe impl NumOps<I32x16> for Avx512Isa {
     }
 }
 
-impl SignedIntOps<I32x16> for Avx512Isa {
+impl SignedIntOps<i32> for Avx512Isa {
     #[inline]
     fn neg(self, x: I32x16) -> I32x16 {
         unsafe { _mm512_sub_epi32(_mm512_setzero_si512(), x.0) }.into()
@@ -365,7 +370,7 @@ impl NarrowSaturate<I32x16, I16x32> for Avx512Isa {
     }
 }
 
-unsafe impl NumOps<I16x32> for Avx512Isa {
+unsafe impl NumOps<i16> for Avx512Isa {
     simd_ops_common!(I16x32, __mmask32);
     simd_int_ops_common!(I16x32);
 
@@ -430,7 +435,7 @@ unsafe impl NumOps<I16x32> for Avx512Isa {
     }
 }
 
-impl SignedIntOps<I16x32> for Avx512Isa {
+impl SignedIntOps<i16> for Avx512Isa {
     #[inline]
     fn neg(self, x: I16x32) -> I16x32 {
         unsafe { _mm512_sub_epi16(_mm512_setzero_si512(), x.0) }.into()
@@ -486,7 +491,7 @@ impl Interleave<I16x32> for Avx512Isa {
     }
 }
 
-unsafe impl NumOps<I8x64> for Avx512Isa {
+unsafe impl NumOps<i8> for Avx512Isa {
     simd_ops_common!(I8x64, __mmask64);
     simd_int_ops_common!(I8x64);
 
@@ -558,7 +563,7 @@ unsafe impl NumOps<I8x64> for Avx512Isa {
     }
 }
 
-impl SignedIntOps<I8x64> for Avx512Isa {
+impl SignedIntOps<i8> for Avx512Isa {
     #[inline]
     fn neg(self, x: I8x64) -> I8x64 {
         unsafe { _mm512_sub_epi8(_mm512_setzero_si512(), x.0) }.into()
@@ -605,7 +610,7 @@ impl Interleave<I8x64> for Avx512Isa {
     }
 }
 
-unsafe impl NumOps<U8x64> for Avx512Isa {
+unsafe impl NumOps<u8> for Avx512Isa {
     simd_ops_common!(U8x64, __mmask64);
     simd_int_ops_common!(U8x64);
 
@@ -753,7 +758,7 @@ impl Narrow<U16x32> for Avx512Isa {
     }
 }
 
-unsafe impl NumOps<U16x32> for Avx512Isa {
+unsafe impl NumOps<u16> for Avx512Isa {
     simd_ops_common!(U16x32, __mmask32);
     simd_int_ops_common!(U16x32);
 

--- a/rten-simd/src/functional.rs
+++ b/rten-simd/src/functional.rs
@@ -1,6 +1,6 @@
 //! Vectorized higher-order operations (map, fold etc.)
 
-use super::{NumOps, Simd};
+use super::{Elem, NumOps};
 use crate::span::SrcDest;
 
 /// Transform a slice by applying a vectorized map function to its elements.
@@ -10,14 +10,11 @@ use crate::span::SrcDest;
 ///
 /// The map function must have the same input and output type.
 #[inline(always)]
-pub fn simd_map<'src, 'dst, S: Simd, Op: FnMut(S) -> S>(
-    ops: impl NumOps<S>,
-    src_dest: impl Into<SrcDest<'src, 'dst, S::Elem>>,
+pub fn simd_map<'src, 'dst, T: Elem + 'static, O: NumOps<T>, Op: FnMut(O::Simd) -> O::Simd>(
+    ops: O,
+    src_dest: impl Into<SrcDest<'src, 'dst, T>>,
     mut op: Op,
-) -> &'dst mut [S::Elem]
-where
-    S::Elem: 'static,
-{
+) -> &'dst mut [T] {
     let mut src_dest = src_dest.into();
     let (mut in_ptr, mut out_ptr, mut n) = src_dest.src_dest_ptr();
 

--- a/rten-simd/src/writer.rs
+++ b/rten-simd/src/writer.rs
@@ -1,6 +1,6 @@
 use std::mem::{transmute, MaybeUninit};
 
-use super::{NumOps, Simd};
+use super::{Elem, NumOps};
 
 /// Utility for incrementally filling an uninitialized slice, one SIMD vector
 /// at a time.
@@ -9,7 +9,7 @@ pub struct SliceWriter<'a, T> {
     n_init: usize,
 }
 
-impl<'a, T> SliceWriter<'a, T> {
+impl<'a, T: Elem> SliceWriter<'a, T> {
     /// Create a writer which initializes elements of `buf`.
     pub fn new(buf: &'a mut [MaybeUninit<T>]) -> Self {
         SliceWriter { buf, n_init: 0 }
@@ -19,7 +19,7 @@ impl<'a, T> SliceWriter<'a, T> {
     /// of SIMD vector `xs`.
     ///
     /// Panics if the slice does not have space for `ops.len()` elements.
-    pub fn write_vec<S: Simd<Elem = T>>(&mut self, ops: impl NumOps<S>, xs: S) {
+    pub fn write_vec<O: NumOps<T>>(&mut self, ops: O, xs: O::Simd) {
         let written = ops.store_uninit(xs, &mut self.buf[self.n_init..]);
         self.n_init += written.len();
     }

--- a/src/gemm/kernels/simd_generic.rs
+++ b/src/gemm/kernels/simd_generic.rs
@@ -656,7 +656,7 @@ pub unsafe fn simd_int8_gemv<I: Isa, const CAST_B_U8: bool>(
             //
             // The second tile contains A4..A7 and so on.
             let b_tile_ptr: [*const i8; 4] =
-                std::array::from_fn(|i| b_ptr.add((k + i) * b_row_stride) as *const i8);
+                std::array::from_fn(|i| b_ptr.add((k + i) * b_row_stride));
             let b0 = i8_ops.load_ptr(b_tile_ptr[0]);
             let b1 = i8_ops.load_ptr(b_tile_ptr[1]);
             let b2 = i8_ops.load_ptr(b_tile_ptr[2]);
@@ -815,7 +815,7 @@ unsafe fn simd_int8_gemv_transposed<I: Isa, const CAST_B_U8: bool>(
 
         for k_tile in k_tiles.by_ref() {
             let a = i8_ops.load_ptr(a_ptr.add(k_tile.start) as *const i8);
-            let b = i8_ops.load_ptr(b_ptr.add(k_tile.start) as *const i8);
+            let b = i8_ops.load_ptr(b_ptr.add(k_tile.start));
             let b = if CAST_B_U8 {
                 i8_ops.xor(b, bit_flip_mask)
             } else {


### PR DESCRIPTION
Make the generic argument to `NumOps` independent of the SIMD ISA. For example `<Avx2Isa as Isa>::f32` now returns an `impl NumOps<f32>` instead of `impl NumOps<float32x4_t>`. This in turn will make it possible to add generic methods to get the `NumOps` impl for a given element type, enabling writing `SimdOp`s that are generic over the element type.

The downside is that a single struct can no longer implement `NumOps` for two different SIMD vectors with the same element type. This would prevent eg. `Avx2Isa` from implementing `NumOps` for both 256 and 128-bit f32 vectors. So far the need to half or quarter-width vectors has been avoided by defining operations in a way that avoids this.