### PR TITLE
Refine formatting of tensor types and shapes in errors

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -118,15 +118,18 @@ impl fmt::Display for RunError {
                 error: ref err,
                 inputs,
             } => {
-                write!(f, "operator \"{}\" failed: {}. Inputs were [", name, err,)?;
-                for input in inputs {
+                write!(f, "operator \"{}\" failed: {}. Inputs were (", name, err,)?;
+                for (i, input) in inputs.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
                     if let Some(meta) = input {
-                        write!(f, "({})", meta)?;
+                        write!(f, "{}", meta)?;
                     } else {
                         write!(f, "-")?;
                     }
                 }
-                write!(f, "]")
+                write!(f, ")")
             }
             RunError::OutputMismatch(err) => write!(f, "output mismatch {:?}", err),
         }

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -315,7 +315,8 @@ pub struct ValueMeta {
 
 impl Display for ValueMeta {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}, {:?}", self.dtype, self.shape)
+        // Produces strings such as "f32 [1, 16, 256]"
+        write!(f, "{} {:?}", self.dtype, self.shape)
     }
 }
 


### PR DESCRIPTION
 - Add commas between input shapes
 - Change formatting of the dtype/shape for an individual tensor to be less noisy
 - Use parens for input list to be easier to distinguish from square brackets used for shapes

With the new format an error looks like:

```
Model run failed: operator "/deberta/encoder/layer.0/attention/self/Not" failed: expected tensor with type bool but has type i32. Inputs were (i32 [1, 1, 64, 64])
```