### PR TITLE
Build docs as part of `make check`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ clean:
 	rm -rf target/
 
 .PHONY: check
-check: checkformatting test lint
+check: checkformatting test lint docs
 
 .PHONY: checkformatting
 checkformatting:


### PR DESCRIPTION
A few times I have run `make check` locally before committing and then CI has failed due to errors during `make docs`.