### PR TITLE
Replace `Operator::run` arguments with a single "context" argument

### DIFF
--- a/src/ops/binary_elementwise.rs
+++ b/src/ops/binary_elementwise.rs
@@ -7,7 +7,8 @@ use rten_tensor::{Tensor, TensorView, TensorViewMut};
 
 use crate::number::{AsBool, Identities, IsInt};
 use crate::ops::{
-    map_input, map_output, Input, InputList, IntoOpResult, OpError, Operator, Output, OutputList,
+    map_input, map_output, Input, InputList, IntoOpResult, OpError, OpRunContext, Operator, Output,
+    OutputList,
 };
 use crate::tensor_pool::TensorPool;
 
@@ -381,8 +382,8 @@ impl Operator for Add {
         "Add"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
-        run_typed_op!(pool, inputs, add)
+    fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+        run_typed_op!(ctx.pool(), ctx.inputs(), add)
     }
 
     fn can_run_in_place(&self) -> bool {
@@ -432,10 +433,11 @@ macro_rules! logical_boolean_op {
                 true
             }
 
-            fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
+            fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+                let inputs = ctx.inputs();
                 let a: TensorView<i32> = inputs.require_as(0)?;
                 let b: TensorView<i32> = inputs.require_as(1)?;
-                $op_fn(pool, a, b).into_op_result()
+                $op_fn(ctx.pool(), a, b).into_op_result()
             }
         }
     };
@@ -489,8 +491,8 @@ impl Operator for Div {
         "Div"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
-        run_typed_op!(pool, inputs, div)
+    fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+        run_typed_op!(ctx.pool(), ctx.inputs(), div)
     }
 
     fn can_run_in_place(&self) -> bool {
@@ -559,8 +561,8 @@ macro_rules! boolean_cmp_op {
                 stringify!($name) == "Equal"
             }
 
-            fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
-                run_typed_op!(pool, inputs, $func)
+            fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+                run_typed_op!(ctx.pool(), ctx.inputs(), $func)
             }
         }
     };
