### PR TITLE
Parametrize additional SIMD op traits by element rather than SIMD type

### DIFF
--- a/rten-simd/src/arch/aarch64.rs
+++ b/rten-simd/src/arch/aarch64.rs
@@ -47,24 +47,24 @@ unsafe impl Isa for ArmNeonIsa {
 
     fn i32(
         self,
-    ) -> impl SignedIntOps<i32, Simd = Self::I32> + NarrowSaturate<Self::I32, Self::I16> {
+    ) -> impl SignedIntOps<i32, Simd = Self::I32> + NarrowSaturate<i32, i16, Output = Self::I16>
+    {
         self
     }
 
     fn i16(
         self,
     ) -> impl SignedIntOps<i16, Simd = Self::I16>
-           + NarrowSaturate<Self::I16, Self::U8>
-           + Extend<Self::I16, Output = Self::I32>
-           + Interleave<Self::I16> {
+           + NarrowSaturate<i16, u8, Output = Self::U8>
+           + Extend<i16, Output = Self::I32>
+           + Interleave<i16> {
         self
     }
 
     fn i8(
         self,
-    ) -> impl SignedIntOps<i8, Simd = Self::I8>
-           + Extend<Self::I8, Output = Self::I16>
-           + Interleave<Self::I8> {
+    ) -> impl SignedIntOps<i8, Simd = Self::I8> + Extend<i8, Output = Self::I16> + Interleave<i8>
+    {
         self
     }
 
@@ -343,7 +343,9 @@ impl SignedIntOps<i32> for ArmNeonIsa {
     }
 }
 
-impl NarrowSaturate<int32x4_t, int16x8_t> for ArmNeonIsa {
+impl NarrowSaturate<i32, i16> for ArmNeonIsa {
+    type Output = int16x8_t;
+
     #[inline]
     fn narrow_saturate(self, low: int32x4_t, high: int32x4_t) -> int16x8_t {
         unsafe {
@@ -354,7 +356,9 @@ impl NarrowSaturate<int32x4_t, int16x8_t> for ArmNeonIsa {
     }
 }
 
-impl NarrowSaturate<int16x8_t, uint8x16_t> for ArmNeonIsa {
+impl NarrowSaturate<i16, u8> for ArmNeonIsa {
+    type Output = uint8x16_t;
+
     #[inline]
     fn narrow_saturate(self, low: int16x8_t, high: int16x8_t) -> uint8x16_t {
         unsafe {
@@ -447,7 +451,7 @@ impl SignedIntOps<i16> for ArmNeonIsa {
     }
 }
 
-impl Extend<int16x8_t> for ArmNeonIsa {
+impl Extend<i16> for ArmNeonIsa {
     type Output = int32x4_t;
 
     #[inline]
@@ -460,7 +464,7 @@ impl Extend<int16x8_t> for ArmNeonIsa {
     }
 }
 
-impl Interleave<int16x8_t> for ArmNeonIsa {
+impl Interleave<i16> for ArmNeonIsa {
     #[inline]
     fn interleave_low(self, a: int16x8_t, b: int16x8_t) -> int16x8_t {
         unsafe { vzip1q_s16(a, b) }
@@ -554,7 +558,7 @@ impl SignedIntOps<i8> for ArmNeonIsa {
     }
 }
 
-impl Extend<int8x16_t> for ArmNeonIsa {
+impl Extend<i8> for ArmNeonIsa {
     type Output = int16x8_t;
 
     #[inline]
@@ -567,7 +571,7 @@ impl Extend<int8x16_t> for ArmNeonIsa {
     }
 }
 
-impl Interleave<int8x16_t> for ArmNeonIsa {
+impl Interleave<i8> for ArmNeonIsa {
     #[inline]
     fn interleave_low(self, a: int8x16_t, b: int8x16_t) -> int8x16_t {
         unsafe { vzip1q_s8(a, b) }

--- a/rten-simd/src/arch/wasm32.rs
+++ b/rten-simd/src/arch/wasm32.rs
@@ -54,24 +54,24 @@ unsafe impl Isa for Wasm32Isa {
 
     fn i32(
         self,
-    ) -> impl SignedIntOps<i32, Simd = Self::I32> + NarrowSaturate<Self::I32, Self::I16> {
+    ) -> impl SignedIntOps<i32, Simd = Self::I32> + NarrowSaturate<i32, i16, Output = Self::I16>
+    {
         self
     }
 
     fn i16(
         self,
     ) -> impl SignedIntOps<i16, Simd = Self::I16>
-           + NarrowSaturate<Self::I16, Self::U8>
-           + Extend<Self::I16, Output = Self::I32>
-           + Interleave<Self::I16> {
+           + NarrowSaturate<i16, u8, Output = Self::U8>
+           + Extend<i16, Output = Self::I32>
+           + Interleave<i16> {
         self
     }
 
     fn i8(
         self,
-    ) -> impl SignedIntOps<i8, Simd = Self::I8>
-           + Extend<Self::I8, Output = Self::I16>
-           + Interleave<Self::I8> {
+    ) -> impl SignedIntOps<i8, Simd = Self::I8> + Extend<i8, Output = Self::I16> + Interleave<i8>
+    {
         self
     }
 
@@ -326,7 +326,9 @@ impl SignedIntOps<i32> for Wasm32Isa {
     }
 }
 
-impl NarrowSaturate<I32x4, I16x8> for Wasm32Isa {
+impl NarrowSaturate<i32, i16> for Wasm32Isa {
+    type Output = I16x8;
+
     #[inline]
     fn narrow_saturate(self, low: I32x4, high: I32x4) -> I16x8 {
         I16x8(i16x8_narrow_i32x4(low.0, high.0))
@@ -384,7 +386,7 @@ impl SignedIntOps<i16> for Wasm32Isa {
     }
 }
 
-impl Extend<I16x8> for Wasm32Isa {
+impl Extend<i16> for Wasm32Isa {
     type Output = I32x4;
 
     #[inline]
@@ -395,7 +397,7 @@ impl Extend<I16x8> for Wasm32Isa {
     }
 }
 
-impl Interleave<I16x8> for Wasm32Isa {
+impl Interleave<i16> for Wasm32Isa {
     #[inline]
     fn interleave_low(self, a: I16x8, b: I16x8) -> I16x8 {
         i16x8_shuffle::<0, 8, 1, 9, 2, 10, 3, 11>(a.0, b.0).into()
@@ -407,7 +409,9 @@ impl Interleave<I16x8> for Wasm32Isa {
     }
 }
 
-impl NarrowSaturate<I16x8, U8x16> for Wasm32Isa {
+impl NarrowSaturate<i16, u8> for Wasm32Isa {
+    type Output = U8x16;
+
     #[inline]
     fn narrow_saturate(self, low: I16x8, high: I16x8) -> U8x16 {
         U8x16(u8x16_narrow_i16x8(low.0, high.0))
@@ -474,7 +478,7 @@ impl SignedIntOps<i8> for Wasm32Isa {
     }
 }
 
-impl Extend<I8x16> for Wasm32Isa {
+impl Extend<i8> for Wasm32Isa {
     type Output = I16x8;
 
     #[inline]
@@ -485,7 +489,7 @@ impl Extend<I8x16> for Wasm32Isa {
     }
 }
 
-impl Interleave<I8x16> for Wasm32Isa {
+impl Interleave<i8> for Wasm32Isa {
     #[inline]
     fn interleave_low(self, a: I8x16, b: I8x16) -> I8x16 {
         i8x16_shuffle::<0, 16, 1, 17, 2, 18, 3, 19, 4, 20, 5, 21, 6, 22, 7, 23>(a.0, b.0).into()

--- a/rten-simd/src/arch/x86_64/avx2.rs
+++ b/rten-simd/src/arch/x86_64/avx2.rs
@@ -63,24 +63,24 @@ unsafe impl Isa for Avx2Isa {
 
     fn i32(
         self,
-    ) -> impl SignedIntOps<i32, Simd = Self::I32> + NarrowSaturate<Self::I32, Self::I16> {
+    ) -> impl SignedIntOps<i32, Simd = Self::I32> + NarrowSaturate<i32, i16, Output = Self::I16>
+    {
         self
     }
 
     fn i16(
         self,
     ) -> impl SignedIntOps<i16, Simd = Self::I16>
-           + NarrowSaturate<Self::I16, Self::U8>
-           + Extend<Self::I16, Output = Self::I32>
-           + Interleave<Self::I16> {
+           + NarrowSaturate<i16, u8, Output = Self::U8>
+           + Extend<i16, Output = Self::I32>
+           + Interleave<i16> {
         self
     }
 
     fn i8(
         self,
-    ) -> impl SignedIntOps<i8, Simd = Self::I8>
-           + Extend<Self::I8, Output = Self::I16>
-           + Interleave<Self::I8> {
+    ) -> impl SignedIntOps<i8, Simd = Self::I8> + Extend<i8, Output = Self::I16> + Interleave<i8>
+    {
         self
     }
 
@@ -374,7 +374,9 @@ const fn _mm_shuffle(z: u32, y: u32, x: u32, w: u32) -> i32 {
     ((z << 6) | (y << 4) | (x << 2) | w) as i32
 }
 
-impl NarrowSaturate<I32x8, I16x16> for Avx2Isa {
+impl NarrowSaturate<i32, i16> for Avx2Isa {
+    type Output = I16x16;
+
     #[inline]
     fn narrow_saturate(self, low: I32x8, high: I32x8) -> I16x16 {
         unsafe {
@@ -495,7 +497,9 @@ impl SignedIntOps<i16> for Avx2Isa {
     }
 }
 
-impl NarrowSaturate<I16x16, U8x32> for Avx2Isa {
+impl NarrowSaturate<i16, u8> for Avx2Isa {
+    type Output = U8x32;
+
     #[inline]
     fn narrow_saturate(self, low: I16x16, high: I16x16) -> U8x32 {
         unsafe {
@@ -510,7 +514,7 @@ impl NarrowSaturate<I16x16, U8x32> for Avx2Isa {
     }
 }
 
-impl Interleave<I16x16> for Avx2Isa {
+impl Interleave<i16> for Avx2Isa {
     #[inline]
     fn interleave_low(self, a: I16x16, b: I16x16) -> I16x16 {
         unsafe {
@@ -556,8 +560,8 @@ unsafe impl NumOps<i8> for Avx2Isa {
 
     #[inline]
     fn mul(self, x: I8x32, y: I8x32) -> I8x32 {
-        let (x_lo, x_hi) = self.extend(x);
-        let (y_lo, y_hi) = self.extend(y);
+        let (x_lo, x_hi) = Extend::<i8>::extend(self, x);
+        let (y_lo, y_hi) = Extend::<i8>::extend(self, y);
 
         let i16_ops = self.i16();
         let prod_lo = i16_ops.mul(x_lo, y_lo);
@@ -642,7 +646,7 @@ impl SignedIntOps<i8> for Avx2Isa {
 
     #[inline]
     fn shift_left<const SHIFT: i32>(self, x: I8x32) -> I8x32 {
-        let (x_lo, x_hi) = self.extend(x);
+        let (x_lo, x_hi) = Extend::<i8>::extend(self, x);
 
         let i16_ops = self.i16();
         let y_lo = i16_ops.shift_left::<SHIFT>(x_lo);
@@ -652,7 +656,7 @@ impl SignedIntOps<i8> for Avx2Isa {
     }
 }
 
-impl Interleave<I8x32> for Avx2Isa {
+impl Interleave<i8> for Avx2Isa {
     #[inline]
     fn interleave_low(self, a: I8x32, b: I8x32) -> I8x32 {
         unsafe {
@@ -698,8 +702,8 @@ unsafe impl NumOps<u8> for Avx2Isa {
 
     #[inline]
     fn mul(self, x: U8x32, y: U8x32) -> U8x32 {
-        let (x_lo, x_hi) = self.extend(x);
-        let (y_lo, y_hi) = self.extend(y);
+        let (x_lo, x_hi) = Extend::<u8>::extend(self, x);
+        let (y_lo, y_hi) = Extend::<u8>::extend(self, y);
 
         let u16_ops = self.u16();
         let prod_lo = u16_ops.mul(x_lo, y_lo);
@@ -927,7 +931,7 @@ unsafe impl MaskOps<F32x8> for Avx2Isa {
     }
 }
 
-impl Extend<I16x16> for Avx2Isa {
+impl Extend<i16> for Avx2Isa {
     type Output = I32x8;
 
     #[inline]
@@ -943,7 +947,7 @@ impl Extend<I16x16> for Avx2Isa {
     }
 }
 
-impl Extend<I8x32> for Avx2Isa {
+impl Extend<i8> for Avx2Isa {
     type Output = I16x16;
 
     #[inline]
@@ -959,7 +963,7 @@ impl Extend<I8x32> for Avx2Isa {
     }
 }
 
-impl Extend<U8x32> for Avx2Isa {
+impl Extend<u8> for Avx2Isa {
     type Output = U16x16;
 
     #[inline]

--- a/rten-simd/src/arch/x86_64/avx512.rs
+++ b/rten-simd/src/arch/x86_64/avx512.rs
@@ -63,24 +63,24 @@ unsafe impl Isa for Avx512Isa {
 
     fn i32(
         self,
-    ) -> impl SignedIntOps<i32, Simd = Self::I32> + NarrowSaturate<Self::I32, Self::I16> {
+    ) -> impl SignedIntOps<i32, Simd = Self::I32> + NarrowSaturate<i32, i16, Output = Self::I16>
+    {
         self
     }
 
     fn i16(
         self,
     ) -> impl SignedIntOps<i16, Simd = Self::I16>
-           + NarrowSaturate<Self::I16, Self::U8>
-           + Extend<Self::I16, Output = Self::I32>
-           + Interleave<Self::I16> {
+           + NarrowSaturate<i16, u8, Output = Self::U8>
+           + Extend<i16, Output = Self::I32>
+           + Interleave<i16> {
         self
     }
 
     fn i8(
         self,
-    ) -> impl SignedIntOps<i8, Simd = Self::I8>
-           + Extend<Self::I8, Output = Self::I16>
-           + Interleave<Self::I8> {
+    ) -> impl SignedIntOps<i8, Simd = Self::I8> + Extend<i8, Output = Self::I16> + Interleave<i8>
+    {
         self
     }
 
@@ -354,7 +354,9 @@ impl SignedIntOps<i32> for Avx512Isa {
     }
 }
 
-impl NarrowSaturate<I32x16, I16x32> for Avx512Isa {
+impl NarrowSaturate<i32, i16> for Avx512Isa {
+    type Output = I16x32;
+
     #[inline]
     fn narrow_saturate(self, low: I32x16, high: I32x16) -> I16x32 {
         unsafe {
@@ -448,7 +450,9 @@ impl SignedIntOps<i16> for Avx512Isa {
     }
 }
 
-impl NarrowSaturate<I16x32, U8x64> for Avx512Isa {
+impl NarrowSaturate<i16, u8> for Avx512Isa {
+    type Output = U8x64;
+
     #[inline]
     fn narrow_saturate(self, low: I16x32, high: I16x32) -> U8x64 {
         unsafe {
@@ -464,7 +468,7 @@ impl NarrowSaturate<I16x32, U8x64> for Avx512Isa {
     }
 }
 
-impl Interleave<I16x32> for Avx512Isa {
+impl Interleave<i16> for Avx512Isa {
     #[inline]
     fn interleave_low(self, a: I16x32, b: I16x32) -> I16x32 {
         unsafe {
@@ -507,8 +511,8 @@ unsafe impl NumOps<i8> for Avx512Isa {
 
     #[inline]
     fn mul(self, x: I8x64, y: I8x64) -> I8x64 {
-        let (x_lo, x_hi) = self.extend(x);
-        let (y_lo, y_hi) = self.extend(y);
+        let (x_lo, x_hi) = Extend::<i8>::extend(self, x);
+        let (y_lo, y_hi) = Extend::<i8>::extend(self, y);
 
         let i16_ops = self.i16();
         let prod_lo = i16_ops.mul(x_lo, y_lo);
@@ -571,7 +575,7 @@ impl SignedIntOps<i8> for Avx512Isa {
 
     #[inline]
     fn shift_left<const SHIFT: i32>(self, x: I8x64) -> I8x64 {
-        let (x_lo, x_hi) = self.extend(x);
+        let (x_lo, x_hi) = Extend::<i8>::extend(self, x);
 
         let i16_ops = self.i16();
         let (y_lo, y_hi) = (
@@ -583,7 +587,7 @@ impl SignedIntOps<i8> for Avx512Isa {
     }
 }
 
-impl Interleave<I8x64> for Avx512Isa {
+impl Interleave<i8> for Avx512Isa {
     #[inline]
     fn interleave_low(self, a: I8x64, b: I8x64) -> I8x64 {
         unsafe {
@@ -626,8 +630,8 @@ unsafe impl NumOps<u8> for Avx512Isa {
 
     #[inline]
     fn mul(self, x: U8x64, y: U8x64) -> U8x64 {
-        let (x_lo, x_hi) = self.extend(x);
-        let (y_lo, y_hi) = self.extend(y);
+        let (x_lo, x_hi) = Extend::<u8>::extend(self, x);
+        let (y_lo, y_hi) = Extend::<u8>::extend(self, y);
 
         let u16_ops = self.u16();
         let prod_lo = u16_ops.mul(x_lo, y_lo);
@@ -682,7 +686,7 @@ unsafe impl NumOps<u8> for Avx512Isa {
     }
 }
 
-impl Extend<I16x32> for Avx512Isa {
+impl Extend<i16> for Avx512Isa {
     type Output = I32x16;
 
     #[inline]
@@ -698,7 +702,7 @@ impl Extend<I16x32> for Avx512Isa {
     }
 }
 
-impl Extend<I8x64> for Avx512Isa {
+impl Extend<i8> for Avx512Isa {
     type Output = I16x32;
 
     #[inline]
@@ -714,7 +718,7 @@ impl Extend<I8x64> for Avx512Isa {
     }
 }
 
-impl Extend<U8x64> for Avx512Isa {
+impl Extend<u8> for Avx512Isa {
     type Output = U16x32;
 
     #[inline]


### PR DESCRIPTION
In 001ce9b8aa61adab53967ef4f752b10c9faa2d6f the core SIMD traits (`NumOps` etc.) were changed to be parametrized by the element type rather than SIMD type.

Change the supplementary SIMD operation traits to also be parametrized by the element type, both for consistency and also to enable writing generic operations involving these traits.