### PR TITLE
Add ShapeSliceToConstant fusion

### DIFF
--- a/src/graph/node.rs
+++ b/src/graph/node.rs
@@ -61,6 +61,14 @@ impl Node {
             _ => None,
         }
     }
+
+    /// Return the contained constant, if this a constant node.
+    pub fn as_constant(&self) -> Option<&Constant> {
+        match self {
+            Node::Constant(c) => Some(c),
+            _ => None,
+        }
+    }
 }
 
 /// Represents the size of a dimension of a runtime-provided value, such as


### PR DESCRIPTION
Add a fusion that converts `Slice(Shape(X))` to a constant if the dimensions of X extracted by the `Slice` are all constant values. This enables constant propagation to precompute values that depend on the extracted dimension size, which in turn can enable additional fusions.

The motivating use case is to enable Transpose + FusedMatMul fusion for cross-attention matmuls in the Whisper encoder. As of this PR this now works, provided that shape inference was run on the ONNX model prior to conversion, as this is needed to have sufficient detail about the input to the relevant `Shape` operators.

A similar fusion that would be useful to add in future is `Gather(Shape(X))` where the gather indices are constant.

**TODO:**
- [x] Do start/end clamping properly in `maybe_fuse`
- [x] Tests