### PR TITLE
Add kernel benchmarks for all GEMM kernels 

### DIFF
--- a/rten-gemm/src/kernels.rs
+++ b/rten-gemm/src/kernels.rs
@@ -153,6 +153,11 @@ pub unsafe trait Kernel<LhsT, RhsT, OutT>: Sync {
     fn nr(&self) -> usize;
 
     /// Return a name for this kernel for use in logging etc.
+    ///
+    /// The naming convention is `{arch}-{dtypes}-{variant}` where `dtypes`
+    /// is either a triple of `{lhs}{rhs}{out}` if the LHS, RHS and output types
+    /// are different, or just the type if all are the same. `variant` refers to
+    /// target features being used (eg. "dotprod") or variants.
     fn name(&self) -> &'static str;
 
     /// Return true if this kernel may encounter saturation in a data type that

--- a/rten-gemm/src/kernels.rs
+++ b/rten-gemm/src/kernels.rs
@@ -535,7 +535,7 @@ mod tests {
                     kernel.mr(),
                     kernel.nr(),
                     k,
-                    0.,              /* alpha */
+                    1.,              /* alpha */
                     OutT::default(), // beta
                     None,            // a_quant
                     None,            // b_quant
@@ -559,28 +559,106 @@ mod tests {
         );
     }
 
+    struct KernelBench<LhsT, RhsT, OutT> {
+        kernels: Vec<Box<dyn Kernel<LhsT, RhsT, OutT>>>,
+    }
+
+    impl<LhsT, RhsT, OutT> KernelBench<LhsT, RhsT, OutT> {
+        fn new() -> Self {
+            Self {
+                kernels: Vec::new(),
+            }
+        }
+
+        /// Register a kernel to benchmark, if supported on the current system.
+        fn add<K: Kernel<LhsT, RhsT, OutT> + 'static>(&mut self) {
+            if let Some(kernel) = K::new() {
+                self.kernels.push(Box::new(kernel))
+            }
+        }
+
+        /// Run benchmarks for all registered kernels.
+        ///
+        /// Set the `RTEN_BENCH_FILTER` environment variable to filter tests
+        /// by kernel name.
+        fn run_bench(&self)
+        where
+            LhsT: Clone + Default,
+            RhsT: Clone + Default,
+            OutT: Clone + Default,
+            XorShiftRng: RandomSource<RhsT> + RandomSource<LhsT>,
+        {
+            let filter = std::env::var("RTEN_BENCH_FILTER").ok();
+
+            for kernel in &self.kernels {
+                let filter_match = filter
+                    .as_ref()
+                    .map(|f| kernel.name().contains(f))
+                    .unwrap_or(true);
+                if !filter_match {
+                    continue;
+                }
+
+                run_kernel_bench(kernel.as_ref())
+            }
+        }
+    }
+
     #[test]
     #[ignore]
-    fn bench_kernel_int8() {
-        let mut kernels: Vec<Box<dyn Kernel<u8, i8, i32>>> = Vec::new();
+    fn bench_kernel_f32() {
+        let mut kernels = KernelBench::<f32, f32, f32>::new();
 
-        macro_rules! add_kernel {
-            ($kernel:ty) => {
-                if let Some(kernel) = <$kernel>::new() {
-                    kernels.push(Box::new(kernel));
-                }
-            };
-        }
+        kernels.add::<super::generic::GenericKernel>();
 
         #[cfg(target_arch = "aarch64")]
         {
-            add_kernel!(super::aarch64::ArmInt8Kernel);
-            add_kernel!(super::aarch64::ArmInt8DotKernel);
-            add_kernel!(super::aarch64::ArmInt8MMKernel);
+            kernels.add::<super::aarch64::ArmNeonKernel>();
         }
 
-        for kernel in kernels {
-            run_kernel_bench(&*kernel);
+        #[cfg(target_arch = "x86_64")]
+        {
+            kernels.add::<super::x86_64::FmaKernel>();
+            #[cfg(feature = "avx512")]
+            kernels.add::<super::x86_64::Avx512Kernel>();
         }
+
+        #[cfg(target_arch = "wasm32")]
+        #[cfg(target_feature = "simd128")]
+        {
+            kernels.add::<super::wasm::WasmKernel>();
+        }
+
+        kernels.run_bench();
+    }
+
+    #[test]
+    #[ignore]
+    fn bench_kernel_int8() {
+        let mut kernels = KernelBench::<u8, i8, i32>::new();
+
+        kernels.add::<super::generic::GenericKernel>();
+
+        #[cfg(target_arch = "aarch64")]
+        {
+            kernels.add::<super::aarch64::ArmInt8Kernel>();
+            kernels.add::<super::aarch64::ArmInt8DotKernel>();
+            kernels.add::<super::aarch64::ArmInt8MMKernel>();
+        }
+
+        #[cfg(target_arch = "x86_64")]
+        {
+            kernels.add::<super::x86_64::Avx2Int8Kernel>();
+            #[cfg(feature = "avx512")]
+            kernels.add::<super::x86_64::Avx512Int8Kernel>();
+        }
+
+        #[cfg(target_arch = "wasm32")]
+        #[cfg(target_feature = "simd128")]
+        {
+            kernels.add::<super::wasm::WasmInt8Kernel>();
+        }
+
+        kernels.run_bench();
     }
 }

--- a/rten-gemm/src/kernels/aarch64.rs
+++ b/rten-gemm/src/kernels/aarch64.rs
@@ -37,7 +37,7 @@ unsafe impl Kernel<f32, f32, f32> for ArmNeonKernel {
     }
 
     fn name(&self) -> &'static str {
-        "arm-neon"
+        "aarch64-f32-neon"
     }
 
     fn mr(&self) -> usize {
@@ -288,7 +288,7 @@ unsafe impl Kernel<u8, i8, i32> for ArmInt8DotKernel {
     }
 
     fn name(&self) -> &'static str {
-        "arm-int8-udot"
+        "aarch64-u8i8i32-dotprod"
     }
 
     impl_arm_int8_common!(ArmInt8DotKernel);
