### PR TITLE
Update main documentation page for rten-simd

### DIFF
--- a/rten-simd/README.md
+++ b/rten-simd/README.md
@@ -1,0 +1,14 @@
+# rten-simd
+
+Portable SIMD library for stable Rust.
+
+rten-simd is a library for defining operations that are accelerated using
+[SIMD](https://en.wikipedia.org/wiki/Single_instruction,_multiple_data)
+instruction sets such as AVX2, Arm Neon or WebAssembly SIMD. Operations are
+defined once using safe, portable APIs, then _dispatched_ at runtime to
+evaluate the operation using the best available SIMD instruction set (ISA)
+on the current CPU.
+                                                                            
+The design is inspired by Google's
+[Highway](https://github.com/google/highway) library for C++ and the
+[pulp](https://docs.rs/pulp/latest/pulp/) crate.

--- a/rten-simd/src/dispatch.rs
+++ b/rten-simd/src/dispatch.rs
@@ -7,6 +7,7 @@ use crate::span::SrcDest;
 /// A vectorized operation which can be instantiated for different instruction
 /// sets.
 pub trait SimdOp {
+    /// The type of the operation's result.
     type Output;
 
     /// Evaluate the operation using the given instruction set.

--- a/rten-simd/src/functional.rs
+++ b/rten-simd/src/functional.rs
@@ -1,4 +1,4 @@
-//! Vectorized higher-order operations (map, fold etc.)
+//! Vectorized higher-order operations (map etc.)
 
 use super::{Elem, NumOps};
 use crate::span::SrcDest;

--- a/rten-simd/src/lib.rs
+++ b/rten-simd/src/lib.rs
@@ -1,18 +1,55 @@
 //! Portable SIMD library.
 //!
-//! _This module contains a new portable SIMD API which is in development. The
-//! focus is to revise the API to reduce the amount of unsafe code needed when
-//! using it._
-//!
 //! rten-simd is a library for defining operations that are accelerated using
 //! [SIMD](https://en.wikipedia.org/wiki/Single_instruction,_multiple_data)
-//! instructions such as AVX2, Arm Neon or WebAssembly SIMD. These operations
-//! can be defined once and then evaluated using the preferred instruction set
-//! at runtime, depending on the platform and available CPU instructions.
+//! instruction sets such as AVX2, Arm Neon or WebAssembly SIMD. Operations are
+//! defined once using safe, portable APIs, then _dispatched_ at runtime to
+//! evaluate the operation using the best available SIMD instruction set (ISA)
+//! on the current CPU.
 //!
 //! The design is inspired by Google's
 //! [Highway](https://github.com/google/highway) library for C++ and the
 //! [pulp](https://docs.rs/pulp/latest/pulp/) crate.
+//!
+//! ## Differences from `std::simd`
+//!
+//! In nightly Rust the standard library has a built-in portable SIMD API,
+//! `std::simd`. This library differs in several ways:
+//!
+//! 1. It is available on stable Rust
+//! 2. The instruction set is selected at runtime rather than compile time. On
+//!    x86 an operation may be compiled for AVX-512, AVX2 and generic (SSE). If
+//!    the binary is run on a system supporting AVX-512 that version will be
+//!    used. The same binary on an older system may use the generic (SSE)
+//!    version.
+//! 3. Operations use the full available SIMD vector width, which varies by
+//!    instruction set, as opposed to specifying a fixed width in the code.
+//!    For example a SIMD vector with f32 elements has 4 lanes on Arm Neon and
+//!    16 lanes under AVX-512.
+//!
+//!    The API is designed to support scalable vector ISAs such as [Arm
+//!    SVE](https://developer.arm.com/Architectures/Scalable%20Vector%20Extensions)
+//!    and RVV in future, where the vector length is known only at runtime.
+//!
+//! 4. Semantics are chosen to be "performance portable". This means that the
+//!    behavior is chosen based on what maps well to the hardware, rather than
+//!    strictly matching Rust behaviors for scalars as `std::simd` generally
+//!    does. It also means some operations may have different behaviors in edge
+//!    cases on different platforms. This is similar to [WebAssembly Relaxed
+//!    SIMD](https://github.com/WebAssembly/relaxed-simd/blob/main/proposals/relaxed-simd/Overview.md).
+//!
+//! ## Supported architectures
+//!
+//! The currently supported SIMD ISAs are:
+//!
+//! - AVX2
+//! - AVX-512 (requires nightly Rust and `avx512` feature enabled)
+//! - Arm Neon
+//! - WebAssembly SIMD (including relaxed SIMD)
+//!
+//! There is also a generic fallback implemented using 128-bit arrays which is
+//! designed to be autovectorization-friendly (ie. it compiles on all platforms,
+//! and should enable the compiler to use SSE or similar instructions).
 //!
 //! ## Example
 //!
@@ -43,27 +80,23 @@
 //! assert_eq!(squared, &expected);
 //! ```
 //!
-//! The above may use AVX2 on an x86 system, Arm Neon on aarch64 and WASM SIMD
-//! on wasm32. In the `simd_map` callback, `x` is the SIMD vector for the chosen
-//! instruction set.
-//!
 //! This example shows the basic steps to define a vectorized operation:
 //!
 //! 1. Create a struct containing the operation's parameters.
 //! 2. Implement the [`SimdOp`] trait for the struct to define how to evaluate
 //!    the operation.
-//! 3. Call [`SimdOp::dispatch`] to select the preferred SIMD instruction set and
-//!    evaluate the operation using it.
+//! 3. Call [`SimdOp::dispatch`] to evaluate the operation using the best
+//!    available instruction set. Here "best" refers to the ISA with the
+//!    widest vectors, and thus the maximum amount of parallelism.
 //!
-//! Note the use of the `#[inline(always)]` attribute on closures and any
-//! functions called within `eval`. See the section on inlining below for an
-//! explanation.
+//! Note the use of the `#[inline(always)]` attribute on closures and functions
+//! called within `eval`. See the section on inlining below for an explanation.
 //!
-//! ## Separation of SIMD vector types and operations
+//! ## Separation of vector types and operations
 //!
-//! SIMD vectors are effectively arrays (like `[T; N]`) with a specific
-//! alignment. A SIMD vector type can be created whether or not the associated
-//! instructions are supported on the system.
+//! SIMD vectors are effectively arrays (like `[T; N]`) with a larger alignment.
+//! A SIMD vector type can be created whether or not the associated instructions
+//! are supported on the system.
 //!
 //! Performing a SIMD operation however requires the caller to first ensure that
 //! the instructions are supported on the current system. To enforce this,
@@ -71,26 +104,35 @@
 //! SIMD operations ([`Isa`]) can only be instantiated if the instruction set is
 //! supported.
 //!
-//! ## Key traits
+//! ## Overview of key traits
 //!
 //! The [`SimdOp`] trait defines an _operation_ which can be vectorized using
 //! different SIMD instruction sets. This trait has a
 //! [`dispatch`](SimdOp::dispatch) method to perform the operation.
 //!
-//! An instance of the [`Isa`] trait is passed to the operation when it is
-//! evaluated. The type of ISA will depend on the selected instruction set.  The
-//! ISA provides access to different implementations of the [`NumOps`] trait
-//! and sub-traits. These in turn provide operations on SIMD vectors with
-//! different data types. The [`NumOps`] trait provides operations that are
-//! available on all SIMD vectors. The sub-traits [`FloatOps`] and
-//! [`SignedIntOps`] provide operations that are only available on SIMD vectors
-//! with float and signed integer elements respectively.
+//! An implementation of the [`Isa`] trait is passed to [`SimdOp::eval`]. The
+//! [`Isa`] is the entry point for operations on SIMD vectors. It provides
+//! access to implementations of the [`NumOps`] trait and sub-traits for each
+//! element type. For example [`Isa::f32`] provides operations on SIMD vectors
+//! with `f32` elements.
 //!
-//! ## Applying SIMD operations to slices
+//! The [`NumOps`] trait provides operations that are available on all SIMD
+//! vectors. The sub-traits [`FloatOps`] and [`SignedIntOps`] provide operations
+//! that are only available on SIMD vectors with float and signed integer
+//! elements respectively.
+//!
+//! SIMD operations (eg. [`NumOps::add`]) take SIMD vectors as arguments. These
+//! vectors are either platform-specific types (eg. `float32x4_t` on Arm)
+//! or transparent wrappers around them. The [`Simd`] trait is implemented for
+//! all vector types. The [`Elem`] trait is implemented for supported element
+//! types, providing required numeric operations.
+//!
+//! ## Use with slices
 //!
 //! SIMD operations are usually applied to a slice of elements. To support this,
 //! the [`SimdIterable`] trait provides a way to iterate over SIMD vector-sized
-//! chunks of a slice.
+//! chunks of a slice, using padding or masking to handle slice lengths that are
+//! not a multiple of the vector size.
 //!
 //! The [`functional`] module provides utilities for defining vectorized
 //! transforms on slices (eg. [`simd_map`](functional::simd_map)).
@@ -99,29 +141,67 @@
 //! contents of a slice with the results of SIMD operations, by writing one
 //! SIMD vector at a time.
 //!
-//! ## The importance of inlining
+//! The [`SimdUnaryOp`] trait provides a convenient way to define unary
+//! operations (like [`Iterator::map`]) on slices.
 //!
-//! In the above example `#[inline(always)]` attributes are applied to ensure
-//! that the whole operation is compiled to a single function, with one instance
-//! generated per enabled ISA on each platform. This is required in current
-//! stable versions of Rust to ensure that the low-level intrinsics (eg.
-//! `_mm256_add_ps` to add two f32 SIMD vectors on x64) are compiled to direct
-//! instructions with no function call overhead.
+//! ## Importance of inlining
+//!
+//! In the above example `#[inline(always)]` attributes are used to ensure
+//! that the whole `eval` implementation is compiled to a single function. This
+//! is required to ensure that the platform-specific intrinsics (from
+//! [`core::arch`]) are compiled to direct instructions with no function call
+//! overhead.
 //!
 //! Failure to inline these intrinsics will significantly harm performance,
-//! since most of the runtime will be spend in function call overhead rather
+//! since most of the runtime will be spent in function call overhead rather
 //! than actual computation. This issue affects platforms where the availability
 //! of the SIMD instruction set is not guaranteed at compile time.  This
 //! includes AVX2 and AVX-512 on x86-64, but not Arm Neon or WASM SIMD.
 //!
-//! If a vectorized operation performs more slowly than expected, it is
-//! recommended to use a profiler such as
-//! [samply](https://github.com/mstange/samply) to verify that the intrinsics
-//! have been inlined and thus do not appear in the list of called functions.
+//! If a vectorized operation performs more slowly than expected, use a profiler
+//! such as [samply](https://github.com/mstange/samply) to verify that the
+//! intrinsics have been inlined and thus do not appear in the list of called
+//! functions.
 //!
-//! The need for this comprehensive and aggressive approach to inlining is
-//! expected to change in future with updates to how Rust's [`target_feature`
+//! The need for this forced inlining is expected to change in future with
+//! updates to how Rust's [`target_feature`
 //! attribute](https://github.com/rust-lang/rust/issues/69098) works.
+//!
+//! ## Generic operations
+//!
+//! It is possible to define operations which are generic over the element
+//! type by using the [`GetNumOps`] trait and related traits. These are
+//! implemented for supported element types and provide a way to get the
+//! [`NumOps`] implementation for that element type from an `Isa`. This can
+//! be used to define [`SimdOp`]s which are generic over the element type.
+//!
+//! This example defines an operation which can sum a slice of any supported
+//! element type:
+//!
+//! ```
+//! use std::iter::Sum;
+//! use rten_simd::{GetNumOps, NumOps, Isa, Simd, SimdIterable, SimdOp};
+//!
+//! struct SimdSum<'a, T>(&'a [T]);
+//!
+//! impl<'a, T: GetNumOps + Sum> SimdOp for SimdSum<'a, T> {
+//!     type Output = T;
+//!
+//!     #[inline(always)]
+//!     fn eval<I: Isa>(self, isa: I) -> Self::Output {
+//!         let ops = T::num_ops(isa);
+//!         let partial_sums = self.0.simd_iter(ops).fold(
+//!             ops.zero(),
+//!             |sum, x| ops.add(sum, x)
+//!         );
+//!         partial_sums.to_array().into_iter().sum()
+//!     }
+//! }
+//!
+//! assert_eq!(SimdSum(&[1.0f32, 2.0, 3.0]).dispatch(), 6.0);
+//! assert_eq!(SimdSum(&[1i32, 2, 3]).dispatch(), 6);
+//! assert_eq!(SimdSum(&[1u8, 2, 3]).dispatch(), 6u8);
+//! ```
 
 #![cfg_attr(
     feature = "avx512",


### PR DESCRIPTION
Improve the main documentation page for the rten-simd crate.

 - Remove note at the top about the new SIMD API being in-development
 - Add section on supported SIMD ISAs
 - Add a section on defining generic operations
 - Add a section on differences from `std::simd`
 - Mention `Simd` and `Elem` traits in trait overview section
 - Revise other sections
 - Add a basic README for the rten-simd crate
