### PR TITLE
Use simplified `Exp` with reduced domain in Softmax op

### DIFF
--- a/rten-vecmath/src/exp.rs
+++ b/rten-vecmath/src/exp.rs
@@ -262,12 +262,10 @@ mod tests {
     };
     use crate::{Exp, Sigmoid, Silu, Swish};
 
-    // Maximum error of `vec_expf` compared to Rust standard library
-    // implementation.
+    // Maximum error of `Exp` compared to Rust standard library implementation.
     const MAX_EXP_ERROR_ULPS: f32 = 1.0;
 
-    // Maximum error of `vec_sigmoid` compared to reference implementation
-    // below.
+    // Maximum error of `Sigmoid` compared to reference implementation below.
     const MAX_SIGMOID_ERROR_ULPS: f32 = 4.0;
 
     fn reference_sigmoid(x: f32) -> f32 {
@@ -308,7 +306,7 @@ mod tests {
     }
 
     #[test]
-    fn test_expf() {
+    fn test_exp_basic() {
         // A few simple test cases, including "typical" +/-ve inputs with
         // |x| above/below ln2, zero and values below/above min/max cutoffs.
         let cases = [-2.0f32, -1., -0.5, 0.1, 0., 0.1, 0.5, 1., 2., -105., 105.];
@@ -330,7 +328,7 @@ mod tests {
     }
 
     #[test]
-    fn test_vec_expf() {
+    fn test_exp() {
         check_simd_vs_reference(
             |src, dest| Exp {}.map(src, dest),
             f32::exp,
@@ -351,7 +349,7 @@ mod tests {
 
     #[test]
     #[ignore] // Ignored by default due to long runtime
-    fn test_expf_exhaustive() {
+    fn test_exp_exhaustive() {
         let exp_op = Exp {};
         check_with_all_f32s(
             |x| (exp_op.scalar_eval(x), x.exp()),
@@ -416,7 +414,7 @@ mod tests {
 
     #[test]
     #[ignore]
-    fn bench_expf() {
+    fn bench_exp() {
         benchmark_op(
             |xs, ys| xs.iter().zip(ys.iter_mut()).for_each(|(x, y)| *y = x.exp()),
             |xs, ys| Exp {}.map(xs, ys),


### PR DESCRIPTION
The middle step of the softmax operation computes `exp(x - max(x))`.  Since we know the exp argument is <= 0, and this operation can tolerate a higher lower cutoff, we can use a simplified version of `Exp` with a reduced range which is
more efficient.

ONNX Runtime has a [similar optimization](https://github.com/microsoft/onnxruntime/blob/25c43c1fd66de00d3e7ebe58ecd4b37e060e5be5/onnxruntime/core/mlas/lib/compute.cpp#L312), as does [XNNPack](https://github.com/google/XNNPACK/blob/7cbb479fd61f01bc56045ac3a449274c78a68409/src/f32-raddstoreexpminusmax/avx2-rr2-p5.c.in#L18).

Tested on M3 Pro, this is approximately 20% faster.

```
 cargo test -p rten-vecmath -r -- --ignored --nocapture bench_softmax

# Before
reference 193835 us vectorized 51013 us. reference / vectorized ratio 3.800

# After
reference 194822 us vectorized 42234 us. reference / vectorized ratio 4.613
```