### PR TITLE
Use slice `contains` instead of `iter().any(...)`

### DIFF
--- a/rten-tensor/src/layout.rs
+++ b/rten-tensor/src/layout.rs
@@ -93,7 +93,7 @@ pub trait Layout {
     /// Return true if iterating over elements in this layout will visit
     /// elements multiple times.
     fn is_broadcast(&self) -> bool {
-        !self.is_empty() && self.strides().as_ref().iter().any(|&stride| stride == 0)
+        !self.is_empty() && self.strides().as_ref().contains(&0)
     }
 
     /// Returns true if the array has no elements.
@@ -183,7 +183,7 @@ pub trait Layout {
     /// Return the minimum length required for the element data buffer used
     /// with this layout.
     fn min_data_len(&self) -> usize {
-        if self.shape().as_ref().iter().any(|&size| size == 0) {
+        if self.shape().as_ref().contains(&0) {
             return 0;
         }
         let max_offset: usize = self
@@ -357,7 +357,7 @@ fn slice_layout<I: AsRef<[usize]>, O: AsMut<[usize]>>(
         }
     }
 
-    if out_shape.iter().any(|size| *size == 0) {
+    if out_shape.contains(&0) {
         offset = 0;
     }
 

--- a/rten-tensor/src/overlap.rs
+++ b/rten-tensor/src/overlap.rs
@@ -43,7 +43,7 @@ pub fn is_contiguous<S: AsRef<[usize]>>(shape: S, strides: S) -> bool {
 pub fn may_have_internal_overlap(shape: &[usize], strides: &[usize]) -> bool {
     // If the tensor is empty (ie. there are no valid indices), there can't be
     // any overlap.
-    if shape.iter().any(|&size| size == 0) {
+    if shape.contains(&0) {
         return false;
     }
 

--- a/src/ops/pad.rs
+++ b/src/ops/pad.rs
@@ -71,7 +71,7 @@ pub fn pad<T: Copy>(
                 ));
             }
 
-            if input.shape()[batch_dims..].iter().any(|&size| size == 0) {
+            if input.shape()[batch_dims..].contains(&0) {
                 return Err(OpError::InvalidValue(
                     "Padded dimension for reflect padding is empty",
                 ));


### PR DESCRIPTION
Address `clippy::manual_contains` lint warning after updating to Rust v1.87.