### PR TITLE
Remove warning when clamping `i64::{MIN, MAX}` to `i32::{MIN, MAX}`

### DIFF
--- a/rten-convert/rten_convert/converter.py
+++ b/rten-convert/rten_convert/converter.py
@@ -90,19 +90,25 @@ def constant_node_from_onnx_initializer(
 
         # Types that need to be narrowed
         case "int64":
-            # Some ONNX exporters use `INT_MIN` and `INT_MAX` to represent
-            # infinity in certain cases, for example slicing to the end of a
-            # dimension with unknown size (see
-            # https://github.com/onnx/onnx/blob/main/docs/Operators.md#slice and
-            # https://github.com/pytorch/pytorch/issues/17606).
-            #
             # In the case where the value is an `int64` and we are converting
             # this to an `int32` in the model, this will cause an overflow. To
             # resolve this, clamp the value to the min/max values for the
             # smaller integer type we are using.
             i32 = np.iinfo(np.int32)
+            i64 = np.iinfo(np.int64)
+
             out_of_range_mask = np.logical_or(data > i32.max, data < i32.min)
             for val in data[out_of_range_mask]:
+                if val == i64.min or val == i64.max:
+                    # Some ONNX exporters use `i64::MIN` and `i64::MAX` to
+                    # represent infinity when slicing to the end of a dimension
+                    # with unknown size (see
+                    # https://github.com/onnx/onnx/blob/main/docs/Operators.md#slice
+                    # and https://github.com/pytorch/pytorch/issues/17606).
+                    #
+                    # Avoid warning about this common usage of specific i64 values
+                    # outside the i32 range.
+                    continue
                 warn_once(
                     f"Clamping out-of-range tensor value {val} to [{i32.min}, {i32.max}]"
                 )


### PR DESCRIPTION
When i64 values are truncated to i32 during model conversion, silence the warning if the i64 values are `i64::{MIN, MAX}` as these are commonly used to represent infinity when slicing to the end of a dimension with unknown size.