### PR TITLE
Support `pytorch_half_pixel` value for `coordinate_transform_mode`

### DIFF
--- a/rten-convert/rten_convert/schema_generated.py
+++ b/rten-convert/rten_convert/schema_generated.py
@@ -143,6 +143,7 @@ class CoordTransformMode(object):
     HalfPixel = 0
     Asymmetric = 1
     AlignCorners = 2
+    PytorchHalfPixel = 3
 
 
 class NearestMode(object):

--- a/src/model_builder.rs
+++ b/src/model_builder.rs
@@ -796,6 +796,9 @@ impl<'mb, 'a> GraphBuilder<'mb, 'a> {
                     CoordTransformMode::Asymmetric => sg::CoordTransformMode::Asymmetric,
                     CoordTransformMode::HalfPixel => sg::CoordTransformMode::HalfPixel,
                     CoordTransformMode::AlignCorners => sg::CoordTransformMode::AlignCorners,
+                    CoordTransformMode::PytorchHalfPixel => {
+                        sg::CoordTransformMode::PytorchHalfPixel
+                    }
                 };
                 let nearest_mode = match args.nearest_mode {
                     NearestMode::Ceil => sg::NearestMode::Ceil,

--- a/src/op_registry.rs
+++ b/src/op_registry.rs
@@ -817,6 +817,7 @@ impl_read_op!(Resize, attrs_as_resize_attrs, |attrs: sg::ResizeAttrs| {
         sg::CoordTransformMode::Asymmetric => CoordTransformMode::Asymmetric,
         sg::CoordTransformMode::HalfPixel => CoordTransformMode::HalfPixel,
         sg::CoordTransformMode::AlignCorners => CoordTransformMode::AlignCorners,
+        sg::CoordTransformMode::PytorchHalfPixel => CoordTransformMode::PytorchHalfPixel,
         _ => CoordTransformMode::default(),
     };
 

--- a/src/schema.fbs
+++ b/src/schema.fbs
@@ -155,7 +155,8 @@ enum DataType: ubyte {
 enum CoordTransformMode: ubyte {
   HalfPixel,
   Asymmetric,
-  AlignCorners
+  AlignCorners,
+  PytorchHalfPixel,
 }
 
 // Rounding modes supported by Resize operator when `ResizeMode` is `Nearest`.

--- a/src/schema_generated.rs
+++ b/src/schema_generated.rs
@@ -835,16 +835,17 @@ pub const ENUM_MIN_COORD_TRANSFORM_MODE: u8 = 0;
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
-pub const ENUM_MAX_COORD_TRANSFORM_MODE: u8 = 2;
+pub const ENUM_MAX_COORD_TRANSFORM_MODE: u8 = 3;
 #[deprecated(
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_COORD_TRANSFORM_MODE: [CoordTransformMode; 3] = [
+pub const ENUM_VALUES_COORD_TRANSFORM_MODE: [CoordTransformMode; 4] = [
     CoordTransformMode::HalfPixel,
     CoordTransformMode::Asymmetric,
     CoordTransformMode::AlignCorners,
+    CoordTransformMode::PytorchHalfPixel,
 ];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -855,17 +856,23 @@ impl CoordTransformMode {
     pub const HalfPixel: Self = Self(0);
     pub const Asymmetric: Self = Self(1);
     pub const AlignCorners: Self = Self(2);
+    pub const PytorchHalfPixel: Self = Self(3);
 
     pub const ENUM_MIN: u8 = 0;
-    pub const ENUM_MAX: u8 = 2;
-    pub const ENUM_VALUES: &'static [Self] =
-        &[Self::HalfPixel, Self::Asymmetric, Self::AlignCorners];
+    pub const ENUM_MAX: u8 = 3;
+    pub const ENUM_VALUES: &'static [Self] = &[
+        Self::HalfPixel,
+        Self::Asymmetric,
+        Self::AlignCorners,
+        Self::PytorchHalfPixel,
+    ];
     /// Returns the variant's name or "" if unknown.
     pub fn variant_name(self) -> Option<&'static str> {
         match self {
             Self::HalfPixel => Some("HalfPixel"),
             Self::Asymmetric => Some("Asymmetric"),
             Self::AlignCorners => Some("AlignCorners"),
+            Self::PytorchHalfPixel => Some("PytorchHalfPixel"),
             _ => None,
         }
     }


### PR DESCRIPTION
Support the `pytorch_half_pixel` transform mode in the `Resize` operator. See https://onnx.ai/onnx/operators/onnx__Resize.html#attributes.