### PR TITLE
Optimize Arm f32 GEMM using FMLA (by element)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,7 @@ assertions_on_constants = "allow"
 # potentially less efficient.
 needless_range_loop = "allow"
 too_many_arguments = "allow"
+manual_repeat_n = "allow"  # TODO - Address existing failures
 
 [package.metadata.docs.rs]
 # These features should match the features enabled by `make docs`.

--- a/rten-examples/Cargo.toml
+++ b/rten-examples/Cargo.toml
@@ -33,6 +33,7 @@ avx512 = ["rten/avx512"]
 # Allows use of `..Default::default()` for future compatibility even when not
 # currently needed.
 needless_update = "allow"
+manual_repeat_n = "allow"  # TODO - Address existing failures
 
 [package.metadata.release]
 release = false

--- a/rten-simd/src/arch/aarch64.rs
+++ b/rten-simd/src/arch/aarch64.rs
@@ -5,14 +5,15 @@ use std::arch::aarch64::{
     vceqq_s16, vceqq_s32, vceqq_s8, vceqq_u16, vceqq_u8, vcgeq_f32, vcgeq_s16, vcgeq_s32, vcgeq_s8,
     vcgeq_u16, vcgeq_u8, vcgtq_f32, vcgtq_s16, vcgtq_s32, vcgtq_s8, vcgtq_u16, vcgtq_u8, vcleq_f32,
     vcleq_s16, vcleq_s8, vcleq_u16, vcleq_u8, vcltq_f32, vcltq_s16, vcltq_s8, vcltq_u16, vcltq_u8,
-    vcombine_s16, vcombine_u8, vcvtnq_s32_f32, vcvtq_s32_f32, vdivq_f32, vdupq_n_f32, vdupq_n_s16,
-    vdupq_n_s32, vdupq_n_s8, vdupq_n_u16, vdupq_n_u8, veorq_u32, vfmaq_f32, vget_low_s16,
-    vget_low_s8, vld1q_f32, vld1q_s16, vld1q_s32, vld1q_s8, vld1q_u16, vld1q_u32, vld1q_u8,
-    vmaxq_f32, vminq_f32, vmovl_high_s16, vmovl_high_s8, vmovl_s16, vmovl_s8, vmulq_f32, vmulq_s16,
-    vmulq_s32, vmulq_s8, vmulq_u16, vmulq_u8, vmvnq_u32, vnegq_f32, vnegq_s16, vnegq_s32, vnegq_s8,
-    vorrq_u32, vqmovn_s32, vqmovun_s16, vshlq_n_s16, vshlq_n_s32, vshlq_n_s8, vshlq_n_u16,
-    vst1q_f32, vst1q_s16, vst1q_s32, vst1q_s8, vst1q_u16, vst1q_u8, vsubq_f32, vsubq_s16,
-    vsubq_s32, vsubq_s8, vsubq_u16, vsubq_u8, vzip1q_s16, vzip1q_s8, vzip2q_s16, vzip2q_s8,
+    vcombine_s16, vcombine_u8, vcvtnq_s32_f32, vcvtq_s32_f32, vdivq_f32, vdupq_laneq_f32,
+    vdupq_n_f32, vdupq_n_s16, vdupq_n_s32, vdupq_n_s8, vdupq_n_u16, vdupq_n_u8, veorq_u32,
+    vfmaq_f32, vget_low_s16, vget_low_s8, vld1q_f32, vld1q_s16, vld1q_s32, vld1q_s8, vld1q_u16,
+    vld1q_u32, vld1q_u8, vmaxq_f32, vminq_f32, vmovl_high_s16, vmovl_high_s8, vmovl_s16, vmovl_s8,
+    vmulq_f32, vmulq_s16, vmulq_s32, vmulq_s8, vmulq_u16, vmulq_u8, vmvnq_u32, vnegq_f32,
+    vnegq_s16, vnegq_s32, vnegq_s8, vorrq_u32, vqmovn_s32, vqmovun_s16, vshlq_n_s16, vshlq_n_s32,
+    vshlq_n_s8, vshlq_n_u16, vst1q_f32, vst1q_s16, vst1q_s32, vst1q_s8, vst1q_u16, vst1q_u8,
+    vsubq_f32, vsubq_s16, vsubq_s32, vsubq_s8, vsubq_u16, vsubq_u8, vzip1q_s16, vzip1q_s8,
+    vzip2q_s16, vzip2q_s8,
 };
 use std::mem::transmute;
 
