### PR TITLE
Include node name in operator errors for If ops

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -969,6 +969,8 @@ impl Graph {
                         )
                     })
             } else if has_subgraph {
+                ctx.set_name(op_node.name());
+
                 let capture_env = CaptureEnv::new(
                     captures.as_ref(),
                     self,

--- a/src/ops/control_flow.rs
+++ b/src/ops/control_flow.rs
@@ -44,8 +44,7 @@ impl Operator for If {
         profiler: Option<&mut Profiler<'a>>,
         run_opts: Option<RunOptions>,
     ) -> Result<OutputList, RunError> {
-        // TODO - This should contain the name of the "If" node.
-        let node_name = "";
+        let node_name = ctx.name().unwrap_or_default();
         let cond: TensorView<i32> = ctx
             .inputs()
             .require_as(0)

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -912,6 +912,7 @@ pub struct OpRunContext<'a, 'i> {
     pool: &'a TensorPool,
     inputs: &'a InputList<'i>,
     n_outputs: Option<u32>,
+    name: Option<&'a str>,
 }
 
 impl<'a, 'i> OpRunContext<'a, 'i> {
@@ -920,6 +921,7 @@ impl<'a, 'i> OpRunContext<'a, 'i> {
             pool,
             inputs,
             n_outputs: None,
+            name: None,
         }
     }
 
@@ -949,6 +951,16 @@ impl<'a, 'i> OpRunContext<'a, 'i> {
     /// specified.
     pub fn num_outputs(&self) -> Option<u32> {
         self.n_outputs
+    }
+
+    /// Set the name of the current node in the graph.
+    pub fn set_name(&mut self, name: Option<&'a str>) {
+        self.name = name;
+    }
+
+    /// Return the name of the current node in the graph.
+    pub fn name(&self) -> Option<&str> {
+        self.name
     }
 }
 


### PR DESCRIPTION
Support passing the node name to an operator via `OpRunContext` and use this to generate better errors in the `If` operator. The name is currently only set when running subgraphs because only control flow operators need it, but it could be set for all operations if useful.