### PR TITLE
Add bitwise AND, OR ops for SIMD types

### DIFF
--- a/rten-simd/src/arch/aarch64.rs
+++ b/rten-simd/src/arch/aarch64.rs
@@ -10,9 +10,9 @@ use std::arch::aarch64::{
     vget_low_s8, vld1q_f32, vld1q_s16, vld1q_s32, vld1q_s8, vld1q_u16, vld1q_u32, vld1q_u8,
     vmaxq_f32, vminq_f32, vmovl_high_s16, vmovl_high_s8, vmovl_s16, vmovl_s8, vmulq_f32, vmulq_s16,
     vmulq_s32, vmulq_s8, vmulq_u16, vmulq_u8, vmvnq_u32, vnegq_f32, vnegq_s16, vnegq_s32, vnegq_s8,
-    vqmovn_s32, vqmovun_s16, vshlq_n_s16, vshlq_n_s32, vshlq_n_s8, vst1q_f32, vst1q_s16, vst1q_s32,
-    vst1q_s8, vst1q_u16, vst1q_u8, vsubq_f32, vsubq_s16, vsubq_s32, vsubq_s8, vsubq_u16, vsubq_u8,
-    vzip1q_s16, vzip1q_s8, vzip2q_s16, vzip2q_s8,
+    vorrq_u32, vqmovn_s32, vqmovun_s16, vshlq_n_s16, vshlq_n_s32, vshlq_n_s8, vst1q_f32, vst1q_s16,
+    vst1q_s32, vst1q_s8, vst1q_u16, vst1q_u8, vsubq_f32, vsubq_s16, vsubq_s32, vsubq_s8, vsubq_u16,
+    vsubq_u8, vzip1q_s16, vzip1q_s8, vzip2q_s16, vzip2q_s8,
 };
 use std::mem::transmute;
 
