### PR TITLE
Support fusing normalization ops where ReduceMean `axes` is positive

### DIFF
--- a/rten-examples/src/whisper.rs
+++ b/rten-examples/src/whisper.rs
@@ -510,9 +510,10 @@ fn main() -> Result<(), Box<dyn Error>> {
 
         // Decode audio chunk into transcript segments. Each segment starts
         // and ends with a timestamp token.
-        let mut generator_config = GeneratorConfig::default();
-        generator_config.kv_cache_capacity = Some(max_tokens_per_chunk);
-
+        let generator_config = GeneratorConfig {
+            kv_cache_capacity: Some(max_tokens_per_chunk),
+            ..Default::default()
+        };
         let generator = Generator::from_model_config(&decoder_model, generator_config)?
             .with_prompt(&prompt)
             .with_constant_input(encoder_hidden_states_id, encoded_audio.view().into())

--- a/src/graph/node.rs
+++ b/src/graph/node.rs
@@ -148,6 +148,11 @@ impl ValueNode {
         }
     }
 
+    /// Return the number of dimensions in this value, if it has shape information.
+    pub fn ndim(&self) -> Option<usize> {
+        self.shape.as_ref().map(|s| s.len())
+    }
+
     fn name(&self) -> Option<&str> {
         self.name.as_deref()
     }
@@ -173,6 +178,10 @@ impl Constant {
 
     pub fn shape(&self) -> &[usize] {
         self.layout().shape()
+    }
+
+    pub fn ndim(&self) -> usize {
+        self.layout().ndim()
     }
 
     /// Clone this constant, but only if it can be done so cheaply by

--- a/src/tensor_pool.rs
+++ b/src/tensor_pool.rs
@@ -88,9 +88,9 @@ impl Drop for Buffer {
     }
 }
 
-impl<T> Into<Buffer> for Vec<T> {
-    fn into(self) -> Buffer {
-        Buffer::from_vec(self)
+impl<T> From<Vec<T>> for Buffer {
+    fn from(val: Vec<T>) -> Buffer {
+        Self::from_vec(val)
     }
 }
 


### PR DESCRIPTION
Support fusing LayerNormalization and RmsNormalization subgraphs where the `ReduceMean` operation uses a positive value to specify the axis, if the graph contains shape information for the op's input value node.

Fixes https://github.com/robertknight/rten/issues/788
