### PR TITLE
Add method to decode tokens and retain token IDs

### DIFF
--- a/rten-generate/src/generator.rs
+++ b/rten-generate/src/generator.rs
@@ -897,6 +897,9 @@ pub trait GeneratorUtils: Iterator<Item = GeneratorItem> + Sized {
     }
 
     /// Decode the tokens to text using a tokenizer.
+    ///
+    /// To get both the decoded text and token IDs, call
+    /// [`with_ids`](TextDecoder::with_ids) on the result.
     #[cfg(feature = "text-decoder")]
     fn decode(self, tokenizer: &Tokenizer) -> TextDecoder<'_, Self> {
         TextDecoder::wrap(self, tokenizer)


### PR DESCRIPTION
For debugging purposes it is useful to be able to decode generator output to text and keep the token IDs. Add an API for this that can be used like so:

```rs
let tokens = generator.decode(&tokenizer).with_ids();

for tok in tokens {
    let (token_ids, token_text) = tok?
    ...
}
```