### PR TITLE
Prevent using `cast_pod_mut_slice` to cast uninit slices to initialized

### DIFF
--- a/src/gemm/im2col.rs
+++ b/src/gemm/im2col.rs
@@ -6,7 +6,7 @@ use rten_simd::{Isa, Mask, Simd};
 use rten_tensor::{NdTensorView, Storage};
 
 use super::packing::int8::shift_cast_i8_u8;
-use crate::slice_cast::cast_pod_mut_slice;
+use crate::slice_cast::cast_uninit_pod_mut_slice;
 
 /// Maps rows of an [`Im2Col`] matrix to locations in the source image.
 ///
@@ -231,7 +231,7 @@ impl Im2Col<'_, i8> {
         rows: Range<usize>,
         cols: Range<usize>,
     ) {
-        let out = cast_pod_mut_slice(out).unwrap();
+        let out = cast_uninit_pod_mut_slice(out).unwrap();
         self.pack_block_int8::<_, NR_REGS, true>(isa, out, rows, cols);
     }
 

--- a/src/gemm/kernels/generic.rs
+++ b/src/gemm/kernels/generic.rs
@@ -8,7 +8,7 @@ use super::simd_generic::{simd_gemv, GemmDispatch};
 use super::{Kernel, Lhs, MatVecOutput, PackedLayout, QuantParams, TempTile};
 use crate::gemm::packing::{pack_a_block, pack_b_block, packed_a_layout, packed_b_layout};
 use crate::gemm::Im2Col;
-use crate::slice_cast::{cast_pod_mut_slice, cast_pod_slice};
+use crate::slice_cast::{cast_pod_slice, cast_uninit_pod_mut_slice};
 
 /// This is the base kernel that does not use architecture-specific intrinsics
 /// but is autovectorization-friendly. It is expected to perform the same as
@@ -68,7 +68,7 @@ unsafe impl Kernel<f32, f32, f32> for GenericKernel {
         cols: Range<usize>,
         _quant: Option<QuantParams<f32>>,
     ) {
-        let out = cast_pod_mut_slice(out).unwrap();
+        let out = cast_uninit_pod_mut_slice(out).unwrap();
         pack_a_block::<f32, { Self::MR }>(out, a, rows, cols);
     }
 
@@ -89,7 +89,7 @@ unsafe impl Kernel<f32, f32, f32> for GenericKernel {
         cols: Range<usize>,
         _quant: Option<QuantParams<f32>>,
     ) {
-        let out = cast_pod_mut_slice(out).unwrap();
+        let out = cast_uninit_pod_mut_slice(out).unwrap();
         pack_b_block::<f32, { Self::NR }>(out, b, rows, cols);
     }
 
@@ -103,7 +103,7 @@ unsafe impl Kernel<f32, f32, f32> for GenericKernel {
         const NR_REGS: usize = GenericKernel::NR / X32_LANES;
 
         // Safety: Scalar "SIMD" types are always supported
-        let out = cast_pod_mut_slice(out).unwrap();
+        let out = cast_uninit_pod_mut_slice(out).unwrap();
         image.pack_block::<_, NR_REGS>(self.isa, out, Self::NR, rows, cols);
     }
 
@@ -219,7 +219,7 @@ unsafe impl Kernel<u8, i8, i32> for GenericKernel {
         cols: Range<usize>,
         _quant: Option<QuantParams<u8>>,
     ) {
-        let out = cast_pod_mut_slice(out).unwrap();
+        let out = cast_uninit_pod_mut_slice(out).unwrap();
         pack_a_block::<u8, { Self::MR }>(out, a, rows, cols);
     }
 
@@ -240,7 +240,7 @@ unsafe impl Kernel<u8, i8, i32> for GenericKernel {
         cols: Range<usize>,
         _quant: Option<QuantParams<i8>>,
     ) {
-        let out = cast_pod_mut_slice(out).unwrap();
+        let out = cast_uninit_pod_mut_slice(out).unwrap();
         pack_b_block::<i8, { Self::NR }>(out, b, rows, cols);
     }
 
@@ -254,7 +254,7 @@ unsafe impl Kernel<u8, i8, i32> for GenericKernel {
         const NR_REGS: usize = GenericKernel::NR / 4;
 
         // Safety: Scalar "SIMD" types are always supported
-        let out = cast_pod_mut_slice(out).unwrap();
+        let out = cast_uninit_pod_mut_slice(out).unwrap();
         image.pack_block::<_, NR_REGS>(self.isa, out, Self::NR, rows, cols);
     }
 

