### PR TITLE
Add int8 GEMM kernel using UMLAL/UMLAL2 instructions

### DIFF
--- a/rten-gemm/src/kernels.rs
+++ b/rten-gemm/src/kernels.rs
@@ -172,6 +172,10 @@ pub unsafe trait Kernel<LhsT, RhsT, OutT>: Sync {
 
     /// Step size used when packing an image usage [`pack_im2col`](Kernel::pack_im2col).
     ///
+    /// This should match the K tile size used when packing the RHS / B matrix.
+    /// For example, if RHS packing pads the K dimension to a multiple of 4,
+    /// then `im2col_row_count_step` would also be 4.
+    ///
     /// The length of the offset arrays in [`Im2Col::row_offsets`] must be a
     /// multiple of this.
     fn im2col_row_count_step(&self) -> usize {
@@ -646,7 +650,7 @@ mod tests {
 
         #[cfg(target_arch = "aarch64")]
         {
-            kernels.add::<super::aarch64::ArmInt8Kernel>();
+            kernels.add::<super::aarch64::ArmInt8MlalKernel>();
             kernels.add::<super::aarch64::ArmInt8DotKernel>();
             kernels.add::<super::aarch64::ArmInt8MMKernel>();
         }

--- a/rten-gemm/src/lib.rs
+++ b/rten-gemm/src/lib.rs
@@ -484,7 +484,7 @@ impl WithKernel for GemmExecutor<u8, i8, i32> {
             #[cfg(target_arch = "x86_64")]
             Int8KernelType::Avx2 => Self::from_kernel::<kernels::x86_64::Avx2Int8Kernel>(),
             #[cfg(target_arch = "aarch64")]
-            Int8KernelType::ArmNeon => Self::from_kernel::<kernels::aarch64::ArmInt8Kernel>(),
+            Int8KernelType::ArmNeon => Self::from_kernel::<kernels::aarch64::ArmInt8MlalKernel>(),
             #[cfg(target_arch = "aarch64")]
             Int8KernelType::ArmDot => Self::from_kernel::<kernels::aarch64::ArmInt8DotKernel>(),
             #[cfg(target_arch = "aarch64")]

--- a/rten-simd/src/arch/generic.rs
+++ b/rten-simd/src/arch/generic.rs
@@ -30,6 +30,7 @@ simd_type!(I16x8, i16, LEN_X32 * 2);
 simd_type!(I8x16, i8, LEN_X32 * 4);
 simd_type!(U8x16, u8, LEN_X32 * 4);
 simd_type!(U16x8, u16, LEN_X32 * 2);
+simd_type!(U32x4, u32, LEN_X32);
 
 // Define mask vector types. `Mn` is a mask for a vector with n-bit lanes.
 simd_type!(M32, i32, LEN_X32);
@@ -61,6 +62,7 @@ unsafe impl Isa for GenericIsa {
     type I8 = I8x16;
     type U8 = U8x16;
     type U16 = U16x8;
+    type U32 = U32x4;
     type Bits = I32x4;
 
     fn f32(self) -> impl FloatOps<f32, Simd = Self::F32, Int = Self::I32> {
@@ -91,7 +93,7 @@ unsafe impl Isa for GenericIsa {
         self
     }
 
-    fn u8(self) -> impl NumOps<u8, Simd = Self::U8> {
+    fn u8(self) -> impl Extend<u8, Output = Self::U16, Simd = Self::U8> {
         self
     }
 
@@ -367,6 +369,7 @@ macro_rules! impl_extend {
 }
 impl_extend!(I8x16, i8, I16x8);
 impl_extend!(I16x8, i16, I32x4);
+impl_extend!(U8x16, u8, U16x8);
 
 macro_rules! impl_concat {
     ($elem:ty, $simd:ty) => {
@@ -522,3 +525,4 @@ impl_simd!(I16x8, i16, M16, 8);
 impl_simd!(I8x16, i8, M8, 16);
 impl_simd!(U8x16, u8, M8, 16);
 impl_simd!(U16x8, u16, M16, 8);
+impl_simd!(U32x4, u32, M32, 4);

--- a/rten-simd/src/arch/x86_64/avx2.rs
+++ b/rten-simd/src/arch/x86_64/avx2.rs
@@ -35,6 +35,7 @@ simd_type!(I16x16, __m256i, i16, I16x16, Avx2Isa);
 simd_type!(I8x32, __m256i, i8, I8x32, Avx2Isa);
 simd_type!(U8x32, __m256i, u8, I8x32, Avx2Isa);
 simd_type!(U16x16, __m256i, u16, I16x16, Avx2Isa);
+simd_type!(U32x8, __m256i, u32, I32x8, Avx2Isa);
 
 #[derive(Copy, Clone)]
 pub struct Avx2Isa {
@@ -59,6 +60,7 @@ unsafe impl Isa for Avx2Isa {
     type I8 = I8x32;
     type U8 = U8x32;
     type U16 = U16x16;
+    type U32 = U32x8;
     type Bits = I32x8;
 
     fn f32(self) -> impl FloatOps<f32, Simd = Self::F32, Int = Self::I32> {
@@ -89,7 +91,7 @@ unsafe impl Isa for Avx2Isa {
         self
     }
 
-    fn u8(self) -> impl NumOps<u8, Simd = Self::U8> {
+    fn u8(self) -> impl NumOps<u8, Simd = Self::U8> + Extend<u8, Output = Self::U16> {
         self
     }
 

--- a/rten-simd/src/arch/x86_64/avx512.rs
+++ b/rten-simd/src/arch/x86_64/avx512.rs
@@ -36,6 +36,7 @@ simd_type!(I16x32, __m512i, i16, __mmask32, Avx512Isa);
 simd_type!(I8x64, __m512i, i8, __mmask64, Avx512Isa);
 simd_type!(U8x64, __m512i, u8, __mmask64, Avx512Isa);
 simd_type!(U16x32, __m512i, u16, __mmask32, Avx512Isa);
+simd_type!(U32x16, __m512i, u32, __mmask16, Avx512Isa);
 
 #[derive(Copy, Clone)]
 pub struct Avx512Isa {
@@ -60,6 +61,7 @@ unsafe impl Isa for Avx512Isa {
     type I8 = I8x64;
     type U8 = U8x64;
     type U16 = U16x32;
+    type U32 = U32x16;
     type Bits = I32x16;
 
     fn f32(self) -> impl FloatOps<f32, Simd = Self::F32, Int = Self::I32> {
@@ -90,7 +92,7 @@ unsafe impl Isa for Avx512Isa {
         self
     }
 
-    fn u8(self) -> impl NumOps<u8, Simd = Self::U8> {
+    fn u8(self) -> impl NumOps<u8, Simd = Self::U8> + Extend<u8, Output = Self::U16> {
         self
     }
 

--- a/rten-simd/src/elem.rs
+++ b/rten-simd/src/elem.rs
@@ -27,6 +27,7 @@ impl_elem_for_int!(i16);
 impl_elem_for_int!(i8);
 impl_elem_for_int!(u8);
 impl_elem_for_int!(u16);
+impl_elem_for_int!(u32);
 
 /// Wrapping addition of numbers.
 ///
@@ -55,6 +56,7 @@ impl_wrapping_add!(i16);
 impl_wrapping_add!(i8);
 impl_wrapping_add!(u8);
 impl_wrapping_add!(u16);
+impl_wrapping_add!(u32);
 
 impl WrappingAdd for f32 {
     type Output = Self;

--- a/rten-simd/src/ops.rs
+++ b/rten-simd/src/ops.rs
@@ -50,6 +50,9 @@ pub unsafe trait Isa: Copy {
     /// SIMD vector with `u16` elements.
     type U16: Simd<Elem = u16, Isa = Self>;
 
+    /// SIMD vector with `u32` elements.
+    type U32: Simd<Elem = u32, Isa = Self>;
+
     /// Operations on SIMD vectors with `f32` elements.
     fn f32(self) -> impl FloatOps<f32, Simd = Self::F32, Int = Self::I32>;
 
@@ -74,7 +77,7 @@ pub unsafe trait Isa: Copy {
     ) -> impl SignedIntOps<i8, Simd = Self::I8> + Extend<i8, Output = Self::I16> + Interleave<i8>;
 
     /// Operations on SIMD vectors with `u8` elements.
-    fn u8(self) -> impl NumOps<u8, Simd = Self::U8>;
+    fn u8(self) -> impl Extend<u8, Output = Self::U16, Simd = Self::U8>;
 
     /// Operations on SIMD vectors with `u16` elements.
     fn u16(self) -> impl IntOps<u16, Simd = Self::U16>;
@@ -1211,6 +1214,7 @@ mod tests {
     }
     test_extend!(test_extend_i8_i16, i8, i16);
     test_extend!(test_extend_i16_i32, i16, i32);
+    test_extend!(test_extend_u8_u16, u8, u16);
 
     macro_rules! test_interleave {
         ($test_name:ident, $elem:ident) => {


### PR DESCRIPTION
Replace the existing GEMM kernel for older Arm CPUs which don't support the dotprod extension with one that uses UMLAL/UMLAL2 instructions.

The previous kernel used an instruction sequence which emulated UDOT.  The inner
loop of the new one computes an outer product of 8 elements of A with 8 elements
of B, similar to how the f32 kernels work.

The new kernel still uses the same matrix-vector/GEMV implementation as the old one. Only matrix-matrix products have been improved. Improving that has been left for a follow-up.

---

The new kernel is ~45% faster on a high end CPU (M3 Pro) and approximately 1/4 the speed of the UDOT / I8MM kernels in the microkernel benchmark, which aligns with expectations. On a low end CPU (Raspberry Pi 2 Zero / Arm Cortex A53), the new kernel is about 50% better.