### PR TITLE
Inline `RangeChunksExact::remainder`

### DIFF
--- a/rten-tensor/src/copy.rs
+++ b/rten-tensor/src/copy.rs
@@ -60,6 +60,7 @@ pub struct RangeChunksExact {
 
 impl RangeChunksExact {
     /// Return the part of the range that has not yet been visited.
+    #[inline]
     pub fn remainder(&self) -> Range<usize> {
         self.remainder.clone()
     }


### PR DESCRIPTION
This trivial method was showing up in `copy_into_slice` calls (during eg. Transpose operations).