### PR TITLE
Add script for applying shape inference to an ONNX model

### DIFF
--- a/tools/infer-shapes.py
+++ b/tools/infer-shapes.py
@@ -1,0 +1,17 @@
+from argparse import ArgumentParser
+
+import onnx
+
+parser = ArgumentParser(description="Apply shape inference to a model")
+parser.add_argument("input")
+parser.add_argument("output", nargs="?")
+args = parser.parse_args()
+
+output = args.output or args.input.replace(".onnx", ".shaped.onnx")
+
+model = onnx.load(args.input)
+
+# See https://onnx.ai/onnx/api/shape_inference.html
+updated_model = onnx.shape_inference.infer_shapes(model, data_prop=True)
+
+onnx.save(updated_model, output)


### PR DESCRIPTION
This should probably be done as part of model conversion and quantization in future, so that optimizations which depend on it ([example](https://github.com/robertknight/rten/pull/805#:~:text=provided%20that%20shape%20inference%20was%20run%20on%20the%20ONNX%20model%20prior%20to%20conversion)) work automatically.