### PR TITLE
Enable fused Transpose -> Concat operations to run in place

### DIFF
--- a/src/ops/transform_inputs.rs
+++ b/src/ops/transform_inputs.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use rten_tensor::prelude::*;
 
-use crate::ops::{map_value_view, OpError, OpRunContext, Operator, OutputList, ValueView};
+use crate::ops::{map_value_view, OpError, OpRunContext, Operator, OutputList, Value, ValueView};
 
 trait TransformInput {
     fn transform(&self, input: &mut ValueView) -> Result<(), OpError>;
@@ -40,9 +40,15 @@ impl TransformInput for Transform {
     }
 }
 
+#[derive(Debug)]
+struct TransformIndex {
+    input_index: usize,
+    transform: Transform,
+}
+
 pub struct TransformInputsBuilder {
     op: Arc<dyn Operator + Send + Sync>,
-    transforms: Vec<(usize, Transform)>,
+    transforms: Vec<TransformIndex>,
 }
 
 impl TransformInputsBuilder {
@@ -54,8 +60,10 @@ impl TransformInputsBuilder {
     }
 
     pub fn permute(mut self, input_index: usize, perm: Option<Vec<usize>>) -> Self {
-        self.transforms
-            .push((input_index, Transform::Permute(PermuteInput { perm })));
+        self.transforms.push(TransformIndex {
+            input_index,
+            transform: Transform::Permute(PermuteInput { perm }),
+        });
         self
     }
 
@@ -76,8 +84,7 @@ pub struct TransformInputs {
 
     inner: Arc<dyn Operator + Send + Sync>,
 
-    /// (input_index, transform) list of transforms to apply.
-    transforms: Vec<(usize, Transform)>,
+    transforms: Vec<TransformIndex>,
 }
 
 impl Operator for TransformInputs {
@@ -87,14 +94,42 @@ impl Operator for TransformInputs {
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let mut inputs = ctx.inputs().clone();
-        for (index, transform) in &self.transforms {
-            let Some(input) = inputs.get_mut(*index) else {
+        for TransformIndex {
+            input_index,
+            transform,
+        } in &self.transforms
+        {
+            let Some(input) = inputs.get_mut(*input_index) else {
                 return Err(OpError::MissingInputs);
             };
             transform.transform(input)?;
         }
         let inner_ctx = OpRunContext::new(ctx.pool(), &inputs);
         self.inner.run(&inner_ctx)
+    }
+
+    fn can_run_in_place(&self) -> bool {
+        // Allow in-place execution if supported by the wrapped operator and
+        // no transforms are applied to the in-place input.
+        self.inner.can_run_in_place() && !self.transforms.iter().any(|t| t.input_index == 0)
+    }
+
+    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<Value, OpError> {
+        let mut inputs = ctx.inputs().clone();
+        for TransformIndex {
+            input_index,
+            transform,
+        } in &self.transforms
+        {
+            // We don't allow in-place execution if any input has index 0, so
+            // the index should always be > 0 here.
+            let Some(input) = inputs.get_mut(*input_index - 1) else {
+                return Err(OpError::MissingInputs);
+            };
+            transform.transform(input)?;
+        }
+        let inner_ctx = OpRunContext::new(ctx.pool(), &inputs);
+        self.inner.run_in_place(input, &inner_ctx)
     }
 }
 
@@ -107,7 +142,7 @@ mod tests {
     use rten_testing::TestCases;
 
     use super::TransformInputsBuilder;
-    use crate::ops::{OperatorExt, Sub};
+    use crate::ops::{Operator, OperatorExt, Sub};
 
     #[test]
     fn test_fused_transpose() {
@@ -158,6 +193,57 @@ mod tests {
             let output: Tensor<i32> = fused_transpose.run_simple((a.view(), b.view())).unwrap();
 
             assert_eq!(output, *expected);
+        })
+    }
+
+    #[test]
+    fn test_fused_transpose_in_place() {
+        #[derive(Clone, Debug)]
+        struct Case {
+            a: Tensor<i32>,
+            b: Tensor<i32>,
+            transpose_input: usize,
+            // Set to `None` if in-place execution is not supported.
+            expected: Option<Tensor<i32>>,
+        }
+
+        let cases = [
+            // Transform of non-first input.
+            Case {
+                a: [[1, 2], [3, 4]].into(),
+                b: [[0, 1], [2, 3]].into(),
+                transpose_input: 1,
+                expected: Some([[1, 0], [2, 1]].into()),
+            },
+            // Transform of first/in-place input.
+            Case {
+                a: [[1, 2], [3, 4]].into(),
+                b: [[0, 1], [2, 3]].into(),
+                transpose_input: 0,
+                expected: None,
+            },
+        ];
+
+        cases.test_each_clone(|case| {
+            let Case {
+                a,
+                b,
+                transpose_input,
+                expected,
+            } = case;
+
+            // nb. `Sub` operator chosen because it is a simple non-commutative
+            // binary op, which can run in place.
+            let sub_op = Sub {};
+            let fused_transpose = TransformInputsBuilder::new(Arc::new(sub_op))
+                .permute(transpose_input, Some([1, 0].into()))
+                .build();
+            assert_eq!(fused_transpose.can_run_in_place(), expected.is_some());
+
+            if let Some(expected) = expected {
+                let output: Tensor<i32> = fused_transpose.run_simple_in_place(a, b.view()).unwrap();
+                assert_eq!(output, expected);
+            }
         })
     }
 }


### PR DESCRIPTION
Efficient KV-cache extension in rten-generate relies on the `Concat` operations which extend KV-cache inputs running in-place. This broke in the Whisper example after enabling Transpose -> Concat fusion because the KV-cache concat ops were fused and did not support running in-place afterwards. As a result a new KV-cache buffer was getting allocated for each run.

The fix is to support running `TransformInputs` ops in place, as long as the transforms don't apply to the first/in-place input.