### PR TITLE
Clamp ranges in Slice operator to enable slicing fast path

### DIFF
--- a/src/ops/slice.rs
+++ b/src/ops/slice.rs
@@ -43,7 +43,15 @@ fn slice_ranges(
         };
 
         let step = steps.map(|s| s[i]).unwrap_or(1);
-        ranges[axis] = SliceRange::new(*start as isize, Some(*end as isize), step as isize);
+        let range = SliceRange::new(*start as isize, Some(*end as isize), step as isize);
+
+        // ONNX models represent ranges that are unbounded on one side by using
+        // `INT_MAX` or `INT_MIN` (when slicing backwards with negative steps)
+        // as the end point. This relies on the ranges being clamped to valid
+        // bounds.
+        let range = range.clamp(input_shape[axis]);
+
+        ranges[axis] = range;
     }
     Ok(ranges)
 }


### PR DESCRIPTION
ONNX models use `i64::{MIN, MAX}` (`i32::{MIN, MAX}` in .rten files) in the `starts` and `ends` attributes of the Slice operator to represent ranges that extend all the way to the start or end of a range. This works as the `Slice` op clamps its ranges.

In rten_tensor, `TensorBase::slice_copy_in` has a fast path using `try_slice` which is supposed to be used for all ranges except those with negative steps. However `try_slice` also fails if the input range extends beyond the end of the axis. The non-fast path clamps its input range in `copy_range_into_slice` as a side-effect of calling `SliceRange::index_range`, so it works correctly.

As a result, some `Slice` operations with one-sided ranges represented this way, which could have used the fast path, ended up falling back to the regular path.

The fix in this commit is to clamp the ranges in the `Slice` operator implementation before calling into `TensorBase::slice_copy_in`. There is a related issue that rten_tensor's various `slice*` methods are not consistent about whether they clamp their inputs. In ModernBERT enabling the faster path reduces time in `Slice` ops by ~25%.