### PR TITLE
Address `mismatched_lifetime_syntaxes` lint warning with nightly Rust

### DIFF
--- a/rten-generate/src/generator.rs
+++ b/rten-generate/src/generator.rs
@@ -898,7 +898,7 @@ pub trait GeneratorUtils: Iterator<Item = GeneratorItem> + Sized {
 
     /// Decode the tokens to text using a tokenizer.
     #[cfg(feature = "text-decoder")]
-    fn decode(self, tokenizer: &Tokenizer) -> TextDecoder<Self> {
+    fn decode(self, tokenizer: &Tokenizer) -> TextDecoder<'_, Self> {
         TextDecoder::wrap(self, tokenizer)
     }
 

--- a/rten-imageproc/src/shapes.rs
+++ b/rten-imageproc/src/shapes.rs
@@ -1112,7 +1112,7 @@ impl Polygons {
     }
 
     /// Return an iterator over individual polygons in the sequence.
-    pub fn iter(&self) -> PolygonsIter {
+    pub fn iter(&self) -> PolygonsIter<'_> {
         PolygonsIter {
             points: &self.points,
             polygons: self.polygons.iter(),

--- a/rten-simd/src/iter.rs
+++ b/rten-simd/src/iter.rs
@@ -13,7 +13,7 @@ pub trait SimdIterable {
     /// If the input length is not divisble by the SIMD vector width, the
     /// iterator yields only the full chunks. The tail is accessible via the
     /// iterator's [`tail`](Iter::tail) method.
-    fn simd_iter<O: NumOps<Self::Elem>>(&self, ops: O) -> Iter<Self::Elem, O>;
+    fn simd_iter<O: NumOps<Self::Elem>>(&self, ops: O) -> Iter<'_, Self::Elem, O>;
 
     /// Iterate over SIMD-sized chunks of the input.
     ///
@@ -29,7 +29,7 @@ impl<T: Elem> SimdIterable for [T] {
     type Elem = T;
 
     #[inline]
-    fn simd_iter<O: NumOps<T>>(&self, ops: O) -> Iter<T, O> {
+    fn simd_iter<O: NumOps<T>>(&self, ops: O) -> Iter<'_, T, O> {
         Iter::new(ops, self)
     }
 

--- a/rten-tensor/src/storage.rs
+++ b/rten-tensor/src/storage.rs
@@ -81,7 +81,7 @@ pub unsafe trait Storage {
     /// Return a view of a sub-region of the storage.
     ///
     /// Panics if the range is out of bounds.
-    fn slice(&self, range: Range<usize>) -> ViewData<Self::Elem> {
+    fn slice(&self, range: Range<usize>) -> ViewData<'_, Self::Elem> {
         assert_storage_range_valid(self, range.clone());
         ViewData {
             // Safety: We verified that `range` is in bounds.
@@ -92,7 +92,7 @@ pub unsafe trait Storage {
     }
 
     /// Return an immutable view of this storage.
-    fn view(&self) -> ViewData<Self::Elem> {
+    fn view(&self) -> ViewData<'_, Self::Elem> {
         ViewData {
             ptr: self.as_ptr(),
             len: self.len(),
@@ -210,7 +210,7 @@ pub unsafe trait StorageMut: Storage {
     }
 
     /// Return a slice of this storage.
-    fn slice_mut(&mut self, range: Range<usize>) -> ViewMutData<Self::Elem> {
+    fn slice_mut(&mut self, range: Range<usize>) -> ViewMutData<'_, Self::Elem> {
         assert_storage_range_valid(self, range.clone());
         ViewMutData {
             // Safety: We verified that `range` is in bounds.
@@ -221,7 +221,7 @@ pub unsafe trait StorageMut: Storage {
     }
 
     /// Return a mutable view of this storage.
-    fn view_mut(&mut self) -> ViewMutData<Self::Elem> {
+    fn view_mut(&mut self) -> ViewMutData<'_, Self::Elem> {
         ViewMutData {
             ptr: self.as_mut_ptr(),
             len: self.len(),

--- a/rten-text/src/models/bpe.rs
+++ b/rten-text/src/models/bpe.rs
@@ -227,7 +227,7 @@ impl BpeBuilder {
 /// Lines that are empty or contain only a `#version` marker are ignored.
 pub fn merge_pairs_from_lines(
     lines: &[impl AsRef<str>],
-) -> Vec<(EncodedByteSlice, EncodedByteSlice)> {
+) -> Vec<(EncodedByteSlice<'_>, EncodedByteSlice<'_>)> {
     lines
         .iter()
         .filter_map(|line| {

--- a/src/gemm/kernels.rs
+++ b/src/gemm/kernels.rs
@@ -444,7 +444,7 @@ impl<'a, T, B: Copy + Default + PartialEq> MatVecOutput<'a, T, B> {
         MatVecOutput { data, beta }
     }
 
-    pub fn slice_mut(&mut self, range: Range<usize>) -> MatVecOutput<T, B> {
+    pub fn slice_mut(&mut self, range: Range<usize>) -> MatVecOutput<'_, T, B> {
         MatVecOutput {
             data: &mut self.data[range],
             beta: self.beta,
@@ -455,7 +455,7 @@ impl<'a, T, B: Copy + Default + PartialEq> MatVecOutput<'a, T, B> {
     ///
     /// This effectively changes the operation from `C = C * beta + AB` to
     /// `C = AB` or `C += AB` depending on the value of beta.
-    pub fn as_bool_beta(&mut self) -> MatVecOutput<T, bool> {
+    pub fn as_bool_beta(&mut self) -> MatVecOutput<'_, T, bool> {
         MatVecOutput {
             data: self.data,
             beta: self.beta != B::default(),

--- a/src/gemm/prepack.rs
+++ b/src/gemm/prepack.rs
@@ -81,7 +81,7 @@ pub struct PackedAMatrix<T> {
 
 impl<T> PackedAMatrix<T> {
     /// Return the packed data for a given range along the M and K dimensions.
-    pub(super) fn block(&self, rows: Range<usize>, depth_block_idx: usize) -> LhsBlock<T> {
+    pub(super) fn block(&self, rows: Range<usize>, depth_block_idx: usize) -> LhsBlock<'_, T> {
         let (data, panel_stride) = self.base.block(rows, depth_block_idx);
         LhsBlock::Packed { data, panel_stride }
     }
@@ -128,7 +128,7 @@ pub struct PackedBMatrix<T> {
 
 impl<T> PackedBMatrix<T> {
     /// Return the packed data for a given range along the N and K dimensions.
-    pub(super) fn block(&self, cols: Range<usize>, depth_block_idx: usize) -> RhsBlock<T> {
+    pub(super) fn block(&self, cols: Range<usize>, depth_block_idx: usize) -> RhsBlock<'_, T> {
         let (data, panel_stride) = self.base.block(cols, depth_block_idx);
         RhsBlock {
             data,

--- a/src/gemm/tiles.rs
+++ b/src/gemm/tiles.rs
@@ -55,7 +55,7 @@ impl<'a, T> OutputTiles<'a, T> {
     ///
     /// Safety: The caller must guarantee that every tile is operated on by
     /// only a single thread at a time.
-    pub unsafe fn tile(&self, row: usize, col: usize) -> OutputTile<T> {
+    pub unsafe fn tile(&self, row: usize, col: usize) -> OutputTile<'_, T> {
         assert!(row < self.n_row_tiles && col < self.n_col_tiles);
 
         let start_row = row * self.tile_rows;

--- a/src/graph/capture_env.rs
+++ b/src/graph/capture_env.rs
@@ -84,7 +84,7 @@ impl<'a> CaptureEnv<'a> {
     /// The child `CaptureEnv` will have no captures of its own. This is useful
     /// in loop operators which need to create a new capture environment to pass
     /// to each iteration of a loop.
-    pub fn child(&self) -> CaptureEnv {
+    pub fn child(&self) -> CaptureEnv<'_> {
         CaptureEnv {
             parent: Some(self),
             graph: None,
@@ -110,7 +110,7 @@ impl<'a> CaptureEnv<'a> {
     }
 
     /// Look up an operator input value by name in this environment.
-    pub fn get_input(&self, name: &str) -> Option<ValueView> {
+    pub fn get_input(&self, name: &str) -> Option<ValueView<'_>> {
         if let Some(graph) = self.graph {
             if let Some(node_id) = graph.get_node_id(name) {
                 // If a node by this name exists in this graph, but is a placeholder

--- a/src/graph/node.rs
+++ b/src/graph/node.rs
@@ -217,7 +217,7 @@ impl Constant {
     }
 
     /// Return the data for this constant as a tensor view.
-    pub fn as_view(&self) -> ValueView {
+    pub fn as_view(&self) -> ValueView<'_> {
         match self {
             Constant::Float(f) => ValueView::FloatTensor(f.view()),
             Constant::Int32(i) => ValueView::Int32Tensor(i.view()),
@@ -250,7 +250,7 @@ impl<T> ConstantNode<T> {
         }
     }
 
-    pub fn view(&self) -> TensorView<T> {
+    pub fn view(&self) -> TensorView<'_, T> {
         match &self.data {
             ConstantNodeData::Owned(data) => data.view(),
             ConstantNodeData::Arc(data) => data.view(),
@@ -318,7 +318,7 @@ impl<T> From<ArcTensorView<T>> for ConstantNodeData<T> {
 
 /// Extract typed data from a [`Constant`].
 pub trait TypedConstant<T> {
-    fn as_view(&self) -> Option<TensorView<T>>;
+    fn as_view(&self) -> Option<TensorView<'_, T>>;
     fn as_scalar(&self) -> Option<T>;
     fn as_vector(&self) -> Option<&[T]>;
 }
@@ -326,7 +326,7 @@ pub trait TypedConstant<T> {
 macro_rules! impl_typed_constant {
     ($type:ty, $variant:ident) => {
         impl TypedConstant<$type> for Constant {
-            fn as_view(&self) -> Option<TensorView<$type>> {
+            fn as_view(&self) -> Option<TensorView<'_, $type>> {
                 match self {
                     Constant::$variant(tensor) => Some(tensor.view()),
                     _ => None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,7 +157,9 @@ pub use value::{DataType, Value, ValueOrView, ValueView};
 #[allow(deprecated)]
 pub use ops::{Input, InputOrOutput, Output};
 
-#[allow(dead_code, unused_imports)]
+// `unknown_lints` is for `mismatched_lifetime_syntaxes`. Remove when that
+// reaches stable.
+#[allow(unknown_lints, dead_code, unused_imports, mismatched_lifetime_syntaxes)]
 mod schema_generated;
 
 // This is currently exposed for use in ocrs tests. That crate should probably

--- a/src/model.rs
+++ b/src/model.rs
@@ -664,7 +664,7 @@ impl Model {
     }
 
     /// Return metadata about a node in the model's graph.
-    pub fn node_info(&self, id: NodeId) -> Option<NodeInfo> {
+    pub fn node_info(&self, id: NodeId) -> Option<NodeInfo<'_>> {
         self.graph.get_node(id).map(|node| NodeInfo { node })
     }
 

--- a/src/tensor_pool.rs
+++ b/src/tensor_pool.rs
@@ -274,13 +274,13 @@ pub trait AutoReturn {
     /// Wrap `self` in a [`PoolRef`].
     ///
     /// When the returned ref is dropped, `self` will be returned to the pool.
-    fn auto_return(self, pool: &TensorPool) -> PoolRef<Self>
+    fn auto_return(self, pool: &TensorPool) -> PoolRef<'_, Self>
     where
         Self: Sized + ExtractBuffer;
 }
 
 impl<EB: ExtractBuffer> AutoReturn for EB {
-    fn auto_return(self, pool: &TensorPool) -> PoolRef<EB> {
+    fn auto_return(self, pool: &TensorPool) -> PoolRef<'_, EB> {
         PoolRef::new(pool, self)
     }
 }

--- a/src/timing.rs
+++ b/src/timing.rs
@@ -75,7 +75,7 @@ trait Table {
     }
 
     /// Return a wrapper around this table which implements [`Display`].
-    fn display(&self, indent: usize) -> DisplayTable<Self>
+    fn display(&self, indent: usize) -> DisplayTable<'_, Self>
     where
         Self: Sized,
     {

--- a/src/value.rs
+++ b/src/value.rs
@@ -327,7 +327,7 @@ impl Value {
     }
 
     /// Return a borrowed view of this tensor.
-    pub fn as_view(&self) -> ValueView {
+    pub fn as_view(&self) -> ValueView<'_> {
         match self {
             Self::FloatTensor(ft) => ValueView::FloatTensor(ft.view()),
             Self::Int32Tensor(it) => ValueView::Int32Tensor(it.view()),
@@ -502,7 +502,7 @@ pub enum ValueOrView<'a> {
 
 impl ValueOrView<'_> {
     /// Convert this value to a tensor view.
-    pub fn as_view(&self) -> ValueView {
+    pub fn as_view(&self) -> ValueView<'_> {
         match self {
             ValueOrView::View(inp) => inp.clone(),
             ValueOrView::Value(outp) => outp.as_view(),


### PR DESCRIPTION
Address lint warnings about [lifetime syntax mismatches](https://github.com/rust-lang/rust/pull/138677) that started appearing when building with nightly Rust.