### PR TITLE
Fix deserialization of CastLike operators

### DIFF
--- a/rten-convert/rten_convert/converter.py
+++ b/rten-convert/rten_convert/converter.py
@@ -351,6 +351,9 @@ def op_node_from_onnx_operator(
             )
             attrs.to = convert_data_type(to)
 
+        case "CastLike":
+            attrs = sg.CastLikeAttrsT()
+
         case "Clip":
             attr_reader.generate_input_from_attr(1, "min", "float")
             attr_reader.generate_input_from_attr(2, "max", "float")


### PR DESCRIPTION
Deserialization of CastLike operators failed because the `ReadOp` implementation expected these operators to have attributes, but the converter was not adding them.

I think there was a mistake in 61ea8b1472597b578afc0f124ef7e8bfa52b59ab where changes to `converter.py` were not committed.

The fix here is to ensure the attributes are added by the converter. However for this operator and others where there are no _required_ attributes, the issue could also be handled by substituting a default value of the attributes struct during deserialization.