### PR TITLE
Fix WASM relaxed-simd and no-SIMD builds and overhaul targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,9 @@ jobs:
       if: ${{ matrix.os == 'ubuntu-latest' }}
     - name: Test (WASM)
       run: |
-        make wasm-test wasm-test-simd
+        make wasm-test
+        make wasm-test PACKAGE=rten-simd
+        make wasm-test PACKAGE=rten-gemm
       if: ${{ matrix.os == 'ubuntu-latest' }}
     - name: Build (Intel macOS)
       run: cargo check --workspace --target x86_64-apple-darwin

--- a/rten-gemm/src/lib.rs
+++ b/rten-gemm/src/lib.rs
@@ -544,6 +544,7 @@ impl Default for GemmExecutor<u8, i8, i32> {
             try_kernel!(Int8KernelType::ArmNeon);
         }
         #[cfg(target_arch = "wasm32")]
+        #[cfg(target_feature = "simd128")]
         {
             try_kernel!(Int8KernelType::Wasm);
         }

--- a/rten-simd/src/arch/wasm32.rs
+++ b/rten-simd/src/arch/wasm32.rs
@@ -14,6 +14,9 @@ use std::arch::wasm32::{
 };
 use std::mem::transmute;
 
+#[cfg(target_feature = "relaxed-simd")]
+use std::arch::wasm32::f32x4_relaxed_madd;
+
 use super::{lanes, simd_type};
 use crate::ops::{
     Concat, Extend, FloatOps, IntOps, Interleave, MaskOps, NarrowSaturate, NumOps, SignedIntOps,


### PR DESCRIPTION
Fix the WASM builds which don't use the default target features (relaxed-simd enabled or simd128 disabled) and overhaul the associated Makefile targets.

 - Add missing import for `f32x4_relaxed_madd` in rten-simd
 - Add missing `simd128` target feature check in rten-gemm
 - Overhaul the WASM-related Makefile targets to make it easier to run tests and benchmarks against different crates and with different WASM features enabled.