@@ -636,7 +638,8 @@ impl Operator for Mod {
         "Mod"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
+    fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+        let inputs = ctx.inputs();
         let a = inputs.require(0)?;
         let mode = if self.fmod {
             DivMode::TruncDiv
@@ -646,7 +649,7 @@ impl Operator for Mod {
 
         map_input!(a, a, [FloatTensor, Int32Tensor], {
             let b = inputs.require_as(1)?;
-            mod_op(pool, a, b, mode).into_op_result()
+            mod_op(ctx.pool(), a, b, mode).into_op_result()
         })
     }
 }
@@ -676,8 +679,8 @@ impl Operator for Mul {
         "Mul"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
-        run_typed_op!(pool, inputs, mul)
+    fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+        run_typed_op!(ctx.pool(), ctx.inputs(), mul)
     }
 
     fn can_run_in_place(&self) -> bool {
@@ -735,10 +738,11 @@ impl Operator for Pow {
         "Pow"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
+    fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+        let inputs = ctx.inputs();
         let a = inputs.require_as(0)?;
         let b = inputs.require_as(1)?;
-        pow(pool, a, b).into_op_result()
+        pow(ctx.pool(), a, b).into_op_result()
     }
 
     fn can_run_in_place(&self) -> bool {
@@ -790,8 +794,8 @@ impl Operator for Sub {
         "Sub"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
-        run_typed_op!(pool, inputs, sub)
+    fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+        run_typed_op!(ctx.pool(), ctx.inputs(), sub)
     }
 
     fn can_run_in_place(&self) -> bool {
@@ -877,13 +881,14 @@ impl Operator for Where {
         "Where"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
+    fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+        let inputs = ctx.inputs();
         let condition = inputs.require_as::<i32>(0)?;
         let x = inputs.require(1)?;
 
         map_input!(x, x, [FloatTensor, Int32Tensor], {
             let y = inputs.require_as(2)?;
-            where_op(pool, condition, x, y).into_op_result()
+            where_op(ctx.pool(), condition, x, y).into_op_result()
         })
     }
 }
@@ -902,7 +907,7 @@ mod tests {
     use crate::ops::{
         add, add_in_place, and, div, div_in_place, equal, greater, greater_or_equal, less,
         less_or_equal, mod_op, mul, mul_in_place, or, pow, pow_in_place, sub, sub_in_place,
-        where_op, xor, Add, DivMode, OpError, Operator, Output,
+        where_op, xor, Add, DivMode, OpError, OpRunContext, Operator, Output,
     };
 
     #[test]
@@ -1086,7 +1091,9 @@ mod tests {
         let b = Tensor::from_data(&[2, 3], vec![1., 2., 3., 4., 5., 6.]);
 
         let op = Add {};
-        let result = op.run(&pool, (&a, &b).into());
+        let inputs = (&a, &b).into();
+        let ctx = OpRunContext::new(&pool, &inputs);
+        let result = op.run(&ctx);
 
         assert_eq!(
             result.err(),

--- a/src/ops/binary_elementwise.rs
+++ b/src/ops/binary_elementwise.rs
@@ -907,7 +907,7 @@ mod tests {
     use crate::ops::{
         add, add_in_place, and, div, div_in_place, equal, greater, greater_or_equal, less,
         less_or_equal, mod_op, mul, mul_in_place, or, pow, pow_in_place, sub, sub_in_place,
-        where_op, xor, Add, DivMode, OpError, OpRunContext, Operator, Output,
+        where_op, xor, Add, DivMode, OpError, Operator, OperatorExt, Output,
     };
 
     #[test]
@@ -1086,14 +1086,11 @@ mod tests {
 
     #[test]
     fn test_add_invalid_broadcast() {
-        let pool = new_pool();
         let a = Tensor::from_data(&[2, 2], vec![1., 2., 3., 4.]);
         let b = Tensor::from_data(&[2, 3], vec![1., 2., 3., 4., 5., 6.]);
 
         let op = Add {};
-        let inputs = (&a, &b).into();
-        let ctx = OpRunContext::new(&pool, &inputs);
-        let result = op.run(&ctx);
+        let result: Result<Tensor<f32>, _> = op.run_simple((&a, &b));
 
         assert_eq!(
             result.err(),

--- a/src/ops/conv.rs
+++ b/src/ops/conv.rs
@@ -828,9 +828,7 @@ mod tests {
     use crate::ops::pooling::calc_output_size_and_padding;
     use crate::ops::tests::expect_eq_1e4;
     use crate::ops::tests::new_pool;
-    use crate::ops::{
-        conv, conv_integer, conv_transpose, Conv, OpError, OpRunContext, Operator, Padding,
-    };
+    use crate::ops::{conv, conv_integer, conv_transpose, Conv, OpError, OperatorExt, Padding};
     use crate::tensor_pool::AutoReturn;
 
     use super::conv_transpose_output_size_and_padding;
@@ -1090,21 +1088,13 @@ mod tests {
             ],
         );
 
-        let pool = new_pool();
         let op = Conv {
             padding: Padding::Same,
             groups: 1,
             strides: vec![1, 1],
             dilations: vec![1, 1],
         };
-        let inputs = (&input, &kernel).into();
-        let ctx = OpRunContext::new(&pool, &inputs);
-        let result = op
-            .run(&ctx)
-            .unwrap()
-            .remove(0)
-            .into_tensor::<f32>()
-            .unwrap();
+        let result: Tensor<f32> = op.run_simple((&input, &kernel)).unwrap();
         let reference_result = reference_conv(
             input.view(),
             kernel.view(),

--- a/src/ops/convert.rs
+++ b/src/ops/convert.rs
@@ -123,8 +123,7 @@ mod tests {
     use rten_tensor::Tensor;
     use rten_testing::TestCases;
 
-    use crate::ops::tests::new_pool;
-    use crate::ops::{Cast, CastLike, DataType, OpRunContext, Operator, Output};
+    use crate::ops::{Cast, CastLike, DataType, OperatorExt, Output};
 
     #[test]
     fn test_cast() {
@@ -192,11 +191,8 @@ mod tests {
         ];
 
         cases.test_each(|case| {
-            let pool = new_pool();
             let cast_op = Cast { to: case.dtype };
-            let inputs = (&case.input).into();
-            let ctx = OpRunContext::new(&pool, &inputs);
-            let result = cast_op.run(&ctx).unwrap().remove(0);
+            let result: Output = cast_op.run_simple_no_cast(&case.input).unwrap();
             assert_eq!(result, case.expected);
         })
     }
@@ -223,11 +219,10 @@ mod tests {
         ];
 
         cases.test_each(|case| {
-            let pool = new_pool();
             let cast_op = CastLike {};
-            let inputs = (&case.input, &case.other).into();
-            let ctx = OpRunContext::new(&pool, &inputs);
-            let result = cast_op.run(&ctx).unwrap().remove(0);
+            let result = cast_op
+                .run_simple_no_cast((&case.input, &case.other))
+                .unwrap();
             assert_eq!(result, case.expected);
         })
     }

--- a/src/ops/einsum.rs
+++ b/src/ops/einsum.rs
@@ -6,7 +6,9 @@ use rten_tensor::{DynLayout, OverlapPolicy, Tensor, TensorView};
 use smallvec::SmallVec;
 
 use crate::ops::layout::expand_to;
-use crate::ops::{matmul, mul, reduce_sum, InputList, IntoOpResult, OpError, Operator, OutputList};
+use crate::ops::{
+    matmul, mul, reduce_sum, IntoOpResult, OpError, OpRunContext, Operator, OutputList,
+};
 use crate::tensor_pool::{AutoReturn, PoolRef, TensorPool};
 
 /// A parsed equation for an Einsum operator.
@@ -133,12 +135,13 @@ impl Operator for Einsum {
         "Einsum"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
+    fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+        let inputs = ctx.inputs();
         let mut typed_inputs: SmallVec<[TensorView; 2]> = SmallVec::with_capacity(inputs.len());
         for i in 0..inputs.len() {
             typed_inputs.push(inputs.require_as(i)?);
         }
-        einsum(pool, &typed_inputs, &self.equation).into_op_result()
+        einsum(ctx.pool(), &typed_inputs, &self.equation).into_op_result()
     }
 }
 

--- a/src/ops/fused.rs
+++ b/src/ops/fused.rs
@@ -95,8 +95,7 @@ mod tests {
     use rten_testing::TestCases;
 
     use super::FusedTranspose;
-    use crate::ops::tests::new_pool;
-    use crate::ops::{InputList, OpRunContext, Operator, Sub};
+    use crate::ops::{OperatorExt, Sub};
 
     #[test]
     fn test_fused_transpose() {
@@ -143,12 +142,7 @@ mod tests {
             let fused_transpose =
                 FusedTranspose::wrap(Arc::new(sub_op), *transpose_input, Some(&[1, 0]));
 
-            let pool = new_pool();
-            let inputs = InputList::from(&[a.view().into(), b.view().into()]);
-            let ctx = OpRunContext::new(&pool, &inputs);
-            let mut outputs = fused_transpose.run(&ctx).unwrap();
-
-            let output: Tensor<i32> = outputs.remove(0).try_into().unwrap();
+            let output: Tensor<i32> = fused_transpose.run_simple((a.view(), b.view())).unwrap();
 
             assert_eq!(output, *expected);
         })

--- a/src/ops/gather.rs
+++ b/src/ops/gather.rs
@@ -8,7 +8,7 @@ use smallvec::SmallVec;
 use crate::number::IsNaN;
 use crate::ops::reduce::{cmp_nan_greater, cmp_nan_less};
 use crate::ops::{
-    map_input, resolve_axis, resolve_index, Input, InputList, IntoOpResult, OpError, Operator,
+    map_input, resolve_axis, resolve_index, Input, IntoOpResult, OpError, OpRunContext, Operator,
     OutputList,
 };
 use crate::tensor_pool::{AutoReturn, TensorPool};
@@ -134,12 +134,13 @@ impl Operator for Gather {
         "Gather"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
+    fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+        let inputs = ctx.inputs();
         let input = inputs.require(0)?;
         let indices = inputs.require_as::<i32>(1)?;
 
         map_input!(input, x, {
-            gather(pool, x, self.axis, indices).into_op_result()
+            gather(ctx.pool(), x, self.axis, indices).into_op_result()
         })
     }
 }
@@ -277,12 +278,13 @@ impl Operator for GatherElements {
         "GatherElements"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
+    fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+        let inputs = ctx.inputs();
         let input = inputs.require(0)?;
         let indices = inputs.require_as::<i32>(1)?;
 
         map_input!(input, x, {
-            gather_elements(pool, x, indices, self.axis).into_op_result()
+            gather_elements(ctx.pool(), x, indices, self.axis).into_op_result()
         })
     }
 }
@@ -394,12 +396,13 @@ impl Operator for GatherND {
         "GatherND"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
+    fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+        let inputs = ctx.inputs();
         let input = inputs.require(0)?;
         let indices = inputs.require_as::<i32>(1)?;
 
         map_input!(input, x, {
-            gather_nd(pool, x, indices, self.batch_dims).into_op_result()
+            gather_nd(ctx.pool(), x, indices, self.batch_dims).into_op_result()
         })
     }
 }
@@ -502,13 +505,15 @@ impl Operator for ScatterElements {
         "ScatterElements"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
+    fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+        let inputs = ctx.inputs();
         let data = inputs.require(0)?;
         let indices = inputs.require_as::<i32>(1)?;
 
         map_input!(data, x, {
             let updates = inputs.require_as(2)?;
-            scatter_elements(pool, x, indices, updates, self.axis, self.reduction).into_op_result()
+            scatter_elements(ctx.pool(), x, indices, updates, self.axis, self.reduction)
+                .into_op_result()
         })
     }
 }
@@ -592,13 +597,14 @@ impl Operator for ScatterND {
         "ScatterND"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
+    fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+        let inputs = ctx.inputs();
         let data = inputs.require(0)?;
         let indices = inputs.require_as::<i32>(1)?;
 
         map_input!(data, x, {
             let updates = inputs.require_as(2)?;
-            scatter_nd(pool, x, indices, updates, self.reduction).into_op_result()
+            scatter_nd(ctx.pool(), x, indices, updates, self.reduction).into_op_result()
         })
     }
 }

--- a/src/ops/generate.rs
+++ b/src/ops/generate.rs
@@ -159,24 +159,15 @@ mod tests {
     use rten_testing::TestCases;
 
     use crate::ops::tests::new_pool;
-    use crate::ops::{onehot, range, ConstantOfShape, OpError, OpRunContext, Operator, Scalar};
+    use crate::ops::{onehot, range, ConstantOfShape, OpError, OperatorExt, Scalar};
 
     #[test]
     fn test_constant_of_shape() {
-        let pool = new_pool();
         let op = ConstantOfShape {
             value: Scalar::Int(42),
         };
         let shape = Tensor::from([1, 5, 10]);
-        let inputs = (&shape).into();
-        let ctx = OpRunContext::new(&pool, &inputs);
-
-        let result = op
-            .run(&ctx)
-            .unwrap()
-            .remove(0)
-            .into_tensor::<i32>()
-            .unwrap();
+        let result: Tensor<i32> = op.run_simple(&shape).unwrap();
 
         assert_eq!(result.shape(), &[1, 5, 10]);
         assert_eq!(result.to_vec(), vec![42; result.shape().iter().product()]);

--- a/src/ops/generate.rs
+++ b/src/ops/generate.rs
@@ -4,8 +4,8 @@ use rten_tensor::prelude::*;
 use rten_tensor::{NdTensorView, Tensor, TensorView};
 
 use crate::ops::{
-    map_input, resolve_axis, resolve_index, static_dims, Input, InputList, IntoOpResult, OpError,
-    Operator, OutputList, Scalar,
+    map_input, resolve_axis, resolve_index, static_dims, Input, IntoOpResult, OpError,
+    OpRunContext, Operator, OutputList, Scalar,
 };
 use crate::tensor_pool::TensorPool;
 
@@ -28,8 +28,9 @@ impl Operator for ConstantOfShape {
         "ConstantOfShape"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
-        let shape = inputs.require_as::<i32>(0)?;
+    fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+        let pool = ctx.pool();
+        let shape = ctx.inputs().require_as::<i32>(0)?;
         let shape = static_dims!(shape, 1)?;
 
         match self.value {
@@ -86,7 +87,8 @@ impl Operator for OneHot {
         "OneHot"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
+    fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+        let inputs = ctx.inputs();
         let indices = inputs.require_as::<i32>(0)?;
         let depth = inputs.require_as::<i32>(1)?;
         let depth = depth
@@ -98,7 +100,7 @@ impl Operator for OneHot {
         map_input!(values, values, [Int32Tensor, FloatTensor], {
             let values = static_dims!(values, 1)?;
             let (on_value, off_value) = extract_on_off_values(values)?;
-            onehot(pool, indices, self.axis, depth, on_value, off_value).into_op_result()
+            onehot(ctx.pool(), indices, self.axis, depth, on_value, off_value).into_op_result()
         })
     }
 }
@@ -132,7 +134,8 @@ impl Operator for Range {
         "Range"
     }
 
-    fn run(&self, _pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
+    fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+        let inputs = ctx.inputs();
         let start = inputs.require(0)?;
         let limit = inputs.require(1)?;
         let delta = inputs.require(2)?;
@@ -156,7 +159,7 @@ mod tests {
     use rten_testing::TestCases;
 
     use crate::ops::tests::new_pool;
-    use crate::ops::{onehot, range, ConstantOfShape, OpError, Operator, Scalar};
+    use crate::ops::{onehot, range, ConstantOfShape, OpError, OpRunContext, Operator, Scalar};
 
     #[test]
     fn test_constant_of_shape() {
@@ -165,9 +168,11 @@ mod tests {
             value: Scalar::Int(42),
         };
         let shape = Tensor::from([1, 5, 10]);
+        let inputs = (&shape).into();
+        let ctx = OpRunContext::new(&pool, &inputs);
 
         let result = op
-            .run(&pool, (&shape).into())
+            .run(&ctx)
             .unwrap()
             .remove(0)
             .into_tensor::<i32>()

--- a/src/ops/identity.rs
+++ b/src/ops/identity.rs
@@ -44,34 +44,18 @@ mod tests {
     use rten_tensor::test_util::expect_equal;
     use rten_tensor::Tensor;
 
-    use crate::ops::tests::new_pool;
-    use crate::ops::{Identity, OpRunContext, Operator};
+    use crate::ops::{Identity, OperatorExt};
 
     #[test]
     fn test_identity() -> Result<(), Box<dyn Error>> {
-        let pool = new_pool();
         let id_op = Identity {};
 
         let int_input = Tensor::from([1, 2, 3]);
-        let inputs = (&int_input).into();
-        let ctx = OpRunContext::new(&pool, &inputs);
-        let result = id_op
-            .run(&ctx)
-            .unwrap()
-            .remove(0)
-            .into_tensor::<i32>()
-            .unwrap();
+        let result: Tensor<i32> = id_op.run_simple(&int_input).unwrap();
         assert_eq!(result, int_input);
 
         let float_input = Tensor::from([1.0, 2.0, 3.0]);
-        let inputs = (&float_input).into();
-        let ctx = OpRunContext::new(&pool, &inputs);
-        let result = id_op
-            .run(&ctx)
-            .unwrap()
-            .remove(0)
-            .into_tensor::<f32>()
-            .unwrap();
+        let result: Tensor<f32> = id_op.run_simple(&float_input).unwrap();
         expect_equal(&result, &float_input)?;
 
         Ok(())

--- a/src/ops/non_max_suppression.rs
+++ b/src/ops/non_max_suppression.rs
@@ -1,7 +1,7 @@
 use rten_tensor::prelude::*;
 use rten_tensor::{NdTensor, NdTensorView};
 
-use crate::ops::{static_dims, InputList, IntoOpResult, OpError, Operator, OutputList};
+use crate::ops::{static_dims, IntoOpResult, OpError, OpRunContext, Operator, OutputList};
 use crate::tensor_pool::TensorPool;
 
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -191,7 +191,8 @@ impl Operator for NonMaxSuppression {
         "NonMaxSuppression"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
+    fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+        let inputs = ctx.inputs();
         let boxes = inputs.require_as(0)?;
         let boxes = static_dims!(boxes, 3, "ND4")?;
 
@@ -203,7 +204,7 @@ impl Operator for NonMaxSuppression {
         let score_threshold = inputs.get_as_scalar(4)?;
 
         let selected_box_indices = non_max_suppression(
-            pool,
+            ctx.pool(),
             boxes,
             scores,
             self.box_order,

--- a/src/ops/pooling.rs
+++ b/src/ops/pooling.rs
@@ -6,7 +6,7 @@ use rten_tensor::prelude::*;
 use rten_tensor::{NdTensor, NdTensorView, NdTensorViewMut, Tensor, TensorView, TensorViewMut};
 use smallvec::SmallVec;
 
-use crate::ops::{static_dims, InputList, IntoOpResult, OpError, Operator, OutputList, Padding};
+use crate::ops::{static_dims, IntoOpResult, OpError, OpRunContext, Operator, OutputList, Padding};
 use crate::tensor_pool::TensorPool;
 
 /// Calculate the output size and padding for a convolution or pooling operation.
@@ -354,10 +354,10 @@ impl Operator for AveragePool {
         "AveragePool"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
-        let input = inputs.require_as(0)?;
+    fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+        let input = ctx.inputs().require_as(0)?;
         average_pool(
-            pool,
+            ctx.pool(),
             input,
             &self.kernel_size,
             &self.strides,
@@ -426,9 +426,9 @@ impl Operator for GlobalAveragePool {
         "GlobalAveragePool"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
-        let input = inputs.require_as(0)?;
-        global_average_pool(pool, input).into_op_result()
+    fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+        let input = ctx.inputs().require_as(0)?;
+        global_average_pool(ctx.pool(), input).into_op_result()
     }
 }
 
@@ -463,10 +463,10 @@ impl Operator for MaxPool {
         "MaxPool"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
-        let input = inputs.require_as(0)?;
+    fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+        let input = ctx.inputs().require_as(0)?;
         max_pool(
-            pool,
+            ctx.pool(),
             input,
             &self.kernel_size,
             &self.strides,

--- a/src/ops/random.rs
+++ b/src/ops/random.rs
@@ -220,8 +220,8 @@ mod tests {
     use rten_testing::TestCases;
 
     use crate::ops::operators::{FloatOperators, Operators};
-    use crate::ops::tests::{new_pool, run_op};
-    use crate::ops::{InputList, OpRunContext, Operator};
+    use crate::ops::tests::new_pool;
+    use crate::ops::{InputList, OpRunContext, Operator, OperatorExt};
 
     use super::{Dropout, RandomNormal, RandomNormalLike, RandomUniform, RandomUniformLike};
 
@@ -272,17 +272,13 @@ mod tests {
             seed,
         }|
         {
-            let pool = new_pool();
             let op = RandomUniform {
                 low,
                 high,
                 shape,
                 seed,
             };
-            let inputs = InputList::new();
-            let ctx = OpRunContext::new(&pool, &inputs);
-            let output = op.run(&ctx).unwrap().remove(0);
-            let output: Tensor = output.try_into().unwrap();
+            let output: Tensor = op.run_simple(InputList::new()).unwrap();
 
             assert_eq!(output.shape(), op.shape);
 
@@ -320,10 +316,7 @@ mod tests {
 
             // Test that repeated generation produces the same output if the
             // seed is fixed, or different output otherwise.
-            let inputs = InputList::new();
-            let ctx = OpRunContext::new(&pool, &inputs);
-            let output_2 = op.run(&ctx).unwrap().remove(0);
-            let output_2: Tensor = output_2.try_into().unwrap();
+            let output_2: Tensor = op.run_simple(InputList::new()).unwrap();
             if let Some(_seed) = seed {
                 assert_eq!(output, output_2);
             } else {
@@ -340,7 +333,7 @@ mod tests {
             high: 2.,
             seed: None,
         };
-        let output: Tensor<f32> = run_op(&op, input.view()).unwrap();
+        let output: Tensor<f32> = op.run_simple(input.view()).unwrap();
         assert_eq!(output.shape(), &[5, 5]);
     }
 
@@ -392,7 +385,7 @@ mod tests {
                 shape,
                 seed,
             };
-            let output: Tensor = run_op(&op, InputList::new()).unwrap();
+            let output: Tensor = op.run_simple(InputList::new()).unwrap();
             assert_eq!(output.shape(), op.shape);
 
             // Test that outputs have expected distribution.
@@ -422,7 +415,7 @@ mod tests {
 
             // Test that repeated generation produces the same output if the
             // seed is fixed, or different output otherwise.
-            let output_2: Tensor = run_op(&op, InputList::new()).unwrap();
+            let output_2: Tensor = op.run_simple(InputList::new()).unwrap();
             if let Some(_seed) = seed {
                 assert_eq!(output, output_2);
             } else {
@@ -439,7 +432,7 @@ mod tests {
             scale: 5.,
             seed: None,
         };
-        let output: Tensor<f32> = run_op(&op, input.view()).unwrap();
+        let output: Tensor<f32> = op.run_simple(input.view()).unwrap();
         assert_eq!(output.shape(), &[5, 5]);
     }
 

--- a/src/ops/reduce.rs
+++ b/src/ops/reduce.rs
@@ -811,11 +811,11 @@ mod tests {
     use rten_tensor::{NdTensor, SliceRange, Tensor};
     use rten_testing::TestCases;
 
-    use crate::ops::tests::{new_pool, run_op};
+    use crate::ops::tests::new_pool;
     use crate::ops::{
         arg_max, arg_min, cum_sum, nonzero, reduce_l2, reduce_max, reduce_mean, reduce_min,
-        reduce_prod, reduce_sum, reduce_sum_square, topk, OpError, Operator, ReduceL2, ReduceMax,
-        ReduceMean, ReduceMin, ReduceProd, ReduceSum, ReduceSumSquare,
+        reduce_prod, reduce_sum, reduce_sum_square, topk, OpError, Operator, OperatorExt, ReduceL2,
+        ReduceMax, ReduceMean, ReduceMin, ReduceProd, ReduceSum, ReduceSumSquare,
     };
 
     #[test]
@@ -993,13 +993,11 @@ mod tests {
         cases.test_each(|case| {
             let input = NdTensor::from([[0., 1., 2.], [3., 4., 5.]]);
             let axes = Tensor::from([0]);
-            let result: NdTensor<f32, 2> =
-                run_op(&*case.op.0, (input.view(), axes.view())).unwrap();
+            let result: NdTensor<f32, 2> = case.op.run_simple((input.view(), axes.view())).unwrap();
             assert_eq!(result.shape(), [1, 3]);
 
             let axes = Tensor::from([1]);
-            let result: NdTensor<f32, 2> =
-                run_op(&*case.op.0, (input.view(), axes.view())).unwrap();
+            let result: NdTensor<f32, 2> = case.op.run_simple((input.view(), axes.view())).unwrap();
             assert_eq!(result.shape(), [2, 1]);
         })
     }

--- a/src/ops/reduce.rs
+++ b/src/ops/reduce.rs
@@ -10,8 +10,8 @@ use rten_vecmath as vecmath;
 use crate::number::{Identities, IsNaN};
 use crate::ops::layout::squeeze_in_place;
 use crate::ops::{
-    map_input, resolve_axes, resolve_axis, Input, InputList, IntoOpResult, OpError, Operator,
-    OutputList,
+    map_input, resolve_axes, resolve_axis, Input, InputList, IntoOpResult, OpError, OpRunContext,
+    Operator, OutputList,
 };
 use crate::slice_reductions::slice_sum;
 use crate::tensor_pool::TensorPool;
@@ -94,10 +94,10 @@ impl Operator for ArgMax {
         "ArgMax"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
-        let input = inputs.require(0)?;
+    fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+        let input = ctx.inputs().require(0)?;
         map_input!(input, input, [FloatTensor, Int32Tensor], {
-            arg_max(pool, input, self.axis, self.keep_dims).into_op_result()
+            arg_max(ctx.pool(), input, self.axis, self.keep_dims).into_op_result()
         })
     }
 }
@@ -130,10 +130,10 @@ impl Operator for ArgMin {
         "ArgMin"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
-        let input = inputs.require(0)?;
+    fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+        let input = ctx.inputs().require(0)?;
         map_input!(input, input, [FloatTensor, Int32Tensor], {
-            arg_min(pool, input, self.axis, self.keep_dims).into_op_result()
+            arg_min(ctx.pool(), input, self.axis, self.keep_dims).into_op_result()
         })
     }
 }
@@ -175,11 +175,12 @@ impl Operator for CumSum {
         "CumSum"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
+    fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+        let inputs = ctx.inputs();
         let input = inputs.require(0)?;
         let axis: i32 = inputs.require_as_scalar(1)?;
         map_input!(input, input, [FloatTensor, Int32Tensor], {
-            cum_sum(pool, input, axis as isize).into_op_result()
+            cum_sum(ctx.pool(), input, axis as isize).into_op_result()
         })
     }
 }
@@ -218,10 +219,10 @@ impl Operator for NonZero {
         "NonZero"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
-        let input = inputs.require(0)?;
+    fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+        let input = ctx.inputs().require(0)?;
         map_input!(input, input, [FloatTensor, Int32Tensor], {
-            nonzero(pool, input).into_op_result()
+            nonzero(ctx.pool(), input).into_op_result()
         })
     }
 }
@@ -409,11 +410,12 @@ impl Operator for ReduceMean {
         "ReduceMean"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
+    fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+        let inputs = ctx.inputs();
         let input = inputs.require_as(0)?;
-        let axes = get_axes(&inputs, &self.axes)?;
+        let axes = get_axes(inputs, &self.axes)?;
         reduce_mean(
-            pool,
+            ctx.pool(),
             input,
             axes.as_ref().map(|axis| &axis[..]),
             self.keep_dims,
@@ -449,11 +451,12 @@ impl Operator for ReduceL2 {
         "ReduceL2"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
+    fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+        let inputs = ctx.inputs();
         let input = inputs.require_as(0)?;
-        let axes = get_axes(&inputs, &self.axes)?;
+        let axes = get_axes(inputs, &self.axes)?;
         reduce_l2(
-            pool,
+            ctx.pool(),
             input,
             axes.as_ref().map(|axis| &axis[..]),
             self.keep_dims,
@@ -548,11 +551,12 @@ impl Operator for ReduceMin {
         "ReduceMin"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
+    fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+        let inputs = ctx.inputs();
         let input = inputs.require(0)?;
-        let axes = get_axes(&inputs, &self.axes)?;
+        let axes = get_axes(inputs, &self.axes)?;
         map_input!(input, input, [FloatTensor, Int32Tensor], {
-            reduce_min(pool, input, axes.as_deref(), self.keep_dims).into_op_result()
+            reduce_min(ctx.pool(), input, axes.as_deref(), self.keep_dims).into_op_result()
         })
     }
 }
@@ -577,11 +581,12 @@ impl Operator for ReduceMax {
         "ReduceMax"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
+    fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+        let inputs = ctx.inputs();
         let input = inputs.require(0)?;
-        let axes = get_axes(&inputs, &self.axes)?;
+        let axes = get_axes(inputs, &self.axes)?;
         map_input!(input, input, [FloatTensor, Int32Tensor], {
-            reduce_max(pool, input, axes.as_deref(), self.keep_dims).into_op_result()
+            reduce_max(ctx.pool(), input, axes.as_deref(), self.keep_dims).into_op_result()
         })
     }
 }
@@ -612,11 +617,12 @@ impl Operator for ReduceProd {
         "ReduceProd"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
+    fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+        let inputs = ctx.inputs();
         let input = inputs.require(0)?;
-        let axes = get_axes(&inputs, &self.axes)?;
+        let axes = get_axes(inputs, &self.axes)?;
         map_input!(input, input, [FloatTensor, Int32Tensor], {
-            reduce_prod(pool, input, axes.as_deref(), self.keep_dims).into_op_result()
+            reduce_prod(ctx.pool(), input, axes.as_deref(), self.keep_dims).into_op_result()
         })
     }
 }
@@ -647,11 +653,12 @@ impl Operator for ReduceSum {
         "ReduceSum"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
+    fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+        let inputs = ctx.inputs();
         let input = inputs.require(0)?;
-        let axes = get_axes(&inputs, &self.axes)?;
+        let axes = get_axes(inputs, &self.axes)?;
         map_input!(input, input, [FloatTensor, Int32Tensor], {
-            reduce_sum(pool, input, axes.as_deref(), self.keep_dims).into_op_result()
+            reduce_sum(ctx.pool(), input, axes.as_deref(), self.keep_dims).into_op_result()
         })
     }
 }
@@ -682,11 +689,12 @@ impl Operator for ReduceSumSquare {
         "ReduceSumSquare"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
+    fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+        let inputs = ctx.inputs();
         let input = inputs.require(0)?;
-        let axes = get_axes(&inputs, &self.axes)?;
+        let axes = get_axes(inputs, &self.axes)?;
         map_input!(input, input, [FloatTensor, Int32Tensor], {
-            reduce_sum_square(pool, input, axes.as_deref(), self.keep_dims).into_op_result()
+            reduce_sum_square(ctx.pool(), input, axes.as_deref(), self.keep_dims).into_op_result()
         })
     }
 }
@@ -775,7 +783,8 @@ impl Operator for TopK {
         "TopK"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
+    fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+        let inputs = ctx.inputs();
         let values = inputs.require(0)?;
         let k = inputs.require_as_scalar::<i32>(1).and_then(|k| {
             if k < 0 {
@@ -786,7 +795,8 @@ impl Operator for TopK {
         })?;
 
         map_input!(values, values, [FloatTensor, Int32Tensor], {
-            let (values, indices) = topk(pool, values, k, self.axis, self.largest, self.sorted)?;
+            let (values, indices) =
+                topk(ctx.pool(), values, k, self.axis, self.largest, self.sorted)?;
             Ok([values.into(), indices.into()].into_iter().collect())
         })
     }

--- a/src/ops/rnn.rs
+++ b/src/ops/rnn.rs
@@ -6,7 +6,7 @@ use rten_tensor::{NdTensor, Tensor, TensorView};
 
 use crate::gemm::{GemmExecutor, GemmInputA, GemmInputB};
 use crate::ops::{
-    add_in_place, mul_in_place, sigmoid, static_dims, tanh, InputList, IntoOpResult, OpError,
+    add_in_place, mul_in_place, sigmoid, static_dims, tanh, IntoOpResult, OpError, OpRunContext,
     Operator, OutputList,
 };
 use crate::tensor_pool::{AutoReturn, TensorPool};
@@ -327,7 +327,8 @@ impl Operator for GRU {
         "GRU"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
+    fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+        let inputs = ctx.inputs();
         let input = inputs.require_as(0)?;
         let weights = inputs.require_as(1)?;
         let recurrent_weights = inputs.require_as(2)?;
@@ -336,7 +337,7 @@ impl Operator for GRU {
         let initial_hidden = inputs.get_as(5)?;
 
         gru(
-            pool,
+            ctx.pool(),
             self.direction,
             input,
             weights,
@@ -573,7 +574,8 @@ impl Operator for LSTM {
         "LSTM"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
+    fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+        let inputs = ctx.inputs();
         let input = inputs.require_as(0)?;
         let weights = inputs.require_as(1)?;
         let recurrent_weights = inputs.require_as(2)?;
@@ -583,7 +585,7 @@ impl Operator for LSTM {
         let initial_cell = inputs.get_as(6)?;
 
         lstm(
-            pool,
+            ctx.pool(),
             self.direction,
             input,
             weights,

--- a/src/ops/split.rs
+++ b/src/ops/split.rs
@@ -3,7 +3,7 @@ use rten_tensor::{NdTensorView, Tensor, TensorView};
 
 use crate::iter_util::range_chunks;
 use crate::ops::{
-    map_input, resolve_axis, static_dims, Input, InputList, OpError, Operator, OutputList,
+    map_input, resolve_axis, static_dims, Input, OpError, OpRunContext, Operator, OutputList,
 };
 use crate::tensor_pool::TensorPool;
 
@@ -84,9 +84,9 @@ impl Operator for Split {
         "Split"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
-        let input = inputs.require(0)?;
-        let splits = inputs.get_as::<i32>(1)?;
+    fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+        let input = ctx.inputs().require(0)?;
+        let splits = ctx.inputs().get_as::<i32>(1)?;
 
         let split_sizes = if let Some(splits) = splits {
             let splits = static_dims!(splits, 1)?;
@@ -100,7 +100,7 @@ impl Operator for Split {
         };
 
         map_input!(input, x, {
-            split(pool, x, self.axis, split_sizes)
+            split(ctx.pool(), x, self.axis, split_sizes)
                 .map(|tensors| tensors.into_iter().map(|t| t.into()).collect())
         })
     }

--- a/src/ops/trilu.rs
+++ b/src/ops/trilu.rs
@@ -1,7 +1,7 @@
 use rten_tensor::prelude::*;
 use rten_tensor::{Tensor, TensorView};
 
-use crate::ops::{map_input, Input, InputList, IntoOpResult, OpError, Operator, OutputList};
+use crate::ops::{map_input, Input, IntoOpResult, OpError, OpRunContext, Operator, OutputList};
 use crate::tensor_pool::TensorPool;
 
 pub fn trilu<T: Copy + Default>(
@@ -43,12 +43,13 @@ impl Operator for Trilu {
         "Trilu"
     }
 
-    fn run(&self, pool: &TensorPool, inputs: InputList) -> Result<OutputList, OpError> {
+    fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+        let inputs = ctx.inputs();
         let input = inputs.require(0)?;
         let k = inputs.get_as_scalar(1)?.unwrap_or(0);
 
         map_input!(input, input, [FloatTensor, Int32Tensor], {
-            trilu(pool, input, k, self.upper).into_op_result()
+            trilu(ctx.pool(), input, k, self.upper).into_op_result()
         })
     }
 }


### PR DESCRIPTION
Replace the `(&TensorPool, InputList)` arguments to `Operator::run` with a single `&OpRunContext` argument. This allows for passing additional information to operator executions without needing to change the signature of `run` each time. This _may_ be useful in solving https://github.com/robertknight/rten/issues/689, although that issue notes some other ways the issue could be resolved.

This makes invoking `run` directly a little more complex. To avoid repeated boilerplate for calling operators in tests, add a new `OperatorExt` trait that provides some convenience methods to simplify this. These method  replace some existing utility functions that existed for the same purpose.