### PR TITLE
Refactor value => tensor conversions

### DIFF
--- a/rten-examples/src/jina_similarity.rs
+++ b/rten-examples/src/jina_similarity.rs
@@ -135,9 +135,7 @@ fn embed_sentence_batch(
 
     let output_id = model.node_id("last_hidden_state")?;
     let [last_hidden_state] = model.run_n(inputs, [output_id], None)?;
-    let last_hidden_state = last_hidden_state
-        .into_tensor::<f32>()
-        .ok_or("wrong output type")?;
+    let last_hidden_state: Tensor = last_hidden_state.try_into()?;
 
     // Mean pool each item in the batch. We process each batch item separately
     // since they can have different lengths.

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -117,11 +117,17 @@ impl fmt::Display for RunError {
                 name,
                 error: ref err,
                 inputs,
-            } => write!(
-                f,
-                "operator \"{}\" failed: {:?}. Inputs {:?}",
-                name, err, inputs
-            ),
+            } => {
+                write!(f, "operator \"{}\" failed: {}. Inputs were [", name, err,)?;
+                for input in inputs {
+                    if let Some(meta) = input {
+                        write!(f, "({})", meta)?;
+                    } else {
+                        write!(f, "-")?;
+                    }
+                }
+                write!(f, "]")
+            }
             RunError::OutputMismatch(err) => write!(f, "output mismatch {:?}", err),
         }
     }

