### PR TITLE
Disable uninlined_format_args lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ assertions_on_constants = "allow"
 needless_range_loop = "allow"
 too_many_arguments = "allow"
 manual_repeat_n = "allow"  # TODO - Address existing failures
+uninlined_format_args = "allow"
 
 [package.metadata.docs.rs]
 # These features should match the features enabled by `make docs`.

--- a/rten-bench/Cargo.toml
+++ b/rten-bench/Cargo.toml
@@ -13,3 +13,6 @@ release = false
 
 [lib]
 crate-type = ["lib"]
+
+[lints.clippy]
+uninlined_format_args = "allow"

--- a/rten-cli/Cargo.toml
+++ b/rten-cli/Cargo.toml
@@ -22,6 +22,9 @@ rten-testing = { path = "../rten-testing" }
 # Use AVX-512 instructions if available. Requires nightly Rust for AVX-512 intrinsics.
 avx512 = ["rten/avx512"]
 
+[lints.clippy]
+uninlined_format_args = "allow"
+
 [[bin]]
 name = "rten"
 path = "src/main.rs"

--- a/rten-examples/Cargo.toml
+++ b/rten-examples/Cargo.toml
@@ -34,6 +34,7 @@ avx512 = ["rten/avx512"]
 # currently needed.
 needless_update = "allow"
 manual_repeat_n = "allow"  # TODO - Address existing failures
+uninlined_format_args = "allow"
 
 [package.metadata.release]
 release = false

--- a/rten-generate/Cargo.toml
+++ b/rten-generate/Cargo.toml
@@ -22,5 +22,8 @@ rten-testing = { path = "../rten-testing" }
 # Enable text decoding using tokenizers from rten-text
 text-decoder = ["dep:rten-text"]
 
+[lints.clippy]
+uninlined_format_args = "allow"
+
 [package.metadata.docs.rs]
 features = ["text-decoder"]

--- a/rten-imageio/Cargo.toml
+++ b/rten-imageio/Cargo.toml
@@ -13,3 +13,6 @@ include = ["/src", "/README.md"]
 png = "0.17.6"
 rten-tensor = { path = "../rten-tensor", version = "0.19.0" }
 image = { workspace = true }
+
+[lints.clippy]
+uninlined_format_args = "allow"

--- a/rten-imageproc/Cargo.toml
+++ b/rten-imageproc/Cargo.toml
@@ -23,3 +23,6 @@ crate-type = ["lib"]
 [features]
 # Implement serde Serialize and Deserialize traits on items where it makes sense
 serde_traits = ["serde"]
+
+[lints.clippy]
+uninlined_format_args = "allow"

--- a/rten-tensor/Cargo.toml
+++ b/rten-tensor/Cargo.toml
@@ -28,6 +28,7 @@ crate-type = ["lib"]
 needless_range_loop = "allow"
 manual_memcpy = "allow"
 manual_repeat_n = "allow"  # TODO - Address existing failures
+uninlined_format_args = "allow"
 
 [features]
 serde = ["dep:serde"]

--- a/rten-testing/Cargo.toml
+++ b/rten-testing/Cargo.toml
@@ -13,3 +13,6 @@ release = false
 
 [lib]
 crate-type = ["lib"]
+
+[lints.clippy]
+uninlined_format_args = "allow"

--- a/rten-text/Cargo.toml
+++ b/rten-text/Cargo.toml
@@ -24,3 +24,4 @@ rten-testing = { path = "../rten-testing" }
 
 [lints.clippy]
 manual_repeat_n = "allow"  # TODO - Address existing failures
+uninlined_format_args = "allow"


### PR DESCRIPTION
Disable stylistic lint enabled by default in Rust v1.88. I don't feel like changing the style of the existing code right now.