### PR TITLE
Implement Dropout operator

### DIFF
--- a/rten-convert/rten_convert/converter.py
+++ b/rten-convert/rten_convert/converter.py
@@ -816,6 +816,10 @@ def op_node_from_onnx_operator(
             attrs.blockSize = attr_reader.require_attr("blocksize", "int")
             attrs.mode = attr_reader.get_enum_attr("mode", sg.DepthToSpaceMode, "dcr")
 
+        case "Dropout":
+            attrs = sg.DropoutAttrsT()
+            attrs.seed = attr_reader.get_attr("seed", "int", None)
+
         case "Einsum":
             attrs = sg.EinsumAttrsT()
             attrs.equation = attr_reader.require_attr("equation", "string")

--- a/rten-convert/rten_convert/schema_generated.py
+++ b/rten-convert/rten_convert/schema_generated.py
@@ -119,6 +119,7 @@ class OperatorType(object):
     DepthToSpace = 109
     ConvInteger = 110
     CastLike = 111
+    Dropout = 112
 
 
 class RNNDirection(object):
@@ -205,6 +206,7 @@ class OperatorAttrs(object):
     DepthToSpaceAttrs = 43
     CastLikeAttrs = 44
     ShapeAttrs = 45
+    DropoutAttrs = 46
 
 def OperatorAttrsCreator(unionType, table):
     from flatbuffers.table import Table
@@ -300,6 +302,8 @@ def OperatorAttrsCreator(unionType, table):
         return CastLikeAttrsT.InitFromBuf(table.Bytes, table.Pos)
     if unionType == OperatorAttrs.ShapeAttrs:
         return ShapeAttrsT.InitFromBuf(table.Bytes, table.Pos)
+    if unionType == OperatorAttrs.DropoutAttrs:
+        return DropoutAttrsT.InitFromBuf(table.Bytes, table.Pos)
     return None
 
 
@@ -1111,6 +1115,83 @@ class DepthToSpaceAttrsT(object):
         DepthToSpaceAttrsAddBlockSize(builder, self.blockSize)
         depthToSpaceAttrs = DepthToSpaceAttrsEnd(builder)
         return depthToSpaceAttrs
+
+
+class DropoutAttrs(object):
+    __slots__ = ['_tab']
+
+    @classmethod
+    def GetRootAs(cls, buf, offset=0):
+        n = flatbuffers.encode.Get(flatbuffers.packer.uoffset, buf, offset)
+        x = DropoutAttrs()
+        x.Init(buf, n + offset)
+        return x
+
+    @classmethod
+    def GetRootAsDropoutAttrs(cls, buf, offset=0):
+        """This method is deprecated. Please switch to GetRootAs."""
+        return cls.GetRootAs(buf, offset)
+    @classmethod
+    def DropoutAttrsBufferHasIdentifier(cls, buf, offset, size_prefixed=False):
+        return flatbuffers.util.BufferHasIdentifier(buf, offset, b"\x52\x54\x45\x4E", size_prefixed=size_prefixed)
+
+    # DropoutAttrs
+    def Init(self, buf, pos):
+        self._tab = flatbuffers.table.Table(buf, pos)
+
+    # DropoutAttrs
+    def Seed(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
+        if o != 0:
+            return self._tab.Get(flatbuffers.number_types.Int32Flags, o + self._tab.Pos)
+        return None
+
+def DropoutAttrsStart(builder):
+    builder.StartObject(1)
+
+def DropoutAttrsAddSeed(builder, seed):
+    builder.PrependInt32Slot(0, seed, None)
+
+def DropoutAttrsEnd(builder):
+    return builder.EndObject()
+
+
+
+class DropoutAttrsT(object):
+
+    # DropoutAttrsT
+    def __init__(self):
+        self.seed = None  # type: Optional[int]
+
+    @classmethod
+    def InitFromBuf(cls, buf, pos):
+        dropoutAttrs = DropoutAttrs()
+        dropoutAttrs.Init(buf, pos)
+        return cls.InitFromObj(dropoutAttrs)
+
+    @classmethod
+    def InitFromPackedBuf(cls, buf, pos=0):
+        n = flatbuffers.encode.Get(flatbuffers.packer.uoffset, buf, pos)
+        return cls.InitFromBuf(buf, pos+n)
+
+    @classmethod
+    def InitFromObj(cls, dropoutAttrs):
+        x = DropoutAttrsT()
+        x._UnPack(dropoutAttrs)
+        return x
+
+    # DropoutAttrsT
+    def _UnPack(self, dropoutAttrs):
+        if dropoutAttrs is None:
+            return
+        self.seed = dropoutAttrs.Seed()
+
+    # DropoutAttrsT
+    def Pack(self, builder):
+        DropoutAttrsStart(builder)
+        DropoutAttrsAddSeed(builder, self.seed)
+        dropoutAttrs = DropoutAttrsEnd(builder)
+        return dropoutAttrs
 
 
 class IntScalar(object):
@@ -5316,7 +5397,7 @@ class OperatorNodeT(object):
     def __init__(self):
         self.type = 0  # type: int
         self.attrsType = 0  # type: int
-        self.attrs = None  # type: Union[None, ArgMaxAttrsT, AveragePoolAttrsT, BatchNormalizationAttrsT, CastAttrsT, ConcatAttrsT, ConstantOfShapeAttrsT, ConvAttrsT, ConvTransposeAttrsT, FlattenAttrsT, GatherAttrsT, GemmAttrsT, GRUAttrsT, LeakyReluAttrsT, LSTMAttrsT, MaxPoolAttrsT, ReduceMeanAttrsT, ReshapeAttrsT, ResizeAttrsT, SplitAttrsT, SoftmaxAttrsT, TransposeAttrsT, ModAttrsT, ScatterElementsAttrsT, OneHotAttrsT, TopKAttrsT, HardSigmoidAttrsT, TriluAttrsT, ScatterNDAttrsT, NonMaxSuppressionAttrsT, LayerNormalizationAttrsT, RandomUniformAttrsT, EluAttrsT, RandomUniformLikeAttrsT, RandomNormalAttrsT, RandomNormalLikeAttrsT, GatherNDAttrsT, GeluAttrsT, EinsumAttrsT, IfAttrsT, PadAttrsT, DequantizeLinearAttrsT, QuantizeLinearAttrsT, DepthToSpaceAttrsT, CastLikeAttrsT, ShapeAttrsT]
+        self.attrs = None  # type: Union[None, ArgMaxAttrsT, AveragePoolAttrsT, BatchNormalizationAttrsT, CastAttrsT, ConcatAttrsT, ConstantOfShapeAttrsT, ConvAttrsT, ConvTransposeAttrsT, FlattenAttrsT, GatherAttrsT, GemmAttrsT, GRUAttrsT, LeakyReluAttrsT, LSTMAttrsT, MaxPoolAttrsT, ReduceMeanAttrsT, ReshapeAttrsT, ResizeAttrsT, SplitAttrsT, SoftmaxAttrsT, TransposeAttrsT, ModAttrsT, ScatterElementsAttrsT, OneHotAttrsT, TopKAttrsT, HardSigmoidAttrsT, TriluAttrsT, ScatterNDAttrsT, NonMaxSuppressionAttrsT, LayerNormalizationAttrsT, RandomUniformAttrsT, EluAttrsT, RandomUniformLikeAttrsT, RandomNormalAttrsT, RandomNormalLikeAttrsT, GatherNDAttrsT, GeluAttrsT, EinsumAttrsT, IfAttrsT, PadAttrsT, DequantizeLinearAttrsT, QuantizeLinearAttrsT, DepthToSpaceAttrsT, CastLikeAttrsT, ShapeAttrsT, DropoutAttrsT]
         self.inputs = None  # type: List[int]
         self.outputs = None  # type: List[int]
 

--- a/src/model_builder.rs
+++ b/src/model_builder.rs
@@ -17,7 +17,7 @@ use crate::ops::{
 use crate::schema_generated as sg;
 
 #[cfg(feature = "random")]
-use crate::ops::{RandomNormal, RandomNormalLike, RandomUniform, RandomUniformLike};
+use crate::ops::{Dropout, RandomNormal, RandomNormalLike, RandomUniform, RandomUniformLike};
 
 /// Struct like `crate::ops::If` with subgraph attributes replaced by
 /// pre-serialized graphs.
@@ -51,6 +51,8 @@ pub enum OpType<'a> {
     DequantizeLinear(DequantizeLinear),
     DepthToSpace(DepthToSpace),
     Div,
+    #[cfg(feature = "random")]
+    Dropout(Dropout),
     DynamicQuantizeLinear,
     Einsum(Einsum),
     Elu(Elu),
@@ -546,6 +548,12 @@ impl<'mb, 'a> GraphBuilder<'mb, 'a> {
                 }
             ),
             OpType::Div => op!(Div),
+            #[cfg(feature = "random")]
+            OpType::Dropout(args) => op_with_attrs!(
+                Dropout,
+                DropoutAttrs,
+                sg::DropoutAttrsArgs { seed: args.seed }
+            ),
             OpType::DynamicQuantizeLinear => op!(DynamicQuantizeLinear),
             OpType::Einsum(args) => {
                 let equation = self.builder.create_string(&args.equation);

--- a/src/op_registry.rs
+++ b/src/op_registry.rs
@@ -105,6 +105,10 @@ impl OpRegistry {
         register_op!(DequantizeLinear);
         register_op!(DepthToSpace);
         register_op!(Div);
+
+        #[cfg(feature = "random")]
+        register_op!(Dropout);
+
         register_op!(DynamicQuantizeLinear);
         register_op!(Einsum);
         register_op!(Elu);
@@ -154,13 +158,12 @@ impl OpRegistry {
         register_op!(QuantizeLinear);
 
         #[cfg(feature = "random")]
-        register_op!(RandomNormal);
-        #[cfg(feature = "random")]
-        register_op!(RandomNormalLike);
-        #[cfg(feature = "random")]
-        register_op!(RandomUniform);
-        #[cfg(feature = "random")]
-        register_op!(RandomUniformLike);
+        {
+            register_op!(RandomNormal);
+            register_op!(RandomNormalLike);
+            register_op!(RandomUniform);
+            register_op!(RandomUniformLike);
+        }
 
         register_op!(Range);
         register_op!(Reciprocal);
@@ -511,6 +514,14 @@ impl_read_op!(
     }
 );
 impl_read_op!(Div);
+
+#[cfg(feature = "random")]
+impl_read_op!(
+    Dropout,
+    attrs_as_dropout_attrs,
+    |attrs: sg::DropoutAttrs| { Ok(ops::Dropout { seed: attrs.seed() }) }
+);
+
 impl_read_op!(DynamicQuantizeLinear);
 impl_read_op!(Einsum, attrs_as_einsum_attrs, |attrs: sg::EinsumAttrs| {
     Ok(ops::Einsum {

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -101,7 +101,7 @@ pub use quantize::{
 };
 
 #[cfg(feature = "random")]
-pub use random::{RandomNormal, RandomNormalLike, RandomUniform, RandomUniformLike};
+pub use random::{Dropout, RandomNormal, RandomNormalLike, RandomUniform, RandomUniformLike};
 
 pub use reduce::{
     arg_max, arg_min, cum_sum, nonzero, reduce_l2, reduce_max, reduce_mean, reduce_min,
@@ -950,6 +950,13 @@ impl<'a> InputList<'a> {
     /// This will copy the existing inputs into a new owned vector.
     pub fn push<I: Into<Input<'a>>>(&mut self, inp: I) {
         self.inputs.to_mut().push(Some(inp.into()))
+    }
+
+    /// Append an optional input to the list.
+    ///
+    /// This will copy the existing inputs into a new owned vector.
+    pub fn push_optional<I: Into<Input<'a>>>(&mut self, inp: Option<I>) {
+        self.inputs.to_mut().push(inp.map(|inp| inp.into()))
     }
 
     /// Construct an input list from a slice of non-optional inputs.

--- a/src/schema.fbs
+++ b/src/schema.fbs
@@ -125,6 +125,7 @@ enum OperatorType: ubyte {
   DepthToSpace,
   ConvInteger,
   CastLike,
+  Dropout,
 }
 
 enum RNNDirection: ubyte {
@@ -222,6 +223,7 @@ union OperatorAttrs {
   DepthToSpaceAttrs,
   CastLikeAttrs,
   ShapeAttrs,
+  DropoutAttrs,
 }
 
 table ArgMaxAttrs {
@@ -265,6 +267,10 @@ enum DepthToSpaceMode: ubyte {
 table DepthToSpaceAttrs {
   mode:DepthToSpaceMode;
   block_size:uint;
+}
+
+table DropoutAttrs {
+  seed:int = null;
 }
 
 union Scalar {

--- a/src/schema_generated.rs
+++ b/src/schema_generated.rs
@@ -18,13 +18,13 @@ pub const ENUM_MIN_OPERATOR_TYPE: u8 = 0;
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
-pub const ENUM_MAX_OPERATOR_TYPE: u8 = 111;
+pub const ENUM_MAX_OPERATOR_TYPE: u8 = 112;
 #[deprecated(
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 112] = [
+pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 113] = [
     OperatorType::Add,
     OperatorType::ArgMin,
     OperatorType::ArgMax,
@@ -137,6 +137,7 @@ pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 112] = [
     OperatorType::DepthToSpace,
     OperatorType::ConvInteger,
     OperatorType::CastLike,
+    OperatorType::Dropout,
 ];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -256,9 +257,10 @@ impl OperatorType {
     pub const DepthToSpace: Self = Self(109);
     pub const ConvInteger: Self = Self(110);
     pub const CastLike: Self = Self(111);
+    pub const Dropout: Self = Self(112);
 
     pub const ENUM_MIN: u8 = 0;
-    pub const ENUM_MAX: u8 = 111;
+    pub const ENUM_MAX: u8 = 112;
     pub const ENUM_VALUES: &'static [Self] = &[
         Self::Add,
         Self::ArgMin,
@@ -372,6 +374,7 @@ impl OperatorType {
         Self::DepthToSpace,
         Self::ConvInteger,
         Self::CastLike,
+        Self::Dropout,
     ];
     /// Returns the variant's name or "" if unknown.
     pub fn variant_name(self) -> Option<&'static str> {
@@ -488,6 +491,7 @@ impl OperatorType {
             Self::DepthToSpace => Some("DepthToSpace"),
             Self::ConvInteger => Some("ConvInteger"),
             Self::CastLike => Some("CastLike"),
+            Self::Dropout => Some("Dropout"),
             _ => None,
         }
     }
@@ -1130,13 +1134,13 @@ pub const ENUM_MIN_OPERATOR_ATTRS: u8 = 0;
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
-pub const ENUM_MAX_OPERATOR_ATTRS: u8 = 45;
+pub const ENUM_MAX_OPERATOR_ATTRS: u8 = 46;
 #[deprecated(
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_OPERATOR_ATTRS: [OperatorAttrs; 46] = [
+pub const ENUM_VALUES_OPERATOR_ATTRS: [OperatorAttrs; 47] = [
     OperatorAttrs::NONE,
     OperatorAttrs::ArgMaxAttrs,
     OperatorAttrs::AveragePoolAttrs,
@@ -1183,6 +1187,7 @@ pub const ENUM_VALUES_OPERATOR_ATTRS: [OperatorAttrs; 46] = [
     OperatorAttrs::DepthToSpaceAttrs,
     OperatorAttrs::CastLikeAttrs,
     OperatorAttrs::ShapeAttrs,
+    OperatorAttrs::DropoutAttrs,
 ];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -1236,9 +1241,10 @@ impl OperatorAttrs {
     pub const DepthToSpaceAttrs: Self = Self(43);
     pub const CastLikeAttrs: Self = Self(44);
     pub const ShapeAttrs: Self = Self(45);
+    pub const DropoutAttrs: Self = Self(46);
 
     pub const ENUM_MIN: u8 = 0;
-    pub const ENUM_MAX: u8 = 45;
+    pub const ENUM_MAX: u8 = 46;
     pub const ENUM_VALUES: &'static [Self] = &[
         Self::NONE,
         Self::ArgMaxAttrs,
@@ -1286,6 +1292,7 @@ impl OperatorAttrs {
         Self::DepthToSpaceAttrs,
         Self::CastLikeAttrs,
         Self::ShapeAttrs,
+        Self::DropoutAttrs,
     ];
     /// Returns the variant's name or "" if unknown.
     pub fn variant_name(self) -> Option<&'static str> {
@@ -1336,6 +1343,7 @@ impl OperatorAttrs {
             Self::DepthToSpaceAttrs => Some("DepthToSpaceAttrs"),
             Self::CastLikeAttrs => Some("CastLikeAttrs"),
             Self::ShapeAttrs => Some("ShapeAttrs"),
+            Self::DropoutAttrs => Some("DropoutAttrs"),
             _ => None,
         }
     }
@@ -3038,6 +3046,108 @@ impl core::fmt::Debug for DepthToSpaceAttrs<'_> {
         let mut ds = f.debug_struct("DepthToSpaceAttrs");
         ds.field("mode", &self.mode());
         ds.field("block_size", &self.block_size());
+        ds.finish()
+    }
+}
+pub enum DropoutAttrsOffset {}
+#[derive(Copy, Clone, PartialEq)]
+
+pub struct DropoutAttrs<'a> {
+    pub _tab: flatbuffers::Table<'a>,
+}
+
+impl<'a> flatbuffers::Follow<'a> for DropoutAttrs<'a> {
+    type Inner = DropoutAttrs<'a>;
+    #[inline]
+    unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self {
+            _tab: flatbuffers::Table::new(buf, loc),
+        }
+    }
+}
+
+impl<'a> DropoutAttrs<'a> {
+    pub const VT_SEED: flatbuffers::VOffsetT = 4;
+
+    #[inline]
+    pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+        DropoutAttrs { _tab: table }
+    }
+    #[allow(unused_mut)]
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
+        args: &'args DropoutAttrsArgs,
+    ) -> flatbuffers::WIPOffset<DropoutAttrs<'bldr>> {
+        let mut builder = DropoutAttrsBuilder::new(_fbb);
+        if let Some(x) = args.seed {
+            builder.add_seed(x);
+        }
+        builder.finish()
+    }
+
+    #[inline]
+    pub fn seed(&self) -> Option<i32> {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe { self._tab.get::<i32>(DropoutAttrs::VT_SEED, None) }
+    }
+}
+
+impl flatbuffers::Verifiable for DropoutAttrs<'_> {
+    #[inline]
+    fn run_verifier(
+        v: &mut flatbuffers::Verifier,
+        pos: usize,
+    ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+        use self::flatbuffers::Verifiable;
+        v.visit_table(pos)?
+            .visit_field::<i32>("seed", Self::VT_SEED, false)?
+            .finish();
+        Ok(())
+    }
+}
+pub struct DropoutAttrsArgs {
+    pub seed: Option<i32>,
+}
+impl<'a> Default for DropoutAttrsArgs {
+    #[inline]
+    fn default() -> Self {
+        DropoutAttrsArgs { seed: None }
+    }
+}
+
+pub struct DropoutAttrsBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+    fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
+    start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> DropoutAttrsBuilder<'a, 'b, A> {
+    #[inline]
+    pub fn add_seed(&mut self, seed: i32) {
+        self.fbb_
+            .push_slot_always::<i32>(DropoutAttrs::VT_SEED, seed);
+    }
+    #[inline]
+    pub fn new(
+        _fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
+    ) -> DropoutAttrsBuilder<'a, 'b, A> {
+        let start = _fbb.start_table();
+        DropoutAttrsBuilder {
+            fbb_: _fbb,
+            start_: start,
+        }
+    }
+    #[inline]
+    pub fn finish(self) -> flatbuffers::WIPOffset<DropoutAttrs<'a>> {
+        let o = self.fbb_.end_table(self.start_);
+        flatbuffers::WIPOffset::new(o.value())
+    }
+}
+
+impl core::fmt::Debug for DropoutAttrs<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut ds = f.debug_struct("DropoutAttrs");
+        ds.field("seed", &self.seed());
         ds.finish()
     }
 }
