### PR TITLE
Support `start` and `end` attributes for `Shape` operator

### DIFF
--- a/rten-convert/rten_convert/converter.py
+++ b/rten-convert/rten_convert/converter.py
@@ -991,8 +991,13 @@ def op_node_from_onnx_operator(
             )
 
         case "Shape":
-            op_reader.check_attr("end", "int", 0)
-            op_reader.check_attr("start", "int", 0)
+            attrs = sg.ShapeAttrsT()
+            start = op_reader.get_attr("start", "int", None)
+            if start is not None:
+                attrs.start = start
+            end = op_reader.get_attr("end", "int", None)
+            if end is not None:
+                attrs.end = end
 
         case "Softmax":
             attrs = sg.SoftmaxAttrsT()

--- a/rten-convert/rten_convert/schema_generated.py
+++ b/rten-convert/rten_convert/schema_generated.py
@@ -204,6 +204,7 @@ class OperatorAttrs(object):
     QuantizeLinearAttrs = 42
     DepthToSpaceAttrs = 43
     CastLikeAttrs = 44
+    ShapeAttrs = 45
 
 def OperatorAttrsCreator(unionType, table):
     from flatbuffers.table import Table
@@ -297,6 +298,8 @@ def OperatorAttrsCreator(unionType, table):
         return DepthToSpaceAttrsT.InitFromBuf(table.Bytes, table.Pos)
     if unionType == OperatorAttrs.CastLikeAttrs:
         return CastLikeAttrsT.InitFromBuf(table.Bytes, table.Pos)
+    if unionType == OperatorAttrs.ShapeAttrs:
+        return ShapeAttrsT.InitFromBuf(table.Bytes, table.Pos)
     return None
 
 
@@ -4631,6 +4634,96 @@ class ScatterNDAttrsT(object):
         return scatterNdattrs
 
 
