### PR TITLE
Add `IntOps` trait for operations on SIMD vectors with integer elements

### DIFF
--- a/rten-simd/src/arch/aarch64.rs
+++ b/rten-simd/src/arch/aarch64.rs
@@ -10,9 +10,9 @@ use std::arch::aarch64::{
     vget_low_s8, vld1q_f32, vld1q_s16, vld1q_s32, vld1q_s8, vld1q_u16, vld1q_u32, vld1q_u8,
     vmaxq_f32, vminq_f32, vmovl_high_s16, vmovl_high_s8, vmovl_s16, vmovl_s8, vmulq_f32, vmulq_s16,
     vmulq_s32, vmulq_s8, vmulq_u16, vmulq_u8, vmvnq_u32, vnegq_f32, vnegq_s16, vnegq_s32, vnegq_s8,
-    vorrq_u32, vqmovn_s32, vqmovun_s16, vshlq_n_s16, vshlq_n_s32, vshlq_n_s8, vst1q_f32, vst1q_s16,
-    vst1q_s32, vst1q_s8, vst1q_u16, vst1q_u8, vsubq_f32, vsubq_s16, vsubq_s32, vsubq_s8, vsubq_u16,
-    vsubq_u8, vzip1q_s16, vzip1q_s8, vzip2q_s16, vzip2q_s8,
+    vorrq_u32, vqmovn_s32, vqmovun_s16, vshlq_n_s16, vshlq_n_s32, vshlq_n_s8, vshlq_n_u16,
+    vst1q_f32, vst1q_s16, vst1q_s32, vst1q_s8, vst1q_u16, vst1q_u8, vsubq_f32, vsubq_s16,
+    vsubq_s32, vsubq_s8, vsubq_u16, vsubq_u8, vzip1q_s16, vzip1q_s8, vzip2q_s16, vzip2q_s8,
 };
 use std::mem::transmute;
 
@@ -73,7 +73,7 @@ unsafe impl Isa for ArmNeonIsa {
         self
     }
 
-    fn u16(self) -> impl NumOps<u16, Simd = Self::U16> {
+    fn u16(self) -> impl IntOps<u16, Simd = Self::U16> {
         self
     }
 }
@@ -748,6 +748,13 @@ unsafe impl NumOps<u16> for ArmNeonIsa {
     #[inline]
     unsafe fn store_ptr(self, x: uint16x8_t, ptr: *mut u16) {
         unsafe { vst1q_u16(ptr, x) }
+    }
+}
+
+impl IntOps<u16> for ArmNeonIsa {
+    #[inline]
+    fn shift_left<const SHIFT: i32>(self, x: uint16x8_t) -> uint16x8_t {
+        unsafe { vshlq_n_u16::<SHIFT>(x) }
     }
 }
 

--- a/rten-simd/src/arch/aarch64.rs
+++ b/rten-simd/src/arch/aarch64.rs
@@ -16,7 +16,9 @@ use std::arch::aarch64::{
 };
 use std::mem::transmute;
 
-use crate::ops::{Extend, FloatOps, Interleave, MaskOps, NarrowSaturate, NumOps, SignedIntOps};
+use crate::ops::{
+    Extend, FloatOps, IntOps, Interleave, MaskOps, NarrowSaturate, NumOps, SignedIntOps,
+};
 use crate::{Isa, Mask, Simd};
 
 #[derive(Copy, Clone)]
@@ -351,15 +353,17 @@ unsafe impl NumOps<i32> for ArmNeonIsa {
     }
 }
 
+impl IntOps<i32> for ArmNeonIsa {
+    #[inline]
+    fn shift_left<const SHIFT: i32>(self, x: int32x4_t) -> int32x4_t {
+        unsafe { vshlq_n_s32::<SHIFT>(x) }
+    }
+}
+
 impl SignedIntOps<i32> for ArmNeonIsa {
     #[inline]
     fn neg(self, x: int32x4_t) -> int32x4_t {
         unsafe { vnegq_s32(x) }
-    }
-
-    #[inline]
-    fn shift_left<const SHIFT: i32>(self, x: int32x4_t) -> int32x4_t {
-        unsafe { vshlq_n_s32::<SHIFT>(x) }
     }
 }
 
