### PR TITLE
Add more information about operator inputs to errors and verbose logs

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -1266,7 +1266,8 @@ mod tests {
             result.err(),
             Some(RunError::OperatorError {
                 name: "shape".to_string(),
-                error: OpError::MissingInputs
+                error: OpError::MissingInputs,
+                inputs: Some(Vec::new()),
             })
         );
     }

--- a/src/ops/control_flow.rs
+++ b/src/ops/control_flow.rs
@@ -10,13 +10,6 @@ fn output_list_from_vec(xs: Vec<Output>) -> OutputList {
     xs.into_iter().collect()
 }
 
-fn run_error_from_op_error(error: OpError) -> RunError {
-    RunError::OperatorError {
-        name: "If".to_string(),
-        error,
-    }
-}
-
 pub struct If {
     pub then_branch: Graph,
     pub else_branch: Graph,
@@ -51,14 +44,18 @@ impl Operator for If {
         profiler: Option<&mut Profiler<'a>>,
         run_opts: Option<RunOptions>,
     ) -> Result<OutputList, RunError> {
+        // TODO - This should contain the name of the "If" node.
+        let node_name = "";
         let cond: TensorView<i32> = ctx
             .inputs()
             .require_as(0)
-            .map_err(run_error_from_op_error)?;
+            .map_err(|e| RunError::op_error(node_name, e, Some(ctx)))?;
         let Some(cond_bool) = cond.item().copied() else {
-            return Err(run_error_from_op_error(OpError::InvalidValue(
-                "cond must be a single value",
-            )));
+            return Err(RunError::op_error(
+                node_name,
+                OpError::InvalidValue("cond must be a single value"),
+                Some(ctx),
+            ));
         };
 
         if cond_bool != 0 {

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -245,8 +245,8 @@ macro_rules! impl_proxy_layout {
 /// a tensor but not the content.
 #[derive(Debug, Eq, PartialEq)]
 pub struct InputMeta {
-    dtype: DataType,
-    shape: Vec<usize>,
+    pub(crate) dtype: DataType,
+    pub(crate) shape: Vec<usize>,
 }
 
 /// Enum of the different types of tensor view that can be used as a model or
@@ -279,6 +279,7 @@ impl Input<'_> {
         }
     }
 
+    /// Extract shape and data type information from this tensor.
     pub fn to_meta(&self) -> InputMeta {
         InputMeta {
             shape: self.shape().to_vec(),
@@ -422,6 +423,14 @@ impl Output {
             Self::Int32Tensor(it) => Input::Int32Tensor(it.view()),
             Self::Int8Tensor(it) => Input::Int8Tensor(it.view()),
             Self::UInt8Tensor(it) => Input::UInt8Tensor(it.view()),
+        }
+    }
+
+    /// Extract shape and data type information from this tensor.
+    pub fn to_meta(&self) -> InputMeta {
+        InputMeta {
+            shape: self.shape().to_vec(),
+            dtype: self.dtype(),
         }
     }
 


### PR DESCRIPTION
- Add input metadata (shape, dtype) to operator evaluation errors. This is useful since failures are often related to unexpected input types or shapes. This information is currently missing when operators run in-place as some further refactoring is needed to capture that.
- Add input dtype information to verbose log entries

---

**TODO:**

- [ ] Handle missing optional inputs to operators. These are currently filtered out when calling `InputList::iter`.