### PR TITLE
Make `Operator::run_in_place` take an `OpRunContext`

### DIFF
--- a/src/ops/convert.rs
+++ b/src/ops/convert.rs
@@ -1,7 +1,7 @@
 use rten_tensor::prelude::*;
 
 use crate::ops::{
-    DataType, Input, InputList, IntoOpResult, OpError, OpRunContext, Operator, Output, OutputList,
+    DataType, Input, IntoOpResult, OpError, OpRunContext, Operator, Output, OutputList,
 };
 use crate::tensor_pool::TensorPool;
 
@@ -65,17 +65,12 @@ impl Operator for Cast {
         true
     }
 
-    fn run_in_place(
-        &self,
-        pool: &TensorPool,
-        input: Output,
-        _: InputList,
-    ) -> Result<Output, OpError> {
+    fn run_in_place(&self, input: Output, ctx: &OpRunContext) -> Result<Output, OpError> {
         if input.dtype() == self.to {
             Ok(input)
         } else {
-            let converted = cast(pool, input.as_input(), self.to)?;
-            input.add_to_pool(pool);
+            let converted = cast(ctx.pool(), input.as_input(), self.to)?;
+            input.add_to_pool(ctx.pool());
             Ok(converted)
         }
     }
@@ -100,19 +95,14 @@ impl Operator for CastLike {
         true
     }
 
-    fn run_in_place(
-        &self,
-        pool: &TensorPool,
-        input: Output,
-        other: InputList,
-    ) -> Result<Output, OpError> {
-        let to_type = other.require(0)?.dtype();
+    fn run_in_place(&self, input: Output, ctx: &OpRunContext) -> Result<Output, OpError> {
+        let to_type = ctx.inputs().require(0)?.dtype();
 
         if input.dtype() == to_type {
             Ok(input)
         } else {
-            let converted = cast(pool, input.as_input(), to_type)?;
-            input.add_to_pool(pool);
+            let converted = cast(ctx.pool(), input.as_input(), to_type)?;
+            input.add_to_pool(ctx.pool());
             Ok(converted)
         }
     }

--- a/src/ops/identity.rs
+++ b/src/ops/identity.rs
@@ -2,7 +2,7 @@ use rten_tensor::prelude::*;
 use rten_tensor::{Tensor, TensorView};
 
 use crate::ops::{
-    map_input, Input, InputList, IntoOpResult, OpError, OpRunContext, Operator, Output, OutputList,
+    map_input, Input, IntoOpResult, OpError, OpRunContext, Operator, Output, OutputList,
 };
 use crate::tensor_pool::TensorPool;
 
@@ -27,12 +27,7 @@ impl Operator for Identity {
         true
     }
 
-    fn run_in_place(
-        &self,
-        _pool: &TensorPool,
-        input: Output,
-        _: InputList,
-    ) -> Result<Output, OpError> {
+    fn run_in_place(&self, input: Output, _ctx: &OpRunContext) -> Result<Output, OpError> {
         Ok(input)
     }
 }

--- a/src/ops/norm.rs
+++ b/src/ops/norm.rs
@@ -8,9 +8,7 @@ use rten_tensor::{NdTensorView, Tensor, TensorView};
 use rten_vecmath as vecmath;
 
 use crate::ops::static_dims;
-use crate::ops::{
-    resolve_axis, InputList, IntoOpResult, OpError, OpRunContext, Operator, Output, OutputList,
-};
+use crate::ops::{resolve_axis, IntoOpResult, OpError, OpRunContext, Operator, Output, OutputList};
 use crate::slice_reductions::slice_max;
 use crate::tensor_pool::TensorPool;
 
@@ -261,25 +259,21 @@ impl Operator for BatchNormalization {
         true
     }
 
-    fn run_in_place(
-        &self,
-        _pool: &TensorPool,
-        input: Output,
-        other: InputList,
-    ) -> Result<Output, OpError> {
+    fn run_in_place(&self, input: Output, ctx: &OpRunContext) -> Result<Output, OpError> {
+        let inputs = ctx.inputs();
         let mut output = input
             .into_tensor::<f32>()
             .ok_or(OpError::IncorrectInputType)?;
-        let scale = other.require_as(0)?;
+        let scale = inputs.require_as(0)?;
         let scale = static_dims!(scale, 1)?;
 
-        let bias = other.require_as(1)?;
+        let bias = inputs.require_as(1)?;
         let bias = static_dims!(bias, 1)?;
 
-        let mean = other.require_as(2)?;
+        let mean = inputs.require_as(2)?;
         let mean = static_dims!(mean, 1)?;
 
-        let var = other.require_as(3)?;
+        let var = inputs.require_as(3)?;
         let var = static_dims!(var, 1)?;
 
         batch_norm_in_place(&mut output, &scale, &bias, &mean, &var, self.epsilon)?;
@@ -362,16 +356,12 @@ impl Operator for InstanceNormalization {
         true
     }
 
-    fn run_in_place(
-        &self,
-        _pool: &TensorPool,
-        output: Output,
-        inputs: InputList,
-    ) -> Result<Output, OpError> {
-        let mut output = output
+    fn run_in_place(&self, input: Output, ctx: &OpRunContext) -> Result<Output, OpError> {
+        let mut output = input
             .into_tensor::<f32>()
             .ok_or(OpError::IncorrectInputType)?;
 
+        let inputs = ctx.inputs();
         let scale = inputs.require_as(0)?;
         let scale = static_dims!(scale, 1)?;
 
@@ -662,12 +652,7 @@ impl Operator for LogSoftmax {
         true
     }
 
-    fn run_in_place(
-        &self,
-        _pool: &TensorPool,
-        input: Output,
-        _other: InputList,
-    ) -> Result<Output, OpError> {
+    fn run_in_place(&self, input: Output, _ctx: &OpRunContext) -> Result<Output, OpError> {
         let mut output = input
             .into_tensor::<f32>()
             .ok_or(OpError::IncorrectInputType)?;
@@ -708,12 +693,7 @@ impl Operator for Softmax {
         true
     }
 
-    fn run_in_place(
-        &self,
-        _pool: &TensorPool,
-        input: Output,
-        _other: InputList,
-    ) -> Result<Output, OpError> {
+    fn run_in_place(&self, input: Output, _ctx: &OpRunContext) -> Result<Output, OpError> {
         let mut output = input
             .into_tensor::<f32>()
             .ok_or(OpError::IncorrectInputType)?;

--- a/src/ops/resize.rs
+++ b/src/ops/resize.rs
@@ -443,15 +443,11 @@ impl Operator for Resize {
         true
     }
 
-    fn run_in_place(
-        &self,
-        pool: &TensorPool,
-        input: Output,
-        other: InputList,
-    ) -> Result<Output, OpError> {
+    fn run_in_place(&self, input: Output, ctx: &OpRunContext) -> Result<Output, OpError> {
         // See note in `run` about the `roi` input.
 
-        let target = target_from_scale_size_inputs(&other, 1)?;
+        let other = ctx.inputs();
+        let target = target_from_scale_size_inputs(other, 1)?;
         let output_size = calc_output_size(input.shape(), target)?;
 
         // If this is a no-op resize, just return the input.
@@ -459,9 +455,9 @@ impl Operator for Resize {
             return Ok(input);
         }
 
-        let input = Tensor::<f32>::try_from(input)?.auto_return(pool);
+        let input = Tensor::<f32>::try_from(input)?.auto_return(ctx.pool());
         resize_impl(
-            pool,
+            ctx.pool(),
             input.view(),
             &output_size,
             self.mode,

--- a/src/ops/slice.rs
+++ b/src/ops/slice.rs
@@ -147,12 +147,8 @@ impl Operator for Slice {
         true
     }
 
-    fn run_in_place(
-        &self,
-        pool: &TensorPool,
-        input: Output,
-        other: InputList,
-    ) -> Result<Output, OpError> {
+    fn run_in_place(&self, input: Output, ctx: &OpRunContext) -> Result<Output, OpError> {
+        let other = ctx.inputs();
         let starts = other.require_as::<i32>(0)?;
         let starts = static_dims!(starts, 1)?;
 
@@ -180,7 +176,7 @@ impl Operator for Slice {
                 }
 
                 let input_list = InputList::from(&inputs);
-                let ctx = OpRunContext::new(pool, &input_list);
+                let ctx = OpRunContext::new(ctx.pool(), &input_list);
                 return self.run(&ctx).map(|mut outputs| outputs.remove(0));
             }
         }


### PR DESCRIPTION
Update the `run_in_place` API to align with recent changes to `Operator::run` by taking an `&OpRunContext` rather than separate arguments for the pool and inputs. When additional services or information is exposed to operators via `OpRunContext` in future, this will make it possible to use that in in-place execution.