@@ -459,15 +463,17 @@ unsafe impl NumOps<i16> for ArmNeonIsa {
     }
 }
 
+impl IntOps<i16> for ArmNeonIsa {
+    #[inline]
+    fn shift_left<const SHIFT: i32>(self, x: int16x8_t) -> int16x8_t {
+        unsafe { vshlq_n_s16::<SHIFT>(x) }
+    }
+}
+
 impl SignedIntOps<i16> for ArmNeonIsa {
     #[inline]
     fn neg(self, x: int16x8_t) -> int16x8_t {
         unsafe { vnegq_s16(x) }
-    }
-
-    #[inline]
-    fn shift_left<const SHIFT: i32>(self, x: int16x8_t) -> int16x8_t {
-        unsafe { vshlq_n_s16::<SHIFT>(x) }
     }
 }
 
@@ -566,15 +572,17 @@ unsafe impl NumOps<i8> for ArmNeonIsa {
     }
 }
 
+impl IntOps<i8> for ArmNeonIsa {
+    #[inline]
+    fn shift_left<const SHIFT: i32>(self, x: int8x16_t) -> int8x16_t {
+        unsafe { vshlq_n_s8::<SHIFT>(x) }
+    }
+}
+
 impl SignedIntOps<i8> for ArmNeonIsa {
     #[inline]
     fn neg(self, x: int8x16_t) -> int8x16_t {
         unsafe { vnegq_s8(x) }
-    }
-
-    #[inline]
-    fn shift_left<const SHIFT: i32>(self, x: int8x16_t) -> int8x16_t {
-        unsafe { vshlq_n_s8::<SHIFT>(x) }
     }
 }
 

--- a/rten-simd/src/arch/generic.rs
+++ b/rten-simd/src/arch/generic.rs
@@ -94,7 +94,7 @@ unsafe impl Isa for GenericIsa {
         self
     }
 
-    fn u16(self) -> impl NumOps<u16, Simd = Self::U16> {
+    fn u16(self) -> impl IntOps<u16, Simd = Self::U16> {
         self
     }
 }
@@ -313,7 +313,7 @@ impl FloatOps<f32> for GenericIsa {
     }
 }
 
