### PR TITLE
Fix Quantize op failure if output has more capacity than requested

### DIFF
--- a/src/ops/quantize.rs
+++ b/src/ops/quantize.rs
@@ -202,7 +202,12 @@ where
             if let Some(data) = input.data() {
                 let mut buf = pool.alloc(data.len());
                 buf.extend_init(|buf_data| {
-                    Quantize::quantize_slice(data, buf_data, inv_scale, zero_point)
+                    Quantize::quantize_slice(
+                        data,
+                        &mut buf_data[..data.len()],
+                        inv_scale,
+                        zero_point,
+                    )
                 });
                 Ok(Tensor::from_data(input.shape(), buf))
             } else {

--- a/src/tensor_pool.rs
+++ b/src/tensor_pool.rs
@@ -126,6 +126,9 @@ impl TensorPool {
     }
 
     /// Allocate an empty vec with a given capacity from the pool.
+    ///
+    /// The returned buffer will have a [`capacity`](Vec::capacity) of at least
+    /// the requested size, but _may have more_.
     pub fn alloc<T>(&self, capacity: usize) -> Vec<T> {
         *self.alloc_count.borrow_mut() += 1;
 


### PR DESCRIPTION
The contract of `TensorPool::alloc` is that it allocates a buffer with at least the requested capacity, but it may have more. The `Quantize` op in rten_vecmath requires the source and dest buffers to have the same size. Therefore we need to trim the slice passed to it.