### PR TITLE
Slightly improve i8mm, enable by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,11 +79,6 @@ mmap = ["dep:memmap2"]
 wasm_api = []
 # Enable operators that generate random numbers.
 random = ["dep:fastrand", "dep:fastrand-contrib"]
-# Enable use of i8mm for matrix multiplication.
-#
-# Off by default as on some systems it is currently slower than the older
-# dotprod instructions. See https://github.com/robertknight/rten/pull/824.
-i8mm = ["rten-gemm/i8mm"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2.100"

--- a/rten-cli/Cargo.toml
+++ b/rten-cli/Cargo.toml
@@ -21,8 +21,6 @@ rten-testing = { path = "../rten-testing" }
 [features]
 # Use AVX-512 instructions if available. Requires nightly Rust for AVX-512 intrinsics.
 avx512 = ["rten/avx512"]
-# Use i8mm instructions if available.
-i8mm = ["rten/i8mm"]
 
 [lints.clippy]
 uninlined_format_args = "allow"

--- a/rten-gemm/Cargo.toml
+++ b/rten-gemm/Cargo.toml
@@ -20,7 +20,6 @@ rten-testing = { path = "../rten-testing" }
 
 [features]
 avx512 = ["rten-simd/avx512"]
-i8mm = []
 
 [lib]
 crate-type = ["lib"]

--- a/rten-gemm/src/kernels/aarch64.rs
+++ b/rten-gemm/src/kernels/aarch64.rs
@@ -765,17 +765,18 @@ unsafe impl Kernel<u8, i8, i32> for ArmInt8MMKernel {
             let col_tiles: [U8; COL_TILES] = std::array::from_fn(|c| {
                 u8_ops.load_ptr(b_ptr.add(k_block * b_tile_size + c * u8_ops.len()))
             });
+            let row_tiles: [U8; ROW_TILES] = std::array::from_fn(|r| {
+                u8_ops.load_ptr(a_ptr.add(k_block * a_tile_size + r * u8_ops.len()))
+            });
 
             for r in 0..ROW_TILES {
-                let row_tile = u8_ops.load_ptr(a_ptr.add(k_block * a_tile_size + r * u8_ops.len()));
-
                 for c in 0..COL_TILES {
                     // Use inline asm here because the `vmmlaq_u32` intrinsic is
                     // not stabilized yet.
                     core::arch::asm! {
                         "ummla {result:v}.4s, {a:v}.16b, {b:v}.16b",
                         result = inout(vreg) tmp[r][c],
-                        a = in(vreg) row_tile,
+                        a = in(vreg) row_tiles[r],
                         b = in(vreg) col_tiles[c],
                         options(nostack)
                     }

--- a/rten-gemm/src/lib.rs
+++ b/rten-gemm/src/lib.rs
@@ -539,13 +539,6 @@ impl Default for GemmExecutor<u8, i8, i32> {
         }
         #[cfg(target_arch = "aarch64")]
         {
-            // i8mm usage is opt-in because the current implementation performs
-            // better than dotprod on some systems but worse on others. Ideally
-            // it would either be better everywhere or we'd auto-detect whether
-            // to use it or not.
-            //
-            // See https://github.com/robertknight/rten/pull/824.
-            #[cfg(feature = "i8mm")]
             try_kernel!(Int8KernelType::ArmI8mm);
             try_kernel!(Int8KernelType::ArmDot);
             try_kernel!(Int8KernelType::ArmNeon);


### PR DESCRIPTION
The first commit contains a small tweak to reduce the number of load instructions in the i8mm kernel (2x `ldp` + 4x `ldr` => 4x `ldp`). The second enables i8mm by default. Though it offers no performance advantage over dotprod on some systems (Apple Silicon), it is much better on others. For the sake of simplicity, use it wherever it is supported.