### PR TITLE
Handle non-contiguous mask tensor efficiently in AddSoftmax

### DIFF
--- a/rten-tensor/src/iterators/parallel.rs
+++ b/rten-tensor/src/iterators/parallel.rs
@@ -367,14 +367,12 @@ impl<'a, T> SplitIterator for Lanes<'a, T> {
         let left = Lanes {
             data: self.data,
             ranges: left_range,
-            size: self.size,
-            stride: self.stride,
+            lane_layout: self.lane_layout,
         };
         let right = Lanes {
             data: self.data,
             ranges: right_range,
-            size: self.size,
-            stride: self.stride,
+            lane_layout: self.lane_layout,
         };
 
         (left, right)
@@ -397,14 +395,12 @@ impl<'a, T> SplitIterator for LanesMut<'a, T> {
         let left = Self {
             data: left_data,
             ranges: left_range,
-            size: self.size,
-            stride: self.stride,
+            lane_layout: self.lane_layout,
         };
         let right = Self {
             data: right_data,
             ranges: right_range,
-            size: self.size,
-            stride: self.stride,
+            lane_layout: self.lane_layout,
         };
 
         (left, right)

--- a/rten-tensor/src/storage.rs
+++ b/rten-tensor/src/storage.rs
@@ -409,6 +409,24 @@ impl<'a, T> ViewMutData<'a, T> {
         };
         (left, right)
     }
+
+    /// A variant of [`StorageMut::slice_mut`] which preserves the lifetime of
+    /// the slice.
+    ///
+    /// # Safety
+    ///
+    /// This is unsafe since this function cannot ensure that multiple references
+    /// to the same element are not created (by using `get_mut` on `self` and
+    /// the slice). It is up to the caller to prevent this.
+    pub unsafe fn to_view_slice_mut(&mut self, range: Range<usize>) -> ViewMutData<'a, T> {
+        assert_storage_range_valid(self, range.clone());
+        ViewMutData {
+            // Safety: We verified that `range` is in bounds.
+            ptr: unsafe { self.as_mut_ptr().add(range.start) },
+            len: range.len(),
+            _marker: PhantomData,
+        }
+    }
 }
 
 unsafe impl<T> Storage for ViewMutData<'_, T> {

--- a/rten-tensor/src/tensor.rs
+++ b/rten-tensor/src/tensor.rs
@@ -552,6 +552,22 @@ impl<S: Storage, L: MutLayout> TensorBase<S, L> {
         TensorBase { data, layout }
     }
 
+    /// Create a tensor from a pre-created storage and layout.
+    ///
+    /// # Safety
+    ///
+    /// Caller must ensure storage length is sufficient for the layout, and
+    /// that, if the storage is mutable, no two indices in the layout map to the
+    /// same offset.
+    pub(crate) unsafe fn from_storage_and_layout_unchecked(data: S, layout: L) -> TensorBase<S, L> {
+        debug_assert!(data.len() >= layout.min_data_len());
+        debug_assert!(
+            !S::MUTABLE
+                || !may_have_internal_overlap(layout.shape().as_ref(), layout.strides().as_ref())
+        );
+        TensorBase { data, layout }
+    }
+
     /// Construct a new tensor from a given shape and storage, and custom
     /// strides.
     ///

--- a/src/ops/attention.rs
+++ b/src/ops/attention.rs
@@ -29,7 +29,7 @@ fn add_softmax_in_place(
     let mut qk = if qk.stride(axis) == 1 {
         qk
     } else {
-        qk.to_tensor_in(pool)
+        qk.auto_return(pool).to_tensor_in(pool)
     };
     let m = if m.stride(axis) == 1 {
         m.as_cow()

--- a/src/ops/attention.rs
+++ b/src/ops/attention.rs
@@ -31,12 +31,6 @@ fn add_softmax_in_place(
     } else {
         qk.auto_return(pool).to_tensor_in(pool)
     };
-    let m = if m.stride(axis) == 1 {
-        m.as_cow()
-    } else {
-        m.to_tensor_in(pool).into_cow()
-    }
-    .auto_return(pool);
 
     qk.lanes_mut(axis)
         .into_par_iter()
@@ -44,8 +38,6 @@ fn add_softmax_in_place(
         .for_each(|(mut qk_inner, m_inner)| {
             // OK, as we made the lanes contiguous above.
             let qk_inner = qk_inner.as_slice_mut().unwrap();
-            let m_inner = m_inner.as_slice().unwrap();
-
             for (qk, m) in qk_inner.iter_mut().zip(m_inner) {
                 *qk += m;
             }


### PR DESCRIPTION
Fix a regression from fusing Add + Softmax when the mask tensor is non-contiguous. This happens in [SmolLM](https://huggingface.co/onnx-community/SmolLM-135M-ONNX/tree/main) because the mask tensor is the output of a `Slice` operation. The changes in AddSoftmax are:

- Fix another mistake where a tensor was not released back to the pool
- Avoid requiring the mask tensor to be contiguous over the softmax-d lane. In order to avoid regressing performance for the common case where the mask tensor _is_ contiguous, it was necessary to make some changes to the `Lane` iterator implementation.

Another possible approach would be to pack non-contiguous lanes into a contiguous buffer before adding them.