### PR TITLE
Move `Scalar` type to `value` mod

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -916,10 +916,9 @@ mod tests {
     };
     use crate::ops;
     use crate::ops::{
-        BoxOrder, CoordTransformMode, DepthToSpaceMode, NearestMode, OpError, ResizeMode, Scalar,
-        Shape,
+        BoxOrder, CoordTransformMode, DepthToSpaceMode, NearestMode, OpError, ResizeMode, Shape,
     };
-    use crate::value::{DataType, Value};
+    use crate::value::{DataType, Scalar, Value};
     use crate::OpRegistry;
 
     fn generate_model_buffer(format: ModelFormat) -> Vec<u8> {

--- a/src/model_builder.rs
+++ b/src/model_builder.rs
@@ -12,11 +12,10 @@ use crate::ops::{
     GatherND, Gelu, Gemm, HardSigmoid, InstanceNormalization, LayerNormalization, LeakyRelu,
     LogSoftmax, MaxPool, Mod, NearestMode, NonMaxSuppression, OneHot, Padding, QuantizeLinear,
     ReduceMax, ReduceMean, ReduceMin, ReduceProd, ReduceSum, ReduceSumSquare, Reshape, Resize,
-    ResizeMode, Scalar, ScatterElements, ScatterReduction, Shape, Softmax, Split, TopK, Transpose,
-    Trilu,
+    ResizeMode, ScatterElements, ScatterReduction, Shape, Softmax, Split, TopK, Transpose, Trilu,
 };
 use crate::schema_generated as sg;
-use crate::value::DataType;
+use crate::value::{DataType, Scalar};
 
 #[cfg(feature = "random")]
 use crate::ops::{Dropout, RandomNormal, RandomNormalLike, RandomUniform, RandomUniformLike};

--- a/src/op_registry.rs
+++ b/src/op_registry.rs
@@ -8,11 +8,11 @@ use crate::graph::Graph;
 use crate::ops;
 use crate::ops::{
     BoxOrder, CoordTransformMode, DepthToSpaceMode, Direction, NearestMode, Operator, PadMode,
-    Padding, ResizeMode, Scalar, ScatterReduction,
+    Padding, ResizeMode, ScatterReduction,
 };
 use crate::schema_generated as sg;
 use crate::schema_generated::{AutoPad, OperatorNode, OperatorType};
-use crate::value::DataType;
+use crate::value::{DataType, Scalar};
 
 /// Context object passed to [`ReadOp::read`] implementations.
 pub trait OpLoadContext {

--- a/src/ops/generate.rs
+++ b/src/ops/generate.rs
@@ -7,9 +7,10 @@ use rten_tensor::{NdTensor, NdTensorView, Tensor, TensorView};
 use crate::number::Identities;
 use crate::ops::{
     map_dtype, map_value_view, resolve_axis, resolve_index, static_dims, DataType, IntoOpResult,
-    OpError, OpRunContext, Operator, OutputList, Scalar, ValueView,
+    OpError, OpRunContext, Operator, OutputList,
 };
 use crate::tensor_pool::TensorPool;
+use crate::value::{Scalar, ValueView};
 
 pub fn constant_of_shape<T: Copy>(
     pool: &TensorPool,
@@ -210,9 +211,8 @@ mod tests {
     use rten_testing::TestCases;
 
     use crate::ops::tests::new_pool;
-    use crate::ops::{
-        onehot, range, ConstantOfShape, DataType, EyeLike, OpError, OperatorExt, Scalar, Value,
-    };
+    use crate::ops::{onehot, range, ConstantOfShape, DataType, EyeLike, OpError, OperatorExt};
+    use crate::value::{Scalar, Value};
 
     #[test]
     fn test_constant_of_shape() {

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -830,12 +830,6 @@ impl<'a, I1: Into<ValueView<'a>>, I2: Into<ValueView<'a>>, I3: Into<ValueView<'a
     }
 }
 
-#[derive(Debug)]
-pub enum Scalar {
-    Int(i32),
-    Float(f32),
-}
-
 /// Resolve an index given as a value in `[-len, len-1]` to a positive index in
 /// `[0, len)`, or return None if the index is out of bounds.
 fn resolve_index(len: usize, index: isize) -> Option<usize> {

--- a/src/value.rs
+++ b/src/value.rs
@@ -559,6 +559,13 @@ impl Layout for ValueOrView<'_> {
     impl_proxy_layout!();
 }
 
+/// A scalar value with runtime-determined type.
+#[derive(Debug)]
+pub enum Scalar {
+    Int(i32),
+    Float(f32),
+}
+
 #[cfg(test)]
 mod tests {
     use rten_tensor::prelude::*;


### PR DESCRIPTION
This was missed when moving `Value` and associated types from src/ops/mod.rs into a new module.