+class ShapeAttrs(object):
+    __slots__ = ['_tab']
+
+    @classmethod
+    def GetRootAs(cls, buf, offset=0):
+        n = flatbuffers.encode.Get(flatbuffers.packer.uoffset, buf, offset)
+        x = ShapeAttrs()
+        x.Init(buf, n + offset)
+        return x
+
+    @classmethod
+    def GetRootAsShapeAttrs(cls, buf, offset=0):
+        """This method is deprecated. Please switch to GetRootAs."""
+        return cls.GetRootAs(buf, offset)
+    @classmethod
+    def ShapeAttrsBufferHasIdentifier(cls, buf, offset, size_prefixed=False):
+        return flatbuffers.util.BufferHasIdentifier(buf, offset, b"\x52\x54\x45\x4E", size_prefixed=size_prefixed)
+
+    # ShapeAttrs
+    def Init(self, buf, pos):
+        self._tab = flatbuffers.table.Table(buf, pos)
+
+    # ShapeAttrs
+    def Start(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
+        if o != 0:
+            return self._tab.Get(flatbuffers.number_types.Int32Flags, o + self._tab.Pos)
+        return None
+
+    # ShapeAttrs
+    def End(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(6))
+        if o != 0:
+            return self._tab.Get(flatbuffers.number_types.Int32Flags, o + self._tab.Pos)
+        return None
+
+def ShapeAttrsStart(builder):
+    builder.StartObject(2)
+
+def ShapeAttrsAddStart(builder, start):
+    builder.PrependInt32Slot(0, start, None)
+
+def ShapeAttrsAddEnd(builder, end):
+    builder.PrependInt32Slot(1, end, None)
+
+def ShapeAttrsEnd(builder):
+    return builder.EndObject()
+
+
+
+class ShapeAttrsT(object):
+
+    # ShapeAttrsT
+    def __init__(self):
+        self.start = None  # type: Optional[int]
+        self.end = None  # type: Optional[int]
+
+    @classmethod
+    def InitFromBuf(cls, buf, pos):
+        shapeAttrs = ShapeAttrs()
+        shapeAttrs.Init(buf, pos)
+        return cls.InitFromObj(shapeAttrs)
+
+    @classmethod
+    def InitFromPackedBuf(cls, buf, pos=0):
+        n = flatbuffers.encode.Get(flatbuffers.packer.uoffset, buf, pos)
+        return cls.InitFromBuf(buf, pos+n)
+
+    @classmethod
+    def InitFromObj(cls, shapeAttrs):
+        x = ShapeAttrsT()
+        x._UnPack(shapeAttrs)
+        return x
+
+    # ShapeAttrsT
+    def _UnPack(self, shapeAttrs):
+        if shapeAttrs is None:
+            return
+        self.start = shapeAttrs.Start()
+        self.end = shapeAttrs.End()
+
+    # ShapeAttrsT
+    def Pack(self, builder):
+        ShapeAttrsStart(builder)
+        ShapeAttrsAddStart(builder, self.start)
+        ShapeAttrsAddEnd(builder, self.end)
+        shapeAttrs = ShapeAttrsEnd(builder)
+        return shapeAttrs
+
+
 class SoftmaxAttrs(object):
     __slots__ = ['_tab']
 
@@ -5223,7 +5316,7 @@ class OperatorNodeT(object):
     def __init__(self):
         self.type = 0  # type: int
         self.attrsType = 0  # type: int
-        self.attrs = None  # type: Union[None, ArgMaxAttrsT, AveragePoolAttrsT, BatchNormalizationAttrsT, CastAttrsT, ConcatAttrsT, ConstantOfShapeAttrsT, ConvAttrsT, ConvTransposeAttrsT, FlattenAttrsT, GatherAttrsT, GemmAttrsT, GRUAttrsT, LeakyReluAttrsT, LSTMAttrsT, MaxPoolAttrsT, ReduceMeanAttrsT, ReshapeAttrsT, ResizeAttrsT, SplitAttrsT, SoftmaxAttrsT, TransposeAttrsT, ModAttrsT, ScatterElementsAttrsT, OneHotAttrsT, TopKAttrsT, HardSigmoidAttrsT, TriluAttrsT, ScatterNDAttrsT, NonMaxSuppressionAttrsT, LayerNormalizationAttrsT, RandomUniformAttrsT, EluAttrsT, RandomUniformLikeAttrsT, RandomNormalAttrsT, RandomNormalLikeAttrsT, GatherNDAttrsT, GeluAttrsT, EinsumAttrsT, IfAttrsT, PadAttrsT, DequantizeLinearAttrsT, QuantizeLinearAttrsT, DepthToSpaceAttrsT, CastLikeAttrsT]
+        self.attrs = None  # type: Union[None, ArgMaxAttrsT, AveragePoolAttrsT, BatchNormalizationAttrsT, CastAttrsT, ConcatAttrsT, ConstantOfShapeAttrsT, ConvAttrsT, ConvTransposeAttrsT, FlattenAttrsT, GatherAttrsT, GemmAttrsT, GRUAttrsT, LeakyReluAttrsT, LSTMAttrsT, MaxPoolAttrsT, ReduceMeanAttrsT, ReshapeAttrsT, ResizeAttrsT, SplitAttrsT, SoftmaxAttrsT, TransposeAttrsT, ModAttrsT, ScatterElementsAttrsT, OneHotAttrsT, TopKAttrsT, HardSigmoidAttrsT, TriluAttrsT, ScatterNDAttrsT, NonMaxSuppressionAttrsT, LayerNormalizationAttrsT, RandomUniformAttrsT, EluAttrsT, RandomUniformLikeAttrsT, RandomNormalAttrsT, RandomNormalLikeAttrsT, GatherNDAttrsT, GeluAttrsT, EinsumAttrsT, IfAttrsT, PadAttrsT, DequantizeLinearAttrsT, QuantizeLinearAttrsT, DepthToSpaceAttrsT, CastLikeAttrsT, ShapeAttrsT]
         self.inputs = None  # type: List[int]
         self.outputs = None  # type: List[int]
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1369,7 +1369,7 @@ mod tests {
         let input_b_id = g.add_value(Some("input_b"), None, None);
 
         let (add_op, add_out) = g.add_simple_op("add", Add {}, &[input_a_id, input_b_id]);
-        let (shape_op, shape_out) = g.add_simple_op("shape", Shape {}, &[input_a_id]);
+        let (shape_op, shape_out) = g.add_simple_op("shape", Shape::default(), &[input_a_id]);
 
         // The execution plan could run operators in either order and produce
         // the correct output. Since the `Add` op has the _potential_ to run in
@@ -1624,7 +1624,12 @@ mod tests {
         // as opposed to passing a shorter input list. This enables omitting
         // an input but still providing subsequent ones.
         let output = g.add_value(None, None, None);
-        g.add_op(Some("shape"), Box::new(Shape {}), &[None], &[Some(output)]);
+        g.add_op(
+            Some("shape"),
+            Box::new(Shape::default()),
+            &[None],
+            &[Some(output)],
+        );
 
         let results = g.run(vec![], &[output], None, None);
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -887,7 +887,7 @@ mod tests {
     use crate::ops;
     use crate::ops::{
         BoxOrder, CoordTransformMode, DataType, DepthToSpaceMode, NearestMode, OpError, Output,
-        ResizeMode, Scalar,
+        ResizeMode, Scalar, Shape,
     };
     use crate::{ModelLoadError, OpRegistry, ReadOpError};
 
@@ -1214,7 +1214,12 @@ mod tests {
 
         let output_node = graph_builder.add_value("output", None, None);
         graph_builder.add_output(output_node);
-        graph_builder.add_operator("shape", OpType::Shape, &[None], &[output_node]);
+        graph_builder.add_operator(
+            "shape",
+            OpType::Shape(Shape::default()),
+            &[None],
+            &[output_node],
+        );
 
         let graph = graph_builder.finish();
         builder.set_graph(graph);
@@ -1597,7 +1602,10 @@ mod tests {
 
         add_operator!(Round, [input_node]);
 
-        add_operator!(Shape, [input_node]);
+        add_operator!(Shape, [input_node], {
+            start: Some(1),
+            end: Some(-1),
+        });
         add_operator!(Sigmoid, [input_node]);
         add_operator!(Sign, [input_node]);
         add_operator!(Sin, [input_node]);

--- a/src/model_builder.rs
+++ b/src/model_builder.rs
@@ -12,7 +12,7 @@ use crate::ops::{
     Gelu, Gemm, HardSigmoid, InstanceNormalization, LayerNormalization, LeakyRelu, LogSoftmax,
     MaxPool, Mod, NearestMode, NonMaxSuppression, OneHot, Padding, QuantizeLinear, ReduceMax,
     ReduceMean, ReduceMin, ReduceProd, ReduceSum, ReduceSumSquare, Reshape, Resize, ResizeMode,
-    Scalar, ScatterElements, ScatterReduction, Softmax, Split, TopK, Transpose, Trilu,
+    Scalar, ScatterElements, ScatterReduction, Shape, Softmax, Split, TopK, Transpose, Trilu,
 };
 use crate::schema_generated as sg;
 
@@ -119,7 +119,7 @@ pub enum OpType<'a> {
     Round,
     QuantizeLinear(QuantizeLinear),
     ScatterElements(ScatterElements),
-    Shape,
+    Shape(Shape),
     Sigmoid,
     Sign,
     Sin,
@@ -828,7 +828,12 @@ impl<'mb, 'a> GraphBuilder<'mb, 'a> {
                     }
                 })
             }
-            OpType::Shape => op!(Shape),
+            OpType::Shape(args) => op_with_attrs!(Shape, ShapeAttrs, {
+                sg::ShapeAttrsArgs {
+                    start: args.start,
+                    end: args.end,
+                }
+            }),
             OpType::Sigmoid => op!(Sigmoid),
             OpType::Slice => op!(Slice),
             OpType::Sin => op!(Sin),

--- a/src/op_registry.rs
+++ b/src/op_registry.rs
@@ -847,7 +847,21 @@ impl_read_op!(
         })
     }
 );
