### PR TITLE
Re-structure rten-simd to put ops traits in a submodule

### DIFF
--- a/rten-simd/src/arch.rs
+++ b/rten-simd/src/arch.rs
@@ -10,7 +10,7 @@ pub mod wasm32;
 
 pub mod generic;
 
-use super::vec::Simd;
+use crate::simd::Simd;
 
 /// Return the number of lanes in a SIMD vector with compile-time known size.
 const fn lanes<S: Simd>() -> usize {

--- a/rten-simd/src/arch/aarch64.rs
+++ b/rten-simd/src/arch/aarch64.rs
@@ -16,9 +16,8 @@ use std::arch::aarch64::{
 };
 use std::mem::transmute;
 
-use crate::{
-    Extend, FloatOps, Interleave, Isa, Mask, MaskOps, NarrowSaturate, NumOps, SignedIntOps, Simd,
-};
+use crate::ops::{Extend, FloatOps, Interleave, MaskOps, NarrowSaturate, NumOps, SignedIntOps};
+use crate::{Isa, Mask, Simd};
 
 #[derive(Copy, Clone)]
 pub struct ArmNeonIsa {

--- a/rten-simd/src/arch/generic.rs
+++ b/rten-simd/src/arch/generic.rs
@@ -1,9 +1,8 @@
 use std::array;
 use std::mem::transmute;
 
-use crate::{
-    Extend, FloatOps, Interleave, Isa, Mask, MaskOps, NarrowSaturate, NumOps, SignedIntOps, Simd,
-};
+use crate::ops::{Extend, FloatOps, Interleave, MaskOps, NarrowSaturate, NumOps, SignedIntOps};
+use crate::{Isa, Mask, Simd};
 
 // Size of SIMD vector in 32-bit lanes.
 const LEN_X32: usize = 4;

--- a/rten-simd/src/arch/wasm32.rs
+++ b/rten-simd/src/arch/wasm32.rs
@@ -15,9 +15,8 @@ use std::arch::wasm32::{
 use std::mem::transmute;
 
 use super::{lanes, simd_type};
-use crate::{
-    Extend, FloatOps, Interleave, Isa, Mask, MaskOps, NarrowSaturate, NumOps, SignedIntOps, Simd,
-};
+use crate::ops::{Extend, FloatOps, Interleave, MaskOps, NarrowSaturate, NumOps, SignedIntOps};
+use crate::{Isa, Mask, Simd};
 
 simd_type!(F32x4, v128, f32, M32, Wasm32Isa);
 simd_type!(I32x4, v128, i32, M32, Wasm32Isa);

--- a/rten-simd/src/arch/x86_64/avx2.rs
+++ b/rten-simd/src/arch/x86_64/avx2.rs
@@ -22,8 +22,10 @@ use std::is_x86_feature_detected;
 use std::mem::transmute;
 
 use super::super::{lanes, simd_type};
-use crate::vec::{Extend, Narrow};
-use crate::{FloatOps, Interleave, Isa, Mask, MaskOps, NarrowSaturate, NumOps, SignedIntOps, Simd};
+use crate::ops::{
+    Extend, FloatOps, Interleave, MaskOps, Narrow, NarrowSaturate, NumOps, SignedIntOps,
+};
+use crate::{Isa, Mask, Simd};
 
 simd_type!(F32x8, __m256, f32, F32x8, Avx2Isa);
 simd_type!(I32x8, __m256i, i32, I32x8, Avx2Isa);

--- a/rten-simd/src/arch/x86_64/avx512.rs
+++ b/rten-simd/src/arch/x86_64/avx512.rs
@@ -22,8 +22,10 @@ use std::arch::x86_64::{
 use std::mem::transmute;
 
 use super::super::{lanes, simd_type};
-use crate::vec::{Extend, Narrow};
-use crate::{FloatOps, Interleave, Isa, Mask, MaskOps, NarrowSaturate, NumOps, SignedIntOps, Simd};
+use crate::ops::{
+    Extend, FloatOps, Interleave, MaskOps, Narrow, NarrowSaturate, NumOps, SignedIntOps,
+};
+use crate::{Isa, Mask, Simd};
 
 simd_type!(F32x16, __m512, f32, __mmask16, Avx512Isa);
 simd_type!(I32x16, __m512i, i32, __mmask16, Avx512Isa);

--- a/rten-simd/src/dispatch.rs
+++ b/rten-simd/src/dispatch.rs
@@ -1,8 +1,9 @@
 use std::mem::MaybeUninit;
 
-use super::functional::simd_map;
-use super::{Elem, GetNumOps, Isa, Simd};
+use crate::functional::simd_map;
+use crate::ops::GetNumOps;
 use crate::span::SrcDest;
+use crate::{Elem, Isa, Simd};
 
 /// A vectorized operation which can be instantiated for different instruction
 /// sets.
@@ -89,7 +90,8 @@ pub trait SimdUnaryOp<T: Elem> {
     /// the specific type used by the ISA:
     ///
     /// ```
-    /// use rten_simd::{Isa, Simd, FloatOps, NumOps, SimdUnaryOp};
+    /// use rten_simd::{Isa, Simd, SimdUnaryOp};
+    /// use rten_simd::ops::{FloatOps, NumOps};
     ///
     /// struct Reciprocal {}
     ///
@@ -209,7 +211,8 @@ pub(crate) use test_simd_op;
 #[cfg(test)]
 mod tests {
     use super::SimdUnaryOp;
-    use crate::{FloatOps, GetNumOps, Isa, NumOps, Simd};
+    use crate::ops::{FloatOps, GetNumOps, NumOps};
+    use crate::{Isa, Simd};
 
     #[test]
     fn test_unary_float_op() {

--- a/rten-simd/src/elem.rs
+++ b/rten-simd/src/elem.rs
@@ -1,0 +1,65 @@
+//! Traits for elements of SIMD vectors.
+
+/// Types used as elements (or _lanes_) of SIMD vectors.
+pub trait Elem: Copy + Default + WrappingAdd<Output = Self> {
+    /// Return the 1 value of this type.
+    fn one() -> Self;
+}
+
+impl Elem for f32 {
+    fn one() -> Self {
+        1.
+    }
+}
+
+macro_rules! impl_elem_for_int {
+    ($int:ty) => {
+        impl Elem for $int {
+            fn one() -> Self {
+                1
+            }
+        }
+    };
+}
+
+impl_elem_for_int!(i32);
+impl_elem_for_int!(i16);
+impl_elem_for_int!(i8);
+impl_elem_for_int!(u8);
+impl_elem_for_int!(u16);
+
+/// Wrapping addition of numbers.
+///
+/// For float types, this is the same as [`std::ops::Add`]. For integer types,
+/// this is the same as the type's inherent `wrapping_add` method.
+pub trait WrappingAdd: Sized {
+    type Output;
+
+    fn wrapping_add(self, x: Self) -> Self;
+}
+
+macro_rules! impl_wrapping_add {
+    ($type:ty) => {
+        impl WrappingAdd for $type {
+            type Output = Self;
+
+            fn wrapping_add(self, x: Self) -> Self {
+                Self::wrapping_add(self, x)
+            }
+        }
+    };
+}
+
+impl_wrapping_add!(i32);
+impl_wrapping_add!(i16);
+impl_wrapping_add!(i8);
+impl_wrapping_add!(u8);
+impl_wrapping_add!(u16);
+
+impl WrappingAdd for f32 {
+    type Output = Self;
+
+    fn wrapping_add(self, x: f32) -> f32 {
+        self + x
+    }
+}

--- a/rten-simd/src/functional.rs
+++ b/rten-simd/src/functional.rs
@@ -1,7 +1,8 @@
 //! Vectorized higher-order operations (map etc.)
 
-use super::{Elem, NumOps};
+use crate::ops::NumOps;
 use crate::span::SrcDest;
+use crate::Elem;
 
 /// Transform a slice by applying a vectorized map function to its elements.
 ///
@@ -53,7 +54,8 @@ pub fn simd_map<'src, 'dst, T: Elem + 'static, O: NumOps<T>, Op: FnMut(O::Simd) 
 
 #[cfg(test)]
 mod tests {
-    use crate::{Isa, NumOps, SimdOp};
+    use crate::ops::NumOps;
+    use crate::{Isa, SimdOp};
 
     use super::simd_map;
 

--- a/rten-simd/src/iter.rs
+++ b/rten-simd/src/iter.rs
@@ -1,6 +1,7 @@
 //! Tools for vectorized iteration over slices.
 
-use crate::{Elem, NumOps, Simd};
+use crate::ops::NumOps;
+use crate::{Elem, Simd};
 
 /// Methods for creating vectorized iterators.
 pub trait SimdIterable {
@@ -197,7 +198,8 @@ impl<T: Elem, O: NumOps<T>> std::iter::FusedIterator for IterPad<'_, T, O> {}
 mod tests {
     use super::SimdIterable;
     use crate::dispatch::test_simd_op;
-    use crate::{Isa, NumOps, Simd, SimdOp};
+    use crate::ops::NumOps;
+    use crate::{Isa, Simd, SimdOp};
 
     // f32 vector length, chosen to exercise main and tail loops for all ISAs.
     const TEST_LEN: usize = 18;

--- a/rten-simd/src/lib.rs
+++ b/rten-simd/src/lib.rs
@@ -57,7 +57,8 @@
 //! evaluates it on a vector of floats:
 //!
 //! ```
-//! use rten_simd::{Isa, SimdOp, NumOps};
+//! use rten_simd::{Isa, SimdOp};
+//! use rten_simd::ops::NumOps;
 //! use rten_simd::functional::simd_map;
 //!
 //! struct Square<'a> {
@@ -112,20 +113,21 @@
 //!
 //! An implementation of the [`Isa`] trait is passed to [`SimdOp::eval`]. The
 //! [`Isa`] is the entry point for operations on SIMD vectors. It provides
-//! access to implementations of the [`NumOps`] trait and sub-traits for each
-//! element type. For example [`Isa::f32`] provides operations on SIMD vectors
-//! with `f32` elements.
+//! access to implementations of the [`NumOps`](ops::NumOps) trait and
+//! sub-traits for each element type. For example [`Isa::f32`] provides
+//! operations on SIMD vectors with `f32` elements.
 //!
-//! The [`NumOps`] trait provides operations that are available on all SIMD
-//! vectors. The sub-traits [`FloatOps`] and [`SignedIntOps`] provide operations
-//! that are only available on SIMD vectors with float and signed integer
-//! elements respectively.
+//! The [`NumOps`](ops::NumOps) trait provides operations that are available on
+//! all SIMD vectors. The sub-traits [`FloatOps`](ops::FloatOps) and
+//! [`SignedIntOps`](ops::SignedIntOps) provide operations that are only
+//! available on SIMD vectors with float and signed integer elements
+//! respectively.
 //!
-//! SIMD operations (eg. [`NumOps::add`]) take SIMD vectors as arguments. These
-//! vectors are either platform-specific types (eg. `float32x4_t` on Arm)
-//! or transparent wrappers around them. The [`Simd`] trait is implemented for
-//! all vector types. The [`Elem`] trait is implemented for supported element
-//! types, providing required numeric operations.
+//! SIMD operations (eg. [`NumOps::add`](ops::NumOps::add) take SIMD vectors as
+//! arguments. These vectors are either platform-specific types (eg.
+//! `float32x4_t` on Arm) or transparent wrappers around them. The [`Simd`]
+//! trait is implemented for all vector types. The [`Elem`] trait is implemented
+//! for supported element types, providing required numeric operations.
 //!
 //! ## Use with slices
 //!
@@ -169,18 +171,20 @@
 //!
 //! ## Generic operations
 //!
-//! It is possible to define operations which are generic over the element
-//! type by using the [`GetNumOps`] trait and related traits. These are
-//! implemented for supported element types and provide a way to get the
-//! [`NumOps`] implementation for that element type from an `Isa`. This can
-//! be used to define [`SimdOp`]s which are generic over the element type.
+//! It is possible to define operations which are generic over the element type
+//! by using the [`GetNumOps`](ops::GetNumOps) trait and related traits. These
+//! are implemented for supported element types and provide a way to get the
+//! [`NumOps`](ops::NumOps) implementation for that element type from an `Isa`.
+//! This can be used to define [`SimdOp`]s which are generic over the element
+//! type.
 //!
 //! This example defines an operation which can sum a slice of any supported
 //! element type:
 //!
 //! ```
 //! use std::iter::Sum;
-//! use rten_simd::{GetNumOps, NumOps, Isa, Simd, SimdIterable, SimdOp};
+//! use rten_simd::{Isa, Simd, SimdIterable, SimdOp};
+//! use rten_simd::ops::{GetNumOps, NumOps};
 //!
 //! struct SimdSum<'a, T>(&'a [T]);
 //!
@@ -211,11 +215,13 @@
 
 mod arch;
 mod dispatch;
+mod elem;
 pub mod functional;
 pub mod isa_detection;
 mod iter;
+pub mod ops;
+mod simd;
 pub mod span;
-mod vec;
 mod writer;
 
 /// Target-specific [`Isa`] implementations.
@@ -243,11 +249,10 @@ pub mod isa {
 }
 
 pub use dispatch::{SimdOp, SimdUnaryOp};
+pub use elem::Elem;
 pub use iter::{Iter, SimdIterable};
-pub use vec::{
-    Elem, Extend, FloatOps, GetFloatOps, GetNumOps, GetSignedIntOps, Interleave, Isa, Mask,
-    MaskOps, NarrowSaturate, NumOps, SignedIntOps, Simd,
-};
+pub use ops::Isa;
+pub use simd::{Mask, Simd};
 pub use writer::SliceWriter;
 
 #[cfg(feature = "avx512")]
@@ -281,7 +286,8 @@ pub(crate) use {assert_simd_eq, assert_simd_ne};
 #[cfg(test)]
 mod tests {
     use super::functional::simd_map;
-    use super::{Isa, NumOps, SimdOp};
+    use super::ops::NumOps;
+    use super::{Isa, SimdOp};
 
     #[test]
     fn test_simd_f32_op() {

--- a/rten-simd/src/simd.rs
+++ b/rten-simd/src/simd.rs
@@ -1,0 +1,90 @@
+//! Traits for SIMD vectors and masks.
+
+use std::fmt::Debug;
+
+use crate::elem::Elem;
+use crate::ops::Isa;
+
+/// Masks used or returned by SIMD operations.
+///
+/// Most operations on masks are available via the
+/// [`MaskOps`](crate::ops::MaskOps) trait. Implementations are obtained via
+/// [`NumOps::mask_ops`](crate::ops::NumOps::mask_ops).
+pub trait Mask: Copy + Debug {
+    type Array: AsRef<[bool]>
+        + Copy
+        + Debug
+        + IntoIterator<Item = bool>
+        + PartialEq<Self::Array>
+        + std::ops::Index<usize, Output = bool>;
+
+    /// Convert this mask to a bool array.
+    fn to_array(self) -> Self::Array;
+
+    /// Return true if all lanes in the mask are one.
+    fn all_true(self) -> bool {
+        self.to_array().as_ref().iter().all(|&x| x)
+    }
+
+    /// Return true if all lanes in the mask are false.
+    fn all_false(self) -> bool {
+        self.to_array().as_ref().iter().all(|&x| !x)
+    }
+}
+
+/// SIMD vector type.
+#[allow(clippy::len_without_is_empty)]
+pub trait Simd: Copy + Debug {
+    /// Representation of this vector as a `[Self::Elem; N]` array.
+    type Array: AsRef<[Self::Elem]>
+        + Copy
+        + Debug
+        + IntoIterator<Item = Self::Elem>
+        + PartialEq<Self::Array>
+        + std::ops::Index<usize, Output = Self::Elem>
+        + std::ops::IndexMut<usize, Output = Self::Elem>;
+
+    /// Type of data held in each SIMD lane.
+    type Elem: Elem;
+
+    /// Mask with the same number of elements as this vector.
+    type Mask: Mask;
+
+    /// The ISA associated with this SIMD vector.
+    type Isa: Isa;
+
+    /// Convert this SIMD vector to the common "bits" type used by all vectors
+    /// in this family.
+    fn to_bits(self) -> <Self::Isa as Isa>::Bits;
+
+    /// Convert this SIMD vector from the common "bits" type used by all vectors
+    /// in this family.
+    fn from_bits(bits: <Self::Isa as Isa>::Bits) -> Self;
+
+    /// Reinterpret the bits of this vector as another vector from the same
+    /// family.
+    fn reinterpret_cast<T>(self) -> T
+    where
+        T: Simd<Isa = Self::Isa>,
+    {
+        T::from_bits(self.to_bits())
+    }
+
+    /// Cast this vector to another with the same ISA and element type.
+    ///
+    /// This cast is a no-op which doesn't generate any code. It is needed in
+    /// some cases to downcast a `Simd` type to one of an `Isa`s associated
+    /// types, or vice-versa.
+    fn same_cast<T>(self) -> T
+    where
+        T: Simd<Elem = Self::Elem, Isa = Self::Isa>,
+    {
+        T::from_bits(self.to_bits())
+    }
+
+    /// Convert `self` to a SIMD array.
+    ///
+    /// This is a cheap transmute in most cases, since SIMD vectors usually
+    /// have the same layout as `[S::Elem; N]` but a greater alignment.
+    fn to_array(self) -> Self::Array;
+}

--- a/rten-simd/src/writer.rs
+++ b/rten-simd/src/writer.rs
@@ -1,6 +1,7 @@
 use std::mem::{transmute, MaybeUninit};
 
-use super::{Elem, NumOps};
+use crate::ops::NumOps;
+use crate::Elem;
 
 /// Utility for incrementally filling an uninitialized slice, one SIMD vector
 /// at a time.
@@ -45,7 +46,8 @@ impl<'a, T: Elem> SliceWriter<'a, T> {
 mod tests {
     use std::mem::MaybeUninit;
 
-    use crate::{Isa, NumOps, SimdOp, SliceWriter};
+    use crate::ops::NumOps;
+    use crate::{Isa, SimdOp, SliceWriter};
 
     #[test]
     fn test_slice_writer() {

--- a/rten-vecmath/src/erf.rs
+++ b/rten-vecmath/src/erf.rs
@@ -4,7 +4,8 @@
 
 use std::f32::consts::SQRT_2;
 
-use rten_simd::{FloatOps, Isa, NumOps, Simd, SimdUnaryOp};
+use rten_simd::ops::{FloatOps, NumOps};
+use rten_simd::{Isa, Simd, SimdUnaryOp};
 
 use crate::Exp;
 

--- a/rten-vecmath/src/exp.rs
+++ b/rten-vecmath/src/exp.rs
@@ -2,7 +2,8 @@
 
 #![allow(clippy::excessive_precision)]
 
-use rten_simd::{FloatOps, Isa, NumOps, SignedIntOps, Simd, SimdUnaryOp};
+use rten_simd::ops::{FloatOps, NumOps, SignedIntOps};
+use rten_simd::{Isa, Simd, SimdUnaryOp};
 
 const INV_LOG2: f32 = std::f32::consts::LOG2_E; // aka. 1 / ln2
 const ROUNDING_MAGIC: f32 = 12582912.; // 0x3 << 22

--- a/rten-vecmath/src/min_max.rs
+++ b/rten-vecmath/src/min_max.rs
@@ -1,4 +1,5 @@
-use rten_simd::{Isa, NumOps, Simd, SimdIterable, SimdOp};
+use rten_simd::ops::NumOps;
+use rten_simd::{Isa, Simd, SimdIterable, SimdOp};
 
 /// Compute the minimum and maximum values in a slice of floats.
 pub struct MinMax<'a> {

--- a/rten-vecmath/src/normalize.rs
+++ b/rten-vecmath/src/normalize.rs
@@ -1,8 +1,9 @@
 use std::mem::MaybeUninit;
 
 use rten_simd::functional::simd_map;
+use rten_simd::ops::NumOps;
 use rten_simd::span::SrcDest;
-use rten_simd::{Isa, NumOps, SimdIterable, SimdOp};
+use rten_simd::{Isa, SimdIterable, SimdOp};
 
 /// Normalize the mean and variance of elements in a slice.
 ///

--- a/rten-vecmath/src/quantize.rs
+++ b/rten-vecmath/src/quantize.rs
@@ -1,6 +1,7 @@
 use std::mem::MaybeUninit;
 
-use rten_simd::{FloatOps, Isa, NarrowSaturate, NumOps, SimdOp, SliceWriter};
+use rten_simd::ops::{FloatOps, NarrowSaturate, NumOps};
+use rten_simd::{Isa, SimdOp, SliceWriter};
 
 /// Quantize a slice of `f32` elements to 8-bit integers using the formula:
 ///
@@ -77,7 +78,8 @@ impl<'d> SimdOp for Quantize<'_, 'd, u8> {
 
 #[cfg(test)]
 mod tests {
-    use rten_simd::{Isa, NumOps, SimdOp};
+    use rten_simd::ops::NumOps;
+    use rten_simd::{Isa, SimdOp};
 
     use super::Quantize;
 

--- a/rten-vecmath/src/softmax.rs
+++ b/rten-vecmath/src/softmax.rs
@@ -1,8 +1,9 @@
 use std::mem::MaybeUninit;
 
 use rten_simd::functional::simd_map;
+use rten_simd::ops::{FloatOps, NumOps};
 use rten_simd::span::SrcDest;
-use rten_simd::{FloatOps, Isa, NumOps, SimdIterable, SimdOp, SimdUnaryOp};
+use rten_simd::{Isa, SimdIterable, SimdOp, SimdUnaryOp};
 
 use crate::Exp;
 

--- a/rten-vecmath/src/sum.rs
+++ b/rten-vecmath/src/sum.rs
@@ -1,4 +1,5 @@
-use rten_simd::{Isa, NumOps, Simd, SimdIterable, SimdOp};
+use rten_simd::ops::NumOps;
+use rten_simd::{Isa, Simd, SimdIterable, SimdOp};
 
 /// Computes the sum of a sequence of numbers.
 ///

--- a/rten-vecmath/src/tanh.rs
+++ b/rten-vecmath/src/tanh.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::excessive_precision)]
 
-use rten_simd::{FloatOps, Isa, NumOps, Simd, SimdUnaryOp};
+use rten_simd::ops::{FloatOps, NumOps};
+use rten_simd::{Isa, Simd, SimdUnaryOp};
 
 use crate::Exp;
 

--- a/src/gemm/im2col.rs
+++ b/src/gemm/im2col.rs
@@ -1,7 +1,8 @@
 use std::mem::MaybeUninit;
 use std::ops::Range;
 
-use rten_simd::{Isa, Mask, MaskOps, NumOps, Simd};
+use rten_simd::ops::{MaskOps, NumOps};
+use rten_simd::{Isa, Mask, Simd};
 use rten_tensor::{NdTensorView, Storage};
 
 use super::packing::int8::shift_cast_i8_u8;

--- a/src/gemm/kernels/simd_generic.rs
+++ b/src/gemm/kernels/simd_generic.rs
@@ -1,4 +1,5 @@
-use rten_simd::{Extend, Interleave, Isa, NumOps, Simd};
+use rten_simd::ops::{Extend, Interleave, NumOps};
+use rten_simd::{Isa, Simd};
 use rten_tensor::{Matrix, MatrixLayout, Storage};
 
 use super::{Int8DotProduct, Lhs, MatVecOutput};


### PR DESCRIPTION
 - Extract the SIMD vector, mask and element type traits out of `vec.rs` and into separate modules.
 - Rename `rten_simd/src/vec.rs` -> `ops.rs` as a more appropriate name for the functionality in the module.
 - Un-export operations traits from the root of the `rten_simd` crate and export the whole `ops` module. This reduces the clutter of the crate root and gives imports of ops traits a more meaningful path like `use rten_simd::ops::Extend`.
 - Add some module documentation to ops.rs