### PR TITLE
Support fusing subgraphs with multiple outputs

### DIFF
--- a/src/graph/node.rs
+++ b/src/graph/node.rs
@@ -102,13 +102,6 @@ impl OperatorNode {
         &self.outputs
     }
 
-    pub fn output_id(&self) -> Option<NodeId> {
-        match &self.outputs[..] {
-            [Some(id)] => Some(*id),
-            _ => None,
-        }
-    }
-
     pub fn operator(&self) -> &dyn Operator {
         self.operator.as_ref()
     }


### PR DESCRIPTION
Lift the restriction that fused operators can only have a single output. This restriction might have simplified the code at an earlier point in time, but that is no longer the case. None of the current fused operators actually have multiple outputs, so this doesn't change what the optimizer does.