### PR TITLE
Refactor int8 GEMM kernels to use dot product instructions via a trait

### DIFF
--- a/src/gemm/kernels.rs
+++ b/src/gemm/kernels.rs
@@ -382,3 +382,27 @@ fn extract_zero_points<T: Copy + Into<i32>, const MAX_LEN: usize>(
     }
     zero_points
 }
+
+/// Trait for computing dot products of SIMD vectors containing 8-bit integers.
+///
+/// This should use native instructions where available (VNNI on x64, UDOT/SDOT
+/// on Arm etc.) or a fallback otherwise.
+///
+/// # Safety
+///
+/// Types implementing this trait must ensure they can only be constructed if
+/// the instructions are supported.
+unsafe trait Int8DotProduct {
+    /// SIMD vector with `i8` or `u8` elements. The signed-ness depends on the
+    /// implementation.
+    type X8;
+
+    /// SIMD vector with `i32` elements.
+    type I32;
+
+    /// Compute the dot product of groups of 4 8-bit integers in `a` and `b`,
+    /// accumulating into 32-bit integers in `c`.
+    ///
+    /// The signed-ness of `a` and `b` depends on the implementation.
+    fn dot_product(self, a: Self::X8, b: Self::X8, c: Self::I32) -> Self::I32;
+}


### PR DESCRIPTION
Refactor the int8 GEMM kernels to use a trait to access dot product instructions. This trait is then implemented for witness types which ensure the availability of the instructions used, following the approach of the new SIMD API. This allows the `dot_product` method to be safe.

In the process the safety comments were updated for the SIMD GEMM / GEMV kernels to reflect the new responsibilities for the caller.