### PR TITLE
Use `Arc` everywhere for boxed operators

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -426,7 +426,7 @@ impl Graph {
     pub fn add_op(
         &mut self,
         name: Option<&str>,
-        op: Box<dyn Operator + Send + Sync>,
+        op: Arc<dyn Operator + Send + Sync>,
         inputs: &[Option<NodeId>],
         outputs: &[Option<NodeId>],
     ) -> NodeId {
@@ -460,7 +460,7 @@ impl Graph {
         let op_out_name = format!("{}_out", name);
         let op_out_id = self.add_value(Some(&op_out_name), None, None);
         let input_ids: Vec<_> = input_ids.iter().copied().map(Some).collect();
-        let op_node_id = self.add_op(Some(name), Box::new(op), &input_ids, &[op_out_id].map(Some));
+        let op_node_id = self.add_op(Some(name), Arc::new(op), &input_ids, &[op_out_id].map(Some));
         (op_node_id, op_out_id)
     }
 

--- a/src/graph/node.rs
+++ b/src/graph/node.rs
@@ -89,13 +89,13 @@ impl OperatorNode {
         name: Option<&str>,
         input_ids: &[Option<NodeId>],
         output_ids: &[Option<NodeId>],
-        operator: Box<dyn Operator + Send + Sync>,
+        operator: Arc<dyn Operator + Send + Sync>,
     ) -> Self {
         OperatorNode {
             name: name.map(|s| s.to_owned()),
             inputs: Vec::from(input_ids),
             outputs: Vec::from(output_ids),
-            operator: Arc::from(operator),
+            operator,
         }
     }
 

--- a/src/graph/tests.rs
+++ b/src/graph/tests.rs
@@ -171,7 +171,7 @@ fn test_graph_node_debug_names() {
     let relu_out_id = g.add_value(Some("relu_out"), None, None);
     let relu_op_id = g.add_op(
         Some("relu"),
-        Box::new(Relu {}),
+        Arc::new(Relu {}),
         &[Some(input_id)],
         &[Some(relu_out_id)],
     );
@@ -185,7 +185,7 @@ fn test_graph_node_debug_names() {
     let anon_out_id = g.add_value(None, None, None);
     let anon_op_id = g.add_op(
         None,
-        Box::new(Relu {}),
+        Arc::new(Relu {}),
         &[Some(input_id)],
         &[Some(anon_out_id)],
     );
@@ -382,7 +382,7 @@ fn test_graph_many_steps() -> Result<(), Box<dyn Error>> {
         let next_output = g.add_value(None, None, None);
         g.add_op(
             None,
-            Box::new(AddOne {}),
+            Arc::new(AddOne {}),
             &[Some(prev_output)],
             &[Some(next_output)],
         );
@@ -601,7 +601,7 @@ fn test_call_op_with_missing_input() {
     let output = g.add_value(None, None, None);
     g.add_op(
         Some("shape"),
-        Box::new(Shape::default()),
+        Arc::new(Shape::default()),
         &[None],
         &[Some(output)],
     );
@@ -808,7 +808,7 @@ fn test_multiple_outputs() {
     let left_split_out = g.add_value(Some("left_split"), None, None);
     let right_split_out = g.add_value(Some("right_split"), None, None);
 
-    let split_op = Box::new(Split::new());
+    let split_op = Arc::new(Split::new());
     let run_count = split_op.run_count.clone();
 
     g.add_op(

--- a/src/op_registry.rs
+++ b/src/op_registry.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::error::Error;
 use std::fmt::{Display, Formatter};
+use std::sync::Arc;
 
 use smallvec::{smallvec, SmallVec};
 
@@ -291,7 +292,7 @@ fn vec_from_attr(attr: Option<flatbuffers::Vector<u32>>, default: &[usize]) -> V
 }
 
 /// Result of deserializing an operator node from a model file.
-pub type ReadOpResult = Result<Box<dyn Operator + Send + Sync>, ReadOpError>;
+pub type ReadOpResult = Result<Arc<dyn Operator + Send + Sync>, ReadOpError>;
 
 /// A function that deserializes an operator node.
 pub type ReadOpFunction = dyn Fn(&OperatorNode, &dyn OpLoadContext) -> ReadOpResult;
@@ -309,7 +310,7 @@ pub trait ReadOp: Operator + Sized + Send + Sync {
     /// The node's type must correspond to the result of `op_type`.
     fn read(op: &OperatorNode, ctx: &dyn OpLoadContext) -> Result<Self, ReadOpError>;
 
-    /// Deserialize an operator and box it into a `Box<dyn Operator>`.
+    /// Deserialize an operator into a boxed `dyn Operator`.
     ///
     /// The node's type must correspond to the result of `op_type`.
     fn read_boxed(op: &OperatorNode, ctx: &dyn OpLoadContext) -> ReadOpResult
@@ -317,7 +318,7 @@ pub trait ReadOp: Operator + Sized + Send + Sync {
         Self: 'static,
     {
         let op = Self::read(op, ctx)?;
-        Ok(Box::new(op))
+        Ok(Arc::new(op))
     }
 }
 

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -1,6 +1,7 @@
 use std::any::Any;
 use std::error::Error;
 use std::fmt::{Display, Formatter};
+use std::sync::Arc;
 
 use rten_tensor::Tensor;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -92,7 +93,7 @@ impl GraphMutator {
     fn add_operator(
         &mut self,
         name: Option<&str>,
-        op: Box<dyn Operator + Send + Sync>,
+        op: Arc<dyn Operator + Send + Sync>,
         inputs: &[Option<NodeId>],
         outputs: &[Option<NodeId>],
     ) {


### PR DESCRIPTION
Graphs ultimately store boxed operators in an `Arc`, so use `Arc` rather than `Box` everywhere to avoid redundant allocations.