### PR TITLE
Add fusion for MatMulInteger + Cast + Mul

### DIFF
--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -85,7 +85,7 @@ pub use layout::{
     depth_to_space, expand, flatten, reshape, squeeze, DepthToSpace, DepthToSpaceMode, Expand,
     Flatten, Reshape, Shape, Size, Squeeze, Transpose, Unsqueeze,
 };
-pub use matmul::{gemm_op, matmul, FusedMatMul, Gemm, MatMul, MatMulInteger};
+pub use matmul::{gemm_op, matmul, FusedMatMul, Gemm, MatMul, MatMulInteger, MatMulIntegerToFloat};
 pub use non_max_suppression::{non_max_suppression, BoxOrder, NonMaxSuppression};
 pub use norm::{
     batch_norm, instance_normalization, layer_normalization, log_softmax, rms_normalization,


### PR DESCRIPTION
Add a fusion for the `Mul(Cast<to=float>(MatMulInteger(a, b)), scale)` graphs produced by dynamic quantization.

For typical transformer models this is a small win for the decoder, where the matmul outputs are vectors, and a larger win for encoders where they are larger matrices.

The fused op currently has two stages: MatMulInteger + fused cast-and-scale. These could just as well be two separate operators. Further improvements are possible in future by pushing the cast down into the matmul kernel. Related to this, quantized ConvInteger would also benefit from a fused cast + scale.

**TODO:**

- [x] Limit this fusion to cases where the `a`, `a_zero_point` and `scale` inputs are outputs of a `DynamicQuantizeLinear` operator. We're not including the `DynamicQuantizeLinear` op in the fusion itself because sometimes the outputs of that op get re-used.