### PR TITLE
Implement Add -> Softmax fusion

### DIFF
--- a/rten-tensor/src/iterators.rs
+++ b/rten-tensor/src/iterators.rs
@@ -923,6 +923,20 @@ pub struct LaneMut<'a, T> {
     size: usize,
 }
 
+impl<'a, T> LaneMut<'a, T> {
+    /// Return the remaining part of the lane as a slice, if it is contiguous.
+    pub fn as_slice_mut(&mut self) -> Option<&mut [T]> {
+        match self.stride {
+            1 => {
+                let remainder = self.data.slice_mut(self.index..self.size);
+                // Safety: The stride is 1, so we know the lane is contiguous.
+                Some(unsafe { remainder.to_slice_mut() })
+            }
+            _ => None,
+        }
+    }
+}
+
 impl<'a, T> Iterator for LaneMut<'a, T> {
     type Item = &'a mut T;
 

--- a/src/ops/attention.rs
+++ b/src/ops/attention.rs
@@ -1,0 +1,211 @@
+//! Attention-related operations.
+
+use rayon::prelude::*;
+use rten_simd::SimdOp;
+use rten_tensor::prelude::*;
+use rten_tensor::{Tensor, TensorView};
+use rten_vecmath::Softmax;
+
+use crate::ops::binary_elementwise::broadcast_shapes;
+use crate::ops::{resolve_axis, IntoOpResult, OpError, OpRunContext, Operator, OutputList, Value};
+use crate::tensor_pool::{AutoReturn, TensorPool};
+
+const BROADCAST_ERROR: OpError = OpError::IncompatibleInputShapes("Cannot broadcast inputs");
+
+/// Perform lanewise `Add + Softmax` on tensors `qk` and `m`.
+///
+/// `m` must be broadcastable to the shape of `qk`.
+fn add_softmax_in_place(
+    pool: &TensorPool,
+    qk: Tensor<f32>,
+    m: TensorView<f32>,
+) -> Result<Tensor, OpError> {
+    let axis = resolve_axis(qk.ndim(), -1)?;
+    let m = m.try_broadcast(qk.shape()).map_err(|_| BROADCAST_ERROR)?;
+
+    // We assume `qk` is likely already contiguous and `m` is likely contiguous
+    // along the `axis` dim, so this will be a no-op, but handle the case where
+    // they are not.
+    let mut qk = if qk.stride(axis) == 1 {
+        qk
+    } else {
+        qk.to_tensor_in(pool)
+    };
+    let m = if m.stride(axis) == 1 {
+        m.as_cow()
+    } else {
+        m.to_tensor_in(pool).into_cow()
+    }
+    .auto_return(pool);
+
+    qk.lanes_mut(axis)
+        .into_par_iter()
+        .zip(m.lanes(axis).into_par_iter())
+        .for_each(|(mut qk_inner, m_inner)| {
+            // OK, as we made the lanes contiguous above.
+            let qk_inner = qk_inner.as_slice_mut().unwrap();
+            let m_inner = m_inner.as_slice().unwrap();
+
+            for (qk, m) in qk_inner.iter_mut().zip(m_inner) {
+                *qk += m;
+            }
+            Softmax::new_mut(qk_inner).dispatch();
+        });
+
+    Ok(qk)
+}
+
+/// Operation which fuses Add(QK, M) -> Softmax(axis = -1).
+///
+/// This sequence is common in attention operations where `QK` is the query-key
+/// product and `M` is a mask matrix.
+///
+/// The fusion takes advantage of the fact that we can perform Add + Softmax
+/// on each lane separately, and get better cache efficiency by having
+/// the lane already be in a higher cache level when the Softmax step runs.
+#[derive(Debug)]
+pub struct AddSoftmax {}
+
+impl Operator for AddSoftmax {
+    fn name(&self) -> &str {
+        "AddSoftmax"
+    }
+
+    fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+        let x: TensorView = ctx.inputs().require_as(0)?;
+        let y: TensorView = ctx.inputs().require_as(1)?;
+
+        let (qk, m) = if x.len() > y.len() { (x, y) } else { (y, x) };
+
+        let out_shape = broadcast_shapes(qk.shape(), m.shape());
+        let qk = match out_shape.as_deref() {
+            // Create a copy and run this operator in-place, on the assumption
+            // that the operator will usually run via `run_in_place`.
+            Some(shape) => qk.broadcast(shape).to_tensor_in(ctx.pool()),
+            None => {
+                return Err(BROADCAST_ERROR);
+            }
+        };
+
+        add_softmax_in_place(ctx.pool(), qk, m).into_op_result()
+    }
+
+    fn is_commutative(&self) -> bool {
+        true
+    }
+
+    fn can_run_in_place(&self) -> bool {
+        true
+    }
+
+    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<Value, OpError> {
+        let qk: Tensor = input.try_into()?;
+        let m: TensorView = ctx.inputs().require_as(0)?;
+
+        let out_shape = broadcast_shapes(qk.shape(), m.shape());
+        let qk = match out_shape.as_deref() {
+            // We expect to always use this path, as commutative ops always
+            // receive the largest input as the in-place input.
+            Some(shape) if shape == qk.shape() => qk,
+
+            // However, the `Add` operation allows for broadcasting _both_
+            // inputs to a larger size, in which case fall back to a copy.
+            Some(shape) => qk.broadcast(shape).to_tensor_in(ctx.pool()),
+
+            None => {
+                return Err(BROADCAST_ERROR);
+            }
+        };
+
+        add_softmax_in_place(ctx.pool(), qk, m).map(|qk| qk.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rten_tensor::prelude::*;
+    use rten_tensor::rng::XorShiftRng;
+    use rten_tensor::test_util::expect_equal;
+    use rten_tensor::{Tensor, TensorView};
+    use rten_testing::TestCases;
+
+    use super::{AddSoftmax, BROADCAST_ERROR};
+    use crate::ops::{Add, OpError, OperatorExt, Softmax};
+
+    fn reference_add_softmax(x: TensorView, y: TensorView) -> Result<Tensor, OpError> {
+        let add = Add {};
+        let softmax = Softmax { axis: -1 };
+        let sum: Tensor = add.run_simple((x, y))?;
+        softmax.run_simple(sum.view())
+    }
+
+    #[test]
+    fn test_add_softmax() {
+        #[derive(Debug)]
+        struct Case {
+            qk_shape: Vec<usize>,
+            m_shape: Vec<usize>,
+            expected_err: Option<OpError>,
+            in_place: bool,
+        }
+
+        let cases = [
+            // Standard attention inputs where QK has shape (batch, n_heads,
+            // sequence_len, head_size) and M has shape (batch, 1, sequence_len,
+            // head_size).
+            Case {
+                qk_shape: [1, 8, 32, 32].into(),
+                m_shape: [1, 1, 32, 32].into(),
+                expected_err: None,
+                in_place: true,
+            },
+            // In-place execution where broadcasting fails
+            Case {
+                qk_shape: [1, 8, 32, 32].into(),
+                m_shape: [1, 2, 32, 32].into(),
+                expected_err: Some(BROADCAST_ERROR),
+                in_place: true,
+            },
+            // Non in-place execution where broadcasting fails
+            Case {
+                qk_shape: [1, 8, 32, 32].into(),
+                m_shape: [1, 2, 32, 32].into(),
+                expected_err: Some(BROADCAST_ERROR),
+                in_place: false,
+            },
+            // In-place execution where both QK and M should be broadcast.
+            Case {
+                qk_shape: [1, 8, 16].into(),
+                m_shape: [8, 1, 16].into(),
+                expected_err: None,
+                in_place: true,
+            },
+            // Non in-place execution where QK and M are swapped.
+            Case {
+                qk_shape: [1, 1, 32, 32].into(),
+                m_shape: [1, 8, 32, 32].into(),
+                expected_err: None,
+                in_place: false,
+            },
+        ];
+
+        cases.test_each(|case| {
+            let mut rng = XorShiftRng::new(1234);
+            let op = AddSoftmax {};
+            let qk = Tensor::rand(&case.qk_shape, &mut rng);
+            let m = Tensor::rand(&case.m_shape, &mut rng);
+
+            let result: Result<Tensor, _> = if case.in_place {
+                op.run_simple_in_place(qk.clone(), m.view())
+            } else {
+                op.run_simple((qk.view(), m.view()))
+            };
+            if let Some(expected_err) = &case.expected_err {
+                assert_eq!(result.as_ref().err().unwrap(), expected_err);
+            } else {
+                let expected = reference_add_softmax(qk.view(), m.view()).unwrap();
+                expect_equal(&result.unwrap(), &expected).unwrap();
+            }
+        });
+    }
+}

--- a/src/ops/unary_elementwise.rs
+++ b/src/ops/unary_elementwise.rs
@@ -661,7 +661,7 @@ mod tests {
 
         // Test in-place variant.
         let input_mut = input.clone();
-        let result: Tensor<T> = op.run_simple_in_place(input_mut).unwrap();
+        let result: Tensor<T> = op.run_simple_in_place(input_mut, ()).unwrap();
         expect_equal(&result, &expected)?;
 
         Ok(())


### PR DESCRIPTION
This sequence is common in attention operations, and we can get better cache efficiency by performing Add + Softmax in a lanewise fashion.
