### PR TITLE
Move input ID -> operator ID map to `Graph`

### DIFF
--- a/src/graph/node.rs
+++ b/src/graph/node.rs
@@ -123,7 +123,11 @@ impl OperatorNode {
         self.operator.clone()
     }
 
-    pub fn replace_input(&mut self, old_id: NodeId, new_id: NodeId) {
+    /// Replace an input in the operator's list of inputs.
+    ///
+    /// Consumers outside the graph module should use graph-level methods instead
+    /// which update edge caches.
+    pub(super) fn replace_input(&mut self, old_id: NodeId, new_id: NodeId) {
         for input_id in self.inputs.iter_mut() {
             if *input_id == Some(old_id) {
                 *input_id = Some(new_id);


### PR DESCRIPTION
Move the hash map used for looking up consumers of a value or constant ID from `GraphMutator` down into `Graph`. The immediate motivation for this is to enable fusion visitors to make decisions based on the consumers of an operator. They currently receive a `Graph` rather than a `GraphMutator`. We could pass them an `&GraphMutator` instead, but input ID -> operator ID lookup seems generally useful enough to make it part of the `Graph` struct.

A downside to this change is that it means this hash map is retained after graph optimization is performed, but isn't currently used afterwards.