-impl_read_op!(Shape);
+
+impl ReadOp for ops::Shape {
+    fn op_type() -> sg::OperatorType {
+        OperatorType::Shape
+    }
+
+    fn read(op: &OperatorNode, _ctx: &dyn OpLoadContext) -> Result<Self, ReadOpError> {
+        // Shape attributes are optional for backwards compatibility
+        let attrs = op.attrs_as_shape_attrs();
+        let start = attrs.and_then(|a| a.start());
+        let end = attrs.and_then(|a| a.end());
+        Ok(ops::Shape { start, end })
+    }
+}
+
 impl_read_op!(Sigmoid);
 impl_read_op!(Sign);
 impl_read_op!(Sin);

--- a/src/schema.fbs
+++ b/src/schema.fbs
@@ -221,6 +221,7 @@ union OperatorAttrs {
   QuantizeLinearAttrs,
   DepthToSpaceAttrs,
   CastLikeAttrs,
+  ShapeAttrs,
 }
 
 table ArgMaxAttrs {
@@ -465,6 +466,11 @@ table ScatterElementsAttrs {
 
 table ScatterNDAttrs {
   reduction:ScatterReduction;
+}
+
+table ShapeAttrs {
+  start:int = null;
+  end:int = null;
 }
 
 table SoftmaxAttrs {

--- a/src/schema_generated.rs
+++ b/src/schema_generated.rs
@@ -1130,13 +1130,13 @@ pub const ENUM_MIN_OPERATOR_ATTRS: u8 = 0;
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
-pub const ENUM_MAX_OPERATOR_ATTRS: u8 = 44;
+pub const ENUM_MAX_OPERATOR_ATTRS: u8 = 45;
 #[deprecated(
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_OPERATOR_ATTRS: [OperatorAttrs; 45] = [
+pub const ENUM_VALUES_OPERATOR_ATTRS: [OperatorAttrs; 46] = [
     OperatorAttrs::NONE,
     OperatorAttrs::ArgMaxAttrs,
     OperatorAttrs::AveragePoolAttrs,
@@ -1182,6 +1182,7 @@ pub const ENUM_VALUES_OPERATOR_ATTRS: [OperatorAttrs; 45] = [
     OperatorAttrs::QuantizeLinearAttrs,
     OperatorAttrs::DepthToSpaceAttrs,
     OperatorAttrs::CastLikeAttrs,
+    OperatorAttrs::ShapeAttrs,
 ];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -1234,9 +1235,10 @@ impl OperatorAttrs {
     pub const QuantizeLinearAttrs: Self = Self(42);
     pub const DepthToSpaceAttrs: Self = Self(43);
     pub const CastLikeAttrs: Self = Self(44);
+    pub const ShapeAttrs: Self = Self(45);
 
     pub const ENUM_MIN: u8 = 0;
-    pub const ENUM_MAX: u8 = 44;
+    pub const ENUM_MAX: u8 = 45;
     pub const ENUM_VALUES: &'static [Self] = &[
         Self::NONE,
         Self::ArgMaxAttrs,
@@ -1283,6 +1285,7 @@ impl OperatorAttrs {
         Self::QuantizeLinearAttrs,
         Self::DepthToSpaceAttrs,
         Self::CastLikeAttrs,
+        Self::ShapeAttrs,
     ];
     /// Returns the variant's name or "" if unknown.
     pub fn variant_name(self) -> Option<&'static str> {
@@ -1332,6 +1335,7 @@ impl OperatorAttrs {
             Self::QuantizeLinearAttrs => Some("QuantizeLinearAttrs"),
             Self::DepthToSpaceAttrs => Some("DepthToSpaceAttrs"),
             Self::CastLikeAttrs => Some("CastLikeAttrs"),
+            Self::ShapeAttrs => Some("ShapeAttrs"),
             _ => None,
         }
     }
@@ -7506,6 +7510,129 @@ impl core::fmt::Debug for ScatterNDAttrs<'_> {
         ds.finish()
     }
 }
+pub enum ShapeAttrsOffset {}
+#[derive(Copy, Clone, PartialEq)]
+
+pub struct ShapeAttrs<'a> {
+    pub _tab: flatbuffers::Table<'a>,
+}
+
+impl<'a> flatbuffers::Follow<'a> for ShapeAttrs<'a> {
+    type Inner = ShapeAttrs<'a>;
+    #[inline]
+    unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self {
+            _tab: flatbuffers::Table::new(buf, loc),
+        }
+    }
+}
+
+impl<'a> ShapeAttrs<'a> {
+    pub const VT_START: flatbuffers::VOffsetT = 4;
+    pub const VT_END: flatbuffers::VOffsetT = 6;
+
+    #[inline]
+    pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+        ShapeAttrs { _tab: table }
+    }
+    #[allow(unused_mut)]
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
+        args: &'args ShapeAttrsArgs,
+    ) -> flatbuffers::WIPOffset<ShapeAttrs<'bldr>> {
+        let mut builder = ShapeAttrsBuilder::new(_fbb);
+        if let Some(x) = args.end {
+            builder.add_end(x);
+        }
+        if let Some(x) = args.start {
+            builder.add_start(x);
+        }
+        builder.finish()
+    }
+
+    #[inline]
+    pub fn start(&self) -> Option<i32> {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe { self._tab.get::<i32>(ShapeAttrs::VT_START, None) }
+    }
+    #[inline]
+    pub fn end(&self) -> Option<i32> {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe { self._tab.get::<i32>(ShapeAttrs::VT_END, None) }
+    }
+}
+
+impl flatbuffers::Verifiable for ShapeAttrs<'_> {
+    #[inline]
+    fn run_verifier(
+        v: &mut flatbuffers::Verifier,
+        pos: usize,
+    ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+        use self::flatbuffers::Verifiable;
+        v.visit_table(pos)?
+            .visit_field::<i32>("start", Self::VT_START, false)?
+            .visit_field::<i32>("end", Self::VT_END, false)?
+            .finish();
+        Ok(())
+    }
+}
+pub struct ShapeAttrsArgs {
+    pub start: Option<i32>,
+    pub end: Option<i32>,
+}
+impl<'a> Default for ShapeAttrsArgs {
+    #[inline]
+    fn default() -> Self {
+        ShapeAttrsArgs {
+            start: None,
+            end: None,
+        }
+    }
+}
+
+pub struct ShapeAttrsBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+    fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
+    start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> ShapeAttrsBuilder<'a, 'b, A> {
+    #[inline]
+    pub fn add_start(&mut self, start: i32) {
+        self.fbb_
+            .push_slot_always::<i32>(ShapeAttrs::VT_START, start);
+    }
+    #[inline]
+    pub fn add_end(&mut self, end: i32) {
+        self.fbb_.push_slot_always::<i32>(ShapeAttrs::VT_END, end);
+    }
+    #[inline]
+    pub fn new(
+        _fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
+    ) -> ShapeAttrsBuilder<'a, 'b, A> {
+        let start = _fbb.start_table();
+        ShapeAttrsBuilder {
+            fbb_: _fbb,
+            start_: start,
+        }
+    }
+    #[inline]
+    pub fn finish(self) -> flatbuffers::WIPOffset<ShapeAttrs<'a>> {
+        let o = self.fbb_.end_table(self.start_);
+        flatbuffers::WIPOffset::new(o.value())
+    }
+}
+
+impl core::fmt::Debug for ShapeAttrs<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut ds = f.debug_struct("ShapeAttrs");
+        ds.field("start", &self.start());
+        ds.field("end", &self.end());
+        ds.finish()
+    }
+}
 pub enum SoftmaxAttrsOffset {}
 #[derive(Copy, Clone, PartialEq)]
 
