### PR TITLE
Support `Split` operators that don't specify expected number of outputs

### DIFF
--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -785,11 +785,16 @@ pub(crate) use static_dims;
 pub struct OpRunContext<'a, 'i> {
     pool: &'a TensorPool,
     inputs: &'a InputList<'i>,
+    n_outputs: Option<u32>,
 }
 
 impl<'a, 'i> OpRunContext<'a, 'i> {
     pub fn new(pool: &'a TensorPool, inputs: &'a InputList<'i>) -> Self {
-        OpRunContext { pool, inputs }
+        OpRunContext {
+            pool,
+            inputs,
+            n_outputs: None,
+        }
     }
 
     /// The pool which should be used to allocate large buffers.
@@ -800,6 +805,15 @@ impl<'a, 'i> OpRunContext<'a, 'i> {
     /// Inputs to the operator execution.
     pub fn inputs(&self) -> &InputList<'i> {
         self.inputs
+    }
+
+    pub fn set_num_outputs(&mut self, n: u32) {
+        self.n_outputs = Some(n);
+    }
+
+    /// The number of requested outputs.
+    pub fn num_outputs(&self) -> Option<u32> {
+        self.n_outputs
     }
 }
 

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -807,11 +807,17 @@ impl<'a, 'i> OpRunContext<'a, 'i> {
         self.inputs
     }
 
+    /// Set the requested number of outputs.
+    ///
+    /// This can be used to skip generating outputs that are unused, or in
+    /// the rare cases that the output count cannot be determined from the
+    /// operator's inputs and attributes alone.
     pub fn set_num_outputs(&mut self, n: u32) {
         self.n_outputs = Some(n);
     }
 
-    /// The number of requested outputs.
+    /// Return the number of requested outputs or `None` if this has not been
+    /// specified.
     pub fn num_outputs(&self) -> Option<u32> {
         self.n_outputs
     }


### PR DESCRIPTION
Support `Split` operators that don't specify the expected number of outputs via the `num_outputs` attribute or `split` input.

- Add `OpRunContext::num_outputs` method which returns the number of output value nodes an operator has in the graph
- Use `OpRunContext::num_outputs` to get the number of outputs in the `Split` operator if the operator doesn't receive a `split` input or `num_outputs` attribute.

Fixes https://github.com/robertknight/rten/issues/689.