-macro_rules! impl_simd_signed_int_ops {
+macro_rules! impl_simd_int_ops {
     ($simd:ident, $elem:ty, $len:expr, $mask:ident) => {
         unsafe impl NumOps<$elem> for GenericIsa {
             type Simd = $simd;
@@ -329,6 +329,12 @@ macro_rules! impl_simd_signed_int_ops {
                 $simd(xs)
             }
         }
+    };
+}
+
+macro_rules! impl_simd_signed_int_ops {
+    ($simd:ident, $elem:ty, $len:expr, $mask:ident) => {
+        impl_simd_int_ops!($simd, $elem, $len, $mask);
 
         impl SignedIntOps<$elem> for GenericIsa {
             #[inline]
@@ -385,18 +391,8 @@ macro_rules! impl_interleave {
 impl_interleave!(i8, I8x16);
 impl_interleave!(i16, I16x8);
 
-macro_rules! impl_simd_unsigned_int_ops {
-    ($simd:ident, $elem:ty, $len:expr, $mask:ident) => {
-        unsafe impl NumOps<$elem> for GenericIsa {
-            type Simd = $simd;
-
-            simd_ops_common!($simd, $elem, $len, $mask);
-            simd_int_ops_common!($simd);
-        }
-    };
-}
-impl_simd_unsigned_int_ops!(U8x16, u8, 16, M8);
-impl_simd_unsigned_int_ops!(U16x8, u16, 8, M16);
+impl_simd_int_ops!(U8x16, u8, 16, M8);
+impl_simd_int_ops!(U16x8, u16, 8, M16);
 
 trait NarrowSaturateElem<T> {
     fn narrow_saturate(self) -> T;

--- a/rten-simd/src/arch/generic.rs
+++ b/rten-simd/src/arch/generic.rs
@@ -1,7 +1,9 @@
 use std::array;
 use std::mem::transmute;
 
-use crate::ops::{Extend, FloatOps, Interleave, MaskOps, NarrowSaturate, NumOps, SignedIntOps};
+use crate::ops::{
+    Extend, FloatOps, IntOps, Interleave, MaskOps, NarrowSaturate, NumOps, SignedIntOps,
+};
 use crate::{Isa, Mask, Simd};
 
 // Size of SIMD vector in 32-bit lanes.
@@ -320,16 +322,18 @@ macro_rules! impl_simd_signed_int_ops {
             simd_int_ops_common!($simd);
         }
 
+        impl IntOps<$elem> for GenericIsa {
+            #[inline]
+            fn shift_left<const SHIFT: i32>(self, x: $simd) -> $simd {
+                let xs = array::from_fn(|i| x.0[i] << SHIFT);
+                $simd(xs)
+            }
+        }
+
         impl SignedIntOps<$elem> for GenericIsa {
             #[inline]
             fn neg(self, x: $simd) -> $simd {
                 let xs = array::from_fn(|i| -x.0[i]);
-                $simd(xs)
-            }
-
-            #[inline]
-            fn shift_left<const SHIFT: i32>(self, x: $simd) -> $simd {
-                let xs = array::from_fn(|i| x.0[i] << SHIFT);
                 $simd(xs)
             }
         }

--- a/rten-simd/src/arch/wasm32.rs
+++ b/rten-simd/src/arch/wasm32.rs
@@ -7,10 +7,10 @@ use std::arch::wasm32::{
     i32x4_extend_low_i16x8, i32x4_ge, i32x4_gt, i32x4_mul, i32x4_neg, i32x4_shl, i32x4_shuffle,
     i32x4_splat, i32x4_sub, i32x4_trunc_sat_f32x4, i8x16_add, i8x16_eq, i8x16_ge, i8x16_gt,
     i8x16_neg, i8x16_shl, i8x16_shuffle, i8x16_splat, i8x16_sub, u16x8_add, u16x8_eq,
-    u16x8_extmul_high_u8x16, u16x8_extmul_low_u8x16, u16x8_ge, u16x8_gt, u16x8_mul, u16x8_splat,
-    u16x8_sub, u8x16_add, u8x16_eq, u8x16_ge, u8x16_gt, u8x16_narrow_i16x8, u8x16_shuffle,
-    u8x16_splat, u8x16_sub, v128, v128_and, v128_bitselect, v128_load, v128_not, v128_or,
-    v128_store, v128_xor,
+    u16x8_extmul_high_u8x16, u16x8_extmul_low_u8x16, u16x8_ge, u16x8_gt, u16x8_mul, u16x8_shl,
+    u16x8_splat, u16x8_sub, u8x16_add, u8x16_eq, u8x16_ge, u8x16_gt, u8x16_narrow_i16x8,
+    u8x16_shuffle, u8x16_splat, u8x16_sub, v128, v128_and, v128_bitselect, v128_load, v128_not,
+    v128_or, v128_store, v128_xor,
 };
 use std::mem::transmute;
 
@@ -80,7 +80,7 @@ unsafe impl Isa for Wasm32Isa {
         self
     }
 
-    fn u16(self) -> impl NumOps<u16, Simd = Self::U16> {
+    fn u16(self) -> impl IntOps<u16, Simd = Self::U16> {
         self
     }
 }
@@ -603,6 +603,13 @@ unsafe impl NumOps<u16> for Wasm32Isa {
     #[inline]
     fn gt(self, x: U16x8, y: U16x8) -> M16 {
         M16(u16x8_gt(x.0, y.0))
+    }
+}
+
+impl IntOps<u16> for Wasm32Isa {
+    #[inline]
+    fn shift_left<const SHIFT: i32>(self, x: U16x8) -> U16x8 {
+        U16x8(u16x8_shl(x.0, SHIFT as u32))
     }
 }
 

--- a/rten-simd/src/arch/wasm32.rs
+++ b/rten-simd/src/arch/wasm32.rs
@@ -15,7 +15,9 @@ use std::arch::wasm32::{
 use std::mem::transmute;
 
 use super::{lanes, simd_type};
-use crate::ops::{Extend, FloatOps, Interleave, MaskOps, NarrowSaturate, NumOps, SignedIntOps};
+use crate::ops::{
+    Extend, FloatOps, IntOps, Interleave, MaskOps, NarrowSaturate, NumOps, SignedIntOps,
+};
 use crate::{Isa, Mask, Simd};
 
 simd_type!(F32x4, v128, f32, M32, Wasm32Isa);
@@ -323,15 +325,17 @@ unsafe impl NumOps<i32> for Wasm32Isa {
     }
 }
 
+impl IntOps<i32> for Wasm32Isa {
+    #[inline]
+    fn shift_left<const SHIFT: i32>(self, x: I32x4) -> I32x4 {
+        I32x4(i32x4_shl(x.0, SHIFT as u32))
+    }
+}
+
 impl SignedIntOps<i32> for Wasm32Isa {
     #[inline]
     fn neg(self, x: I32x4) -> I32x4 {
         I32x4(i32x4_neg(x.0))
-    }
-
-    #[inline]
-    fn shift_left<const SHIFT: i32>(self, x: I32x4) -> I32x4 {
-        I32x4(i32x4_shl(x.0, SHIFT as u32))
     }
 }
 
@@ -383,15 +387,17 @@ unsafe impl NumOps<i16> for Wasm32Isa {
     }
 }
 
+impl IntOps<i16> for Wasm32Isa {
+    #[inline]
+    fn shift_left<const SHIFT: i32>(self, x: I16x8) -> I16x8 {
+        I16x8(i16x8_shl(x.0, SHIFT as u32))
+    }
+}
+
 impl SignedIntOps<i16> for Wasm32Isa {
     #[inline]
     fn neg(self, x: I16x8) -> I16x8 {
         I16x8(i16x8_neg(x.0))
-    }
-
-    #[inline]
-    fn shift_left<const SHIFT: i32>(self, x: I16x8) -> I16x8 {
-        I16x8(i16x8_shl(x.0, SHIFT as u32))
     }
 }
 
@@ -475,15 +481,17 @@ unsafe impl NumOps<i8> for Wasm32Isa {
     }
 }
 
+impl IntOps<i8> for Wasm32Isa {
+    #[inline]
+    fn shift_left<const SHIFT: i32>(self, x: I8x16) -> I8x16 {
+        I8x16(i8x16_shl(x.0, SHIFT as u32))
+    }
+}
+
 impl SignedIntOps<i8> for Wasm32Isa {
     #[inline]
     fn neg(self, x: I8x16) -> I8x16 {
         I8x16(i8x16_neg(x.0))
-    }
-
-    #[inline]
-    fn shift_left<const SHIFT: i32>(self, x: I8x16) -> I8x16 {
-        I8x16(i8x16_shl(x.0, SHIFT as u32))
     }
 }
 

--- a/rten-simd/src/arch/x86_64/avx2.rs
+++ b/rten-simd/src/arch/x86_64/avx2.rs
@@ -24,7 +24,7 @@ use std::mem::transmute;
 
 use super::super::{lanes, simd_type};
 use crate::ops::{
-    Extend, FloatOps, Interleave, MaskOps, Narrow, NarrowSaturate, NumOps, SignedIntOps,
+    Extend, FloatOps, IntOps, Interleave, MaskOps, Narrow, NarrowSaturate, NumOps, SignedIntOps,
 };
 use crate::{Isa, Mask, Simd};
 
@@ -380,15 +380,17 @@ unsafe impl NumOps<i32> for Avx2Isa {
     }
 }
 
+impl IntOps<i32> for Avx2Isa {
+    #[inline]
+    fn shift_left<const SHIFT: i32>(self, x: I32x8) -> I32x8 {
+        unsafe { _mm256_slli_epi32(x.0, SHIFT) }.into()
+    }
+}
+
 impl SignedIntOps<i32> for Avx2Isa {
     #[inline]
     fn neg(self, x: I32x8) -> I32x8 {
         unsafe { _mm256_sub_epi32(_mm256_setzero_si256(), x.0) }.into()
-    }
-
-    #[inline]
-    fn shift_left<const SHIFT: i32>(self, x: I32x8) -> I32x8 {
-        unsafe { _mm256_slli_epi32(x.0, SHIFT) }.into()
     }
 }
 
@@ -508,15 +510,17 @@ unsafe impl NumOps<i16> for Avx2Isa {
     }
 }
 
+impl IntOps<i16> for Avx2Isa {
+    #[inline]
+    fn shift_left<const SHIFT: i32>(self, x: I16x16) -> I16x16 {
+        unsafe { _mm256_slli_epi16(x.0, SHIFT) }.into()
+    }
+}
+
 impl SignedIntOps<i16> for Avx2Isa {
     #[inline]
     fn neg(self, x: I16x16) -> I16x16 {
         unsafe { _mm256_sub_epi16(_mm256_setzero_si256(), x.0) }.into()
-    }
-
-    #[inline]
-    fn shift_left<const SHIFT: i32>(self, x: I16x16) -> I16x16 {
-        unsafe { _mm256_slli_epi16(x.0, SHIFT) }.into()
     }
 }
 
@@ -661,12 +665,7 @@ unsafe impl NumOps<i8> for Avx2Isa {
     }
 }
 
-impl SignedIntOps<i8> for Avx2Isa {
-    #[inline]
-    fn neg(self, x: I8x32) -> I8x32 {
-        unsafe { _mm256_sub_epi8(_mm256_setzero_si256(), x.0) }.into()
-    }
-
+impl IntOps<i8> for Avx2Isa {
     #[inline]
     fn shift_left<const SHIFT: i32>(self, x: I8x32) -> I8x32 {
         let (x_lo, x_hi) = Extend::<i8>::extend(self, x);
@@ -676,6 +675,13 @@ impl SignedIntOps<i8> for Avx2Isa {
         let y_hi = i16_ops.shift_left::<SHIFT>(x_hi);
 
         self.narrow_truncate(y_lo, y_hi)
+    }
+}
+
+impl SignedIntOps<i8> for Avx2Isa {
+    #[inline]
+    fn neg(self, x: I8x32) -> I8x32 {
+        unsafe { _mm256_sub_epi8(_mm256_setzero_si256(), x.0) }.into()
     }
 }
 

--- a/rten-simd/src/arch/x86_64/avx2.rs
+++ b/rten-simd/src/arch/x86_64/avx2.rs
@@ -91,7 +91,7 @@ unsafe impl Isa for Avx2Isa {
         self
     }
 
-    fn u16(self) -> impl NumOps<u16, Simd = Self::U16> {
+    fn u16(self) -> impl IntOps<u16, Simd = Self::U16> {
         self
     }
 }
@@ -917,6 +917,13 @@ unsafe impl NumOps<u16> for Avx2Isa {
                 unsafe { *ptr.add(i) = xs[i] }
             }
         }
+    }
+}
+
+impl IntOps<u16> for Avx2Isa {
+    #[inline]
+    fn shift_left<const SHIFT: i32>(self, x: U16x16) -> U16x16 {
+        unsafe { _mm256_slli_epi16(x.0, SHIFT) }.into()
     }
 }
 

