### PR TITLE
Add traits to enable writing SIMD operations that are generic over element type

### DIFF
--- a/rten-simd/src/lib.rs
+++ b/rten-simd/src/lib.rs
@@ -165,8 +165,8 @@ pub mod isa {
 pub use dispatch::{SimdOp, SimdUnaryOp};
 pub use iter::{Iter, SimdIterable};
 pub use vec::{
-    Elem, Extend, FloatOps, Interleave, Isa, Mask, MaskOps, NarrowSaturate, NumOps, SignedIntOps,
-    Simd,
+    Elem, Extend, FloatOps, GetFloatOps, GetNumOps, GetSignedIntOps, Interleave, Isa, Mask,
+    MaskOps, NarrowSaturate, NumOps, SignedIntOps, Simd,
 };
 pub use writer::SliceWriter;
 


### PR DESCRIPTION
Add `Get{Num, Float, SignedInt}Ops` traits to rten-simd which are implemented for supported element types and return the `{Num, Float, SignedInt}Ops` impl for that type from a given SIMD `Isa`. These can be used to create SIMD operations which are generic over the element type.

The `SimdUnaryOp::{map, map_mut}` methods have been modified to use this traits, in order to support all element types.