### PR TITLE
Include input metadata in op errors for in-place operations

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -1267,7 +1267,7 @@ mod tests {
             Some(RunError::OperatorError {
                 name: "shape".to_string(),
                 error: OpError::MissingInputs,
-                inputs: Some([None].into()),
+                inputs: [None].into(),
             })
         );
     }

--- a/src/ops/control_flow.rs
+++ b/src/ops/control_flow.rs
@@ -49,12 +49,12 @@ impl Operator for If {
         let cond: TensorView<i32> = ctx
             .inputs()
             .require_as(0)
-            .map_err(|e| RunError::op_error(node_name, e, Some(ctx)))?;
+            .map_err(|e| RunError::op_error(node_name, e, ctx))?;
         let Some(cond_bool) = cond.item().copied() else {
             return Err(RunError::op_error(
                 node_name,
                 OpError::InvalidValue("cond must be a single value"),
-                Some(ctx),
+                ctx,
             ));
         };
 

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -969,7 +969,7 @@ pub trait Operator: Any + Debug {
         #[allow(unused)] run_opts: Option<RunOptions>,
     ) -> Result<OutputList, RunError> {
         self.run(ctx)
-            .map_err(|error| RunError::op_error(self.name(), error, Some(ctx)))
+            .map_err(|error| RunError::op_error(self.name(), error, ctx))
     }
 }
 


### PR DESCRIPTION
Add input metadata (dtype, shapes) to execution errors for in-place operations. Since the main input is passed by value to `Operator::run_in_place` and thus not available afterwards, its shape and dtype has to be captured before the operator runs.

Example error when an operator receives an unsupported combination of input types:

Before:

```
Error: OperatorError { name: "/Pow", error: IncorrectInputType }
```

After:

```
Error: OperatorError { name: "/Pow", error: IncorrectInputType, inputs: [Some(InputMeta { dtype: Int32, shape: [] }), Some(InputMeta { dtype: Float, shape: [] })] }
```