### PR TITLE
Add more detail to operator attribute errors

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -565,7 +565,7 @@ impl Model {
         });
         let dtype = value
             .dtype()
-            .map(convert_dtype)
+            .map(|dtype| convert_dtype("", dtype))
             .transpose()
             .map_err(|err| {
                 ModelLoadError::OperatorInvalid(NodeError::for_node(name, err).into())


### PR DESCRIPTION
Add more details to the errors produced if deserializing an operator's attributes fails. In particular distinguish between a missing `attrs` field (or incorrect type of `attrs` field) versus an error deserializing a specific attribute.