### PR TITLE
Add Arm Linux CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         # The macOS build tests Arm and macOS-specific code paths.
         # The Linux build tests everything else (x64, wasm, Python ...)
-        os: [ubuntu-latest, macos-14]
+        os: [ubuntu-latest, macos-14, ubuntu-24.04-arm]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout
@@ -33,13 +33,17 @@ jobs:
     - name: Install Rust x86_64-apple-darwin target
       run: rustup target add x86_64-apple-darwin
       if: ${{ matrix.os == 'macos-14' }}
+    - name: Query Rust version
+      run: |
+        rustc --version
+        cargo --version
     - name: Cache
       uses: actions/cache@v3
       with:
         path: |
           ~/.cargo/
           target/
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ matrix.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Install wasm-bindgen
       # nb. wasm-bindgen-cli version must match `wasm-bindgen` version in Cargo.lock
       run: cargo install wasm-bindgen-cli --version 0.2.100


### PR DESCRIPTION
Test Arm build under Linux in CI. See
https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/.

This would have caught the issue fixed in https://github.com/robertknight/rten/pull/670.