### PR TITLE
Change Arm GEMM tile size to MR=4, NR=16

### DIFF
--- a/src/gemm/kernels/aarch64.rs
+++ b/src/gemm/kernels/aarch64.rs
@@ -19,8 +19,8 @@ pub struct ArmNeonKernel {
 }
 
 impl ArmNeonKernel {
-    const MR: usize = 8;
-    const NR: usize = 8;
+    const MR: usize = 4;
+    const NR: usize = 16;
 }
 
 /// Number of 32-bit lanes in an Arm Neon SIMD vector.
@@ -142,11 +142,8 @@ unsafe impl Kernel<f32, f32, f32> for ArmNeonKernel {
             dest_beta,
         );
 
+        debug_assert_eq!(MR, 4);
         match used_rows {
-            8 => gemm.dispatch::<8>(),
-            7 => gemm.dispatch::<7>(),
-            6 => gemm.dispatch::<6>(),
-            5 => gemm.dispatch::<5>(),
             4 => gemm.dispatch::<4>(),
             3 => gemm.dispatch::<3>(),
             2 => gemm.dispatch::<2>(),


### PR DESCRIPTION
Change f32 GEMM tile size on Arm from 8x8 to 4x16. Practical tests on a handful of devices (Apple M3, Raspberry Pi 5) found this to be faster and llvm-mca analysis of the main loop reported that this computes the same number of output elements in fewer cycles (tested across a range of `--mcpu` values)

The speedup varies by CPU. On an M3 this makes f32 MatMul ops about 8% faster.