### PR TITLE
Support approximate Gelu

### DIFF
--- a/rten-convert/rten_convert/converter.py
+++ b/rten-convert/rten_convert/converter.py
@@ -450,9 +450,10 @@ def op_node_from_onnx_operator(
             attrs.batchDims = attr_reader.get_attr("batch_dims", "int", 0)
 
         case "Gelu":
-            # Gelu has an "approximate" attr in the ONNX spec, but this is
-            # not currently implemented.
             attrs = sg.GeluAttrsT()
+            attrs.approximate = attr_reader.get_enum_attr(
+                "approximate", sg.GeluApproximation, "none"
+            )
 
         case "Gemm":
             attrs = sg.GemmAttrsT()

--- a/rten-convert/rten_convert/schema_generated.py
+++ b/rten-convert/rten_convert/schema_generated.py
@@ -328,6 +328,11 @@ def ScalarCreator(unionType, table):
     return None
 
 
+class GeluApproximation(object):
+    None_ = 0
+    Tanh = 1
+
+
 class NMSBoxOrder(object):
     TopLeftBottomRight = 0
     CenterWidthHeight = 1
@@ -2455,8 +2460,18 @@ class GeluAttrs(object):
     def Init(self, buf, pos):
         self._tab = flatbuffers.table.Table(buf, pos)
 
+    # GeluAttrs
+    def Approximate(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
+        if o != 0:
+            return self._tab.Get(flatbuffers.number_types.Uint8Flags, o + self._tab.Pos)
+        return 0
+
 def GeluAttrsStart(builder):
-    builder.StartObject(0)
+    builder.StartObject(1)
+
+def GeluAttrsAddApproximate(builder, approximate):
+    builder.PrependUint8Slot(0, approximate, 0)
 
 def GeluAttrsEnd(builder):
     return builder.EndObject()
@@ -2467,7 +2482,7 @@ class GeluAttrsT(object):
 
     # GeluAttrsT
     def __init__(self):
-        pass
+        self.approximate = 0  # type: int
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -2490,10 +2505,12 @@ class GeluAttrsT(object):
     def _UnPack(self, geluAttrs):
         if geluAttrs is None:
             return
+        self.approximate = geluAttrs.Approximate()
 
     # GeluAttrsT
     def Pack(self, builder):
         GeluAttrsStart(builder)
+        GeluAttrsAddApproximate(builder, self.approximate)
         geluAttrs = GeluAttrsEnd(builder)
         return geluAttrs
 

--- a/rten-vecmath/src/lib.rs
+++ b/rten-vecmath/src/lib.rs
@@ -112,7 +112,7 @@ mod testing;
 mod extend_init;
 
 // Unary functions.
-pub use erf::{Erf, Gelu};
+pub use erf::{ApproxGelu, Erf, Gelu};
 pub use exp::{Exp, Sigmoid, Silu, Swish};
 pub use quantize::Quantize;
 pub use tanh::Tanh;

--- a/rten-vecmath/src/tanh.rs
+++ b/rten-vecmath/src/tanh.rs
@@ -6,6 +6,7 @@ use rten_simd::{Isa, Simd, SimdUnaryOp};
 use crate::Exp;
 
 /// Vectorized tanh implementation.
+#[derive(Default)]
 pub struct Tanh {}
 
 impl SimdUnaryOp<f32> for Tanh {

--- a/src/model.rs
+++ b/src/model.rs
@@ -1446,7 +1446,7 @@ mod tests {
         let gather_elements_indices =
             graph_builder.add_constant(gather_elements_indices_val.view());
         add_operator!(GatherElements, [input_node, gather_elements_indices], { axis: 0 });
-        add_operator!(Gelu, [input_node], {});
+        add_operator!(Gelu, [input_node], { approximate: false });
         add_operator!(Gemm, [input_2d, input_2d], {
             alpha: 1.0,
             beta: 1.0,

--- a/src/model_builder.rs
+++ b/src/model_builder.rs
@@ -601,7 +601,17 @@ impl<'mb, 'a> GraphBuilder<'mb, 'a> {
                     batch_dims: args.batch_dims as i32,
                 }
             ),
-            OpType::Gelu(_args) => op_with_attrs!(Gelu, GeluAttrs, sg::GeluAttrsArgs {}),
+            OpType::Gelu(args) => op_with_attrs!(
+                Gelu,
+                GeluAttrs,
+                sg::GeluAttrsArgs {
+                    approximate: if args.approximate {
+                        sg::GeluApproximation::Tanh
+                    } else {
+                        sg::GeluApproximation::None
+                    }
+                }
+            ),
             OpType::Gemm(args) => op_with_attrs!(
                 Gemm,
                 GemmAttrs,

--- a/src/op_registry.rs
+++ b/src/op_registry.rs
@@ -561,8 +561,18 @@ impl_read_op!(
         })
     }
 );
-impl_read_op!(Gelu, attrs_as_gelu_attrs, |_attrs: sg::GeluAttrs| {
-    Ok(ops::Gelu {})
+impl_read_op!(Gelu, attrs_as_gelu_attrs, |attrs: sg::GeluAttrs| {
+    let approximate = match attrs.approximate() {
+        sg::GeluApproximation::None => false,
+        sg::GeluApproximation::Tanh => true,
+        _ => {
+            return Err(ReadOpError::AttrError {
+                attr: "approximate",
+                error: "unsupported gelu approximation",
+            });
+        }
+    };
+    Ok(ops::Gelu { approximate })
 });
 impl_read_op!(Gemm, attrs_as_gemm_attrs, |attrs: sg::GemmAttrs| {
     Ok(ops::Gemm {

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -838,7 +838,7 @@ impl PatternFusion for GeluFusion {
     }
 
     fn create_fused_op(&self, _: &Match, _: &Graph) -> FuseResult {
-        Ok(Box::new(Gelu {}))
+        Ok(Box::new(Gelu { approximate: false }))
     }
 }
 

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -338,7 +338,12 @@ impl GraphOptimizer {
         // Fuse patterns for unary operators.
         self.fuse_patterns(
             &mut graph_mut,
-            &[&SiluFusion {}, &SwishFusion {}, &GeluFusion {}],
+            &[
+                &SiluFusion {},
+                &SwishFusion {},
+                &GeluFusion {},
+                &ApproxGeluFusion {},
+            ],
         )?;
 
         self.fuse_layer_norm(&mut graph_mut)?;
@@ -842,6 +847,28 @@ impl PatternFusion for GeluFusion {
     }
 }
 
+struct ApproxGeluFusion {}
+
+impl PatternFusion for ApproxGeluFusion {
+    fn pattern(&self) -> Pattern {
+        // Pattern for tanh approximate of gelu. See
+        // https://onnx.ai/onnx/operators/onnx__Gelu.html.
+        let sqrt_2_pi = (2.0f32 / std::f32::consts::PI).sqrt();
+        let x = symbol("x");
+        x.clone()
+            * 0.5
+            * (1.
+                + unary_op(
+                    "Tanh",
+                    sqrt_2_pi * (x.clone() + binary_op("Pow", x.clone(), 3.0) * 0.044715),
+                ))
+    }
+
+    fn create_fused_op(&self, _: &Match, _: &Graph) -> FuseResult {
+        Ok(Box::new(Gelu { approximate: true }))
+    }
+}
+
 struct SiluFusion {}
 
 impl PatternFusion for SiluFusion {
@@ -887,8 +914,8 @@ mod tests {
     use crate::graph::builder::Expr;
     use crate::graph::{CaptureEnv, Constant, Graph, Node, NodeId};
     use crate::ops::{
-        Add, Erf, FusedMatMul, LayerNormalization, MatMul, Neg, Pow, ReduceMean, RmsNormalization,
-        Sigmoid, Sqrt, Swish, Transpose,
+        Add, Erf, FusedMatMul, Gelu, LayerNormalization, MatMul, Neg, Pow, ReduceMean,
+        RmsNormalization, Sigmoid, Sqrt, Swish, Tanh, Transpose,
     };
 
     fn optimize_graph(graph: Graph) -> Result<Graph, OptimizeError> {
@@ -921,11 +948,13 @@ mod tests {
     /// node with `a` and `b` as inputs.
     trait OpExprs {
         fn erf(&self) -> Expr;
+        fn pow(&self, rhs: Expr) -> Expr;
         fn matmul(&self, rhs: Expr) -> Expr;
         fn mean(&self) -> Expr;
         fn sigmoid(&self) -> Expr;
         fn square(&self) -> Expr;
         fn sqrt(&self) -> Expr;
+        fn tanh(&self) -> Expr;
         fn transpose(&self) -> Expr;
     }
 
@@ -945,6 +974,10 @@ mod tests {
             })
         }
 
+        fn pow(&self, rhs: Expr) -> Expr {
+            self.binary(Pow {}, rhs)
+        }
+
         fn sigmoid(&self) -> Expr {
             self.unary(Sigmoid {})
         }
@@ -955,6 +988,10 @@ mod tests {
 
         fn sqrt(&self) -> Expr {
             self.unary(Sqrt {})
+        }
+
+        fn tanh(&self) -> Expr {
+            self.unary(Tanh {})
         }
 
         fn transpose(&self) -> Expr {
@@ -1187,7 +1224,27 @@ mod tests {
         let graph = optimize_graph(graph).unwrap();
 
         let (_, op) = graph.get_source_node(graph.output_ids()[0]).unwrap();
-        assert_eq!(op.operator().name(), "Gelu");
+        let gelu = op.operator().downcast_ref::<Gelu>().unwrap();
+        assert_eq!(gelu.approximate, false);
+    }
+
+    #[test]
+    fn test_fuse_approx_gelu() {
+        let graph = {
+            let x = Expr::value("x");
+            let sqrt_2_pi = Expr::constant((2.0f32 / std::f32::consts::PI).sqrt());
+            let expr = x.clone()
+                * 0.5
+                * (Expr::constant(1.)
+                    + (sqrt_2_pi * (x.clone() + x.pow(Expr::constant(3.0)) * 0.044715)).tanh());
+            expr.build_graph(["x"])
+        };
+
+        let graph = optimize_graph(graph).unwrap();
+
+        let (_, op) = graph.get_source_node(graph.output_ids()[0]).unwrap();
+        let gelu = op.operator().downcast_ref::<Gelu>().unwrap();
+        assert_eq!(gelu.approximate, true);
     }
 
     fn layer_norm_graph(with_bias: bool) -> Graph {

--- a/src/schema.fbs
+++ b/src/schema.fbs
@@ -340,8 +340,14 @@ table GatherNDAttrs {
   batch_dims:int;
 }
 
-// Reserved for supporting `approximate` attr in future.
-table GeluAttrs {}
+enum GeluApproximation: ubyte {
+  None,
+  Tanh,
+}
+
+table GeluAttrs {
+  approximate:GeluApproximation = None;
+}
 
 table GemmAttrs {
   alpha:float;

--- a/src/schema_generated.rs
+++ b/src/schema_generated.rs
@@ -1589,6 +1589,96 @@ pub struct ScalarUnionTableOffset {}
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
+pub const ENUM_MIN_GELU_APPROXIMATION: u8 = 0;
+#[deprecated(
+    since = "2.0.0",
+    note = "Use associated constants instead. This will no longer be generated in 2021."
+)]
+pub const ENUM_MAX_GELU_APPROXIMATION: u8 = 1;
+#[deprecated(
+    since = "2.0.0",
+    note = "Use associated constants instead. This will no longer be generated in 2021."
+)]
+#[allow(non_camel_case_types)]
+pub const ENUM_VALUES_GELU_APPROXIMATION: [GeluApproximation; 2] =
+    [GeluApproximation::None, GeluApproximation::Tanh];
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[repr(transparent)]
+pub struct GeluApproximation(pub u8);
+#[allow(non_upper_case_globals)]
+impl GeluApproximation {
+    pub const None: Self = Self(0);
+    pub const Tanh: Self = Self(1);
+
+    pub const ENUM_MIN: u8 = 0;
+    pub const ENUM_MAX: u8 = 1;
+    pub const ENUM_VALUES: &'static [Self] = &[Self::None, Self::Tanh];
+    /// Returns the variant's name or "" if unknown.
+    pub fn variant_name(self) -> Option<&'static str> {
+        match self {
+            Self::None => Some("None"),
+            Self::Tanh => Some("Tanh"),
+            _ => None,
+        }
+    }
+}
+impl core::fmt::Debug for GeluApproximation {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        if let Some(name) = self.variant_name() {
+            f.write_str(name)
+        } else {
+            f.write_fmt(format_args!("<UNKNOWN {:?}>", self.0))
+        }
+    }
+}
+impl<'a> flatbuffers::Follow<'a> for GeluApproximation {
+    type Inner = Self;
+    #[inline]
+    unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        let b = flatbuffers::read_scalar_at::<u8>(buf, loc);
+        Self(b)
+    }
+}
+
+impl flatbuffers::Push for GeluApproximation {
+    type Output = GeluApproximation;
+    #[inline]
+    unsafe fn push(&self, dst: &mut [u8], _written_len: usize) {
+        flatbuffers::emplace_scalar::<u8>(dst, self.0);
+    }
+}
+
+impl flatbuffers::EndianScalar for GeluApproximation {
+    type Scalar = u8;
+    #[inline]
+    fn to_little_endian(self) -> u8 {
+        self.0.to_le()
+    }
+    #[inline]
+    #[allow(clippy::wrong_self_convention)]
+    fn from_little_endian(v: u8) -> Self {
+        let b = u8::from_le(v);
+        Self(b)
+    }
+}
+
+impl<'a> flatbuffers::Verifiable for GeluApproximation {
+    #[inline]
+    fn run_verifier(
+        v: &mut flatbuffers::Verifier,
+        pos: usize,
+    ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+        use self::flatbuffers::Verifiable;
+        u8::run_verifier(v, pos)
+    }
+}
+
+impl flatbuffers::SimpleToVerifyInSlice for GeluApproximation {}
+#[deprecated(
+    since = "2.0.0",
+    note = "Use associated constants instead. This will no longer be generated in 2021."
+)]
 pub const ENUM_MIN_NMSBOX_ORDER: u8 = 0;
 #[deprecated(
     since = "2.0.0",
@@ -4702,6 +4792,8 @@ impl<'a> flatbuffers::Follow<'a> for GeluAttrs<'a> {
 }
 
 impl<'a> GeluAttrs<'a> {
+    pub const VT_APPROXIMATE: flatbuffers::VOffsetT = 4;
+
     #[inline]
     pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
         GeluAttrs { _tab: table }
@@ -4709,10 +4801,23 @@ impl<'a> GeluAttrs<'a> {
     #[allow(unused_mut)]
     pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
         _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
-        _args: &'args GeluAttrsArgs,
+        args: &'args GeluAttrsArgs,
     ) -> flatbuffers::WIPOffset<GeluAttrs<'bldr>> {
         let mut builder = GeluAttrsBuilder::new(_fbb);
+        builder.add_approximate(args.approximate);
         builder.finish()
+    }
+
+    #[inline]
+    pub fn approximate(&self) -> GeluApproximation {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab
+                .get::<GeluApproximation>(GeluAttrs::VT_APPROXIMATE, Some(GeluApproximation::None))
+                .unwrap()
+        }
     }
 }
 
@@ -4723,15 +4828,21 @@ impl flatbuffers::Verifiable for GeluAttrs<'_> {
         pos: usize,
     ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
         use self::flatbuffers::Verifiable;
-        v.visit_table(pos)?.finish();
+        v.visit_table(pos)?
+            .visit_field::<GeluApproximation>("approximate", Self::VT_APPROXIMATE, false)?
+            .finish();
         Ok(())
     }
 }
