### PR TITLE
Add a fusion that converts ReduceMean axes inputs to attributes

### DIFF
--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -711,7 +711,7 @@ mod tests {
         // takes multiple non-constant inputs would work.
         let graph = {
             let x = Expr::value("x");
-            let bias = [1., 2., 3.];
+            let bias = Tensor::from([1., 2., 3.]);
             let expr = x.matmul(x.clone()) + bias;
             expr.build_graph(["x"])
         };
@@ -804,7 +804,7 @@ mod tests {
         let graph = {
             let a = Expr::value("a");
             let b = Expr::value("b");
-            let bias = [1., 2., 3.];
+            let bias = Tensor::from([1., 2., 3.]);
             let expr = a.matmul(b) + bias;
             expr.build_graph(["a", "b"])
         };
@@ -918,9 +918,9 @@ mod tests {
         let normalized = x_sub_mean.clone() / (x_sub_mean.square().mean() + epsilon).sqrt();
 
         // Shift and scale result
-        let scale = [3., 4., 5.];
+        let scale = Tensor::from([3., 4., 5.]);
         let expr = if with_bias {
-            let bias = [1., 2., 3.];
+            let bias = Tensor::from([1., 2., 3.]);
             normalized * scale + bias
         } else {
             normalized * scale
@@ -957,7 +957,7 @@ mod tests {
             let x = Expr::value("x");
             let epsilon = 1e-6;
             let rms = (x.square().mean() + epsilon).sqrt();
-            let scale = [3., 4., 5.];
+            let scale = Tensor::from([3., 4., 5.]);
             let expr = x * (Expr::constant(1.) / rms) * scale;
             expr.build_graph(["x"])
         };

--- a/src/value.rs
+++ b/src/value.rs
@@ -403,6 +403,13 @@ impl ExtractBuffer for Value {
 /// Declare conversions between `Value` and `Tensor<T>` / `NdTensor<T, N>`.
 macro_rules! impl_value_conversions {
     ($variant:ident, $element_type:ty) => {
+        // T => Value
+        impl From<$element_type> for Value {
+            fn from(scalar: $element_type) -> Value {
+                Value::$variant(Tensor::from(scalar))
+            }
+        }
+
         // Tensor<T> => Value
         impl From<Tensor<$element_type>> for Value {
             fn from(t: Tensor<$element_type>) -> Value {


### PR DESCRIPTION
Add a fusion (or rather, a canonicalization) that converts `ReduceMean(X, axes)` to `ReduceMean<axes>(X)` where `axes` is a constant vector.

Part of https://github.com/robertknight/rten/issues/788.
