### PR TITLE
Make transpose fusion more flexible

### DIFF
--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -60,8 +60,8 @@ mod trilu;
 mod unary_elementwise;
 mod variadic_elementwise;
 
-// Fused operators.
-pub(crate) mod fused;
+// Fused operations
+pub(crate) mod transform_inputs;
 
 pub use binary_elementwise::{
     add, add_in_place, and, div, div_in_place, equal, greater, greater_or_equal, less,


### PR DESCRIPTION
Rework transpose fusion to support:

 - Fusing subgraphs where multiple inputs to the same operator are transposed
 - Transposing all supported input types

The new structure replaces the `FusedTranspose` operator with a `TransformInputs` operator which contains a list of `(input_index, transform)` tuples of transformations to apply to inputs. This structure should also make it easier to fuse other layout transformations (slicing, broadcasting etc.) in future. When matching Transpose operations, instead of finding a Transpose operator and then looking for its target, instead start with the potential target and look for all source nodes that are transposed.