-pub struct GeluAttrsArgs {}
+pub struct GeluAttrsArgs {
+    pub approximate: GeluApproximation,
+}
 impl<'a> Default for GeluAttrsArgs {
     #[inline]
     fn default() -> Self {
-        GeluAttrsArgs {}
+        GeluAttrsArgs {
+            approximate: GeluApproximation::None,
+        }
     }
 }
 
@@ -4740,6 +4851,14 @@ pub struct GeluAttrsBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
     start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
 impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> GeluAttrsBuilder<'a, 'b, A> {
+    #[inline]
+    pub fn add_approximate(&mut self, approximate: GeluApproximation) {
+        self.fbb_.push_slot::<GeluApproximation>(
+            GeluAttrs::VT_APPROXIMATE,
+            approximate,
+            GeluApproximation::None,
+        );
+    }
     #[inline]
     pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> GeluAttrsBuilder<'a, 'b, A> {
         let start = _fbb.start_table();
@@ -4758,6 +4877,7 @@ impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> GeluAttrsBuilder<'a, 'b, A> {
 impl core::fmt::Debug for GeluAttrs<'_> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let mut ds = f.debug_struct("GeluAttrs");
+        ds.field("approximate", &self.approximate());
         ds.finish()
     }
 }


### PR DESCRIPTION
Support the tanh-based approximation of Gelu used when the `approximate="tanh"` for the ONNX `Gelu` operator, and add a fusion that matches the corresponding pattern.

The fusion was tested with the encoder model from https://huggingface.co/onnx-community/byt5-small-ONNX.

Approximate gelu is vectorized and parallelized the same as regular `Gelu`.