### PR TITLE
Remove `stdarch_x86_avx512` feature opt-in

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -156,4 +156,5 @@ and the issue can be reproduced using an open source model and code, please
 ### AVX-512
 
 On modern x64 CPUs which support AVX-512, you can get better performance by
-enabling the `avx512` feature. As of Rust v1.75, this requires nightly Rust.
+enabling the `avx512` feature. This requires nightly Rust and is expected to
+become available in stable Rust v1.89.

--- a/rten-simd/src/lib.rs
+++ b/rten-simd/src/lib.rs
@@ -210,8 +210,6 @@
 //! assert_eq!(SimdSum(&[1u8, 2, 3]).dispatch(), 6u8);
 //! ```
 
-#![cfg_attr(feature = "avx512", feature(stdarch_x86_avx512))]
-
 mod arch;
 mod dispatch;
 mod elem;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,8 +47,8 @@
 //! RTen currently executes models on the CPU. It can build for most
 //! architectures that the Rust compiler supports. SIMD acceleration is
 //! available for x86-64, Arm 64 and WebAssembly. For x86-64, AVX-512 support
-//! is available but requires Nightly Rust and enabling the `avx512` crate
-//! feature.
+//! is available but requires enabling the `avx512` crate feature and
+//! Rust v1.89 or later (or nightly).
 //!
 //! ## Data types
 //!
@@ -109,7 +109,6 @@
 //! [onnx_operators]: https://onnx.ai/onnx/operators/
 //! [schema_fbs]: https://github.com/robertknight/rten/blob/main/src/schema.fbs
 //! [file_format]: https://github.com/robertknight/rten/blob/main/docs/rten-file-format.md
-#![cfg_attr(feature = "avx512", feature(stdarch_x86_avx512))]
 
 #[allow(unused)] // Docs only
 use rten_tensor::{NdTensor, Tensor};


### PR DESCRIPTION
AVX-512 is stable in nightly Rust, currently expected to land in Rust v1.89.