### PR TITLE
Generate better error if output cannot be computed

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1567,6 +1567,19 @@ mod tests {
     }
 
     #[test]
+    fn test_no_source_for_output() {
+        let mut g = Graph::new();
+        let output_id = g.add_value(Some("output"), None, None);
+        let err = g.run(vec![], &[output_id], None, None);
+        assert_eq!(
+            err,
+            Err(RunError::PlanningError(
+                "Source node not found for output \"output\"".into()
+            ))
+        );
+    }
+
+    #[test]
     fn test_invalid_input_id() {
         let mut g = Graph::new();
 

--- a/src/graph/planner.rs
+++ b/src/graph/planner.rs
@@ -267,7 +267,8 @@ impl<'a> Planner<'a> {
                     if let Some((op_node_id, op_node)) = self.graph.get_source_node(*output_id) {
                         self.visit(op_node_id, op_node)?;
                     } else {
-                        let msg = format!("Missing output {}", output_id);
+                        let output_name = self.graph.node_name(*output_id);
+                        let msg = format!("Source node not found for output \"{}\"", output_name);
                         return Err(RunError::PlanningError(msg));
                     }
                 }


### PR DESCRIPTION
Generate a better error when a call to `Model::run` fails because there isn't an operator in the graph which computes a requested output.

The issue was found testing `decoder_model.onnx` from https://huggingface.co/onnx-community/parakeet-tdt-0.6b-v2-ONNX/tree/main/onnx (commit [8802298](https://huggingface.co/onnx-community/parakeet-tdt-0.6b-v2-ONNX/commit/880229804d73bb700be355a7e4f7b294a4df3d2b)).

Before: "Missing output 21"
After: "Source node not found for output "prednet_lengths""