### PR TITLE
Rename `Input`, `Output` and `InputOrOutput` types

### DIFF
--- a/rten-examples/src/bert_qa.rs
+++ b/rten-examples/src/bert_qa.rs
@@ -3,7 +3,7 @@ use std::error::Error;
 use std::fs;
 
 use rten::ops::FloatOperators;
-use rten::{InputOrOutput, Model, NodeId};
+use rten::{Model, NodeId, ValueOrView};
 use rten_tensor::prelude::*;
 use rten_tensor::*;
 use rten_text::tokenizer::{EncodeOptions, Encoded, Tokenizer};
@@ -99,7 +99,7 @@ fn extract_nbest_answers<'a>(
     let start_logits_id = model.node_id("start_logits")?;
     let end_logits_id = model.node_id("end_logits")?;
 
-    let mut inputs: Vec<(NodeId, InputOrOutput)> = vec![
+    let mut inputs: Vec<(NodeId, ValueOrView)> = vec![
         (input_ids_id, input_ids.view().into()),
         (attention_mask_id, attention_mask.view().into()),
     ];

--- a/rten-examples/src/jina_similarity.rs
+++ b/rten-examples/src/jina_similarity.rs
@@ -2,7 +2,7 @@ use std::collections::VecDeque;
 use std::error::Error;
 
 use rten::ops::concat;
-use rten::{FloatOperators, InputOrOutput, Model, NodeId, Operators, TensorPool};
+use rten::{FloatOperators, Model, NodeId, Operators, TensorPool, ValueOrView};
 use rten_tensor::prelude::*;
 use rten_tensor::{NdTensor, Tensor};
 use rten_text::tokenizer::{EncodeOptions, Tokenizer};
@@ -120,7 +120,7 @@ fn embed_sentence_batch(
     let input_ids_id = model.node_id("input_ids")?;
     let attention_mask_id = model.node_id("attention_mask")?;
 
-    let mut inputs: Vec<(NodeId, InputOrOutput)> = vec![
+    let mut inputs: Vec<(NodeId, ValueOrView)> = vec![
         (input_ids_id, input_ids.view().into()),
         (attention_mask_id, attention_mask.view().into()),
     ];

--- a/rten-generate/src/model.rs
+++ b/rten-generate/src/model.rs
@@ -2,7 +2,7 @@
 
 use std::error::Error;
 
-use rten::{Dimension, InputOrOutput, NodeId, Output, RunOptions};
+use rten::{Dimension, NodeId, RunOptions, Value, ValueOrView};
 
 /// Describes the name and shape of a model input or output.
 ///
@@ -51,19 +51,19 @@ pub trait Model {
     /// Run the model with the provided inputs and return the results.
     fn run(
         &self,
-        inputs: Vec<(NodeId, InputOrOutput)>,
+        inputs: Vec<(NodeId, ValueOrView)>,
         outputs: &[NodeId],
         opts: Option<RunOptions>,
-    ) -> Result<Vec<Output>, Box<dyn Error>>;
+    ) -> Result<Vec<Value>, Box<dyn Error>>;
 
     /// Run as much of the model as possible given the provided inputs and
     /// return the leaves of the evaluation where execution stopped.
     fn partial_run(
         &self,
-        inputs: Vec<(NodeId, InputOrOutput)>,
+        inputs: Vec<(NodeId, ValueOrView)>,
         outputs: &[NodeId],
         opts: Option<RunOptions>,
-    ) -> Result<Vec<(NodeId, Output)>, Box<dyn Error>>;
+    ) -> Result<Vec<(NodeId, Value)>, Box<dyn Error>>;
 }
 
 impl Model for rten::Model {
@@ -89,19 +89,19 @@ impl Model for rten::Model {
 
     fn run(
         &self,
-        inputs: Vec<(NodeId, InputOrOutput)>,
+        inputs: Vec<(NodeId, ValueOrView)>,
         outputs: &[NodeId],
         opts: Option<RunOptions>,
-    ) -> Result<Vec<Output>, Box<dyn Error>> {
+    ) -> Result<Vec<Value>, Box<dyn Error>> {
         self.run(inputs, outputs, opts).map_err(|e| e.into())
     }
 
     fn partial_run(
         &self,
-        inputs: Vec<(NodeId, InputOrOutput)>,
+        inputs: Vec<(NodeId, ValueOrView)>,
         outputs: &[NodeId],
         opts: Option<RunOptions>,
-    ) -> Result<Vec<(NodeId, Output)>, Box<dyn Error>> {
+    ) -> Result<Vec<(NodeId, Value)>, Box<dyn Error>> {
         self.partial_run(inputs, outputs, opts)
             .map_err(|e| e.into())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,7 +147,7 @@ pub use graph::{Dimension, NodeId, RunError, RunOptions};
 pub use model::{Model, ModelLoadError, ModelOptions, NodeInfo};
 pub use model_metadata::ModelMetadata;
 pub use op_registry::{OpRegistry, ReadOp, ReadOpError};
-pub use ops::{DataType, FloatOperators, Input, InputOrOutput, Operators, Output};
+pub use ops::{DataType, FloatOperators, Operators, Value, ValueOrView, ValueView};
 pub use tensor_pool::{ExtractBuffer, PoolRef, TensorPool};
 pub use threading::{thread_pool, ThreadPool};
 pub use timing::TimingSort;

--- a/src/ops/control_flow.rs
+++ b/src/ops/control_flow.rs
@@ -2,11 +2,11 @@ use rten_tensor::TensorView;
 use smallvec::SmallVec;
 
 use crate::graph::{CaptureEnv, Graph, RunError, RunOptions};
-use crate::ops::{OpError, OpRunContext, Operator, Output, OutputList};
+use crate::ops::{OpError, OpRunContext, Operator, OutputList, Value};
 use crate::timing::Profiler;
 use crate::weight_cache::WeightCache;
 
-fn output_list_from_vec(xs: Vec<Output>) -> OutputList {
+fn output_list_from_vec(xs: Vec<Value>) -> OutputList {
     xs.into_iter().collect()
 }
 

--- a/src/ops/conv.rs
+++ b/src/ops/conv.rs
@@ -13,7 +13,7 @@ use crate::gemm::{
 use crate::ops::matmul::zero_point_to_vec;
 use crate::ops::pooling::calc_output_size_and_padding;
 use crate::ops::{
-    static_dims, Input, IntoOpResult, OpError, OpRunContext, Operator, OutputList, Padding,
+    static_dims, IntoOpResult, OpError, OpRunContext, Operator, OutputList, Padding, ValueView,
 };
 use crate::shift_cast::ShiftCast;
 use crate::tensor_pool::{AutoReturn, PoolRef, TensorPool};
@@ -522,10 +522,10 @@ impl Operator for ConvInteger {
         }
 
         match (input, weight) {
-            (Input::Int8Tensor(x), Input::Int8Tensor(w)) => conv_integer!(x, w),
-            (Input::Int8Tensor(x), Input::UInt8Tensor(w)) => conv_integer!(x, w),
-            (Input::UInt8Tensor(x), Input::Int8Tensor(w)) => conv_integer!(x, w),
-            (Input::UInt8Tensor(x), Input::UInt8Tensor(w)) => conv_integer!(x, w),
+            (ValueView::Int8Tensor(x), ValueView::Int8Tensor(w)) => conv_integer!(x, w),
+            (ValueView::Int8Tensor(x), ValueView::UInt8Tensor(w)) => conv_integer!(x, w),
+            (ValueView::UInt8Tensor(x), ValueView::Int8Tensor(w)) => conv_integer!(x, w),
+            (ValueView::UInt8Tensor(x), ValueView::UInt8Tensor(w)) => conv_integer!(x, w),
             _ => Err(OpError::UnsupportedType),
         }
     }

--- a/src/ops/gather.rs
+++ b/src/ops/gather.rs
@@ -8,8 +8,8 @@ use smallvec::SmallVec;
 use crate::number::IsNaN;
 use crate::ops::reduce::{cmp_nan_greater, cmp_nan_less};
 use crate::ops::{
-    map_input, resolve_axis, resolve_index, Input, IntoOpResult, OpError, OpRunContext, Operator,
-    OutputList,
+    map_value_view, resolve_axis, resolve_index, IntoOpResult, OpError, OpRunContext, Operator,
+    OutputList, ValueView,
 };
 use crate::tensor_pool::{AutoReturn, TensorPool};
 
@@ -139,7 +139,7 @@ impl Operator for Gather {
         let input = inputs.require(0)?;
         let indices = inputs.require_as(1)?;
 
-        map_input!(input, x, {
+        map_value_view!(input, x, {
             gather(ctx.pool(), x, self.axis, indices).into_op_result()
         })
     }
@@ -283,7 +283,7 @@ impl Operator for GatherElements {
         let input = inputs.require(0)?;
         let indices = inputs.require_as(1)?;
 
-        map_input!(input, x, {
+        map_value_view!(input, x, {
             gather_elements(ctx.pool(), x, indices, self.axis).into_op_result()
         })
     }
@@ -401,7 +401,7 @@ impl Operator for GatherND {
         let input = inputs.require(0)?;
         let indices = inputs.require_as(1)?;
 
-        map_input!(input, x, {
+        map_value_view!(input, x, {
             gather_nd(ctx.pool(), x, indices, self.batch_dims).into_op_result()
         })
     }
@@ -510,7 +510,7 @@ impl Operator for ScatterElements {
         let data = inputs.require(0)?;
         let indices = inputs.require_as(1)?;
 
-        map_input!(data, x, {
+        map_value_view!(data, x, {
             let updates = inputs.require_as(2)?;
             scatter_elements(ctx.pool(), x, indices, updates, self.axis, self.reduction)
                 .into_op_result()
@@ -602,7 +602,7 @@ impl Operator for ScatterND {
         let data = inputs.require(0)?;
         let indices = inputs.require_as(1)?;
 
-        map_input!(data, x, {
+        map_value_view!(data, x, {
             let updates = inputs.require_as(2)?;
             scatter_nd(ctx.pool(), x, indices, updates, self.reduction).into_op_result()
         })

--- a/src/ops/generate.rs
+++ b/src/ops/generate.rs
@@ -4,8 +4,8 @@ use rten_tensor::prelude::*;
 use rten_tensor::{NdTensorView, Tensor, TensorView};
 
 use crate::ops::{
-    map_input, resolve_axis, resolve_index, static_dims, Input, IntoOpResult, OpError,
-    OpRunContext, Operator, OutputList, Scalar,
+    map_value_view, resolve_axis, resolve_index, static_dims, IntoOpResult, OpError, OpRunContext,
+    Operator, OutputList, Scalar, ValueView,
 };
 use crate::tensor_pool::TensorPool;
 
@@ -96,7 +96,7 @@ impl Operator for OneHot {
             .ok_or(OpError::InvalidValue("`depth` must be a positive scalar"))?;
         let values = inputs.require(2)?;
 
-        map_input!(values, values, [Int32Tensor, FloatTensor], {
+        map_value_view!(values, values, [Int32Tensor, FloatTensor], {
             let values = static_dims!(values, 1)?;
             let (on_value, off_value) = extract_on_off_values(values)?;
             onehot(ctx.pool(), indices, self.axis, depth, on_value, off_value).into_op_result()
@@ -139,7 +139,7 @@ impl Operator for Range {
         let limit = inputs.require(1)?;
         let delta = inputs.require(2)?;
 
-        map_input!(start, start, [FloatTensor, Int32Tensor], {
+        map_value_view!(start, start, [FloatTensor, Int32Tensor], {
             let start = start
                 .item()
                 .copied()

--- a/src/ops/identity.rs
+++ b/src/ops/identity.rs
@@ -2,7 +2,7 @@ use rten_tensor::prelude::*;
 use rten_tensor::{Tensor, TensorView};
 
 use crate::ops::{
-    map_input, Input, IntoOpResult, OpError, OpRunContext, Operator, Output, OutputList,
+    map_value_view, IntoOpResult, OpError, OpRunContext, Operator, OutputList, Value, ValueView,
 };
 use crate::tensor_pool::TensorPool;
 
@@ -20,14 +20,14 @@ impl Operator for Identity {
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let input = ctx.inputs().require(0)?;
-        map_input!(input, x, { identity(ctx.pool(), x).into_op_result() })
+        map_value_view!(input, x, { identity(ctx.pool(), x).into_op_result() })
     }
 
     fn can_run_in_place(&self) -> bool {
         true
     }
 
-    fn run_in_place(&self, input: Output, _ctx: &OpRunContext) -> Result<Output, OpError> {
+    fn run_in_place(&self, input: Value, _ctx: &OpRunContext) -> Result<Value, OpError> {
         Ok(input)
     }
 }

--- a/src/ops/norm.rs
+++ b/src/ops/norm.rs
@@ -7,7 +7,7 @@ use rten_tensor::prelude::*;
 use rten_tensor::{NdTensorView, Tensor, TensorView};
 use rten_vecmath as vecmath;
 
-use crate::ops::{resolve_axis, IntoOpResult, OpError, OpRunContext, Operator, Output, OutputList};
+use crate::ops::{resolve_axis, IntoOpResult, OpError, OpRunContext, Operator, OutputList, Value};
 use crate::slice_reductions::slice_max;
 use crate::tensor_pool::TensorPool;
 
@@ -250,7 +250,7 @@ impl Operator for BatchNormalization {
         true
     }
 
-    fn run_in_place(&self, input: Output, ctx: &OpRunContext) -> Result<Output, OpError> {
+    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<Value, OpError> {
         let inputs = ctx.inputs();
         let mut output: Tensor = input.try_into()?;
         let scale = inputs.require_as(0)?;
@@ -335,7 +335,7 @@ impl Operator for InstanceNormalization {
         true
     }
 
-    fn run_in_place(&self, input: Output, ctx: &OpRunContext) -> Result<Output, OpError> {
+    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<Value, OpError> {
         let mut output: Tensor = input.try_into()?;
         let inputs = ctx.inputs();
         let scale = inputs.require_as(0)?;
@@ -618,7 +618,7 @@ impl Operator for LogSoftmax {
         true
     }
 
-    fn run_in_place(&self, input: Output, _ctx: &OpRunContext) -> Result<Output, OpError> {
+    fn run_in_place(&self, input: Value, _ctx: &OpRunContext) -> Result<Value, OpError> {
         let mut output: Tensor = input.try_into()?;
         log_softmax_in_place(&mut output, self.axis)?;
         Ok(output.into())
@@ -657,7 +657,7 @@ impl Operator for Softmax {
         true
     }
 
-    fn run_in_place(&self, input: Output, _ctx: &OpRunContext) -> Result<Output, OpError> {
+    fn run_in_place(&self, input: Value, _ctx: &OpRunContext) -> Result<Value, OpError> {
         let mut output = input.try_into()?;
         softmax_in_place(&mut output, self.axis)?;
         Ok(output.into())

--- a/src/ops/pad.rs
+++ b/src/ops/pad.rs
@@ -1,7 +1,9 @@
 use rten_tensor::prelude::*;
 use rten_tensor::{NdTensorView, SliceItem, Tensor, TensorView};
 
-use crate::ops::{map_input, Input, IntoOpResult, OpError, OpRunContext, Operator, OutputList};
+use crate::ops::{
+    map_value_view, IntoOpResult, OpError, OpRunContext, Operator, OutputList, ValueView,
+};
 use crate::tensor_pool::TensorPool;
 
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -187,7 +189,7 @@ impl Operator for Pad {
             ));
         }
 
-        map_input!(input, x, {
+        map_value_view!(input, x, {
             let const_val = inputs.get_as(2)?.unwrap_or_default();
             pad(ctx.pool(), x, &pads, self.mode, const_val).into_op_result()
         })

--- a/src/ops/random.rs
+++ b/src/ops/random.rs
@@ -3,7 +3,7 @@ use fastrand_contrib::RngExt;
 use rten_tensor::prelude::*;
 use rten_tensor::{Tensor, TensorView};
 
-use crate::ops::{IntoOpResult, OpError, OpRunContext, Operator, Output, OutputList};
+use crate::ops::{IntoOpResult, OpError, OpRunContext, Operator, OutputList, Value};
 
 #[derive(Debug)]
 pub struct RandomUniform {
@@ -198,7 +198,7 @@ impl Operator for Dropout {
             (output, mask)
         };
 
-        Ok([Output::from(output), Output::from(mask)]
+        Ok([Value::from(output), Value::from(mask)]
             .into_iter()
             .collect())
     }

--- a/src/ops/reduce.rs
+++ b/src/ops/reduce.rs
@@ -10,8 +10,8 @@ use rten_vecmath as vecmath;
 use crate::number::{Identities, IsNaN};
 use crate::ops::layout::squeeze_in_place;
 use crate::ops::{
-    map_input, resolve_axes, resolve_axis, Input, InputList, IntoOpResult, OpError, OpRunContext,
-    Operator, OutputList,
+    map_value_view, resolve_axes, resolve_axis, InputList, IntoOpResult, OpError, OpRunContext,
+    Operator, OutputList, ValueView,
 };
 use crate::slice_reductions::slice_sum;
 use crate::tensor_pool::TensorPool;
@@ -96,7 +96,7 @@ impl Operator for ArgMax {
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let input = ctx.inputs().require(0)?;
-        map_input!(input, input, [FloatTensor, Int32Tensor], {
+        map_value_view!(input, input, [FloatTensor, Int32Tensor], {
             arg_max(ctx.pool(), input, self.axis, self.keep_dims).into_op_result()
         })
     }
@@ -132,7 +132,7 @@ impl Operator for ArgMin {
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let input = ctx.inputs().require(0)?;
-        map_input!(input, input, [FloatTensor, Int32Tensor], {
+        map_value_view!(input, input, [FloatTensor, Int32Tensor], {
             arg_min(ctx.pool(), input, self.axis, self.keep_dims).into_op_result()
         })
     }
@@ -179,7 +179,7 @@ impl Operator for CumSum {
         let inputs = ctx.inputs();
         let input = inputs.require(0)?;
         let axis: i32 = inputs.require_as(1)?;
-        map_input!(input, input, [FloatTensor, Int32Tensor], {
+        map_value_view!(input, input, [FloatTensor, Int32Tensor], {
             cum_sum(ctx.pool(), input, axis as isize).into_op_result()
         })
     }
@@ -221,7 +221,7 @@ impl Operator for NonZero {
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let input = ctx.inputs().require(0)?;
-        map_input!(input, input, [FloatTensor, Int32Tensor], {
+        map_value_view!(input, input, [FloatTensor, Int32Tensor], {
             nonzero(ctx.pool(), input).into_op_result()
         })
     }
@@ -555,7 +555,7 @@ impl Operator for ReduceMin {
         let inputs = ctx.inputs();
         let input = inputs.require(0)?;
         let axes = get_axes(inputs, &self.axes)?;
-        map_input!(input, input, [FloatTensor, Int32Tensor], {
+        map_value_view!(input, input, [FloatTensor, Int32Tensor], {
             reduce_min(ctx.pool(), input, axes.as_deref(), self.keep_dims).into_op_result()
         })
     }
@@ -585,7 +585,7 @@ impl Operator for ReduceMax {
         let inputs = ctx.inputs();
         let input = inputs.require(0)?;
         let axes = get_axes(inputs, &self.axes)?;
-        map_input!(input, input, [FloatTensor, Int32Tensor], {
+        map_value_view!(input, input, [FloatTensor, Int32Tensor], {
             reduce_max(ctx.pool(), input, axes.as_deref(), self.keep_dims).into_op_result()
         })
     }
@@ -621,7 +621,7 @@ impl Operator for ReduceProd {
         let inputs = ctx.inputs();
         let input = inputs.require(0)?;
         let axes = get_axes(inputs, &self.axes)?;
-        map_input!(input, input, [FloatTensor, Int32Tensor], {
+        map_value_view!(input, input, [FloatTensor, Int32Tensor], {
             reduce_prod(ctx.pool(), input, axes.as_deref(), self.keep_dims).into_op_result()
         })
     }
@@ -657,7 +657,7 @@ impl Operator for ReduceSum {
         let inputs = ctx.inputs();
         let input = inputs.require(0)?;
         let axes = get_axes(inputs, &self.axes)?;
-        map_input!(input, input, [FloatTensor, Int32Tensor], {
+        map_value_view!(input, input, [FloatTensor, Int32Tensor], {
             reduce_sum(ctx.pool(), input, axes.as_deref(), self.keep_dims).into_op_result()
         })
     }
@@ -693,7 +693,7 @@ impl Operator for ReduceSumSquare {
         let inputs = ctx.inputs();
         let input = inputs.require(0)?;
         let axes = get_axes(inputs, &self.axes)?;
-        map_input!(input, input, [FloatTensor, Int32Tensor], {
+        map_value_view!(input, input, [FloatTensor, Int32Tensor], {
             reduce_sum_square(ctx.pool(), input, axes.as_deref(), self.keep_dims).into_op_result()
         })
     }
@@ -794,7 +794,7 @@ impl Operator for TopK {
             }
         })?;
 
-        map_input!(values, values, [FloatTensor, Int32Tensor], {
+        map_value_view!(values, values, [FloatTensor, Int32Tensor], {
             let (values, indices) =
                 topk(ctx.pool(), values, k, self.axis, self.largest, self.sorted)?;
             Ok([values.into(), indices.into()].into_iter().collect())

--- a/src/ops/resize.rs
+++ b/src/ops/resize.rs
@@ -7,8 +7,8 @@ use rten_tensor::{NdTensor, NdTensorView, NdTensorViewMut, Tensor, TensorView};
 
 use crate::iter_util::range_chunks;
 use crate::ops::{
-    static_dims, CastError, Input, InputList, IntoOpResult, OpError, OpRunContext, Operator,
-    Output, OutputList,
+    static_dims, CastError, InputList, IntoOpResult, OpError, OpRunContext, Operator, OutputList,
+    Value, ValueView,
 };
 use crate::tensor_pool::{AutoReturn, TensorPool};
 
@@ -382,7 +382,7 @@ fn get_optional_input<'a, T>(
     index: usize,
 ) -> Result<Option<TensorView<'a, T>>, OpError>
 where
-    TensorView<'a, T>: TryFrom<Input<'a>, Error = CastError>,
+    TensorView<'a, T>: TryFrom<ValueView<'a>, Error = CastError>,
 {
     let tensor = inputs
         .get_as::<TensorView<T>>(index)?
@@ -445,7 +445,7 @@ impl Operator for Resize {
         true
     }
 
-    fn run_in_place(&self, input: Output, ctx: &OpRunContext) -> Result<Output, OpError> {
+    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<Value, OpError> {
         // See note in `run` about the `roi` input.
 
         let other = ctx.inputs();

--- a/src/ops/split.rs
+++ b/src/ops/split.rs
@@ -2,7 +2,9 @@ use rten_tensor::prelude::*;
 use rten_tensor::{NdTensorView, Tensor, TensorView};
 
 use crate::iter_util::range_chunks;
-use crate::ops::{map_input, resolve_axis, Input, OpError, OpRunContext, Operator, OutputList};
+use crate::ops::{
+    map_value_view, resolve_axis, OpError, OpRunContext, Operator, OutputList, ValueView,
+};
 use crate::tensor_pool::TensorPool;
 
 #[derive(Clone, Debug)]
@@ -105,7 +107,7 @@ impl Operator for Split {
             ));
         };
 
-        map_input!(input, x, {
+        map_value_view!(input, x, {
             split(ctx.pool(), x, self.axis, split_sizes)
                 .map(|tensors| tensors.into_iter().map(|t| t.into()).collect())
         })

--- a/src/ops/transform_inputs.rs
+++ b/src/ops/transform_inputs.rs
@@ -2,10 +2,10 @@ use std::sync::Arc;
 
 use rten_tensor::prelude::*;
 
-use crate::ops::{map_input, Input, OpError, OpRunContext, Operator, OutputList};
+use crate::ops::{map_value_view, OpError, OpRunContext, Operator, OutputList, ValueView};
 
 trait TransformInput {
-    fn transform(&self, input: &mut Input) -> Result<(), OpError>;
+    fn transform(&self, input: &mut ValueView) -> Result<(), OpError>;
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -15,8 +15,8 @@ struct PermuteInput {
 }
 
 impl TransformInput for PermuteInput {
-    fn transform(&self, input: &mut Input) -> Result<(), OpError> {
-        map_input!(input, tensor, {
+    fn transform(&self, input: &mut ValueView) -> Result<(), OpError> {
+        map_value_view!(input, tensor, {
             if let Some(perm) = self.perm.as_ref() {
                 tensor.permute(perm);
             } else {
@@ -33,7 +33,7 @@ enum Transform {
 }
 
 impl TransformInput for Transform {
-    fn transform(&self, input: &mut Input) -> Result<(), OpError> {
+    fn transform(&self, input: &mut ValueView) -> Result<(), OpError> {
         match self {
             Self::Permute(spec) => spec.transform(input),
         }

--- a/src/ops/trilu.rs
+++ b/src/ops/trilu.rs
@@ -1,7 +1,9 @@
 use rten_tensor::prelude::*;
 use rten_tensor::{Tensor, TensorView};
 
-use crate::ops::{map_input, Input, IntoOpResult, OpError, OpRunContext, Operator, OutputList};
+use crate::ops::{
+    map_value_view, IntoOpResult, OpError, OpRunContext, Operator, OutputList, ValueView,
+};
 use crate::tensor_pool::TensorPool;
 
 pub fn trilu<T: Copy + Default>(
@@ -48,7 +50,7 @@ impl Operator for Trilu {
         let input = inputs.require(0)?;
         let k = inputs.get_as(1)?.unwrap_or(0);
 
-        map_input!(input, input, [FloatTensor, Int32Tensor], {
+        map_value_view!(input, input, [FloatTensor, Int32Tensor], {
             trilu(ctx.pool(), input, k, self.upper).into_op_result()
         })
     }

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -14,7 +14,7 @@ use crate::ops::{
     FusedMatMul, Gelu, LayerNormalization, Operator, ReduceMean, RmsNormalization, Silu, Swish,
     Transpose,
 };
-use crate::Output;
+use crate::Value;
 
 mod pattern_matcher;
 
@@ -422,10 +422,10 @@ impl GraphOptimizer {
             let const_name = const_name.as_deref();
 
             let const_id = match output {
-                Output::FloatTensor(tensor) => graph.add_constant(const_name, tensor),
-                Output::Int32Tensor(tensor) => graph.add_constant(const_name, tensor),
-                Output::Int8Tensor(tensor) => graph.add_constant(const_name, tensor),
-                Output::UInt8Tensor(tensor) => graph.add_constant(const_name, tensor),
+                Value::FloatTensor(tensor) => graph.add_constant(const_name, tensor),
+                Value::Int32Tensor(tensor) => graph.add_constant(const_name, tensor),
+                Value::Int8Tensor(tensor) => graph.add_constant(const_name, tensor),
+                Value::UInt8Tensor(tensor) => graph.add_constant(const_name, tensor),
             };
             graph.replace_value(value_node_id, const_id);
         }

--- a/src/optimize/pattern_matcher.rs
+++ b/src/optimize/pattern_matcher.rs
@@ -1,7 +1,7 @@
 use std::ops::{Add, Div, Mul, Neg, Sub};
 
 use crate::graph::{Constant, Graph, Node, NodeId, OperatorNode};
-use crate::ops::Input;
+use crate::ops::ValueView;
 
 /// Tracks an association between named symbols (variables) in a pattern and
 /// the node IDs they have been resolved to.
@@ -76,8 +76,8 @@ pub struct ConstantPattern {
 
 impl ConstantPattern {
     fn matches(&self, node: &Constant) -> bool {
-        match node.as_input() {
-            Input::FloatTensor(t) => t
+        match node.as_view() {
+            ValueView::FloatTensor(t) => t
                 .item()
                 .is_some_and(|x| (x - self.value).abs() <= CONST_TOLERANCE),
             _ => false,

--- a/src/timing.rs
+++ b/src/timing.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 use std::time;
 
-use crate::ops::InputMeta;
+use crate::ops::ValueMeta;
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 type Seconds = f64;
@@ -250,7 +250,7 @@ fn shape_to_string(shape: &[usize]) -> String {
 }
 
 /// Format a list of operator input shapes as a string.
-fn shapes_to_string(meta: &[Option<InputMeta>]) -> String {
+fn shapes_to_string(meta: &[Option<ValueMeta>]) -> String {
     let formatted_shapes: Vec<_> = meta
         .iter()
         .map(|meta| {
@@ -386,7 +386,7 @@ pub struct TimingRecord<'a> {
     pub node_name: &'a str,
 
     /// Shapes of the operator's inputs
-    pub input_meta: Vec<Option<InputMeta>>,
+    pub input_meta: Vec<Option<ValueMeta>>,
 
     /// Execution time of this step
     pub elapsed: Duration,


### PR DESCRIPTION
Rename:

 - `Input` => `ValueView`
 - `Output` => `Value`
 - `InputOrOutput` => `ValueOrView`

The `Input` and `Output` types were originally used for operator inputs and outputs respectively but are now used in other contexts where tensor views or owned tensors of dynamic element type are needed. For example `Operator::run_in_place` takes its mutable, owned-input as an `Output`.  Rename these types to make their current purpose clearer.