### PR TITLE
Add type aliases with old names for value types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,6 +151,10 @@ pub use tensor_pool::{ExtractBuffer, PoolRef, TensorPool};
 pub use threading::{thread_pool, ThreadPool};
 pub use timing::TimingSort;
 
+// Deprecated aliases for `ValueView`, `ValueOrView` and `Value`.
+#[allow(deprecated)]
+pub use ops::{Input, InputOrOutput, Output};
+
 #[allow(dead_code, unused_imports)]
 mod schema_generated;
 

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -761,6 +761,15 @@ impl Layout for ValueOrView<'_> {
     impl_proxy_layout!();
 }
 
+#[deprecated = "renamed to `ValueOrView`"]
+pub type InputOrOutput<'a> = ValueOrView<'a>;
+
+#[deprecated = "renamed to `ValueView`"]
+pub type Input<'a> = ValueView<'a>;
+
+#[deprecated = "renamed to `Value`"]
+pub type Output = Value;
+
 /// Trait for values that can be converted into the result type used by
 /// [`Operator::run`].
 pub trait IntoOpResult {


### PR DESCRIPTION
This makes migration to the newest release easier and also allows downstream projects to be compatible with a wider range of RTen versions.