### PR TITLE
Add i8mm GEMM kernel for i8 x u8 -> i32 matmul

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,11 @@ mmap = ["dep:memmap2"]
 wasm_api = []
 # Enable operators that generate random numbers.
 random = ["dep:fastrand", "dep:fastrand-contrib"]
+# Enable use of i8mm for matrix multiplication.
+#
+# Off by default as on some systems it is currently slower than the older
+# dotprod instructions. See https://github.com/robertknight/rten/pull/824.
+i8mm = ["rten-gemm/i8mm"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2.100"

--- a/rten-cli/Cargo.toml
+++ b/rten-cli/Cargo.toml
@@ -21,6 +21,8 @@ rten-testing = { path = "../rten-testing" }
 [features]
 # Use AVX-512 instructions if available. Requires nightly Rust for AVX-512 intrinsics.
 avx512 = ["rten/avx512"]
+# Use i8mm instructions if available.
+i8mm = ["rten/i8mm"]
 
 [lints.clippy]
 uninlined_format_args = "allow"

--- a/rten-gemm/Cargo.toml
+++ b/rten-gemm/Cargo.toml
@@ -20,6 +20,7 @@ rten-testing = { path = "../rten-testing" }
 
 [features]
 avx512 = ["rten-simd/avx512"]
+i8mm = []
 
 [lib]
 crate-type = ["lib"]

--- a/rten-gemm/src/lib.rs
+++ b/rten-gemm/src/lib.rs
@@ -539,6 +539,13 @@ impl Default for GemmExecutor<u8, i8, i32> {
         }
         #[cfg(target_arch = "aarch64")]
         {
+            // i8mm usage is opt-in because the current implementation performs
+            // better than dotprod on some systems but worse on others. Ideally
+            // it would either be better everywhere or we'd auto-detect whether
+            // to use it or not.
+            //
+            // See https://github.com/robertknight/rten/pull/824.
+            #[cfg(feature = "i8mm")]
             try_kernel!(Int8KernelType::ArmI8mm);
             try_kernel!(Int8KernelType::ArmDot);
             try_kernel!(Int8KernelType::ArmNeon);

--- a/rten-gemm/src/lib.rs
+++ b/rten-gemm/src/lib.rs
@@ -166,6 +166,8 @@ enum Int8KernelType {
     Avx512,
 
     #[cfg(target_arch = "aarch64")]
+    ArmI8mm,
+    #[cfg(target_arch = "aarch64")]
     ArmDot,
     #[cfg(target_arch = "aarch64")]
     ArmNeon,
@@ -485,6 +487,8 @@ impl WithKernel for GemmExecutor<u8, i8, i32> {
             Int8KernelType::ArmNeon => Self::from_kernel::<kernels::aarch64::ArmInt8Kernel>(),
             #[cfg(target_arch = "aarch64")]
             Int8KernelType::ArmDot => Self::from_kernel::<kernels::aarch64::ArmInt8DotKernel>(),
+            #[cfg(target_arch = "aarch64")]
+            Int8KernelType::ArmI8mm => Self::from_kernel::<kernels::aarch64::ArmInt8MMKernel>(),
             #[cfg(target_arch = "wasm32")]
             #[cfg(target_feature = "simd128")]
             Int8KernelType::Wasm => Self::from_kernel::<kernels::wasm::WasmInt8Kernel>(),
@@ -504,6 +508,7 @@ impl WithKernel for GemmExecutor<u8, i8, i32> {
 
         #[cfg(target_arch = "aarch64")]
         {
+            types.push(Int8KernelType::ArmI8mm);
             types.push(Int8KernelType::ArmDot);
             types.push(Int8KernelType::ArmNeon);
         }
@@ -534,6 +539,7 @@ impl Default for GemmExecutor<u8, i8, i32> {
         }
         #[cfg(target_arch = "aarch64")]
         {
+            try_kernel!(Int8KernelType::ArmI8mm);
             try_kernel!(Int8KernelType::ArmDot);
             try_kernel!(Int8KernelType::ArmNeon);
         }

--- a/rten-testing/src/lib.rs
+++ b/rten-testing/src/lib.rs
@@ -114,8 +114,10 @@ impl<I: IntoIterator> TestCases for I {
     where
         Self::Case: Debug + RefUnwindSafe,
     {
+        let mut total = 0;
         let mut failures = Vec::new();
         for case in self {
+            total += 1;
             if std::panic::catch_unwind(|| {
                 test(&case);
             })
@@ -124,11 +126,11 @@ impl<I: IntoIterator> TestCases for I {
                 failures.push(case);
             }
         }
-        assert_eq!(
+        assert!(
+            failures.is_empty(),
+            "{} of {} test cases failed: {:?}",
             failures.len(),
-            0,
-            "{} test cases failed: {:?}",
-            failures.len(),
+            total,
             failures
         );
     }


### PR DESCRIPTION
Add a new GEMM kernel for int8 matmul that uses [i8mm](https://developer.arm.com/documentation/ddi0602/2025-06/SIMD-FP-Instructions/UMMLA--vector---Unsigned-8-bit-integer-matrix-multiply-accumulate-to-32-bit-integer--vector--?lang=en) instructions.

The current implementation is very slightly slower on M3 Pro than the dotprod kernels. On an AWS Graviton 4 (c8g.xlarge), the i8mm kernel is about 22% faster for int8 matmuls, as tested on a modernbert-base model (with sequence_length 512). The marginal drop on M3 Pro might be due to the different kernel tile shape (8x8 instead of 16x4) rather than compute, but I need to verify.

Because the performance isn't always as good or better than dotprod, this is initially opt-in via an `i8mm` crate feature.

**Summary of changes:**

 - Add a new GEMM kernel that uses i8mm. Each kernel call updates an 8x8xi32 output tile from 8x8 int8 LHS and RHS inputs. The LHS is packed as a `(K/8, MR, 8)` panel. The RHS is packed as a `(K/8, NR, 8)` panel. The kernel loops over K tiles of size 8 and each iteration performs 16 2x8 @ 8x2 mini-matmuls to update an accumulator arranged as a 4x4 grid of 2x2 tiles. After the main accumulator loop, the 4x4 grid is shuffled to an 8x2 grid in row-major order for adding the zero point adjustment and writing back to memory.
 
Part of https://github.com/robertknight/rten/issues/685