### PR TITLE
Fix invalid use of memcpy when cloning tensor with non-Copy element type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,6 +476,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
+ "typeid",
 ]
 
 [[package]]
@@ -610,6 +611,12 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "unicode-ident"

--- a/rten-tensor/Cargo.toml
+++ b/rten-tensor/Cargo.toml
@@ -13,6 +13,7 @@ include = ["/src", "/README.md"]
 rayon = { workspace = true }
 serde = { workspace = true, optional = true }
 smallvec = { version = "1.10.0", features=["union", "const_generics", "const_new"] }
+typeid = "1.0.3"
 
 [dev-dependencies]
 rten-testing = { path = "../rten-testing" }

--- a/rten-tensor/src/tensor.rs
+++ b/rten-tensor/src/tensor.rs
@@ -2384,6 +2384,7 @@ impl_scalar!(usize);
 impl_scalar!(isize);
 impl_scalar!(f32);
 impl_scalar!(f64);
+impl_scalar!(String);
 
 // The `T: Scalar` bound avoids ambiguity when choosing a `Tensor::from`
 // impl for a nested array literal, as it prevents `T` from matching an array


### PR DESCRIPTION
Fix a crash when cloning a non-contiguous tensor with a stride-1 inner axis and non-Copy element type due to invalid use of `std::ptr::copy_nonoverlapping`. The issue went unnoticed since all usage of tensors in RTen has involved Copy types until now.

To preserve performance for common element types that are `Copy` (`f32` etc), the typeid crate is used to specialize on known Copy types, since the compiler is not able to translate the generic zip+Clone loop into a memcpy.