--- a/rten-simd/src/arch/x86_64/avx512.rs
+++ b/rten-simd/src/arch/x86_64/avx512.rs
@@ -24,7 +24,7 @@ use std::mem::transmute;
 
 use super::super::{lanes, simd_type};
 use crate::ops::{
-    Extend, FloatOps, Interleave, MaskOps, Narrow, NarrowSaturate, NumOps, SignedIntOps,
+    Extend, FloatOps, IntOps, Interleave, MaskOps, Narrow, NarrowSaturate, NumOps, SignedIntOps,
 };
 use crate::{Isa, Mask, Simd};
 
@@ -364,16 +364,18 @@ unsafe impl NumOps<i32> for Avx512Isa {
     }
 }
 
-impl SignedIntOps<i32> for Avx512Isa {
-    #[inline]
-    fn neg(self, x: I32x16) -> I32x16 {
-        unsafe { _mm512_sub_epi32(_mm512_setzero_si512(), x.0) }.into()
-    }
-
+impl IntOps<i32> for Avx512Isa {
     #[inline]
     fn shift_left<const SHIFT: i32>(self, x: I32x16) -> I32x16 {
         let count: I32x16 = self.splat(SHIFT);
         unsafe { _mm512_sllv_epi32(x.0, count.0) }.into()
+    }
+}
+
+impl SignedIntOps<i32> for Avx512Isa {
+    #[inline]
+    fn neg(self, x: I32x16) -> I32x16 {
+        unsafe { _mm512_sub_epi32(_mm512_setzero_si512(), x.0) }.into()
     }
 }
 
@@ -460,16 +462,18 @@ unsafe impl NumOps<i16> for Avx512Isa {
     }
 }
 