@@ -367,7 +367,7 @@ unsafe impl Kernel<u8, i8, i32> for ArmInt8Kernel {
     }
 
     fn name(&self) -> &'static str {
-        "arm-int8"
+        "aarch64-u8i8i32"
     }
 
     impl_arm_int8_common!(ArmInt8Kernel);
@@ -588,7 +588,7 @@ unsafe impl Kernel<u8, i8, i32> for ArmInt8MMKernel {
     }
 
     fn name(&self) -> &'static str {
-        "arm-int8-i8mm"
+        "aarch64-u8i8i32-i8mm"
     }
 
     fn mr(&self) -> usize {

--- a/rten-gemm/src/kernels/generic.rs
+++ b/rten-gemm/src/kernels/generic.rs
@@ -45,7 +45,7 @@ unsafe impl Kernel<f32, f32, f32> for GenericKernel {
     }
 
     fn name(&self) -> &'static str {
-        "base"
+        "generic-f32"
     }
 
     fn packed_a_layout(
@@ -197,7 +197,7 @@ unsafe impl Kernel<u8, i8, i32> for GenericKernel {
     }
 
     fn name(&self) -> &'static str {
-        "generic-i8"
+        "generic-u8i8i32"
     }
 
     fn packed_a_layout(

--- a/rten-gemm/src/kernels/wasm.rs
+++ b/rten-gemm/src/kernels/wasm.rs
@@ -34,7 +34,7 @@ unsafe impl Kernel<f32, f32, f32> for WasmKernel {
     }
 
     fn name(&self) -> &'static str {
-        "wasm32"
+        "wasm-f32"
     }
 
     fn mr(&self) -> usize {
@@ -196,7 +196,7 @@ unsafe impl Kernel<u8, i8, i32> for WasmInt8Kernel {
     }
 
     fn name(&self) -> &'static str {
-        "wasm-int8"
+        "wasm-u8i8i32"
     }
 
     fn mr(&self) -> usize {

--- a/rten-gemm/src/kernels/x86_64.rs
+++ b/rten-gemm/src/kernels/x86_64.rs
@@ -65,7 +65,7 @@ unsafe impl Kernel<f32, f32, f32> for FmaKernel {
     }
 
     fn name(&self) -> &'static str {
-        "fma"
+        "x86_64-f32-fma"
     }
 
     fn mr(&self) -> usize {
@@ -274,7 +274,7 @@ unsafe impl Kernel<f32, f32, f32> for Avx512Kernel {
     }
 
     fn name(&self) -> &'static str {
-        "avx512"
+        "x86_64-f32-avx512"
     }
 
     fn mr(&self) -> usize {
@@ -475,7 +475,7 @@ unsafe impl Kernel<u8, i8, i32> for Avx2Int8Kernel {
     }
 
     fn name(&self) -> &'static str {
-        "avx2-int8"
+        "x86_64-u8i8i32-avx2"
     }
 
     fn mr(&self) -> usize {
@@ -702,7 +702,7 @@ unsafe impl Kernel<u8, i8, i32> for Avx512Int8Kernel {
     }
 
     fn name(&self) -> &'static str {
-        "avx512-int8"
+        "x86_64-u8i8i32-avx512"
     }
 
     fn mr(&self) -> usize {


### PR DESCRIPTION
Extend https://github.com/robertknight/rten/pull/827 by adding benchmarks for f32 kernels and non-Arm platforms. Also use a consistent naming scheme for kernel identifiers across the different platforms (`{arch}-{dtypes}-{variant}`).