### PR TITLE
Return unused input buffer to pool in `Slice` in-place fallback

### DIFF
--- a/src/gemm/prepack.rs
+++ b/src/gemm/prepack.rs
@@ -3,10 +3,10 @@ use std::ops::Range;
 
 use rten_tensor::{Alloc, Matrix, MatrixLayout};
 
-use super::packing::{PackElem, PackingBuffer};
+use super::packing::PackingBuffer;
 use super::{depth_block_size, GemmError, Kernel, LhsBlock, RhsBlock};
 use crate::iter_util::range_chunks;
-use crate::tensor_pool::ExtractBuffer;
+use crate::tensor_pool::{Buffer, ExtractBuffer};
 
 /// Common data and logic for a pre-packed A or B matrix.
 ///
@@ -114,10 +114,8 @@ impl<T> PackedAMatrix<T> {
 }
 
 impl<T> ExtractBuffer for PackedAMatrix<T> {
-    type Elem = PackElem;
-
-    fn extract_buffer(self) -> Option<Vec<Self::Elem>> {
-        Some(self.base.data.into_vec())
+    fn extract_buffer(self) -> Option<Buffer> {
+        Some(self.base.data.into_vec().into())
     }
 }
 
@@ -167,10 +165,8 @@ impl<T> PackedBMatrix<T> {
 }
 
 impl<T> ExtractBuffer for PackedBMatrix<T> {
-    type Elem = PackElem;
-
-    fn extract_buffer(self) -> Option<Vec<Self::Elem>> {
-        Some(self.base.data.into_vec())
+    fn extract_buffer(self) -> Option<Buffer> {
+        Some(self.base.data.into_vec().into())
     }
 }
 

--- a/src/ops/slice.rs
+++ b/src/ops/slice.rs
@@ -7,7 +7,7 @@ use crate::ops::{
     map_value, map_value_view, resolve_axis, InputList, IntoOpResult, OpError, OpRunContext,
     Operator, OutputList, Value, ValueView,
 };
-use crate::tensor_pool::TensorPool;
+use crate::tensor_pool::{AutoReturn, TensorPool};
 
 macro_rules! check_input {
     ($cond:expr, $msg:literal) => {
@@ -148,6 +148,7 @@ impl Operator for Slice {
         // Fall back to copying if non-default steps are given.
         if let Some(steps) = steps {
             if steps.iter().any(|step| *step != 1) {
+                let input = input.auto_return(ctx.pool());
                 let mut inputs: Vec<_> = vec![input.as_view()];
 
                 // `inputs.extend(other.iter())` not used here as it triggers

--- a/src/value.rs
+++ b/src/value.rs
@@ -10,7 +10,7 @@ use rten_tensor::{
     TensorView, ViewData,
 };
 
-use crate::tensor_pool::{ExtractBuffer, TensorPool};
+use crate::tensor_pool::{Buffer, ExtractBuffer, TensorPool};
 
 /// Enum specifying the data type of a tensor.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -389,6 +389,17 @@ impl Layout for Value {
     impl_proxy_layout!();
 }
 
+impl ExtractBuffer for Value {
+    fn extract_buffer(self) -> Option<Buffer> {
+        match self {
+            Value::Int32Tensor(t) => t.extract_buffer(),
+            Value::Int8Tensor(t) => t.extract_buffer(),
+            Value::UInt8Tensor(t) => t.extract_buffer(),
+            Value::FloatTensor(t) => t.extract_buffer(),
+        }
+    }
+}
+
 /// Declare conversions between `Value` and `Tensor<T>` / `NdTensor<T, N>`.
 macro_rules! impl_value_conversions {
     ($variant:ident, $element_type:ty) => {
@@ -557,6 +568,15 @@ impl<'a> From<&'a Value> for ValueOrView<'a> {
 
 impl Layout for ValueOrView<'_> {
     impl_proxy_layout!();
+}
+
+impl ExtractBuffer for ValueOrView<'_> {
+    fn extract_buffer(self) -> Option<Buffer> {
+        match self {
+            Self::View(_) => None,
+            Self::Value(val) => val.extract_buffer(),
+        }
+    }
 }
 
 /// A scalar value with runtime-determined type.


### PR DESCRIPTION
If the `Slice` op can't run in place, return the unused input buffer to the pool.

In the process the `ExtractBuffer` trait was revised so it can be implemented for types where the element type is dynamic.