### PR TITLE
Fix "instruction requires: dotprod" error in Arm Linux build

### DIFF
--- a/src/gemm/kernels/aarch64.rs
+++ b/src/gemm/kernels/aarch64.rs
@@ -446,7 +446,9 @@ unsafe impl Int8DotProduct for NeonNativeDotProd {
 
     #[inline]
     fn dot_product(self, a: Self::X8, b: Self::X8, c: Self::I32) -> Self::I32 {
-        unsafe {
+        #[target_feature(enable = "dotprod")]
+        #[inline]
+        unsafe fn dot_product(a: int8x16_t, b: int8x16_t, c: int32x4_t) -> int32x4_t {
             use core::arch::aarch64::{
                 vreinterpretq_s32_u32, vreinterpretq_u32_s32, vreinterpretq_u8_s8,
             };
@@ -468,6 +470,7 @@ unsafe impl Int8DotProduct for NeonNativeDotProd {
 
             vreinterpretq_s32_u32(c)
         }
+        unsafe { dot_product(a, b, c) }
     }
 }
 


### PR DESCRIPTION
On macOS using `udot` in inline assembly works when the calling function doesn't have the `dotprod` target feature enabled. In a Linux arm64 build this is not the case, resulting in an error:

```
error: instruction requires: dotprod
   --> src/gemm/kernels/aarch64.rs:462:18
    |
462 |                 "udot {result:v}.4s, {a:v}.16b, {b:v}.16b",
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
```

Fix the problem by surrounding the instruction in a function with `target_feature` enabled, making sure that function is inlined into the surrounding GEMM kernel.

This fix was tested manually locally in Docker. https://github.com/robertknight/rten/pull/669 will add an Arm CI build.