### PR TITLE
Combine profiling summary for main graph and subgraphs

### DIFF
--- a/src/ops/control_flow.rs
+++ b/src/ops/control_flow.rs
@@ -3,6 +3,7 @@ use smallvec::SmallVec;
 
 use crate::graph::{CaptureEnv, Graph, RunError, RunOptions};
 use crate::ops::{OpError, OpRunContext, Operator, Output, OutputList};
+use crate::timing::Profiler;
 use crate::weight_cache::WeightCache;
 
 fn output_list_from_vec(xs: Vec<Output>) -> OutputList {
@@ -42,11 +43,12 @@ impl Operator for If {
         [&self.then_branch, &self.else_branch].into()
     }
 
-    fn run_subgraph(
-        &self,
+    fn run_subgraph<'a>(
+        &'a self,
         ctx: &OpRunContext,
         captures: CaptureEnv,
         weight_caches: Option<&[WeightCache]>,
+        profiler: Option<&mut Profiler<'a>>,
         run_opts: Option<RunOptions>,
     ) -> Result<OutputList, RunError> {
         let cond: TensorView<i32> = ctx
@@ -67,6 +69,7 @@ impl Operator for If {
                     captures,
                     Some(ctx.pool()),
                     weight_caches.map(|wcs| &wcs[0]),
+                    profiler,
                     run_opts,
                 )
                 .map(output_list_from_vec)
@@ -78,6 +81,7 @@ impl Operator for If {
                     captures,
                     Some(ctx.pool()),
                     weight_caches.map(|wcs| &wcs[1]),
+                    profiler,
                     run_opts,
                 )
                 .map(output_list_from_vec)

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -29,6 +29,7 @@ use crate::downcast::impl_downcastdyn;
 use crate::gemm::PackedBMatrix;
 use crate::graph::{CaptureEnv, Graph, RunError, RunOptions};
 use crate::tensor_pool::{ExtractBuffer, TensorPool};
+use crate::timing::Profiler;
 use crate::weight_cache::WeightCache;
 
 mod binary_elementwise;
@@ -931,11 +932,12 @@ pub trait Operator: Any + Debug {
     ///
     /// The default implementation delegates to `run`. In other words it treats
     /// the operator as a subgraph with a single node.
-    fn run_subgraph(
-        &self,
+    fn run_subgraph<'a>(
+        &'a self,
         ctx: &OpRunContext,
         #[allow(unused)] captures: CaptureEnv,
         #[allow(unused)] weight_cache: Option<&[WeightCache]>,
+        #[allow(unused)] profiler: Option<&mut Profiler<'a>>,
         #[allow(unused)] run_opts: Option<RunOptions>,
     ) -> Result<OutputList, RunError> {
         self.run(ctx).map_err(|error| RunError::OperatorError {


### PR DESCRIPTION
Combine operator timings from the main graph and subgraphs into a single summary, instead of printing output after each sub-graph run. This makes it easier to see where time was spent in a model that has many subgraphs.

Instead of printing op timings in `Graph::run_plan`, make that method take a `Profiler` which collects metrics. The profiler is allocated once at the start of the main graph run, passed along to sub-graphs when they execute, and a single summary is printed at the end of the main graph run.