### PR TITLE
Make use of `unsafe` more narrowly scoped in int8 gemv

### DIFF
--- a/src/gemm/kernels/aarch64.rs
+++ b/src/gemm/kernels/aarch64.rs
@@ -330,19 +330,7 @@ unsafe impl Kernel<u8, i8, i32> for ArmInt8DotKernel {
         let a_zero = a_quant.map(|aq| aq.zero_point[0]).unwrap_or(0);
         let b_zero = b_quant.map(|bq| bq.zero_point);
         let out = out.as_bool_beta();
-
-        // Safety: Target features were checked when this kernel was constructed.
-        unsafe {
-            simd_int8_gemv::<_, true /* CAST_B_U8 */>(
-                self.isa,
-                out,
-                a,
-                b,
-                a_zero,
-                b_zero,
-                self.dot_isa,
-            )
-        }
+        simd_int8_gemv::<_, true /* CAST_B_U8 */>(self.isa, out, a, b, a_zero, b_zero, self.dot_isa)
     }
 }
 
@@ -423,19 +411,15 @@ unsafe impl Kernel<u8, i8, i32> for ArmInt8Kernel {
         let a_zero = a_quant.map(|aq| aq.zero_point[0]).unwrap_or(0);
         let b_zero = b_quant.map(|bq| bq.zero_point);
         let out = out.as_bool_beta();
-
-        // Safety: Target features were checked when kernel was constructed.
-        unsafe {
-            simd_int8_gemv::<_, true /* CAST_B_U8 */>(
-                self.isa,
-                out,
-                a,
-                b,
-                a_zero,
-                b_zero,
-                NeonDotProd {},
-            )
-        }
+        simd_int8_gemv::<_, true /* CAST_B_U8 */>(
+            self.isa,
+            out,
+            a,
+            b,
+            a_zero,
+            b_zero,
+            NeonDotProd {},
+        )
     }
 }
 

--- a/src/gemm/kernels/simd_generic.rs
+++ b/src/gemm/kernels/simd_generic.rs
@@ -23,12 +23,11 @@ pub fn simd_gemv<I: Isa, const NR_REGS: usize>(
         return simd_gemv_fallback(out, a, b, alpha);
     }
 
+    assert_eq!(a.len(), b.rows());
+    assert_eq!(out.data.len(), b.cols());
+    assert_eq!(b.col_stride(), 1);
+
     let ops = isa.f32();
-
-    assert!(b.col_stride() == 1);
-    assert!(a.len() == b.rows());
-    assert!(out.data.len() == b.cols());
-
     let out_ptr = out.data.as_mut_ptr();
     let a_ptr = a.as_ptr();
     let b_ptr = b.storage().as_ptr();
@@ -110,9 +109,9 @@ fn simd_gemv_transposed<I: Isa>(
     b: Matrix,
     alpha: f32,
 ) {
-    assert!(b.row_stride() == 1);
-    assert!(a.len() == b.rows());
-    assert!(out.data.len() == b.cols());
+    assert_eq!(b.row_stride(), 1);
+    assert_eq!(a.len(), b.rows());
+    assert_eq!(out.data.len(), b.cols());
 
     let ops = isa.f32();
     let b_ptr = b.storage().as_ptr();
@@ -176,8 +175,8 @@ fn simd_gemv_transposed<I: Isa>(
 /// can benefit from the kernel's instruction set (eg. for FMA operations).
 #[inline(always)]
 fn simd_gemv_fallback(out: MatVecOutput<f32>, a: &[f32], b: Matrix, alpha: f32) {
-    assert!(a.len() == b.rows());
-    assert!(out.data.len() == b.cols());
+    assert_eq!(a.len(), b.rows());
+    assert_eq!(out.data.len(), b.cols());
 
     for (col, out_el) in out.data.iter_mut().enumerate() {
         let mut acc = 0.;

--- a/src/gemm/kernels/wasm.rs
+++ b/src/gemm/kernels/wasm.rs
@@ -320,11 +320,7 @@ unsafe impl Kernel<u8, i8, i32> for WasmInt8Kernel {
         let a_zero = a_quant.map(|aq| aq.zero_point[0]).unwrap_or(0);
         let b_zero = b_quant.map(|bq| bq.zero_point);
         let out = out.as_bool_beta();
-
-        // Safety: Target features were checked when kernel was constructed.
-        unsafe {
-            simd_int8_gemv::<_, true /* CAST_B_U8 */>(self.isa, out, a, b, a_zero, b_zero, self.isa)
-        }
+        simd_int8_gemv::<_, true /* CAST_B_U8 */>(self.isa, out, a, b, a_zero, b_zero, self.isa)
     }
 }
 


### PR DESCRIPTION
Refactor the int8 GEMV implementation so that the entry point `simd_int8_gemv` is a safe function. Requirements are either enforced by the type system (SIMD ISA is supported, output is initialized) or checked as preconditions at the entry point. This entry point then dispatches to the unsafe helpers which handle the various cases, assuming the preconditions have been checked.

The float GEMV implementation has a similar structure, except there the helpers individually check their own preconditions as they are simpler (no quantization parameters) and can thus be safe.

In the process some outdated comments relating to the old SIMD API (references to `S::LEN`) were cleaned up or removed.