### PR TITLE
Make avx512 feature enable rten-gemm/avx512

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ crate-type = ["lib", "cdylib"]
 
 [features]
 # Use AVX-512 instructions if available. Requires nightly Rust for AVX-512 intrinsics.
-avx512 = ["rten-simd/avx512", "rten-vecmath/avx512"]
+avx512 = ["rten-gemm/avx512", "rten-simd/avx512", "rten-vecmath/avx512"]
 # Enable loading models using memory mapping
 mmap = ["dep:memmap2"]
 # Generate WebAssembly API using wasm-bindgen.

--- a/rten-gemm/src/kernels/x86_64.rs
+++ b/rten-gemm/src/kernels/x86_64.rs
@@ -820,8 +820,8 @@ unsafe impl Kernel<u8, i8, i32> for Avx512Int8Kernel {
         depth: usize,
         _alpha: f32,
         beta: i32,
-        a_quant: Option<QuantParams<u8>>,
-        b_quant: Option<QuantParams<i8>>,
+        _a_quant: Option<QuantParams<u8>>,
+        _b_quant: Option<QuantParams<i8>>,
     ) {
         let a_data = match a {
             Lhs::Packed(data) => data,


### PR DESCRIPTION
Make sure the main crate uses AVX-512 kernels when the avx512 flag is enabled.