### PR TITLE
Make Whisper example work with multi-channel .wav files

### DIFF
--- a/rten-examples/src/whisper.rs
+++ b/rten-examples/src/whisper.rs
@@ -86,8 +86,14 @@ fn read_wav_file(path: &str, expected_sample_rate: u32) -> Result<Vec<f32>, houn
         );
     }
 
+    let channels = spec.channels.max(1);
+
     reader
         .samples::<i16>()
+        // When an audio file has multiple channels, the samples from different
+        // channels are interleaved. The model expects mono input, so take samples
+        // from only the first channel.
+        .step_by(channels as usize)
         .map(|sample| {
             // Convert sample value in [i16::MIN, i16::MAX] to [-1, 1]
             Ok((sample? as f32) / (i16::MAX as f32))


### PR DESCRIPTION
When an audio file has multiple channels, the samples from different channels
are interleaved when reading the data. The Whisper preprocessing and model
expect single-channel input and the samples from other channels caused incorrect
results. Fix the issue by taking samples only from the first channel when
reading the audio file.

This fixes an issue where some of the test files (`en-0-ref.txt`) from the
whisper.cpp repository produced incorrect transcriptions.

