### PR TITLE
Skip collecting timing records for control flops

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1034,12 +1034,16 @@ impl Graph {
                 let op_duration = op_end - op_start;
                 op_start = op_end;
 
-                profiler.add_record(TimingRecord {
-                    name: op_node.operator().name(),
-                    input_meta,
-                    elapsed: op_duration,
-                    node_name: op_node.name().unwrap_or(""),
-                });
+                // Skip control flow ops to avoid double-counting the time from
+                // ops inside the subgraph.
+                if !has_subgraph {
+                    profiler.add_record(TimingRecord {
+                        name: op_node.operator().name(),
+                        input_meta,
+                        elapsed: op_duration,
+                        node_name: op_node.name().unwrap_or(""),
+                    });
+                }
             }
         }
 


### PR DESCRIPTION
Following ae5d7c814105725497bd333079dc6d42e67a527f, which combined profiling from the main graph and subgraphs into one output, time spent in operators inside subgraphs was double counted: once for the op itself, once as part of the "parent" control flow op. Fix this by skipping timing records for the parent op.