### PR TITLE
Remove inherent methods on layouts that duplicate trait methods

### DIFF
--- a/rten-tensor/src/layout.rs
+++ b/rten-tensor/src/layout.rs
@@ -583,16 +583,6 @@ impl Layout for DynLayout {
 }
 
 impl DynLayout {
-    /// Create a new `DynLayout` with the same shape and strides as `layout`.
-    pub fn from_layout<L: Layout>(layout: &L) -> DynLayout {
-        DynLayout::from_shape_and_strides(
-            layout.shape().as_ref(),
-            layout.strides().as_ref(),
-            OverlapPolicy::AllowOverlap,
-        )
-        .expect("invalid layout")
-    }
-
     pub fn make_contiguous(&mut self) {
         self.shape_and_strides = Self::contiguous_shape_and_strides(self.shape());
     }
@@ -633,15 +623,20 @@ impl DynLayout {
     }
 }
 
-impl<const N: usize> From<&NdLayout<N>> for DynLayout {
-    fn from(value: &NdLayout<N>) -> DynLayout {
-        DynLayout::from_layout(value)
+impl<L: Layout> From<&L> for DynLayout {
+    fn from(layout: &L) -> DynLayout {
+        DynLayout::from_shape_and_strides(
+            layout.shape().as_ref(),
+            layout.strides().as_ref(),
+            OverlapPolicy::AllowOverlap,
+        )
+        .expect("invalid layout")
     }
 }
 
 impl<const N: usize> From<NdLayout<N>> for DynLayout {
     fn from(value: NdLayout<N>) -> DynLayout {
-        DynLayout::from_layout(&value)
+        Self::from(&value)
     }
 }
 

--- a/rten-tensor/src/tensor.rs
+++ b/rten-tensor/src/tensor.rs
@@ -697,7 +697,7 @@ impl<S: StorageMut, L: Clone + Layout> TensorBase<S, L> {
     /// Return a mutable view of this tensor with a dynamic dimension count.
     pub fn as_dyn_mut(&mut self) -> TensorBase<ViewMutData<S::Elem>, DynLayout> {
         TensorBase {
-            layout: DynLayout::from_layout(&self.layout),
+            layout: DynLayout::from(&self.layout),
             data: self.data.view_mut(),
         }
     }
@@ -1401,7 +1401,7 @@ impl<'a, T, L: Clone + Layout> TensorBase<ViewData<'a, T>, L> {
     pub fn as_dyn(&self) -> TensorBase<ViewData<'a, T>, DynLayout> {
         TensorBase {
             data: self.data,
-            layout: DynLayout::from_layout(&self.layout),
+            layout: DynLayout::from(&self.layout),
         }
     }
 

--- a/rten-tensor/src/tensor.rs
+++ b/rten-tensor/src/tensor.rs
@@ -652,9 +652,8 @@ impl<S: Storage, L: Layout> TensorBase<S, L> {
         }
         let shape: [usize; N] = std::array::from_fn(|i| self.size(i));
         let strides: [usize; N] = std::array::from_fn(|i| self.stride(i));
-        let layout =
-            NdLayout::try_from_shape_and_strides(shape, strides, OverlapPolicy::AllowOverlap)
-                .expect("invalid layout");
+        let layout = NdLayout::from_shape_and_strides(shape, strides, OverlapPolicy::AllowOverlap)
+            .expect("invalid layout");
         Some(layout)
     }
 
@@ -2507,7 +2506,7 @@ mod tests {
 
     use super::{AsView, NdTensor, NdTensorView, NdTensorViewMut, Tensor};
     use crate::errors::{ExpandError, FromDataError};
-    use crate::layout::{DynLayout, MatrixLayout};
+    use crate::layout::{DynLayout, MatrixLayout, MutLayout};
     use crate::prelude::*;
     use crate::rng::XorShiftRng;
     use crate::{Alloc, SliceItem, SliceRange, Storage};

--- a/src/ops/einsum.rs
+++ b/src/ops/einsum.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use rten_tensor::prelude::*;
-use rten_tensor::{DynLayout, OverlapPolicy, Tensor, TensorView};
+use rten_tensor::{DynLayout, MutLayout, OverlapPolicy, Tensor, TensorView};
 
 use smallvec::SmallVec;
 
@@ -265,12 +265,9 @@ fn take_diagonals<'a>(term: &str, x: &TensorView<'a>) -> Result<(String, TensorV
         out_strides.push(diagonal_stride);
     }
 
-    let out_layout = DynLayout::try_from_shape_and_strides(
-        &out_shape,
-        &out_strides,
-        OverlapPolicy::AllowOverlap,
-    )
-    .expect("failed to create diagonal layout");
+    let out_layout =
+        DynLayout::from_shape_and_strides(&out_shape, &out_strides, OverlapPolicy::AllowOverlap)
+            .expect("failed to create diagonal layout");
     let out_view = TensorView::from_storage_and_layout(x.storage(), out_layout);
 
     Ok((unique_dims, out_view))


### PR DESCRIPTION
The `NdLayout` and `DynLayout` types had many inherent methods that duplicated trait methods, from the `Layout`, `MutLayout` or other layout traits. This dates back to early versions of the library where static and dynamic rank tensors were unrelated types.

Remove these inherent methods in favor of the trait methods. In cases where the trait methods forwarded to the inherent methods, the bodies have been moved to the trait impls.

While doing this I found that `DynLayout` had some outdated documentation around strides and internal overlap. This has been moved to the `MutLayout` trait since it pertains to the `MutLayout::from_shape_and_strides` method.