### PR TITLE
Add internal batched GEMM API

### DIFF
--- a/src/gemm.rs
+++ b/src/gemm.rs
@@ -954,7 +954,7 @@ struct RhsBlock<'a, T> {
 /// `col_tiles` and `row_tiles` specifies the range of output tiles to update.
 /// `a` and `b` are the inputs. `depth_range` specifies the range along the K
 /// dimension.
-fn gemm_block<LhsT, RhsT, OutT: GemmOutT>(
+fn gemm_block<LhsT: Sync, RhsT: Sync, OutT: GemmOutT>(
     kernel: &dyn Kernel<LhsT, RhsT, OutT>,
     output: &OutputTiles<MaybeUninit<OutT>>,
     col_tiles: Range<usize>,

--- a/src/gemm/errors.rs
+++ b/src/gemm/errors.rs
@@ -5,6 +5,8 @@ use std::fmt::Display;
 /// Errors with matrix multiplication inputs.
 #[derive(Clone, Debug, PartialEq)]
 pub enum GemmError {
+    /// Number of LHS and RHS batch inputs do not match.
+    BatchSizeMismatch,
     /// Number of columns in LHS does not match rows of RHS.
     KSizeMismatch,
     /// Bias vector length does not match the corresponding output matrix size.
@@ -24,6 +26,9 @@ pub enum GemmError {
 impl Display for GemmError {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         match self {
+            Self::BatchSizeMismatch => {
+                write!(fmt, "batches of `a` and `b` matrices must have same length")
+            }
             Self::KSizeMismatch => {
                 write!(fmt, "columns of matrix `a` must match rows of matrix `b`")
             }


### PR DESCRIPTION
Add an API for batched matmuls to `GemmExecutor`. This will allow parallelism across batch, column and row dimensions of the output to be handled holistically in one place.

Part of https://github.com/robertknight/rten/issues/707.