### PR TITLE
Don't fuse subgraphs if intermediate values are used outside the subgraph

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -651,7 +651,7 @@ impl Graph {
 
         // Count how often each temporary output is used, so we can free them
         // when no longer needed.
-        let mut temp_value_refcount = NodeRefCount::with_capacity(self.nodes.len());
+        let mut temp_value_refcount = NodeRefCount::with_capacity(self.next_node_id as usize);
         for &op_node_id in plan.iter() {
             let Some(Node::Operator(op_node)) = self.nodes.get(&op_node_id) else {
                 return Err(RunError::PlanningError(

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1620,12 +1620,11 @@ mod tests {
     fn test_invalid_input_id() {
         let mut g = Graph::new();
 
-        let const_id = g.add_constant(None, Tensor::<f32>::zeros(&[5, 5]));
         let (op_id, op_out) = g.add_simple_op("op", AddOne {}, &[]);
         let input = Tensor::from([1.]);
         let invalid_id = NodeId::from_u32(1234);
 
-        for wrong_input_id in [const_id, op_id, invalid_id] {
+        for wrong_input_id in [op_id, invalid_id] {
             let result = g.run(
                 [(wrong_input_id, input.view().into())].into(),
                 &[op_out],

--- a/src/graph/node.rs
+++ b/src/graph/node.rs
@@ -52,6 +52,14 @@ impl Node {
             Node::Operator(_) => None,
         }
     }
+
+    /// Return the contained operator, if this an operator node.
+    pub fn as_operator(&self) -> Option<&OperatorNode> {
+        match self {
+            Node::Operator(op) => Some(op),
+            _ => None,
+        }
+    }
 }
 
 /// Represents the size of a dimension of a runtime-provided value, such as

--- a/src/graph/planner.rs
+++ b/src/graph/planner.rs
@@ -135,7 +135,7 @@ impl<'a> Planner<'a> {
         }
         for (input_index, input_id) in inputs.iter().enumerate() {
             match self.graph.get_node(*input_id) {
-                Some(Node::Value(_)) => {}
+                Some(Node::Value(_) | Node::Constant(_)) => {}
                 _ => {
                     let name = self.graph.node_name(*input_id);
                     return Err(RunError::PlanningError(format!(


### PR DESCRIPTION
Don't fuse operations if intermediate values generated by sub-steps of the
un-fused operation are consumed by other operators in the graph or are used as
graph outputs. Previously such a situation could lead to both the fused and
un-fused versions of the operator being run, which could end up being slower
than just running the un-fused version.

Fixes https://github.com/robertknight/rten/issues/708

---

**TODO:**

- [x] Tests for new graph APIs
- [x] Tests for fusion changes
- [x] Investigate why some ops that should be fused in ModernBERT are no longer fused (but most fusions do still work)