@@ -8977,6 +9087,21 @@ impl<'a> OperatorNode<'a> {
             None
         }
     }
+
+    #[inline]
+    #[allow(non_snake_case)]
+    pub fn attrs_as_dropout_attrs(&self) -> Option<DropoutAttrs<'a>> {
+        if self.attrs_type() == OperatorAttrs::DropoutAttrs {
+            self.attrs().map(|t| {
+                // Safety:
+                // Created from a valid Table for this object
+                // Which contains a valid union in this slot
+                unsafe { DropoutAttrs::init_from_table(t) }
+            })
+        } else {
+            None
+        }
+    }
 }
 
 impl flatbuffers::Verifiable for OperatorNode<'_> {
@@ -9035,6 +9160,7 @@ impl flatbuffers::Verifiable for OperatorNode<'_> {
           OperatorAttrs::DepthToSpaceAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<DepthToSpaceAttrs>>("OperatorAttrs::DepthToSpaceAttrs", pos),
           OperatorAttrs::CastLikeAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<CastLikeAttrs>>("OperatorAttrs::CastLikeAttrs", pos),
           OperatorAttrs::ShapeAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<ShapeAttrs>>("OperatorAttrs::ShapeAttrs", pos),
+          OperatorAttrs::DropoutAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<DropoutAttrs>>("OperatorAttrs::DropoutAttrs", pos),
           _ => Ok(()),
         }
      })?
@@ -9562,6 +9688,16 @@ impl core::fmt::Debug for OperatorNode<'_> {
             }
             OperatorAttrs::ShapeAttrs => {
                 if let Some(x) = self.attrs_as_shape_attrs() {
+                    ds.field("attrs", &x)
+                } else {
+                    ds.field(
+                        "attrs",
+                        &"InvalidFlatbuffer: Union discriminant does not match value.",
+                    )
+                }
+            }
+            OperatorAttrs::DropoutAttrs => {
+                if let Some(x) = self.attrs_as_dropout_attrs() {
                     ds.field("attrs", &x)
                 } else {
                     ds.field(


### PR DESCRIPTION
This operator requires the "random" crate feature to be enabled because it _may_ need to generate random numbers, although in most cases the operator will be a no-op when it appears in exported ONNX models, a vestige of the training process.