### PR TITLE
Support tensors which borrow their layouts

### DIFF
--- a/rten-tensor/src/layout.rs
+++ b/rten-tensor/src/layout.rs
@@ -296,6 +296,39 @@ impl<const N: usize> Layout for NdLayout<N> {
     }
 }
 
+impl<L: Layout> Layout for &L {
+    type Index<'b> = L::Index<'b>;
+    type Indices = L::Indices;
+
+    fn ndim(&self) -> usize {
+        (*self).ndim()
+    }
+
+    fn len(&self) -> usize {
+        (*self).len()
+    }
+
+    fn try_offset(&self, index: Self::Index<'_>) -> Option<usize> {
+        (*self).try_offset(index)
+    }
+
+    fn offset_unchecked(&self, index: Self::Index<'_>) -> usize {
+        (*self).offset_unchecked(index)
+    }
+
+    fn shape(&self) -> Self::Index<'_> {
+        (*self).shape()
+    }
+
+    fn strides(&self) -> Self::Index<'_> {
+        (*self).strides()
+    }
+
+    fn indices(&self) -> Self::Indices {
+        (*self).indices()
+    }
+}
+
 impl MatrixLayout for NdLayout<2> {
     #[inline]
     fn rows(&self) -> usize {
@@ -1382,6 +1415,14 @@ pub trait RemoveDim {
 
     /// Return a copy of this layout with the dimension at index `dim` removed.
     fn remove_dim(&self, dim: usize) -> Self::Output;
+}
+
+impl<R: RemoveDim> RemoveDim for &R {
+    type Output = R::Output;
+
+    fn remove_dim(&self, dim: usize) -> Self::Output {
+        (*self).remove_dim(dim)
+    }
 }
 
 impl RemoveDim for DynLayout {

--- a/rten-tensor/src/tensor.rs
+++ b/rten-tensor/src/tensor.rs
@@ -10,7 +10,7 @@ use crate::copy::{
 use crate::errors::{DimensionError, ExpandError, FromDataError, ReshapeError, SliceError};
 use crate::iterators::{
     for_each_mut, AxisChunks, AxisChunksMut, AxisIter, AxisIterMut, InnerIter, InnerIterMut, Iter,
-    IterMut, Lanes, LanesMut, MutViewRef, ViewRef,
+    IterMut, Lanes, LanesMut,
 };
 use crate::layout::{
     AsIndex, BroadcastLayout, DynLayout, IntoLayout, Layout, MatrixLayout, MutLayout, NdLayout,
@@ -800,8 +800,11 @@ impl<S: StorageMut, L: Clone + Layout> TensorBase<S, L> {
             .get_unchecked_mut(self.layout.offset_unchecked(index.as_index()))
     }
 
-    pub(crate) fn mut_view_ref(&mut self) -> MutViewRef<S::Elem, L> {
-        MutViewRef::new(self.data.view_mut(), &self.layout)
+    pub(crate) fn mut_view_ref(&mut self) -> TensorBase<ViewMutData<S::Elem>, &L> {
+        TensorBase {
+            data: self.data.view_mut(),
+            layout: &self.layout,
+        }
     }
 
     /// Return a mutable iterator over the N innermost dimensions of this tensor.
@@ -1793,8 +1796,11 @@ impl<'a, T, L: Clone + Layout> TensorBase<ViewData<'a, T>, L> {
         }
     }
 
-    pub(crate) fn view_ref(&self) -> ViewRef<'a, '_, T, L> {
-        ViewRef::new(self.data, &self.layout)
+    pub(crate) fn view_ref(&self) -> TensorBase<ViewData<'a, T>, &L> {
+        TensorBase {
+            data: self.data,
+            layout: &self.layout,
+        }
     }
 
     pub fn weakly_checked_view(&self) -> WeaklyCheckedView<ViewData<'a, T>, L> {


### PR DESCRIPTION
Revise bounds on `TensorBase` and various impls to support creating tensors which borrow their layouts. Also add a blanket implementation of `Layout` for `&L where L: Layout`. This makes it possible to create `TensorBase<ViewData<T>, &L>` which are views that borrow both their storage and layout and have a size of three words (data pointer, data length, layout pointer). This is currently used internally in rten-tensor to replace some pseudo-tensor types (ViewRef, MutViewRef). In future it might come in useful to save some dynamic-rank view copies elsewhere.