@@ -225,6 +226,11 @@ unsafe impl NumOps<f32> for ArmNeonIsa {
     #[inline]
     fn max(self, x: float32x4_t, y: float32x4_t) -> float32x4_t {
         unsafe { vmaxq_f32(x, y) }
+    }
+
+    #[inline]
+    fn broadcast_lane<const LANE: i32>(self, x: float32x4_t) -> float32x4_t {
+        unsafe { vdupq_laneq_f32(x, LANE) }
     }
 
     #[inline]

--- a/rten-simd/src/arch/x86_64/avx512.rs
+++ b/rten-simd/src/arch/x86_64/avx512.rs
@@ -340,7 +340,7 @@ unsafe impl NumOps<i32> for Avx512Isa {
 
     #[inline]
     unsafe fn load_ptr(self, ptr: *const i32) -> I32x16 {
-        unsafe { _mm512_loadu_si512(ptr as *const i32) }.into()
+        unsafe { _mm512_loadu_si512(ptr as *const __m512i) }.into()
     }
 
     #[inline]
@@ -438,7 +438,7 @@ unsafe impl NumOps<i16> for Avx512Isa {
 
     #[inline]
     unsafe fn load_ptr(self, ptr: *const i16) -> I16x32 {
-        unsafe { _mm512_loadu_si512(ptr as *const i32) }.into()
+        unsafe { _mm512_loadu_si512(ptr as *const __m512i) }.into()
     }
 
     #[inline]
@@ -570,7 +570,7 @@ unsafe impl NumOps<i8> for Avx512Isa {
 
     #[inline]
     unsafe fn load_ptr(self, ptr: *const i8) -> I8x64 {
-        unsafe { _mm512_loadu_si512(ptr as *const i32) }.into()
+        unsafe { _mm512_loadu_si512(ptr as *const __m512i) }.into()
     }
 
     #[inline]
@@ -691,7 +691,7 @@ unsafe impl NumOps<u8> for Avx512Isa {
 
     #[inline]
     unsafe fn load_ptr(self, ptr: *const u8) -> U8x64 {
-        unsafe { _mm512_loadu_si512(ptr as *const i32) }.into()
+        unsafe { _mm512_loadu_si512(ptr as *const __m512i) }.into()
     }
 
     #[inline]
@@ -832,7 +832,7 @@ unsafe impl NumOps<u16> for Avx512Isa {
 
     #[inline]
     unsafe fn load_ptr(self, ptr: *const u16) -> U16x32 {
-        unsafe { _mm512_loadu_si512(ptr as *const i32) }.into()
+        unsafe { _mm512_loadu_si512(ptr as *const __m512i) }.into()
     }
 
     #[inline]

--- a/rten-tensor/Cargo.toml
+++ b/rten-tensor/Cargo.toml
@@ -24,6 +24,7 @@ crate-type = ["lib"]
 # See comments about `needless_range_loop` in root Cargo.toml.
 needless_range_loop = "allow"
 manual_memcpy = "allow"
+manual_repeat_n = "allow"  # TODO - Address existing failures
 
 [features]
 serde = ["dep:serde"]

--- a/rten-text/Cargo.toml
+++ b/rten-text/Cargo.toml
@@ -21,3 +21,6 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 rten-testing = { path = "../rten-testing" }
+
+[lints.clippy]
+manual_repeat_n = "allow"  # TODO - Address existing failures

--- a/src/gemm/im2col.rs
+++ b/src/gemm/im2col.rs
@@ -96,10 +96,6 @@ impl<T: Copy + Default> Im2Col<'_, T> {
     /// `NR_REGS` specifies the width of each column panel as a multiple of
     /// `S::LEN` elements. In other words, `panel_width` must exactly equal
     /// `NR_REGS * S::LEN`.
-    ///
-    /// # Safety
-    ///
-    /// Caller must ensure SIMD type is supported.
     #[inline(always)]
     pub(super) fn pack_block<I: Isa, const NR_REGS: usize>(
         &self,

--- a/src/gemm/kernels/aarch64.rs
+++ b/src/gemm/kernels/aarch64.rs
@@ -144,10 +144,10 @@ unsafe impl Kernel<f32, f32, f32> for ArmNeonKernel {
 
         debug_assert_eq!(MR, 4);
         match used_rows {
-            4 => gemm.dispatch::<4>(),
-            3 => gemm.dispatch::<3>(),
-            2 => gemm.dispatch::<2>(),
-            1 => gemm.dispatch::<1>(),
+            4 => gemm.dispatch_broadcast_lane::<4>(),
+            3 => gemm.dispatch_broadcast_lane::<3>(),
+            2 => gemm.dispatch_broadcast_lane::<2>(),
+            1 => gemm.dispatch_broadcast_lane::<1>(),
             _ => panic!("unsupported `used_rows` {}", used_rows),
         }
 


### PR DESCRIPTION
Arm supports an FMLA instruction variant [^1] which multiples one _lane_ of a
vector by values in another vector and then accumulates into a destination.
This enables reducing the number of loads from A in each iteration of the GEMM
microkernel by a factor of 4. Instead of broadcasting one scalar value from A at
a time into a register used as an FMA operand, we can load a vector of 4
elements from A and then each FMA specifies which of the 4 elements to use.

The way this is implemented is by using `broadcast_lane` + `mul_add` generic
operations (`vdupq_laneq_f32` followed by `fmla`) which LLVM will fuse into a
single `fmla`.

[^1]: https://developer.arm.com/documentation/ddi0596/2021-03/SIMD-FP-Instructions/FMLA--by-element---Floating-point-fused-Multiply-Add-to-accumulator--by-element--?lang=en

---

Future work:

- Apply the same operation for int8 GEMM via UDOT-by-element (probably a separate PR)