@@ -124,13 +124,24 @@ macro_rules! simd_ops_common {
 
         // Since bitwise ops work on individual bits, we can use the same
         // implementation regardless of numeric type.
-
         #[inline]
-        fn xor(self, x: $simd, y: $simd) -> $simd {
+        fn and(self, x: $simd, y: $simd) -> $simd {
             unsafe {
                 let x = transmute::<$simd, uint32x4_t>(x);
                 let y = transmute::<$simd, uint32x4_t>(y);
-                let tmp = veorq_u32(x, y);
+                let tmp = vandq_u32(x, y);
+                transmute::<uint32x4_t, $simd>(tmp)
+            }
+        }
+
+        // Since bitwise ops work on individual bits, we can use the same
+        // implementation regardless of numeric type.
+        #[inline]
+        fn or(self, x: $simd, y: $simd) -> $simd {
+            unsafe {
+                let x = transmute::<$simd, uint32x4_t>(x);
+                let y = transmute::<$simd, uint32x4_t>(y);
+                let tmp = vorrq_u32(x, y);
                 transmute::<uint32x4_t, $simd>(tmp)
             }
         }
@@ -140,6 +151,16 @@ macro_rules! simd_ops_common {
             unsafe {
                 let x = transmute::<$simd, uint32x4_t>(x);
                 let tmp = vmvnq_u32(x);
+                transmute::<uint32x4_t, $simd>(tmp)
+            }
+        }
+
+        #[inline]
+        fn xor(self, x: $simd, y: $simd) -> $simd {
+            unsafe {
+                let x = transmute::<$simd, uint32x4_t>(x);
+                let y = transmute::<$simd, uint32x4_t>(y);
+                let tmp = veorq_u32(x, y);
                 transmute::<uint32x4_t, $simd>(tmp)
             }
         }

--- a/rten-simd/src/arch/generic.rs
+++ b/rten-simd/src/arch/generic.rs
@@ -230,13 +230,23 @@ macro_rules! simd_ops_common {
 macro_rules! simd_int_ops_common {
     ($simd:ty) => {
         #[inline]
-        fn xor(self, x: $simd, y: $simd) -> $simd {
-            array::from_fn(|i| x.0[i] ^ y.0[i]).into()
+        fn and(self, x: $simd, y: $simd) -> $simd {
+            array::from_fn(|i| x.0[i] & y.0[i]).into()
+        }
+
+        #[inline]
+        fn or(self, x: $simd, y: $simd) -> $simd {
+            array::from_fn(|i| x.0[i] | y.0[i]).into()
         }
 
         #[inline]
         fn not(self, x: $simd) -> $simd {
             array::from_fn(|i| !x.0[i]).into()
+        }
+
+        #[inline]
+        fn xor(self, x: $simd, y: $simd) -> $simd {
+            array::from_fn(|i| x.0[i] ^ y.0[i]).into()
         }
     };
 }
@@ -247,13 +257,23 @@ unsafe impl NumOps<f32> for GenericIsa {
     simd_ops_common!(F32x4, f32, 4, M32);
 
     #[inline]
-    fn xor(self, x: F32x4, y: F32x4) -> F32x4 {
-        array::from_fn(|i| f32::from_bits(x.0[i].to_bits() ^ y.0[i].to_bits())).into()
+    fn and(self, x: F32x4, y: F32x4) -> F32x4 {
+        array::from_fn(|i| f32::from_bits(x.0[i].to_bits() & y.0[i].to_bits())).into()
     }
 
     #[inline]
     fn not(self, x: F32x4) -> F32x4 {
         array::from_fn(|i| f32::from_bits(!x.0[i].to_bits())).into()
+    }
+
+    #[inline]
+    fn or(self, x: F32x4, y: F32x4) -> F32x4 {
+        array::from_fn(|i| f32::from_bits(x.0[i].to_bits() | y.0[i].to_bits())).into()
+    }
+
+    #[inline]
+    fn xor(self, x: F32x4, y: F32x4) -> F32x4 {
+        array::from_fn(|i| f32::from_bits(x.0[i].to_bits() ^ y.0[i].to_bits())).into()
     }
 }
 

--- a/rten-simd/src/arch/wasm32.rs
+++ b/rten-simd/src/arch/wasm32.rs
@@ -9,8 +9,8 @@ use std::arch::wasm32::{
     i8x16_neg, i8x16_shl, i8x16_shuffle, i8x16_splat, i8x16_sub, u16x8_add, u16x8_eq,
     u16x8_extmul_high_u8x16, u16x8_extmul_low_u8x16, u16x8_ge, u16x8_gt, u16x8_mul, u16x8_splat,
     u16x8_sub, u8x16_add, u8x16_eq, u8x16_ge, u8x16_gt, u8x16_narrow_i16x8, u8x16_shuffle,
-    u8x16_splat, u8x16_sub, v128, v128_and, v128_bitselect, v128_load, v128_not, v128_store,
-    v128_xor,
+    u8x16_splat, u8x16_sub, v128, v128_and, v128_bitselect, v128_load, v128_not, v128_or,
+    v128_store, v128_xor,
 };
 use std::mem::transmute;
 
@@ -151,13 +151,23 @@ macro_rules! simd_ops_common {
         }
 
         #[inline]
-        fn xor(self, x: $simd, y: $simd) -> $simd {
-            v128_xor(x.0, y.0).into()
+        fn and(self, x: $simd, y: $simd) -> $simd {
+            v128_and(x.0, y.0).into()
         }
 
         #[inline]
         fn not(self, x: $simd) -> $simd {
             v128_not(x.0).into()
+        }
+
+        #[inline]
+        fn or(self, x: $simd, y: $simd) -> $simd {
+            v128_or(x.0, y.0).into()
+        }
+
+        #[inline]
+        fn xor(self, x: $simd, y: $simd) -> $simd {
+            v128_xor(x.0, y.0).into()
         }
     };
 }

--- a/rten-simd/src/arch/x86_64/avx2.rs
+++ b/rten-simd/src/arch/x86_64/avx2.rs
@@ -8,15 +8,16 @@ use std::arch::x86_64::{
     _mm256_extractf128_ps, _mm256_extracti128_si256, _mm256_fmadd_ps, _mm256_insertf128_si256,
     _mm256_loadu_ps, _mm256_loadu_si256, _mm256_maskload_epi32, _mm256_maskload_ps,
     _mm256_maskstore_epi32, _mm256_maskstore_ps, _mm256_max_ps, _mm256_min_ps,
-    _mm256_movemask_epi8, _mm256_mul_ps, _mm256_mullo_epi16, _mm256_mullo_epi32, _mm256_or_si256,
-    _mm256_packs_epi32, _mm256_packus_epi16, _mm256_permute2x128_si256, _mm256_permute4x64_epi64,
-    _mm256_set1_epi16, _mm256_set1_epi32, _mm256_set1_epi8, _mm256_set1_ps, _mm256_setr_m128i,
-    _mm256_setzero_si256, _mm256_slli_epi16, _mm256_slli_epi32, _mm256_storeu_ps,
-    _mm256_storeu_si256, _mm256_sub_epi16, _mm256_sub_epi32, _mm256_sub_epi8, _mm256_sub_ps,
-    _mm256_unpackhi_epi16, _mm256_unpackhi_epi8, _mm256_unpacklo_epi16, _mm256_unpacklo_epi8,
-    _mm256_xor_ps, _mm256_xor_si256, _mm_add_ps, _mm_cvtss_f32, _mm_movehl_ps, _mm_prefetch,
-    _mm_setr_epi8, _mm_shuffle_epi8, _mm_shuffle_ps, _mm_unpacklo_epi64, _CMP_EQ_OQ, _CMP_GE_OQ,
-    _CMP_GT_OQ, _CMP_LE_OQ, _CMP_LT_OQ, _MM_HINT_ET0, _MM_HINT_T0,
+    _mm256_movemask_epi8, _mm256_mul_ps, _mm256_mullo_epi16, _mm256_mullo_epi32, _mm256_or_ps,
+    _mm256_or_si256, _mm256_packs_epi32, _mm256_packus_epi16, _mm256_permute2x128_si256,
+    _mm256_permute4x64_epi64, _mm256_set1_epi16, _mm256_set1_epi32, _mm256_set1_epi8,
+    _mm256_set1_ps, _mm256_setr_m128i, _mm256_setzero_si256, _mm256_slli_epi16, _mm256_slli_epi32,
+    _mm256_storeu_ps, _mm256_storeu_si256, _mm256_sub_epi16, _mm256_sub_epi32, _mm256_sub_epi8,
+    _mm256_sub_ps, _mm256_unpackhi_epi16, _mm256_unpackhi_epi8, _mm256_unpacklo_epi16,
+    _mm256_unpacklo_epi8, _mm256_xor_ps, _mm256_xor_si256, _mm_add_ps, _mm_cvtss_f32,
+    _mm_movehl_ps, _mm_prefetch, _mm_setr_epi8, _mm_shuffle_epi8, _mm_shuffle_ps,
+    _mm_unpacklo_epi64, _CMP_EQ_OQ, _CMP_GE_OQ, _CMP_GT_OQ, _CMP_LE_OQ, _CMP_LT_OQ, _MM_HINT_ET0,
+    _MM_HINT_T0,
 };
 use std::is_x86_feature_detected;
 use std::mem::transmute;
@@ -124,6 +125,16 @@ macro_rules! simd_ops_common {
 macro_rules! simd_int_ops_common {
     ($simd:ty) => {
         #[inline]
+        fn and(self, x: $simd, y: $simd) -> $simd {
+            unsafe { _mm256_and_si256(x.0, y.0) }.into()
+        }
+
+        #[inline]
+        fn or(self, x: $simd, y: $simd) -> $simd {
+            unsafe { _mm256_or_si256(x.0, y.0) }.into()
+        }
+
+        #[inline]
         fn xor(self, x: $simd, y: $simd) -> $simd {
             unsafe { _mm256_xor_si256(x.0, y.0) }.into()
         }
@@ -200,14 +211,24 @@ unsafe impl NumOps<f32> for Avx2Isa {
     }
 
     #[inline]
-    fn xor(self, x: F32x8, y: F32x8) -> F32x8 {
-        unsafe { _mm256_xor_ps(x.0, y.0) }.into()
+    fn and(self, x: F32x8, y: F32x8) -> F32x8 {
+        unsafe { _mm256_and_ps(x.0, y.0) }.into()
     }
 
     #[inline]
     fn not(self, x: F32x8) -> F32x8 {
         let all_ones: F32x8 = self.splat(f32::from_bits(0xFFFFFFFF));
         unsafe { _mm256_andnot_ps(x.0, all_ones.0) }.into()
+    }
+
+    #[inline]
+    fn or(self, x: F32x8, y: F32x8) -> F32x8 {
+        unsafe { _mm256_or_ps(x.0, y.0) }.into()
+    }
+
+    #[inline]
+    fn xor(self, x: F32x8, y: F32x8) -> F32x8 {
+        unsafe { _mm256_xor_ps(x.0, y.0) }.into()
     }
 
     #[inline]

--- a/rten-simd/src/arch/x86_64/avx512.rs
+++ b/rten-simd/src/arch/x86_64/avx512.rs
@@ -1,16 +1,17 @@
 use std::arch::x86_64::{
     __m512, __m512i, __mmask16, __mmask32, __mmask64, _mm512_add_epi16, _mm512_add_epi32,
-    _mm512_add_epi8, _mm512_add_ps, _mm512_andnot_ps, _mm512_andnot_si512, _mm512_castsi256_si512,
-    _mm512_cmp_epi16_mask, _mm512_cmp_epi32_mask, _mm512_cmp_epu16_mask, _mm512_cmp_ps_mask,
-    _mm512_cmpeq_epi8_mask, _mm512_cmpeq_epu8_mask, _mm512_cmpge_epi8_mask, _mm512_cmpge_epu8_mask,
-    _mm512_cmpgt_epi8_mask, _mm512_cmpgt_epu8_mask, _mm512_cvtepi16_epi32, _mm512_cvtepi16_epi8,
-    _mm512_cvtepi8_epi16, _mm512_cvtepu8_epi16, _mm512_cvtps_epi32, _mm512_cvttps_epi32,
-    _mm512_div_ps, _mm512_extracti64x4_epi64, _mm512_fmadd_ps, _mm512_inserti64x4, _mm512_loadu_ps,
-    _mm512_loadu_si512, _mm512_mask_blend_epi16, _mm512_mask_blend_epi32, _mm512_mask_blend_epi8,
-    _mm512_mask_blend_ps, _mm512_mask_loadu_epi16, _mm512_mask_loadu_epi32, _mm512_mask_loadu_epi8,
-    _mm512_mask_loadu_ps, _mm512_mask_storeu_epi16, _mm512_mask_storeu_epi32,
-    _mm512_mask_storeu_epi8, _mm512_mask_storeu_ps, _mm512_max_ps, _mm512_min_ps, _mm512_mul_ps,
-    _mm512_mullo_epi16, _mm512_mullo_epi32, _mm512_packs_epi32, _mm512_packus_epi16,
+    _mm512_add_epi8, _mm512_add_ps, _mm512_and_ps, _mm512_and_si512, _mm512_andnot_ps,
+    _mm512_andnot_si512, _mm512_castsi256_si512, _mm512_cmp_epi16_mask, _mm512_cmp_epi32_mask,
+    _mm512_cmp_epu16_mask, _mm512_cmp_ps_mask, _mm512_cmpeq_epi8_mask, _mm512_cmpeq_epu8_mask,
+    _mm512_cmpge_epi8_mask, _mm512_cmpge_epu8_mask, _mm512_cmpgt_epi8_mask, _mm512_cmpgt_epu8_mask,
+    _mm512_cvtepi16_epi32, _mm512_cvtepi16_epi8, _mm512_cvtepi8_epi16, _mm512_cvtepu8_epi16,
+    _mm512_cvtps_epi32, _mm512_cvttps_epi32, _mm512_div_ps, _mm512_extracti64x4_epi64,
+    _mm512_fmadd_ps, _mm512_inserti64x4, _mm512_loadu_ps, _mm512_loadu_si512,
+    _mm512_mask_blend_epi16, _mm512_mask_blend_epi32, _mm512_mask_blend_epi8, _mm512_mask_blend_ps,
+    _mm512_mask_loadu_epi16, _mm512_mask_loadu_epi32, _mm512_mask_loadu_epi8, _mm512_mask_loadu_ps,
+    _mm512_mask_storeu_epi16, _mm512_mask_storeu_epi32, _mm512_mask_storeu_epi8,
+    _mm512_mask_storeu_ps, _mm512_max_ps, _mm512_min_ps, _mm512_mul_ps, _mm512_mullo_epi16,
+    _mm512_mullo_epi32, _mm512_or_ps, _mm512_or_si512, _mm512_packs_epi32, _mm512_packus_epi16,
     _mm512_permutex2var_epi32, _mm512_permutexvar_epi64, _mm512_reduce_add_ps, _mm512_set1_epi16,
     _mm512_set1_epi32, _mm512_set1_epi8, _mm512_set1_ps, _mm512_setr_epi32, _mm512_setr_epi64,
     _mm512_setzero_si512, _mm512_sllv_epi16, _mm512_sllv_epi32, _mm512_storeu_ps,
@@ -133,6 +134,16 @@ macro_rules! simd_ops_common {
 macro_rules! simd_int_ops_common {
     ($simd:ty) => {
         #[inline]
+        fn and(self, x: $simd, y: $simd) -> $simd {
+            unsafe { _mm512_and_si512(x.0, y.0) }.into()
+        }
+
+        #[inline]
+        fn or(self, x: $simd, y: $simd) -> $simd {
+            unsafe { _mm512_or_si512(x.0, y.0) }.into()
+        }
+
+        #[inline]
         fn xor(self, x: $simd, y: $simd) -> $simd {
             unsafe { _mm512_xor_si512(x.0, y.0) }.into()
         }
@@ -203,14 +214,24 @@ unsafe impl NumOps<f32> for Avx512Isa {
     }
 
     #[inline]
-    fn xor(self, x: F32x16, y: F32x16) -> F32x16 {
-        unsafe { _mm512_xor_ps(x.0, y.0) }.into()
+    fn and(self, x: F32x16, y: F32x16) -> F32x16 {
+        unsafe { _mm512_and_ps(x.0, y.0) }.into()
     }
 
     #[inline]
     fn not(self, x: F32x16) -> F32x16 {
         let all_ones: F32x16 = self.splat(f32::from_bits(0xFFFFFFFF));
         unsafe { _mm512_andnot_ps(x.0, all_ones.0) }.into()
+    }
+
+    #[inline]
+    fn or(self, x: F32x16, y: F32x16) -> F32x16 {
+        unsafe { _mm512_or_ps(x.0, y.0) }.into()
+    }
+
+    #[inline]
+    fn xor(self, x: F32x16, y: F32x16) -> F32x16 {
+        unsafe { _mm512_xor_ps(x.0, y.0) }.into()
     }
 
     #[inline]

--- a/rten-simd/src/ops.rs
+++ b/rten-simd/src/ops.rs
@@ -287,8 +287,14 @@ pub unsafe trait NumOps<T: Elem>: Copy {
         self.min(self.max(x, min), max)
     }
 
+    /// Return the bitwise AND of `x` and `y`.
+    fn and(self, x: Self::Simd, y: Self::Simd) -> Self::Simd;
+
     /// Return the bitwise NOT of `x`.
     fn not(self, x: Self::Simd) -> Self::Simd;
+
+    /// Return the bitwise OR of `x` and `y`.
+    fn or(self, x: Self::Simd, y: Self::Simd) -> Self::Simd;
 
     /// Return the bitwise XOR of `x` and `y`.
     fn xor(self, x: Self::Simd, y: Self::Simd) -> Self::Simd;
@@ -706,6 +712,22 @@ mod tests {
                 }
 
                 #[test]
+                fn test_and() {
+                    test_simd_op!(isa, {
+                        let ops = isa.$elem();
+                        let zeros = ops.zero();
+                        let ones = ops.not(zeros);
+
+                        // Cast to bits here because all-ones is a NaN if elements
+                        // are floats, and NaNs are not equal to themselves.
+                        assert_simd_eq!(ops.and(zeros, zeros).to_bits(), zeros.to_bits());
+                        assert_simd_eq!(ops.and(zeros, ones).to_bits(), zeros.to_bits());
+                        assert_simd_eq!(ops.and(ones, zeros).to_bits(), zeros.to_bits());
+                        assert_simd_eq!(ops.and(ones, ones).to_bits(), ones.to_bits());
+                    })
+                }
+
+                #[test]
                 fn test_not() {
                     test_simd_op!(isa, {
                         let ops = isa.$elem();
@@ -719,6 +741,22 @@ mod tests {
                 }
 
                 #[test]
+                fn test_or() {
+                    test_simd_op!(isa, {
+                        let ops = isa.$elem();
+                        let zeros = ops.zero();
+                        let ones = ops.not(zeros);
+
+                        // Cast to bits here because all-ones is a NaN if elements
+                        // are floats, and NaNs are not equal to themselves.
+                        assert_simd_eq!(ops.or(zeros, zeros).to_bits(), zeros.to_bits());
+                        assert_simd_eq!(ops.or(zeros, ones).to_bits(), ones.to_bits());
+                        assert_simd_eq!(ops.or(ones, zeros).to_bits(), ones.to_bits());
+                        assert_simd_eq!(ops.or(ones, ones).to_bits(), ones.to_bits());
+                    })
+                }
+
+                #[test]
                 fn test_xor() {
                     test_simd_op!(isa, {
                         let ops = isa.$elem();
@@ -726,12 +764,11 @@ mod tests {
                         let zeros = ops.zero();
                         let ones = ops.not(zeros);
 
-                        assert_simd_eq!(ops.xor(zeros, zeros), zeros);
-                        assert_simd_eq!(ops.xor(ones, ones), zeros);
-
                         // Cast to bits here because all-ones is a NaN if the
                         // element type is a float, and NaNs are not equal to
                         // themselves.
+                        assert_simd_eq!(ops.xor(zeros, zeros).to_bits(), zeros.to_bits());
+                        assert_simd_eq!(ops.xor(ones, ones).to_bits(), zeros.to_bits());
                         assert_simd_eq!(ops.xor(zeros, ones).to_bits(), ones.to_bits());
                         assert_simd_eq!(ops.xor(ones, zeros).to_bits(), ones.to_bits());
                     })


### PR DESCRIPTION
The NOR and XOR operations were already implemented. Add AND and OR for completeness.