### PR TITLE
Improve instruction level parallelism in LayerNormalization, Softmax operations

### DIFF
--- a/rten-vecmath/src/softmax.rs
+++ b/rten-vecmath/src/softmax.rs
@@ -46,8 +46,10 @@ impl<'dst> SimdOp for Softmax<'_, 'dst> {
     fn eval<I: Isa>(self, isa: I) -> Self::Output {
         let ops = isa.f32();
 
-        let max_val = self.src_dest.src().simd_iter(ops).fold(
+        let max_val = self.src_dest.src().simd_iter(ops).fold_unroll::<4>(
             ops.splat(f32::MIN),
+            #[inline(always)]
+            |max, x| ops.max(max, x),
             #[inline(always)]
             |max, x| ops.max(max, x),
         );


### PR DESCRIPTION
Reduction operations in the Softmax (`max(x)`) and LayerNormalization (`sum(x)`, `sum((x-mean)^2)`) operations were vectorized but bottlenecked on data dependencies between iterations. Add a `fold_unroll` API to rten-simd for explicitly unrolled reductions and use this to improve ILP.

On an M3 this is a ~13% improvement for Softmax and ~40% improvement for LayerNormalization.