### PR TITLE
Reduce GEMM int8 tile size on Arm

### DIFF
--- a/src/gemm/kernels/aarch64.rs
+++ b/src/gemm/kernels/aarch64.rs
@@ -256,7 +256,7 @@ pub struct ArmInt8DotKernel {
 
 impl ArmInt8DotKernel {
     const MR: usize = 4;
-    const NR: usize = 16;
+    const NR: usize = 12;
 }
 
 unsafe impl Kernel<u8, i8, i32> for ArmInt8DotKernel {


### PR DESCRIPTION
Work around an issue where, after updating from Rust v1.86 to Rust v1.87, the Arm int8 UDOT kernel started storing the tile of C on the stack instead of in registers. Reducing the tile size results in the tile being stored in registers again.

With the reduced tile size, performance on M3 ended up being the same as under v1.86.

Fixes https://github.com/robertknight/rten/issues/701

**TODO:**

- [ ] Check the non-UDOT kernel