### PR TITLE
Refactor internal GEMM APIs that accept uninitialized output buffers

### DIFF
--- a/src/gemm/errors.rs
+++ b/src/gemm/errors.rs
@@ -12,7 +12,7 @@ pub enum GemmError {
     /// Quantization parameter size does not match corresponding input size.
     WrongQuantParamSize,
     /// The buffer provided for the output is too short.
-    OutputNotLargeEnough,
+    OutputSizeMismatch,
     /// The data was packed with a kernel that uses a different layout than
     /// the current kernel.
     PackedDataKernelMismatch,
@@ -31,7 +31,7 @@ impl Display for GemmError {
             Self::WrongQuantParamSize => {
                 write!(fmt, "quantization parameter size does not match input")
             }
-            Self::OutputNotLargeEnough => write!(fmt, "output buffer is too small"),
+            Self::OutputSizeMismatch => write!(fmt, "output buffer has wrong length"),
             Self::PackedDataKernelMismatch => {
                 write!(fmt, "matrix was packed with a different kernel")
             }

--- a/src/ops/conv.rs
+++ b/src/ops/conv.rs
@@ -52,7 +52,6 @@ where
 
     for n in 0..batch {
         let mut out_item = output.slice_mut([n]);
-        let out_row_stride = out_item.stride(0);
 
         let in_mat = input
             .slice([n])
@@ -61,7 +60,6 @@ where
 
         gemm.gemm_uninit(
             out_item.data_mut().unwrap(),
-            out_row_stride,
             GemmInputA::Unpacked(kernel_mat.view()),
             GemmInputB::Unpacked(in_mat.view()),
             1., // alpha
@@ -309,7 +307,6 @@ where
                 let mut out_mat = out_item
                     .reshaped_mut([out_channels_per_group, out_h * out_w])
                     .unwrap();
-                let out_row_stride = out_mat.stride(0);
 
                 let im2col = build_im2col(
                     in_item,
@@ -326,7 +323,6 @@ where
                     .map(|b| BiasVector::Column(&b.data().unwrap()[out_chans.clone()]));
                 gemm.gemm_uninit(
                     out_mat.data_mut().unwrap(),
-                    out_row_stride,
                     prepacked_kernel
                         .map(GemmInputA::Packed)
                         .unwrap_or(GemmInputA::Unpacked(kernel_mat.view())),
@@ -754,10 +750,8 @@ pub fn conv_transpose(
             .reshaped_in(pool, [in_c, in_h * in_w])
             .auto_return(pool);
 
-        let col2im_row_stride = col2im_mat.stride(0);
         gemm.gemm_uninit(
             col2im_mat.data_mut().unwrap(),
-            col2im_row_stride,
             GemmInputA::Unpacked(kernel_mat),
             GemmInputB::Unpacked(input_mat.view()),
             1.,   // alpha

--- a/src/ops/matmul.rs
+++ b/src/ops/matmul.rs
@@ -51,10 +51,8 @@ where
                 ));
             }
             let mut output = expand_to(pool, c, out_shape);
-            let out_row_stride = output.stride(0);
             gemm.gemm(
                 output.data_mut().unwrap(),
-                out_row_stride,
                 GemmInputA::Unpacked(a.nd_view()),
                 GemmInputB::Unpacked(b.nd_view()),
                 alpha,
@@ -68,10 +66,8 @@ where
         }
         _ => {
             let mut output = Tensor::uninit_in(pool, out_shape);
-            let out_row_stride = output.stride(0);
             gemm.gemm_uninit(
                 output.data_mut().unwrap(),
-                out_row_stride,
                 GemmInputA::Unpacked(a.nd_view()),
                 GemmInputB::Unpacked(b.nd_view()),
                 alpha,
@@ -323,7 +319,6 @@ where
 
             gemm.gemm_uninit(
                 out_mat,
-                out_row_stride,
                 a_input,
                 b_input,
                 alpha.unwrap_or(1.),
@@ -592,11 +587,9 @@ mod tests {
 
     fn gemm_tensors(c: &mut Tensor, a: &Tensor, b: &Tensor, alpha: f32, beta: f32) {
         c.make_contiguous();
-        let c_row_stride = c.stride(c.ndim() - 2);
         GemmExecutor::default()
             .gemm(
                 c.data_mut().unwrap(),
-                c_row_stride,
                 GemmInputA::Unpacked(a.nd_view()),
                 GemmInputB::Unpacked(b.nd_view()),
                 alpha,
@@ -670,10 +663,8 @@ mod tests {
             .zip(b.broadcast(b_bcast.as_slice()).inner_iter::<2>())
             .zip(c.inner_iter_mut::<2>())
             .for_each(|((a, b), mut c)| {
-                let c_row_stride = c.stride(0);
                 gemm.gemm(
                     c.data_mut().unwrap(),
-                    c_row_stride,
                     GemmInputA::Unpacked(a),
                     GemmInputB::Unpacked(b),
                     alpha.unwrap_or(1.),

--- a/src/ops/rnn.rs
+++ b/src/ops/rnn.rs
@@ -231,10 +231,8 @@ pub fn gru(
             // `hidden @ hidden_weights`.
 
             // Compute `input @ weights + bias` for all gates.
-            let gates_row_stride = gates.stride(gates.ndim() - 2);
             gemm.gemm(
                 gates.data_mut().expect("expected contiguous input"),
-                gates_row_stride,
                 GemmInputA::Unpacked(in_item),
                 input_weights,
                 1.,   // alpha
@@ -249,10 +247,8 @@ pub fn gru(
             }
 
             // Compute `hidden @ hidden_weights + hidden_bias` for all gates.
-            let hidden_scratch_row_stride = hidden_scratch.stride(hidden_scratch.ndim() - 2);
             gemm.gemm(
                 hidden_scratch.data_mut().unwrap(),
-                hidden_scratch_row_stride,
                 GemmInputA::Unpacked(hidden_item),
                 hidden_weights,
                 1.,   // alpha
@@ -493,10 +489,8 @@ pub fn lstm(
             let hidden_item = hidden.slice([dir]);
 
             // Update input, output, forget and cell gates.
-            let gates_row_stride = gates.stride(gates.ndim() - 2);
             gemm.gemm(
                 gates.data_mut().expect("expected contiguous input"),
-                gates_row_stride,
                 GemmInputA::Unpacked(in_item),
                 input_weights,
                 1.,   // alpha
@@ -512,7 +506,6 @@ pub fn lstm(
 
             gemm.gemm(
                 gates.data_mut().expect("expected contiguous input"),
-                gates_row_stride,
                 GemmInputA::Unpacked(hidden_item),
                 hidden_weights,
                 1.,   // alpha


### PR DESCRIPTION
Refactor the GEMM APIs that accept uninitialized output buffers to fix safety hazards and make it possible to use the result without an unsafe uninitialized -> initialized cast:

- Require that the output buffer is exactly the right length, rather than just large enough. This avoids the need to deal with partially-initialized outputs.
- Make `GemmExecutor::gemm_uninit` return the initialized output. This can be combined with `ExtendInit` to safely update the length of a `Vec` after initialization.
- Fix a safety hazard where `gemm_uninit` would check for an output that "should" be empty and return early, before verifying that the actual length of the output buffer was zero. This could lead to callers incorrectly marking an uninit buffer as initialized.