@@ -8835,6 +8962,21 @@ impl<'a> OperatorNode<'a> {
             None
         }
     }
+
+    #[inline]
+    #[allow(non_snake_case)]
+    pub fn attrs_as_shape_attrs(&self) -> Option<ShapeAttrs<'a>> {
+        if self.attrs_type() == OperatorAttrs::ShapeAttrs {
+            self.attrs().map(|t| {
+                // Safety:
+                // Created from a valid Table for this object
+                // Which contains a valid union in this slot
+                unsafe { ShapeAttrs::init_from_table(t) }
+            })
+        } else {
+            None
+        }
+    }
 }
 
 impl flatbuffers::Verifiable for OperatorNode<'_> {
@@ -8892,6 +9034,7 @@ impl flatbuffers::Verifiable for OperatorNode<'_> {
           OperatorAttrs::QuantizeLinearAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<QuantizeLinearAttrs>>("OperatorAttrs::QuantizeLinearAttrs", pos),
           OperatorAttrs::DepthToSpaceAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<DepthToSpaceAttrs>>("OperatorAttrs::DepthToSpaceAttrs", pos),
           OperatorAttrs::CastLikeAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<CastLikeAttrs>>("OperatorAttrs::CastLikeAttrs", pos),
+          OperatorAttrs::ShapeAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<ShapeAttrs>>("OperatorAttrs::ShapeAttrs", pos),
           _ => Ok(()),
         }
      })?
@@ -9409,6 +9552,16 @@ impl core::fmt::Debug for OperatorNode<'_> {
             }
             OperatorAttrs::CastLikeAttrs => {
                 if let Some(x) = self.attrs_as_cast_like_attrs() {
+                    ds.field("attrs", &x)
+                } else {
+                    ds.field(
+                        "attrs",
+                        &"InvalidFlatbuffer: Union discriminant does not match value.",
+                    )
+                }
+            }
+            OperatorAttrs::ShapeAttrs => {
+                if let Some(x) = self.attrs_as_shape_attrs() {
                     ds.field("attrs", &x)
                 } else {
                     ds.field(


### PR DESCRIPTION
 - Support attributes for `Shape` operator in rten model files. This is optional for backwards compatibility.
 - Support `start` and `end` attributes in `Shape` op implementation

**TODO:**
- [x] Allow `start` and `end` values to be out of range, in which case they are clamped, per [the spec](https://onnx.ai/onnx/operators/onnx__Shape.html)