### PR TITLE
Apply model optimization when exporting timm models using TorchDynamo

### DIFF
--- a/tools/export-timm-model.py
+++ b/tools/export-timm-model.py
@@ -89,7 +89,13 @@ def export_timm_model(config: str, onnx_path: str, dynamo: bool = False):
     print_predictions(output)
 
     print(f"Exporting model to {onnx_path}")
-    torch.onnx.export(model, input_img, onnx_path, dynamo=dynamo)
+    if dynamo:
+        onnx_prog = torch.onnx.export(model, input_img, dynamo=True)
+        # Optimize model to inline functions. See https://github.com/robertknight/rten/issues/655.
+        onnx_prog.optimize()
+        onnx_prog.save(onnx_path)
+    else:
+        torch.onnx.export(model, input_img, onnx_path)
 
     # Test exported model with ONNX Runtime as a reference implementation.
     #


### PR DESCRIPTION
The un-optimized exported model contains ONNX functions which are not yet supported in RTen [^1]. Optimizing the model will (usually?) inline these functions, allowing the resulting model to be converted for use with RTen.

[^1]: https://github.com/robertknight/rten/issues/655