### PR TITLE
Add API and CLI option to set number of threads

### DIFF
--- a/rten-cli/src/main.rs
+++ b/rten-cli/src/main.rs
@@ -4,7 +4,7 @@ use std::time::Instant;
 
 use rten::{
     DataType, Dimension, InputOrOutput, Model, ModelMetadata, ModelOptions, NodeId, Output,
-    RunOptions,
+    RunOptions, ThreadPool,
 };
 use rten_tensor::prelude::*;
 use rten_tensor::Tensor;
@@ -39,6 +39,9 @@ struct Args {
 
     /// Load model using `Model::load_mmap`.
     mmap: bool,
+
+    /// Number of threads to use.
+    num_threads: Option<u32>,
 }
 
 fn parse_args() -> Result<Args, lexopt::Error> {
@@ -54,19 +57,27 @@ fn parse_args() -> Result<Args, lexopt::Error> {
     let mut input_sizes = Vec::new();
     let mut optimize = true;
     let mut prepack_weights = false;
+    let mut num_threads = None;
+
+    let parse_uint = |parser: &mut lexopt::Parser, opt_name| -> Result<u32, lexopt::Error> {
+        let value = parser.value()?.string()?;
+        value
+            .parse()
+            .map_err(|_| format!("Unable to parse `{}`", opt_name).into())
+    };
 
     let mut parser = lexopt::Parser::from_env();
     while let Some(arg) = parser.next()? {
         match arg {
             Value(val) => values.push_back(val.string()?),
             Long("mmap") => mmap = true,
-            Short('n') | Long("n_iters") => {
-                let value = parser.value()?.string()?;
-                n_iters = value
-                    .parse()
-                    .map_err(|_| "Unable to parse `n_iters`".to_string())?;
+            Short('n') | Long("num-iters") => {
+                n_iters = parse_uint(&mut parser, "num-iters")?;
             }
             Long("no-optimize") => optimize = false,
+            Long("num-threads") => {
+                num_threads = Some(parse_uint(&mut parser, "num-threads")?);
+            }
             Short('p') | Long("prepack") => prepack_weights = true,
             Short('q') | Long("quiet") => quiet = true,
             Short('v') | Long("verbose") => verbose = true,
@@ -96,10 +107,12 @@ Options:
 
   --mmap         Load model via memory mapping
 
-  -n, --n_iters <n>
+  -n, --num-iters <n>
                  Number of times to evaluate model
 
   --no-optimize  Disable graph optimizations
+
+  --num-threads  Specify number of threads to use
 
   -q, --quiet    Run model and don't produce other output
 
@@ -132,6 +145,7 @@ Options:
         mmap,
         model,
         n_iters,
+        num_threads,
         optimize,
         prepack_weights,
         quiet,
@@ -486,14 +500,19 @@ fn main() -> Result<(), Box<dyn Error>> {
         println!("Running model with random inputs...");
     }
 
+    let run_opts = RunOptions {
+        timing: args.timing,
+        verbose: args.verbose,
+        thread_pool: args
+            .num_threads
+            .map(|nt| ThreadPool::with_num_threads(nt as usize).into()),
+        ..Default::default()
+    };
+
     if let Err(err) = run_with_random_input(
         &model,
         &args.input_sizes,
-        RunOptions {
-            timing: args.timing,
-            verbose: args.verbose,
-            ..Default::default()
-        },
+        run_opts,
         args.n_iters,
         args.quiet,
     ) {

--- a/src/threading.rs
+++ b/src/threading.rs
@@ -22,6 +22,16 @@ impl ThreadPool {
             op()
         }
     }
+
+    /// Create a thread pool with a given number of threads.
+    pub fn with_num_threads(num_threads: usize) -> ThreadPool {
+        let pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(num_threads)
+            .thread_name(|index| format!("rten-{}", index))
+            .build();
+
+        ThreadPool { pool: pool.ok() }
+    }
 }
 
 /// Return the optimal number of cores to use for maximum performance.
@@ -53,6 +63,9 @@ fn optimal_core_count() -> u32 {
 /// `RTEN_NUM_THREADS` environment variable, whose value must be a number
 /// between 1 and the logical core count.
 ///
+/// The thread count can be overridden for each model run by configuring a
+/// custom thread pool in [`RunOptions`](crate::RunOptions).
+///
 /// To run your own tasks in this thread pool, you can use
 /// [`ThreadPool::run`].
 ///
@@ -72,12 +85,7 @@ pub fn thread_pool() -> &'static ThreadPool {
             physical_cpus
         };
 
-        let pool = rayon::ThreadPoolBuilder::new()
-            .num_threads(num_threads as usize)
-            .thread_name(|index| format!("rten-{}", index))
-            .build();
-
-        ThreadPool { pool: pool.ok() }
+        ThreadPool::with_num_threads(num_threads as usize)
     })
 }
 


### PR DESCRIPTION
Add an API (`RunOptions::thread_pool`) and CLI options (`-t, --num-threads`) to set the number of threads used by inference. The `RunOptions::thread_pool` field is an `Arc` to avoid needing to add a lifetime to `RunOptions` everywhere.

This is a breaking change for the CLI as several existing options have been renamed in order to give `--num-threads` a shorthand that matches `ort-infer.py`. See last commit.