### PR TITLE
Improve `Split` operator implementation, add `TensorBase::{slice_axis, slice_axis_mut}`

### DIFF
--- a/rten-tensor/src/errors.rs
+++ b/rten-tensor/src/errors.rs
@@ -56,6 +56,10 @@ pub enum SliceError {
         range_ndim: usize,
     },
 
+    /// The slice spec specified an axis that is equal to or greater than the
+    /// dimension count.
+    InvalidAxis { axis: usize },
+
     /// An index in the slice spec is out of bounds for the corresponding tensor
     /// dimension.
     InvalidIndex {
@@ -105,6 +109,7 @@ impl Display for SliceError {
                     range_ndim, ndim
                 )
             }
+            SliceError::InvalidAxis { axis } => write!(f, "slice axis {} is invalid", axis),
             SliceError::InvalidIndex { axis, index, size } => write!(
                 f,
                 "slice index {} is invalid for axis ({}) of size {}",

--- a/rten-tensor/src/tensor.rs
+++ b/rten-tensor/src/tensor.rs
@@ -1531,7 +1531,7 @@ impl<'a, T, L: Clone + MutLayout> TensorBase<ViewData<'a, T>, L> {
         }
     }
 
-    /// Divide this tensor into two mutable views along a given axis.
+    /// Divide this tensor into two views along a given axis.
     ///
     /// Returns a `(left, right)` tuple of views, where the `left` view
     /// contains the slice from `[0, mid)` along `axis` and the `right`

--- a/src/ops/split.rs
+++ b/src/ops/split.rs
@@ -1,5 +1,5 @@
 use rten_tensor::prelude::*;
-use rten_tensor::{NdTensorView, SliceItem, Tensor, TensorView};
+use rten_tensor::{NdTensorView, Tensor, TensorView};
 
 use crate::ops::{
     map_input, resolve_axis, static_dims, Input, InputList, OpError, Operator, OutputList,
@@ -29,19 +29,9 @@ pub fn split<T: Copy>(
         .iter()
         .map(|&split_size| {
             let split_size = split_size as usize;
-            let slice_range: Vec<SliceItem> = (0..input.ndim())
-                .map(|dim| {
-                    if dim == axis {
-                        (split_start..split_start + split_size).into()
-                    } else {
-                        SliceItem::full_range()
-                    }
-                })
-                .collect();
-
+            let split_range = split_start..split_start + split_size;
             split_start += split_size;
-
-            input.slice(slice_range.as_slice()).to_tensor_in(pool)
+            input.slice_axis(axis, split_range).to_tensor_in(pool)
         })
         .collect();
 


### PR DESCRIPTION
The implementation of the `Split` operator was clunky and inefficient as it constructed a dynamically sized set of arguments for `TensorBase::slice`. Internally rten-tensor had a more ergonomic and efficient API for slicing a tensor along an axis. Expose and add tests for this API, and use it in the `Split` operator implementation.

This change will also make it easier to add support for the `num_outputs` attribute in the Split operator.