### PR TITLE
Fix execution planning for subgraphs in optimizer

### DIFF
--- a/src/graph/capture_env.rs
+++ b/src/graph/capture_env.rs
@@ -63,6 +63,22 @@ impl<'a> CaptureEnv<'a> {
         }
     }
 
+    /// Simplified constructor for capture environments associated with top
+    /// level graphs.
+    ///
+    /// All of the sources of runtime-provided inputs are set to `None`, so
+    /// only captured constants are available.
+    #[cfg(test)]
+    pub fn top_level_static(graph: &'a Graph) -> Self {
+        CaptureEnv {
+            parent: None,
+            graph: Some(graph),
+            inputs: None,
+            temp_values_by_ref: None,
+            temp_values: None,
+        }
+    }
+
     /// Return a new capture environment which has `self` as a parent.
     ///
     /// The child `CaptureEnv` will have no captures of its own. This is useful

--- a/src/graph/planner.rs
+++ b/src/graph/planner.rs
@@ -3,7 +3,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use super::{Graph, Node, NodeId, OperatorNode, RunError};
 
 /// Options for creating a graph execution plan using [`Planner`].
-#[derive(Default)]
+#[derive(Clone)]
 pub struct PlanOptions {
     /// Whether a plan can be successfully created if certain inputs are
     /// missing. If true, the planner will create the plan as if those inputs
@@ -16,6 +16,21 @@ pub struct PlanOptions {
     /// run, but false if a plan is being generated that will run a subgraph
     /// on its own.
     pub captures_available: bool,
+}
+
+impl Default for PlanOptions {
+    fn default() -> Self {
+        PlanOptions {
+            allow_missing_inputs: false,
+
+            // Assume subgraphs will usually be run as part of their parent
+            // graph, with captures available.
+            //
+            // An exception is when we're doing partial evaluation of the graph
+            // as part of constant propagation.
+            captures_available: true,
+        }
+    }
 }
 
 /// An execution plan specifying the sequence of operations to run from a graph

--- a/src/ops/conv.rs
+++ b/src/ops/conv.rs
@@ -621,10 +621,8 @@ fn col2im(
                             // Safety: We computed x, y, out_x and out_y such that they are
                             // in-bounds for out_img and in_img.
                             unsafe {
-                                *out_img.get_unchecked_mut([
-                                    (out_y - pad_top) as usize,
-                                    (out_x - pad_left) as usize,
-                                ]) += in_img.get_unchecked([y as usize, x as usize]);
+                                *out_img.get_unchecked_mut([out_y - pad_top, out_x - pad_left]) +=
+                                    in_img.get_unchecked([y, x]);
                             }
                         }
                     }
@@ -805,7 +803,13 @@ pub fn conv_transpose(
             )
             .unwrap();
 
-        let col2im_mat = NdTensorView::from_data(col2im_shape, col2im_init.as_ref());
+        let col2im_mat = NdTensorView::from_data(
+            col2im_shape,
+            // False positive. The conversion from `&mut [f32]` -> `&[f32]` here
+            // is necessary.
+            #[allow(clippy::useless_asref)]
+            col2im_init.as_ref(),
+        );
         let mut out_img = output.slice_mut(n);
 
         col2im(


### PR DESCRIPTION
When generating the reverse-order execution plan in `GraphOptimizer::apply_fusions`, assume that values captured from parent graphs will be available.

This fixes an issue in the Whisper example where Transpose -> MatMul fusion was not applied for cross-attention
(/model/decoder/layers.0/encoder_attn/Transpose_1), resulting in most of the decoder execution time being spent in that transpose. This is because the transpose input comes from a captured KV-cache input.

The implementation changes the defaults for `PlanOptions` to assume captures are available, as that is true during "normal" execution and only false when running constant propagation, and changes `Graph::execution_plan` to take a `PlanOptions` which is set to the default in `GraphOptimizer::apply_fusions`.