### PR TITLE
Support 3D inputs in AveragePool and MaxPool

### DIFF
--- a/rten-convert/rten_convert/converter.py
+++ b/rten-convert/rten_convert/converter.py
@@ -49,7 +49,7 @@ class Metadata:
     run_url: Optional[str] = None
 
 
-def check_ints_length(name: str, ints: list[int], allowed_length: int):
+def check_ints_length(name: str, ints: list[int], allowed_lengths: list[int]):
     """
     Check that an ints attribute has a fixed length.
 
@@ -57,8 +57,10 @@ def check_ints_length(name: str, ints: list[int], allowed_length: int):
     values (eg. for strides, dilations, padding...) than this library currently
     supports.
     """
-    if len(ints) != allowed_length:
-        raise ConversionError(f'Attribute "{name}" must have {allowed_length} values')
+    if len(ints) not in allowed_lengths:
+        raise ConversionError(
+            f'Attribute "{name}" length must be one of {allowed_lengths}'
+        )
 
 
 def constant_node_from_onnx_initializer(
@@ -320,7 +322,7 @@ def op_node_from_onnx_operator(
 
         case "AveragePool":
             kernel_shape = attr_reader.require_attr("kernel_shape", "ints")
-            check_ints_length("kernel_shape", kernel_shape, 2)
+            check_ints_length("kernel_shape", kernel_shape, [1, 2])
             attr_reader.check_attr("ceil_mode", "int", 0)
 
             attrs = sg.AveragePoolAttrsT()
@@ -518,7 +520,7 @@ def op_node_from_onnx_operator(
         case "MaxPool":
             attrs = sg.MaxPoolAttrsT()
             kernel_shape = attr_reader.require_attr("kernel_shape", "ints")
-            check_ints_length("kernel_shape", kernel_shape, 2)
+            check_ints_length("kernel_shape", kernel_shape, [1, 2])
             attrs.kernelSize = kernel_shape
             read_pads(attr_reader, attrs)
             attrs.strides = read_strides(attr_reader)

--- a/rten-examples/src/whisper.rs
+++ b/rten-examples/src/whisper.rs
@@ -288,8 +288,7 @@ impl LogitsFilter for TimestampFilter {
         let prev_timestamp = prev_tokens[self.prompt_len..]
             .iter()
             .rev()
-            .filter(|t| self.is_timestamp_token(**t))
-            .next()
+            .find(|t| self.is_timestamp_token(**t))
             .copied()
             .unwrap_or(self.timestamp_min);
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -1312,8 +1312,8 @@ mod tests {
         add_operator!(Asin, [input_node]);
         add_operator!(Atan, [input_node]);
         add_operator!(AveragePool, [input_node], {
-            kernel_size: [2, 2],
-            strides: [2, 2],
+            kernel_size: [2, 2].into(),
+            strides: [2, 2].into(),
             padding: [0, 0, 0, 0].into(),
             count_include_pad: false,
         });
@@ -1493,8 +1493,8 @@ mod tests {
 
         add_operator!(Max, [input_node, input_node]);
         add_operator!(MaxPool, [input_node], {
-            kernel_size: [2, 2],
-            strides: [2, 2],
+            kernel_size: [2, 2].into(),
+            strides: [2, 2].into(),
             padding: [0, 0, 0, 0].into(),
         });
         add_operator!(Mean, [input_node, input_node]);

--- a/src/model_builder.rs
+++ b/src/model_builder.rs
@@ -428,8 +428,8 @@ impl<'mb, 'a> GraphBuilder<'mb, 'a> {
             OpType::AveragePool(args) => op_with_attrs!(AveragePool, AveragePoolAttrs, {
                 let pad_args = pad_args_from_padding(args.padding);
                 let pads = self.create_vec(pad_args.pads, |pad| pad as u32);
-                let kernel_size = self.create_vec(Some(args.kernel_size.into()), |sz| sz as u32);
-                let strides = self.create_vec(Some(args.strides.into()), |s| s as u32);
+                let kernel_size = self.create_vec(Some(args.kernel_size.to_vec()), |sz| sz as u32);
+                let strides = self.create_vec(Some(args.strides.to_vec()), |s| s as u32);
                 sg::AveragePoolAttrsArgs {
                     kernel_size,
                     auto_pad: pad_args.auto_pad,
@@ -669,8 +669,8 @@ impl<'mb, 'a> GraphBuilder<'mb, 'a> {
             OpType::MaxPool(args) => op_with_attrs!(MaxPool, MaxPoolAttrs, {
                 let pad_args = pad_args_from_padding(args.padding);
                 let pads = self.create_vec(pad_args.pads, |pad| pad as u32);
-                let kernel_size = self.create_vec(Some(args.kernel_size.into()), |sz| sz as u32);
-                let strides = self.create_vec(Some(args.strides.into()), |s| s as u32);
+                let kernel_size = self.create_vec(Some(args.kernel_size.to_vec()), |sz| sz as u32);
+                let strides = self.create_vec(Some(args.strides.to_vec()), |s| s as u32);
                 sg::MaxPoolAttrsArgs {
                     kernel_size,
                     auto_pad: pad_args.auto_pad,


### PR DESCRIPTION
Change AveragePool and MaxPool to support 3D inputs that have one spatial dim instead of two. Similar to the Conv operator, this is handled by inserting an extra spatial dim, invoking the 2D implementation and then removing the extra
spatial dim from the result.

Tested with https://huggingface.co/onnx-community/snac_24khz-ONNX.