-impl SignedIntOps<i16> for Avx512Isa {
-    #[inline]
-    fn neg(self, x: I16x32) -> I16x32 {
-        unsafe { _mm512_sub_epi16(_mm512_setzero_si512(), x.0) }.into()
-    }
-
+impl IntOps<i16> for Avx512Isa {
     #[inline]
     fn shift_left<const SHIFT: i32>(self, x: I16x32) -> I16x32 {
         let count: I16x32 = self.splat(SHIFT as i16);
         unsafe { _mm512_sllv_epi16(x.0, count.0) }.into()
+    }
+}
+
+impl SignedIntOps<i16> for Avx512Isa {
+    #[inline]
+    fn neg(self, x: I16x32) -> I16x32 {
+        unsafe { _mm512_sub_epi16(_mm512_setzero_si512(), x.0) }.into()
     }
 }
 
@@ -590,12 +594,7 @@ unsafe impl NumOps<i8> for Avx512Isa {
     }
 }
 
-impl SignedIntOps<i8> for Avx512Isa {
-    #[inline]
-    fn neg(self, x: I8x64) -> I8x64 {
-        unsafe { _mm512_sub_epi8(_mm512_setzero_si512(), x.0) }.into()
-    }
-
+impl IntOps<i8> for Avx512Isa {
     #[inline]
     fn shift_left<const SHIFT: i32>(self, x: I8x64) -> I8x64 {
         let (x_lo, x_hi) = Extend::<i8>::extend(self, x);
@@ -607,6 +606,13 @@ impl SignedIntOps<i8> for Avx512Isa {
         );
 
         self.narrow_truncate(y_lo, y_hi)
+    }
+}
+
+impl SignedIntOps<i8> for Avx512Isa {
+    #[inline]
+    fn neg(self, x: I8x64) -> I8x64 {
+        unsafe { _mm512_sub_epi8(_mm512_setzero_si512(), x.0) }.into()
     }
 }
 

--- a/rten-simd/src/arch/x86_64/avx512.rs
+++ b/rten-simd/src/arch/x86_64/avx512.rs
@@ -91,7 +91,7 @@ unsafe impl Isa for Avx512Isa {
         self
     }
 
-    fn u16(self) -> impl NumOps<u16, Simd = Self::U16> {
+    fn u16(self) -> impl IntOps<u16, Simd = Self::U16> {
         self
     }
 }
@@ -853,6 +853,14 @@ unsafe impl NumOps<u16> for Avx512Isa {
     #[inline]
     unsafe fn store_ptr_mask(self, x: U16x32, ptr: *mut u16, mask: __mmask32) {
         unsafe { _mm512_mask_storeu_epi16(ptr as *mut i16, mask, x.0) }
+    }
+}
+
+impl IntOps<u16> for Avx512Isa {
+    #[inline]
+    fn shift_left<const SHIFT: i32>(self, x: U16x32) -> U16x32 {
+        let count: I16x32 = self.splat(SHIFT as i16);
+        unsafe { _mm512_sllv_epi16(x.0, count.0) }.into()
     }
 }
 

--- a/rten-simd/src/lib.rs
+++ b/rten-simd/src/lib.rs
@@ -119,9 +119,12 @@
 //!
 //! The [`NumOps`](ops::NumOps) trait provides operations that are available on
 //! all SIMD vectors. The sub-traits [`FloatOps`](ops::FloatOps) and
-//! [`SignedIntOps`](ops::SignedIntOps) provide operations that are only
-//! available on SIMD vectors with float and signed integer elements
-//! respectively.
+//! [`IntOps`](ops::IntOps) provide operations that are only available on SIMD
+//! vectors with float and integer elements respectively. There is also
+//! [`SignedIntOps`](ops::SignedIntOps) for signed integer operations. Finally
+//! there are additional traits for operations only available for other subsets
+//! of element types. For example [`Extend`](ops::Extend) widens each lane to
+//! one with twice the bit-width.
 //!
 //! SIMD operations (eg. [`NumOps::add`](ops::NumOps::add) take SIMD vectors as
 //! arguments. These vectors are either platform-specific types (eg.

--- a/rten-simd/src/ops.rs
+++ b/rten-simd/src/ops.rs
@@ -75,7 +75,7 @@ pub unsafe trait Isa: Copy {
     fn u8(self) -> impl NumOps<u8, Simd = Self::U8>;
 
     /// Operations on SIMD vectors with `u16` elements.
-    fn u16(self) -> impl NumOps<u16, Simd = Self::U16>;
+    fn u16(self) -> impl IntOps<u16, Simd = Self::U16>;
 }
 
 /// Get the [`NumOps`] implementation from an [`Isa`] for a given element type.
@@ -167,7 +167,8 @@ where
 impl_get_ops!(GetIntOps, int_ops, IntOps, i16);
 impl_get_ops!(GetIntOps, int_ops, IntOps, i32);
 impl_get_ops!(GetIntOps, int_ops, IntOps, i8);
-// TODO: Implement `IntOps` for unsigned types and add them here.
+impl_get_ops!(GetIntOps, int_ops, IntOps, u16);
+// TODO: Implement `IntOps` for u8
 
 /// Get the [`SignedIntOps`] implementation from an [`Isa`] for a given element type.
 ///
@@ -949,6 +950,29 @@ mod tests {
 
     test_float_ops!(float_ops_f32, f32, i32);
 
+    // Generate tests for operations available on unsigned integer types.
+    macro_rules! test_unsigned_int_ops {
+        ($modname:ident, $elem:ident) => {
+            mod $modname {
+                use super::{assert_simd_eq, test_simd_op, IntOps, Isa, NumOps, Simd, SimdOp};
+
+                #[test]
+                fn test_shift_left() {
+                    test_simd_op!(isa, {
+                        let ops = isa.$elem();
+
+                        let x = ops.splat(42);
+                        let y = ops.shift_left::<1>(x);
+                        let expected = ops.splat(42 << 1);
+                        assert_simd_eq!(y, expected);
+                    })
+                }
+            }
+        };
+    }
+
+    test_unsigned_int_ops!(uint_ops_u16, u16);
+
     // Generate tests for operations available on signed integer types.
     macro_rules! test_signed_int_ops {
         ($modname:ident, $elem:ident) => {
@@ -1002,7 +1026,7 @@ mod tests {
                 }
 
                 #[test]
-                fn test_shl() {
+                fn test_shift_left() {
                     test_simd_op!(isa, {
                         let ops = isa.$elem();
 

--- a/rten-vecmath/src/exp.rs
+++ b/rten-vecmath/src/exp.rs
@@ -2,7 +2,7 @@
 
 #![allow(clippy::excessive_precision)]
 
-use rten_simd::ops::{FloatOps, NumOps, SignedIntOps};
+use rten_simd::ops::{FloatOps, IntOps, NumOps};
 use rten_simd::{Isa, Simd, SimdUnaryOp};
 
 const INV_LOG2: f32 = std::f32::consts::LOG2_E; // aka. 1 / ln2


### PR DESCRIPTION
Add a new trait in-between `NumOps` and `SignedIntOps` in the hierarchy which provides operations available on all integer types. Move the `shift_left` method from `SignedIntOps` to `IntOps` and implement `IntOps` for all integer types except u8, as that is more involved for some architectures (ie. x64).