### PR TITLE
Optimize Arm int8 GEMM using UDOT-by-element

### DIFF
--- a/src/gemm/kernels.rs
+++ b/src/gemm/kernels.rs
@@ -399,11 +399,33 @@ unsafe trait Int8DotProduct {
     /// SIMD vector with `i32` elements.
     type I32;
 
+    /// Return true if [`indexed_dot_product`](Int8DotProduct::indexed_dot_product)
+    /// is supported.
+    fn supports_indexed_dot_product() -> bool {
+        false
+    }
+
     /// Compute the dot product of groups of 4 8-bit integers in `a` and `b`,
     /// accumulating into 32-bit integers in `c`.
     ///
     /// The signed-ness of `a` and `b` depends on the implementation.
     fn dot_product(self, a: Self::X8, b: Self::X8, c: Self::I32) -> Self::I32;
+
+    /// Broadcast 4 8-bit integers from a 32-bit lane of `b` selected by `IDX`
+    /// and then compute the dot product as with
+    /// [`dot_product`](Int8DotProduct::dot_product).
+    #[allow(unused_variables)]
+    fn indexed_dot_product<const IDX: u32>(
+        self,
+        a: Self::X8,
+        b: Self::X8,
+        c: Self::I32,
+    ) -> Self::I32
+    where
+        Self: Sized,
+    {
+        unimplemented!("indexed_dot_product not supported")
+    }
 }
 
 /// Output for matrix-vector multiplication.

--- a/src/gemm/kernels/wasm.rs
+++ b/src/gemm/kernels/wasm.rs
@@ -290,7 +290,7 @@ unsafe impl Kernel<u8, i8, i32> for WasmInt8Kernel {
         let (b, b_col_sums) = packing::int8::extract_packed_b::<{ Self::NR }>(b);
 
         const NR_REGS: usize = WasmInt8Kernel::NR / X32_LANES;
-        simd_int8_gemm::<_, { Self::MR }, { Self::NR }, NR_REGS>(
+        simd_int8_gemm::<_, _, { Self::MR }, { Self::NR }, NR_REGS>(
             self.isa,
             tile_ptr,
             tile_row_stride,

--- a/src/gemm/kernels/x86_64.rs
+++ b/src/gemm/kernels/x86_64.rs
@@ -589,7 +589,7 @@ unsafe impl Kernel<u8, i8, i32> for Avx2Int8Kernel {
         let (b, b_col_sums) = packing::int8::extract_packed_b::<{ Self::NR }>(b);
 
         const NR_REGS: usize = Avx2Int8Kernel::NR / AVX2_X32_LANES;
-        simd_int8_gemm::<_, { Self::MR }, { Self::NR }, NR_REGS>(
+        simd_int8_gemm::<_, _, { Self::MR }, { Self::NR }, NR_REGS>(
             self.isa,
             tile_ptr,
             tile_row_stride,
@@ -804,7 +804,7 @@ unsafe impl Kernel<u8, i8, i32> for Avx512Int8Kernel {
 
         const NR_REGS: usize = Avx512Int8Kernel::NR / AVX512_X32_LANES;
         if let Some(vnni_dot) = self.vnni_dot {
-            simd_int8_gemm::<_, { Self::MR }, { Self::NR }, NR_REGS>(
+            simd_int8_gemm::<_, _, { Self::MR }, { Self::NR }, NR_REGS>(
                 self.isa,
                 tile_ptr,
                 tile_row_stride,
@@ -821,7 +821,7 @@ unsafe impl Kernel<u8, i8, i32> for Avx512Int8Kernel {
                 vnni_dot,
             )
         } else {
-            simd_int8_gemm::<_, { Self::MR }, { Self::NR }, NR_REGS>(
+            simd_int8_gemm::<_, _, { Self::MR }, { Self::NR }, NR_REGS>(
                 self.isa,
                 tile_ptr,
                 tile_row_stride,


### PR DESCRIPTION
Similar to https://github.com/robertknight/rten/pull/679, use the by-element variant of UDOT [^1] to reduce the number of loads in the int8 GEMM microkernel. Instead of performing 4 scalar 32-bit loads and broadcasting these, perform one 128-bit load and use indexed UDOT to implicitly broadcast a 32-bit block, containing 4 8-bit elements, for each of the 4 rows.

[^1]: https://developer.arm.com/documentation/100069/0609/A64-SIMD-Vector-Instructions/UDOT--vector--by-element-