### PR TITLE
Account for first input being omitted in `InputList` methods

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -945,7 +945,9 @@ impl Graph {
                     .flatten()
                     .and_then(|node_id| weight_cache.and_then(|wc| wc.get(node_id)))
             };
-            let inputs = InputList::from_optional(&op_inputs).with_prepacked(&get_prepacked);
+            let inputs = InputList::from_optional(&op_inputs)
+                .with_prepacked(&get_prepacked)
+                .with_first_input_omitted(in_place_input.is_some());
             let mut ctx = OpRunContext::new(pool, &inputs);
             ctx.set_num_outputs(op_node.output_ids().len() as u32);
 


### PR DESCRIPTION
When an operator is run in-place input indices passed to `InputList` methods are offset by one because the first input is passed separately.  Account for this when generating errors so that error messages reflect the real index of the input rather than the one passed to eg. `InputList::require`, which will be one lower.