--- a/src/gemm/kernels/wasm.rs
+++ b/src/gemm/kernels/wasm.rs
@@ -11,7 +11,7 @@ use super::{
 };
 use crate::gemm::packing::{pack_a_block, pack_b_block, packed_a_layout, packed_b_layout};
 use crate::gemm::{packing, Im2Col};
-use crate::slice_cast::{cast_pod_mut_slice, cast_pod_slice};
+use crate::slice_cast::{cast_pod_slice, cast_uninit_pod_mut_slice};
 
 pub struct WasmKernel {
     isa: Wasm32Isa,
@@ -68,7 +68,7 @@ unsafe impl Kernel<f32, f32, f32> for WasmKernel {
         cols: Range<usize>,
         _quant: Option<QuantParams<f32>>,
     ) {
-        let out = cast_pod_mut_slice(out).unwrap();
+        let out = cast_uninit_pod_mut_slice(out).unwrap();
         pack_a_block::<f32, { Self::MR }>(out, a, rows, cols);
     }
 
@@ -89,7 +89,7 @@ unsafe impl Kernel<f32, f32, f32> for WasmKernel {
         cols: Range<usize>,
         _quant: Option<QuantParams<f32>>,
     ) {
-        let out = cast_pod_mut_slice(out).unwrap();
+        let out = cast_uninit_pod_mut_slice(out).unwrap();
         pack_b_block::<f32, { Self::NR }>(out, b, rows, cols);
     }
 
@@ -103,7 +103,7 @@ unsafe impl Kernel<f32, f32, f32> for WasmKernel {
         const NR_REGS: usize = WasmKernel::NR / X32_LANES;
 
         // Safety: WASM SIMD types are supported
-        let out = cast_pod_mut_slice(out).unwrap();
+        let out = cast_uninit_pod_mut_slice(out).unwrap();
         image.pack_block::<_, NR_REGS>(self.isa, out, Self::NR, rows, cols);
     }
 
@@ -230,7 +230,7 @@ unsafe impl Kernel<u8, i8, i32> for WasmInt8Kernel {
         cols: Range<usize>,
         _quant: Option<QuantParams<u8>>,
     ) {
-        let out = cast_pod_mut_slice(out).unwrap();
+        let out = cast_uninit_pod_mut_slice(out).unwrap();
         packing::int8::pack_a::<{ Self::MR }>(out, a.slice((rows, cols)))
     }
 

--- a/src/gemm/packing.rs
+++ b/src/gemm/packing.rs
@@ -5,7 +5,7 @@ use rten_tensor::{Alloc, Matrix, MatrixLayout, Storage};
 
 use super::kernels::PackedLayout;
 use crate::iter_util::range_chunks;
-use crate::slice_cast::{cast_pod_mut_slice, cast_pod_slice};
+use crate::slice_cast::{cast_pod_slice, cast_uninit_pod_mut_slice};
 
 pub mod int8;
 
@@ -239,7 +239,7 @@ impl PackingBuffer {
         self.used_len = 0;
 
         let uninit_data = &mut self.buf.spare_capacity_mut()[..buf_len];
-        cast_pod_mut_slice(uninit_data).unwrap()
+        cast_uninit_pod_mut_slice(uninit_data).unwrap()
     }
 
     /// Clear the buffer and allocate a new one using `alloc`.
@@ -260,7 +260,7 @@ impl PackingBuffer {
         self.used_len = 0;
 
         let uninit_data = &mut self.buf.spare_capacity_mut()[..buf_len];
-        cast_pod_mut_slice(uninit_data).unwrap()
+        cast_uninit_pod_mut_slice(uninit_data).unwrap()
     }
 
     /// Set the number of bytes in the buffer which have been initialized.


### PR DESCRIPTION
Fix a soundness hole where `cast_pod_mut_slice` and `cast_pod_slice` could be used to transmute `[MaybeUninit<T>]` to `[T]` without `unsafe`.

Un-implement the `Pod` trait for `MaybeUninit<T: Pod>` and add a separate function for casting uninitialized mutable slices. There is no counterpart for casting uninitialized non-mutable slices because there isn't a need yet.