### PR TITLE
Upgrade to actions/checkout@v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Install Rust WASM targets
       run: |
         rustup target add wasm32-unknown-unknown


### PR DESCRIPTION
This might help with a recent CI failure on main: https://github.com/robertknight/rten/actions/runs/15250154351/job/42884956471

Edit: Nope, the failure was probably due to ongoing issues with GitHub Actions.