### PR TITLE
Fix identity fusions not removing old operator from graph

### DIFF
--- a/src/optimize/fusions.rs
+++ b/src/optimize/fusions.rs
@@ -84,9 +84,9 @@ impl Fusion {
         match self {
             Fusion::Op(op) => op.output_ids.iter().copied().flatten().collect(),
             Fusion::Identity {
-                input_id,
-                output_id: _,
-            } => [*input_id].into(),
+                input_id: _,
+                output_id,
+            } => [*output_id].into(),
             Fusion::Constant { output_id, .. } => [*output_id].into(),
         }
     }


### PR DESCRIPTION
`Fusion::output_ids` returned the wrong value for identity fusions. As a result the list of operators to remove after applying the fusion was computed incorrectly in `GraphMutator::apply_fusion`. Consumers of the identity operator's output were still updated, but the identity operator itself was still left in the graph. This could subsequently prevent other fusions from being applied.

For example, given:

```
MatMul(Mul(Transpose(A), 1.0), Mul(Transpose(B), 1.0))
```

The result should be:

```
TransformInputs<MatMul>(A, B)
```

But the MatMul + Transpose did not get fused because the identity `Mul` operator was not properly removed from the graph.