--- a/src/ops/binary_elementwise.rs
+++ b/src/ops/binary_elementwise.rs
@@ -893,7 +893,7 @@ impl Operator for Where {
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let inputs = ctx.inputs();
-        let condition = inputs.require_as::<i32>(0)?;
+        let condition = inputs.require_as(0)?;
         let x = inputs.require(1)?;
 
         map_input!(x, x, [FloatTensor, Int32Tensor], {

--- a/src/ops/concat.rs
+++ b/src/ops/concat.rs
@@ -6,8 +6,8 @@ use rten_tensor::{AssumeInit, NdTensorView, Tensor, TensorView};
 use smallvec::SmallVec;
 
 use crate::ops::{
-    map_input, map_output, resolve_axis, Input, InputList, IntoOpResult, OpError, OpRunContext,
-    Operator, Output, OutputList,
+    map_input, map_output, resolve_axis, CastError, Input, InputList, IntoOpResult, OpError,
+    OpRunContext, Operator, Output, OutputList,
 };
 use crate::tensor_pool::{AutoReturn, TensorPool};
 
@@ -46,7 +46,7 @@ fn typed_inputs<'a, T>(
     _: TensorView<T>,
 ) -> Result<SmallVec<[TensorView<'a, T>; 4]>, OpError>
 where
-    TensorView<'a, T>: TryFrom<Input<'a>, Error = OpError>,
+    TensorView<'a, T>: TryFrom<Input<'a>, Error = CastError>,
 {
     let mut typed_inputs: SmallVec<_> = SmallVec::with_capacity(inputs.len());
     for input in inputs.iter().flatten() {

--- a/src/ops/concat.rs
+++ b/src/ops/concat.rs
@@ -5,7 +5,6 @@ use rten_tensor::{AssumeInit, NdTensorView, Tensor, TensorView};
 
 use smallvec::SmallVec;
 
-use crate::ops::static_dims;
 use crate::ops::{
     map_input, map_output, resolve_axis, Input, InputList, IntoOpResult, OpError, OpRunContext,
     Operator, Output, OutputList,
@@ -250,8 +249,7 @@ impl Operator for Tile {
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let inputs = ctx.inputs();
         let input = inputs.require(0)?;
-        let repeats = inputs.require_as::<i32>(1)?;
-        let repeats = static_dims!(repeats, 1)?;
+        let repeats = inputs.require_as(1)?;
 
         map_input!(input, input, [FloatTensor, Int32Tensor], {
             tile(ctx.pool(), input, repeats).into_op_result()
@@ -264,8 +262,7 @@ impl Operator for Tile {
     }
 
     fn run_in_place(&self, input: Output, ctx: &OpRunContext) -> Result<Output, OpError> {
-        let repeats = ctx.inputs().require_as::<i32>(0)?;
-        let repeats = static_dims!(repeats, 1)?;
+        let repeats: NdTensorView<i32, 1> = ctx.inputs().require_as(0)?;
 
         if repeats.iter().all(|n| *n == 1) {
             return Ok(input);

--- a/src/ops/conv.rs
+++ b/src/ops/conv.rs
@@ -526,7 +526,7 @@ impl Operator for ConvInteger {
             (Input::Int8Tensor(x), Input::UInt8Tensor(w)) => conv_integer!(x, w),
             (Input::UInt8Tensor(x), Input::Int8Tensor(w)) => conv_integer!(x, w),
             (Input::UInt8Tensor(x), Input::UInt8Tensor(w)) => conv_integer!(x, w),
-            _ => Err(OpError::IncorrectInputType),
+            _ => Err(OpError::UnsupportedType),
         }
     }
 }

--- a/src/ops/gather.rs
+++ b/src/ops/gather.rs
@@ -137,7 +137,7 @@ impl Operator for Gather {
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let inputs = ctx.inputs();
         let input = inputs.require(0)?;
-        let indices = inputs.require_as::<i32>(1)?;
+        let indices = inputs.require_as(1)?;
 
         map_input!(input, x, {
             gather(ctx.pool(), x, self.axis, indices).into_op_result()
@@ -281,7 +281,7 @@ impl Operator for GatherElements {
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let inputs = ctx.inputs();
         let input = inputs.require(0)?;
-        let indices = inputs.require_as::<i32>(1)?;
+        let indices = inputs.require_as(1)?;
 
         map_input!(input, x, {
             gather_elements(ctx.pool(), x, indices, self.axis).into_op_result()
@@ -399,7 +399,7 @@ impl Operator for GatherND {
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let inputs = ctx.inputs();
         let input = inputs.require(0)?;
-        let indices = inputs.require_as::<i32>(1)?;
+        let indices = inputs.require_as(1)?;
 
         map_input!(input, x, {
             gather_nd(ctx.pool(), x, indices, self.batch_dims).into_op_result()
@@ -508,7 +508,7 @@ impl Operator for ScatterElements {
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let inputs = ctx.inputs();
         let data = inputs.require(0)?;
-        let indices = inputs.require_as::<i32>(1)?;
+        let indices = inputs.require_as(1)?;
 
         map_input!(data, x, {
             let updates = inputs.require_as(2)?;
@@ -600,7 +600,7 @@ impl Operator for ScatterND {
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let inputs = ctx.inputs();
         let data = inputs.require(0)?;
-        let indices = inputs.require_as::<i32>(1)?;
+        let indices = inputs.require_as(1)?;
 
         map_input!(data, x, {
             let updates = inputs.require_as(2)?;

--- a/src/ops/generate.rs
+++ b/src/ops/generate.rs
@@ -30,8 +30,7 @@ impl Operator for ConstantOfShape {
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let pool = ctx.pool();
-        let shape = ctx.inputs().require_as::<i32>(0)?;
-        let shape = static_dims!(shape, 1)?;
+        let shape = ctx.inputs().require_as(0)?;
 
         match self.value {
             Scalar::Int(value) => constant_of_shape(pool, value, &shape).into_op_result(),
@@ -89,8 +88,8 @@ impl Operator for OneHot {
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let inputs = ctx.inputs();
-        let indices = inputs.require_as::<i32>(0)?;
-        let depth = inputs.require_as::<i32>(1)?;
+        let indices = inputs.require_as(0)?;
+        let depth: TensorView<i32> = inputs.require_as(1)?;
         let depth = depth
             .item()
             .and_then(|&val| if val > 0 { Some(val as usize) } else { None })

--- a/src/ops/layout.rs
+++ b/src/ops/layout.rs
@@ -154,7 +154,6 @@ impl Operator for Expand {
         let inputs = ctx.inputs();
         let input = inputs.require(0)?;
         let shape = inputs.require_as(1)?;
-        let shape = static_dims!(shape, 1)?;
 
         map_input!(input, x, { expand(ctx.pool(), x, &shape).into_op_result() })
     }
@@ -167,7 +166,6 @@ impl Operator for Expand {
 
     fn run_in_place(&self, input: Output, ctx: &OpRunContext) -> Result<Output, OpError> {
         let shape = ctx.inputs().require_as(0)?;
-        let shape = static_dims!(shape, 1)?;
 
         let out_shape = expand_output_shape(input.shape(), &shape)?;
         if input.shape() == out_shape.as_slice() {
@@ -352,7 +350,6 @@ impl Operator for Reshape {
         let inputs = ctx.inputs();
         let input = inputs.require(0)?;
         let shape = inputs.require_as(1)?;
-        let shape = static_dims!(shape, 1)?;
 
         map_input!(input, x, {
             reshape(ctx.pool(), x, &shape, self.allow_zero).into_op_result()
@@ -365,7 +362,6 @@ impl Operator for Reshape {
 
     fn run_in_place(&self, input: Output, ctx: &OpRunContext) -> Result<Output, OpError> {
         let shape = ctx.inputs().require_as(0)?;
-        let shape = static_dims!(shape, 1)?;
 
         map_output!(input, output, {
             reshape_in_place(ctx.pool(), &mut output, &shape, self.allow_zero)?;
@@ -504,7 +500,6 @@ impl Operator for Squeeze {
         let inputs = ctx.inputs();
         let input = inputs.require(0)?;
         let axes = inputs.get_as(1)?;
-        let axes = axes.map(|axes| static_dims!(axes, 1)).transpose()?;
 
         map_input!(input, x, { squeeze(ctx.pool(), x, axes).into_op_result() })
     }
@@ -515,7 +510,6 @@ impl Operator for Squeeze {
 
     fn run_in_place(&self, input: Output, ctx: &OpRunContext) -> Result<Output, OpError> {
         let axes = ctx.inputs().get_as(0)?;
-        let axes = axes.map(|axes| static_dims!(axes, 1)).transpose()?;
 
         map_output!(input, output, {
             squeeze_in_place(&mut output, axes)?;
@@ -616,7 +610,6 @@ impl Operator for Unsqueeze {
         let inputs = ctx.inputs();
         let input = inputs.require(0)?;
         let axes = inputs.require_as(1)?;
-        let axes = static_dims!(axes, 1)?;
 
         map_input!(input, x, {
             unsqueeze(ctx.pool(), x, &axes).into_op_result()
@@ -629,7 +622,6 @@ impl Operator for Unsqueeze {
 
     fn run_in_place(&self, input: Output, ctx: &OpRunContext) -> Result<Output, OpError> {
         let axes = ctx.inputs().require_as(0)?;
-        let axes = static_dims!(axes, 1)?;
 
         map_output!(input, output, {
             Ok(unsqueeze_in_place(output, &axes)?.into())

--- a/src/ops/matmul.rs
+++ b/src/ops/matmul.rs
@@ -548,7 +548,7 @@ impl Operator for MatMulInteger {
             (Input::Int8Tensor(_), Input::UInt8Tensor(_)) => Err(OpError::UnsupportedType),
             (Input::UInt8Tensor(_), Input::UInt8Tensor(_)) => Err(OpError::UnsupportedType),
 
-            _ => Err(OpError::IncorrectInputType),
+            _ => Err(OpError::UnsupportedType),
         }
     }
 

--- a/src/ops/matmul.rs
+++ b/src/ops/matmul.rs
@@ -424,9 +424,7 @@ impl Operator for FusedMatMul {
         };
 
         let bias = inputs
-            .get_as::<f32>(2)?
-            .map(|bias| static_dims!(bias, 1, "N"))
-            .transpose()?
+            .get_as::<NdTensorView<f32, 1>>(2)?
             .map(|b| b.to_contiguous_in(ctx.pool()));
         let bias = bias.as_ref().map(|b| BiasVector::Row(b.data().unwrap()));
 

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -313,6 +313,12 @@ pub struct InputMeta {
     pub(crate) shape: Vec<usize>,
 }
 
+impl Display for InputMeta {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}, {:?}", self.dtype, self.shape)
+    }
+}
+
 /// Enum of the different types of tensor view that can be used as a model or
 /// operator input.
 #[derive(Clone)]

--- a/src/ops/non_max_suppression.rs
+++ b/src/ops/non_max_suppression.rs
@@ -1,7 +1,7 @@
 use rten_tensor::prelude::*;
 use rten_tensor::{NdTensor, NdTensorView};
 
-use crate::ops::{static_dims, IntoOpResult, OpError, OpRunContext, Operator, OutputList};
+use crate::ops::{IntoOpResult, OpError, OpRunContext, Operator, OutputList};
 use crate::tensor_pool::TensorPool;
 
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -194,14 +194,11 @@ impl Operator for NonMaxSuppression {
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let inputs = ctx.inputs();
         let boxes = inputs.require_as(0)?;
-        let boxes = static_dims!(boxes, 3, "ND4")?;
-
         let scores = inputs.require_as(1)?;
-        let scores = static_dims!(scores, 3, "NCD")?;
 
-        let max_output_boxes_per_class = inputs.get_as_scalar(2)?;
-        let iou_threshold = inputs.get_as_scalar(3)?;
-        let score_threshold = inputs.get_as_scalar(4)?;
+        let max_output_boxes_per_class = inputs.get_as(2)?;
+        let iou_threshold = inputs.get_as(3)?;
+        let score_threshold = inputs.get_as(4)?;
 
         let selected_box_indices = non_max_suppression(
             ctx.pool(),

--- a/src/ops/norm.rs
+++ b/src/ops/norm.rs
@@ -252,9 +252,7 @@ impl Operator for BatchNormalization {
 
     fn run_in_place(&self, input: Output, ctx: &OpRunContext) -> Result<Output, OpError> {
         let inputs = ctx.inputs();
-        let mut output = input
-            .into_tensor::<f32>()
-            .ok_or(OpError::IncorrectInputType)?;
+        let mut output: Tensor = input.try_into()?;
         let scale = inputs.require_as(0)?;
         let bias = inputs.require_as(1)?;
         let mean = inputs.require_as(2)?;
@@ -338,10 +336,7 @@ impl Operator for InstanceNormalization {
     }
 
     fn run_in_place(&self, input: Output, ctx: &OpRunContext) -> Result<Output, OpError> {
-        let mut output = input
-            .into_tensor::<f32>()
-            .ok_or(OpError::IncorrectInputType)?;
-
+        let mut output: Tensor = input.try_into()?;
         let inputs = ctx.inputs();
         let scale = inputs.require_as(0)?;
         let bias = inputs.require_as(1)?;
@@ -624,9 +619,7 @@ impl Operator for LogSoftmax {
     }
 
     fn run_in_place(&self, input: Output, _ctx: &OpRunContext) -> Result<Output, OpError> {
-        let mut output = input
-            .into_tensor::<f32>()
-            .ok_or(OpError::IncorrectInputType)?;
+        let mut output: Tensor = input.try_into()?;
         log_softmax_in_place(&mut output, self.axis)?;
         Ok(output.into())
     }
@@ -665,9 +658,7 @@ impl Operator for Softmax {
     }
 
     fn run_in_place(&self, input: Output, _ctx: &OpRunContext) -> Result<Output, OpError> {
-        let mut output = input
-            .into_tensor::<f32>()
-            .ok_or(OpError::IncorrectInputType)?;
+        let mut output = input.try_into()?;
         softmax_in_place(&mut output, self.axis)?;
         Ok(output.into())
     }

--- a/src/ops/pad.rs
+++ b/src/ops/pad.rs
@@ -204,7 +204,7 @@ mod tests {
     use rten_testing::TestCases;
 
     use crate::ops::tests::new_pool;
-    use crate::ops::{pad, DataType, OpError, OperatorExt, Pad, PadMode};
+    use crate::ops::{pad, CastError, DataType, OpError, OperatorExt, Pad, PadMode};
 
     fn from_slice<T: Clone>(data: &[T]) -> Tensor<T> {
         Tensor::from_data(&[data.len()], data.to_vec())
@@ -443,9 +443,12 @@ mod tests {
         let result = op.run_simple::<_, Tensor<f32>>((&input, &invalid_pads, &const_int));
         assert_eq!(
             result.err(),
-            Some(OpError::IncorrectType {
-                actual: DataType::Int32,
-                expected: DataType::Float,
+            Some(OpError::InputCastFailed {
+                index: 2,
+                error: CastError::WrongType {
+                    actual: DataType::Int32,
+                    expected: DataType::Float,
+                },
             })
         );
 
@@ -455,7 +458,13 @@ mod tests {
         let result = op.run_simple::<_, Tensor<f32>>((&input, &invalid_pads, &int_vec));
         assert_eq!(
             result.err(),
-            Some(OpError::InvalidValue("Expected scalar value"))
+            Some(OpError::InputCastFailed {
+                index: 2,
+                error: CastError::WrongRank {
+                    actual: 1,
+                    expected: 0,
+                }
+            })
         );
     }
 }

--- a/src/ops/pad.rs
+++ b/src/ops/pad.rs
@@ -1,9 +1,7 @@
 use rten_tensor::prelude::*;
 use rten_tensor::{NdTensorView, SliceItem, Tensor, TensorView};
 
-use crate::ops::{
-    map_input, static_dims, Input, IntoOpResult, OpError, OpRunContext, Operator, OutputList,
-};
+use crate::ops::{map_input, Input, IntoOpResult, OpError, OpRunContext, Operator, OutputList};
 use crate::tensor_pool::TensorPool;
 
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -180,9 +178,8 @@ impl Operator for Pad {
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let inputs = ctx.inputs();
         let input = inputs.require(0)?;
-        let pads = inputs.require_as::<i32>(1)?;
-        let pads = static_dims!(pads, 1)?;
-        let axes = inputs.get_as::<i32>(3)?;
+        let pads = inputs.require_as(1)?;
+        let axes: Option<NdTensorView<i32, 1>> = inputs.get_as(3)?;
 
         if axes.is_some() {
             return Err(OpError::UnsupportedValue(
@@ -191,7 +188,7 @@ impl Operator for Pad {
         }
 
         map_input!(input, x, {
-            let const_val = inputs.get_as_scalar(2)?.unwrap_or_default();
+            let const_val = inputs.get_as(2)?.unwrap_or_default();
             pad(ctx.pool(), x, &pads, self.mode, const_val).into_op_result()
         })
     }

--- a/src/ops/pad.rs
+++ b/src/ops/pad.rs
@@ -204,7 +204,7 @@ mod tests {
     use rten_testing::TestCases;
 
     use crate::ops::tests::new_pool;
-    use crate::ops::{pad, OpError, OperatorExt, Pad, PadMode};
+    use crate::ops::{pad, DataType, OpError, OperatorExt, Pad, PadMode};
 
     fn from_slice<T: Clone>(data: &[T]) -> Tensor<T> {
         Tensor::from_data(&[data.len()], data.to_vec())
@@ -441,7 +441,13 @@ mod tests {
         let invalid_pads = from_slice(&[1, 1, 1, -1]);
         let const_int = Tensor::from(1);
         let result = op.run_simple::<_, Tensor<f32>>((&input, &invalid_pads, &const_int));
-        assert_eq!(result.err(), Some(OpError::IncorrectInputType));
+        assert_eq!(
+            result.err(),
+            Some(OpError::IncorrectType {
+                actual: DataType::Int32,
+                expected: DataType::Float,
+            })
+        );
 
         // Constant value not a scalar.
         let invalid_pads = from_slice(&[1, 1, 1, -1]);

--- a/src/ops/quantize.rs
+++ b/src/ops/quantize.rs
@@ -269,14 +269,8 @@ impl Operator for QuantizeLinear {
 
         match (y_zero_point, self.output_dtype) {
             (Some(Input::UInt8Tensor(y_zero_point)), Some(DataType::UInt8) | None) => {
-                quantize_linear(
-                    pool,
-                    input.view(),
-                    y_scale.view(),
-                    Some(y_zero_point.view()),
-                    self.axis,
-                )
-                .into_op_result()
+                quantize_linear(pool, input, y_scale, Some(y_zero_point.view()), self.axis)
+                    .into_op_result()
             }
             (None, Some(DataType::UInt8)) => {
                 quantize_linear::<u8>(pool, input.view(), y_scale.view(), None, self.axis)

--- a/src/ops/reduce.rs
+++ b/src/ops/reduce.rs
@@ -178,7 +178,7 @@ impl Operator for CumSum {
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let inputs = ctx.inputs();
         let input = inputs.require(0)?;
-        let axis: i32 = inputs.require_as_scalar(1)?;
+        let axis: i32 = inputs.require_as(1)?;
         map_input!(input, input, [FloatTensor, Int32Tensor], {
             cum_sum(ctx.pool(), input, axis as isize).into_op_result()
         })
@@ -525,7 +525,7 @@ fn get_axes<'a>(
     attr: &'a Option<Vec<i32>>,
 ) -> Result<Option<Cow<'a, [i32]>>, OpError> {
     let axes = inputs
-        .get_as::<i32>(1)?
+        .get_as::<TensorView<i32>>(1)?
         .map(|x| x.to_slice())
         .or(attr.as_ref().map(|a| Cow::Borrowed(a.as_slice())));
     Ok(axes)
@@ -786,7 +786,7 @@ impl Operator for TopK {
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let inputs = ctx.inputs();
         let values = inputs.require(0)?;
-        let k = inputs.require_as_scalar::<i32>(1).and_then(|k| {
+        let k = inputs.require_as::<i32>(1).and_then(|k| {
             if k < 0 {
                 Err(OpError::InvalidValue("k must be positive"))
             } else {

--- a/src/ops/resize.rs
+++ b/src/ops/resize.rs
@@ -7,8 +7,8 @@ use rten_tensor::{NdTensor, NdTensorView, NdTensorViewMut, Tensor, TensorView};
 
 use crate::iter_util::range_chunks;
 use crate::ops::{
-    static_dims, Input, InputList, IntoOpResult, OpError, OpRunContext, Operator, Output,
-    OutputList,
+    static_dims, CastError, Input, InputList, IntoOpResult, OpError, OpRunContext, Operator,
+    Output, OutputList,
 };
 use crate::tensor_pool::{AutoReturn, TensorPool};
 
@@ -382,7 +382,7 @@ fn get_optional_input<'a, T>(
     index: usize,
 ) -> Result<Option<TensorView<'a, T>>, OpError>
 where
-    TensorView<'a, T>: TryFrom<Input<'a>, Error = OpError>,
+    TensorView<'a, T>: TryFrom<Input<'a>, Error = CastError>,
 {
     let tensor = inputs
         .get_as::<TensorView<T>>(index)?

--- a/src/ops/resize.rs
+++ b/src/ops/resize.rs
@@ -384,7 +384,9 @@ fn get_optional_input<'a, T>(
 where
     TensorView<'a, T>: TryFrom<Input<'a>, Error = OpError>,
 {
-    let tensor = inputs.get_as(index)?.filter(|t| !t.is_empty());
+    let tensor = inputs
+        .get_as::<TensorView<T>>(index)?
+        .filter(|t| !t.is_empty());
     Ok(tensor)
 }
 

--- a/src/ops/rnn.rs
+++ b/src/ops/rnn.rs
@@ -332,7 +332,7 @@ impl Operator for GRU {
         let weights = inputs.require_as(1)?;
         let recurrent_weights = inputs.require_as(2)?;
         let bias = inputs.get_as(3)?;
-        let _seq_len = inputs.get_as::<i32>(4)?;
+        let _seq_len = inputs.get_as::<TensorView<i32>>(4)?;
         let initial_hidden = inputs.get_as(5)?;
 
         gru(
@@ -579,7 +579,7 @@ impl Operator for LSTM {
         let weights = inputs.require_as(1)?;
         let recurrent_weights = inputs.require_as(2)?;
         let bias = inputs.get_as(3)?;
-        let _seq_len = inputs.get_as::<i32>(4)?;
+        let _seq_len = inputs.get_as::<TensorView<i32>>(4)?;
         let initial_hidden = inputs.get_as(5)?;
         let initial_cell = inputs.get_as(6)?;
 

--- a/src/ops/split.rs
+++ b/src/ops/split.rs
@@ -2,9 +2,7 @@ use rten_tensor::prelude::*;
 use rten_tensor::{NdTensorView, Tensor, TensorView};
 
 use crate::iter_util::range_chunks;
-use crate::ops::{
-    map_input, resolve_axis, static_dims, Input, OpError, OpRunContext, Operator, OutputList,
-};
+use crate::ops::{map_input, resolve_axis, Input, OpError, OpRunContext, Operator, OutputList};
 use crate::tensor_pool::TensorPool;
 
 #[derive(Clone, Debug)]
@@ -94,11 +92,10 @@ impl Operator for Split {
         // outputs.
         //
         // See https://github.com/robertknight/rten/issues/689.
-        let splits = ctx.inputs().get_as::<i32>(1)?;
+        let splits = ctx.inputs().get_as(1)?;
         let num_outputs = self.num_outputs.or(ctx.num_outputs());
 
         let split_sizes = if let Some(splits) = splits {
-            let splits = static_dims!(splits, 1)?;
             SplitSizes::Sizes(splits)
         } else if let Some(num_outputs) = num_outputs {
             SplitSizes::NumSplits(num_outputs)

--- a/src/ops/trilu.rs
+++ b/src/ops/trilu.rs
@@ -46,7 +46,7 @@ impl Operator for Trilu {
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let inputs = ctx.inputs();
         let input = inputs.require(0)?;
-        let k = inputs.get_as_scalar(1)?.unwrap_or(0);
+        let k = inputs.get_as(1)?.unwrap_or(0);
 
         map_input!(input, input, [FloatTensor, Int32Tensor], {
             trilu(ctx.pool(), input, k, self.upper).into_op_result()

--- a/src/ops/unary_elementwise.rs
+++ b/src/ops/unary_elementwise.rs
@@ -49,9 +49,7 @@ impl<Op: Any + Debug + UnaryFloatOp> Operator for Op {
     }
 
     fn run_in_place(&self, input: Output, _ctx: &OpRunContext) -> Result<Output, OpError> {
-        let mut output = input
-            .into_tensor::<f32>()
-            .ok_or(OpError::IncorrectInputType)?;
+        let mut output: Tensor = input.try_into()?;
         self.apply(output.view_mut());
         Ok(output.into())
     }
@@ -185,9 +183,7 @@ macro_rules! parallel_unary_float_op {
             }
 
             fn run_in_place(&self, input: Output, ctx: &OpRunContext) -> Result<Output, OpError> {
-                let tensor = input
-                    .into_tensor::<f32>()
-                    .ok_or(OpError::IncorrectInputType)?;
+                let tensor: Tensor = input.try_into()?;
                 let kernel = $simd_kernel;
                 let result = par_unary_op_in_place(ctx.pool(), tensor, kernel);
                 Ok(result.into())
@@ -393,9 +389,7 @@ impl Operator for Gelu {
     }
 
     fn run_in_place(&self, input: Output, ctx: &OpRunContext) -> Result<Output, OpError> {
-        let tensor = input
-            .into_tensor::<f32>()
-            .ok_or(OpError::IncorrectInputType)?;
+        let tensor: Tensor = input.try_into()?;
         let result = if self.approximate {
             par_unary_op_in_place(ctx.pool(), tensor, vecmath::ApproxGelu {})
         } else {
@@ -518,9 +512,7 @@ impl Operator for Not {
     }
 
     fn run_in_place(&self, input: Output, _ctx: &OpRunContext) -> Result<Output, OpError> {
-        let mut output = input
-            .into_tensor::<i32>()
-            .ok_or(OpError::IncorrectInputType)?;
+        let mut output: Tensor<i32> = input.try_into()?;
         not_in_place(output.view_mut());
         Ok(output.into())
     }
@@ -582,9 +574,7 @@ impl Operator for Swish {
     }
 
     fn run_in_place(&self, input: Output, ctx: &OpRunContext) -> Result<Output, OpError> {
-        let tensor = input
-            .into_tensor::<f32>()
-            .ok_or(OpError::IncorrectInputType)?;
+        let tensor: Tensor = input.try_into()?;
         let output = swish_in_place(ctx.pool(), tensor, self.beta);
         Ok(output.into())
     }

--- a/src/ops/unary_elementwise.rs
+++ b/src/ops/unary_elementwise.rs
@@ -641,7 +641,7 @@ mod tests {
         Silu, Sin, Softplus, Sqrt, Swish, Tan, Tanh,
     };
     use crate::ops::tests::new_pool;
-    use crate::ops::{Input, OpError, Operator, OperatorExt, Output};
+    use crate::ops::{CastError, Input, Operator, OperatorExt, Output};
     use rten_tensor::test_util::ApproxEq;
 
     fn test_unary_op_impl<T: Clone + std::fmt::Debug + ApproxEq>(
@@ -651,7 +651,7 @@ mod tests {
     ) -> Result<(), Box<dyn Error>>
     where
         for<'a> TensorView<'a, T>: Into<Input<'a>>,
-        Tensor<T>: Into<Output> + TryFrom<Output, Error = OpError>,
+        Tensor<T>: Into<Output> + TryFrom<Output, Error = CastError>,
     {
         // Test copying variant.
         let expected = input.map(reference_op);

--- a/src/ops/unary_elementwise.rs
+++ b/src/ops/unary_elementwise.rs
@@ -317,8 +317,8 @@ impl Operator for Clip {
         let inputs = ctx.inputs();
         let input = inputs.require(0)?;
         map_input!(input, input, [FloatTensor, Int32Tensor], {
-            let min = inputs.get_as_scalar(1)?;
-            let max = inputs.get_as_scalar(2)?;
+            let min = inputs.get_as(1)?;
+            let max = inputs.get_as(2)?;
             clip(ctx.pool(), input, min, max).into_op_result()
         })
     }
@@ -329,8 +329,8 @@ impl Operator for Clip {
 
     fn run_in_place(&self, input: Output, ctx: &OpRunContext) -> Result<Output, OpError> {
         map_output!(input, input, [FloatTensor, Int32Tensor], {
-            let min = ctx.inputs().get_as_scalar(0)?;
-            let max = ctx.inputs().get_as_scalar(1)?;
+            let min = ctx.inputs().get_as(0)?;
+            let max = ctx.inputs().get_as(1)?;
             clip_in_place(&mut input, min, max);
             Ok(input.into())
         })
@@ -509,7 +509,7 @@ impl Operator for Not {
     }
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
-        let input = ctx.inputs().require_as::<i32>(0)?;
+        let input: TensorView<i32> = ctx.inputs().require_as(0)?;
         not(ctx.pool(), input).into_op_result()
     }
 

--- a/src/ops/variadic_elementwise.rs
+++ b/src/ops/variadic_elementwise.rs
@@ -7,7 +7,8 @@ use crate::number::IsNaN;
 use crate::ops::binary_elementwise::binary_op;
 use crate::ops::reduce::{cmp_nan_greater, cmp_nan_less};
 use crate::ops::{
-    map_input, Input, InputList, IntoOpResult, OpError, OpRunContext, Operator, OutputList,
+    map_input, CastError, Input, InputList, IntoOpResult, OpError, OpRunContext, Operator,
+    OutputList,
 };
 use crate::tensor_pool::{AutoReturn, TensorPool};
 
@@ -40,7 +41,7 @@ fn typed_views<'a, T>(
     _: TensorView<T>,
 ) -> Result<Vec<TensorView<'a, T>>, OpError>
 where
-    Input<'a>: TryInto<TensorView<'a, T>, Error = OpError>,
+    Input<'a>: TryInto<TensorView<'a, T>, Error = CastError>,
 {
     inputs
         .iter()


### PR DESCRIPTION
Refactor conversions from dynamically typed values (`Input`/`Output`) to statically typed `TensorView`/`NdTensorView`, in order to:

- Streamline conversions by allowing `InputList::{require_as, get_as}` to convert directly to a static-type, static-rank view rather than converting first to a static-type, dynamic-rank.
- Add input indexes to the errors returned by `require_as` and `get_as` for easier debugging
- Add actual/expected data type information to dtype mismatch errors
- Avoid confusing errors due to the use of the terms "input" and "output" in various errors although the `Input` and `Output` types are really just tensors with dynamic type and not used exclusively for operator inputs and outputs any more.
- Improve `Display` formatting of errors when an operator receives an input of the wrong type or rank