### PR TITLE
Use native instruction for computing `abs(x)` in Erf op

### DIFF
--- a/rten-vecmath/src/erf.rs
+++ b/rten-vecmath/src/erf.rs
@@ -28,8 +28,7 @@ impl SimdUnaryOp<f32> for Erf {
 
         let neg_mask = ops.lt(x, ops.zero());
 
-        // x = x.abs()
-        let x = ops.select(ops.neg(x), x, neg_mask);
+        let x = ops.abs(x);
 
         let p = ops.splat(0.3275911);
 


### PR DESCRIPTION
This is a small clarity and performance improvement for Erf and derived ops (Gelu). On an M3 it makes Gelu about 6% faster.