### PR TITLE
Support IsInf and IsNaN operators

### DIFF
--- a/rten-convert/rten_convert/converter.py
+++ b/rten-convert/rten_convert/converter.py
@@ -510,6 +510,11 @@ def op_node_from_onnx_operator(
             attrs = sg.BatchNormalizationAttrsT()
             attrs.epsilon = attr_reader.get_attr("epsilon", "float", 1e-5)
 
+        case "IsInf":
+            attrs = sg.IsInfAttrsT()
+            attr_reader.check_attr("detect_positive", "int", 1)
+            attr_reader.check_attr("detect_negative", "int", 1)
+
         case "LayerNormalization":
             attrs = sg.LayerNormalizationAttrsT()
             attrs.axis = attr_reader.get_attr("axis", "int", -1)

--- a/rten-convert/rten_convert/schema_generated.py
+++ b/rten-convert/rten_convert/schema_generated.py
@@ -121,6 +121,8 @@ class OperatorType(object):
     CastLike = 111
     Dropout = 112
     EyeLike = 113
+    IsNaN = 114
+    IsInf = 115
 
 
 class RNNDirection(object):
@@ -209,6 +211,7 @@ class OperatorAttrs(object):
     ShapeAttrs = 45
     DropoutAttrs = 46
     EyeLikeAttrs = 47
+    IsInfAttrs = 48
 
 def OperatorAttrsCreator(unionType, table):
     from flatbuffers.table import Table
@@ -308,6 +311,8 @@ def OperatorAttrsCreator(unionType, table):
         return DropoutAttrsT.InitFromBuf(table.Bytes, table.Pos)
     if unionType == OperatorAttrs.EyeLikeAttrs:
         return EyeLikeAttrsT.InitFromBuf(table.Bytes, table.Pos)
+    if unionType == OperatorAttrs.IsInfAttrs:
+        return IsInfAttrsT.InitFromBuf(table.Bytes, table.Pos)
     return None
 
 
@@ -1291,6 +1296,71 @@ class EyeLikeAttrsT(object):
         EyeLikeAttrsAddK(builder, self.k)
         eyeLikeAttrs = EyeLikeAttrsEnd(builder)
         return eyeLikeAttrs
+
+
+class IsInfAttrs(object):
+    __slots__ = ['_tab']
+
+    @classmethod
+    def GetRootAs(cls, buf, offset=0):
+        n = flatbuffers.encode.Get(flatbuffers.packer.uoffset, buf, offset)
+        x = IsInfAttrs()
+        x.Init(buf, n + offset)
+        return x
+
+    @classmethod
+    def GetRootAsIsInfAttrs(cls, buf, offset=0):
+        """This method is deprecated. Please switch to GetRootAs."""
+        return cls.GetRootAs(buf, offset)
+    @classmethod
+    def IsInfAttrsBufferHasIdentifier(cls, buf, offset, size_prefixed=False):
+        return flatbuffers.util.BufferHasIdentifier(buf, offset, b"\x52\x54\x45\x4E", size_prefixed=size_prefixed)
+
+    # IsInfAttrs
+    def Init(self, buf, pos):
+        self._tab = flatbuffers.table.Table(buf, pos)
+
+def IsInfAttrsStart(builder):
+    builder.StartObject(0)
+
+def IsInfAttrsEnd(builder):
+    return builder.EndObject()
+
+
+
+class IsInfAttrsT(object):
+
+    # IsInfAttrsT
+    def __init__(self):
+        pass
+
+    @classmethod
+    def InitFromBuf(cls, buf, pos):
+        isInfAttrs = IsInfAttrs()
+        isInfAttrs.Init(buf, pos)
+        return cls.InitFromObj(isInfAttrs)
+
+    @classmethod
+    def InitFromPackedBuf(cls, buf, pos=0):
+        n = flatbuffers.encode.Get(flatbuffers.packer.uoffset, buf, pos)
+        return cls.InitFromBuf(buf, pos+n)
+
+    @classmethod
+    def InitFromObj(cls, isInfAttrs):
+        x = IsInfAttrsT()
+        x._UnPack(isInfAttrs)
+        return x
+
+    # IsInfAttrsT
+    def _UnPack(self, isInfAttrs):
+        if isInfAttrs is None:
+            return
+
+    # IsInfAttrsT
+    def Pack(self, builder):
+        IsInfAttrsStart(builder)
+        isInfAttrs = IsInfAttrsEnd(builder)
+        return isInfAttrs
 
 
 class IntScalar(object):
@@ -5521,7 +5591,7 @@ class OperatorNodeT(object):
     def __init__(self):
         self.type = 0  # type: int
         self.attrsType = 0  # type: int
-        self.attrs = None  # type: Union[None, ArgMaxAttrsT, AveragePoolAttrsT, BatchNormalizationAttrsT, CastAttrsT, ConcatAttrsT, ConstantOfShapeAttrsT, ConvAttrsT, ConvTransposeAttrsT, FlattenAttrsT, GatherAttrsT, GemmAttrsT, GRUAttrsT, LeakyReluAttrsT, LSTMAttrsT, MaxPoolAttrsT, ReduceMeanAttrsT, ReshapeAttrsT, ResizeAttrsT, SplitAttrsT, SoftmaxAttrsT, TransposeAttrsT, ModAttrsT, ScatterElementsAttrsT, OneHotAttrsT, TopKAttrsT, HardSigmoidAttrsT, TriluAttrsT, ScatterNDAttrsT, NonMaxSuppressionAttrsT, LayerNormalizationAttrsT, RandomUniformAttrsT, EluAttrsT, RandomUniformLikeAttrsT, RandomNormalAttrsT, RandomNormalLikeAttrsT, GatherNDAttrsT, GeluAttrsT, EinsumAttrsT, IfAttrsT, PadAttrsT, DequantizeLinearAttrsT, QuantizeLinearAttrsT, DepthToSpaceAttrsT, CastLikeAttrsT, ShapeAttrsT, DropoutAttrsT, EyeLikeAttrsT]
+        self.attrs = None  # type: Union[None, ArgMaxAttrsT, AveragePoolAttrsT, BatchNormalizationAttrsT, CastAttrsT, ConcatAttrsT, ConstantOfShapeAttrsT, ConvAttrsT, ConvTransposeAttrsT, FlattenAttrsT, GatherAttrsT, GemmAttrsT, GRUAttrsT, LeakyReluAttrsT, LSTMAttrsT, MaxPoolAttrsT, ReduceMeanAttrsT, ReshapeAttrsT, ResizeAttrsT, SplitAttrsT, SoftmaxAttrsT, TransposeAttrsT, ModAttrsT, ScatterElementsAttrsT, OneHotAttrsT, TopKAttrsT, HardSigmoidAttrsT, TriluAttrsT, ScatterNDAttrsT, NonMaxSuppressionAttrsT, LayerNormalizationAttrsT, RandomUniformAttrsT, EluAttrsT, RandomUniformLikeAttrsT, RandomNormalAttrsT, RandomNormalLikeAttrsT, GatherNDAttrsT, GeluAttrsT, EinsumAttrsT, IfAttrsT, PadAttrsT, DequantizeLinearAttrsT, QuantizeLinearAttrsT, DepthToSpaceAttrsT, CastLikeAttrsT, ShapeAttrsT, DropoutAttrsT, EyeLikeAttrsT, IsInfAttrsT]
         self.inputs = None  # type: List[int]
         self.outputs = None  # type: List[int]
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -1497,6 +1497,8 @@ mod tests {
         add_operator!(InstanceNormalization, [
             input_node, instance_norm_scale, instance_norm_bias
         ], { epsilon: Some(1e-5) });
+        add_operator!(IsInf, [input_node]);
+        add_operator!(IsNaN, [input_node]);
 
         let layer_norm_scale_val = Tensor::full(&[input_shape[input_shape.len() - 1]], 1.);
         let layer_norm_scale = graph_builder.add_constant(layer_norm_scale_val.view());

--- a/src/model_builder.rs
+++ b/src/model_builder.rs
@@ -77,6 +77,8 @@ pub enum OpType<'a> {
     Identity,
     If(IfArgs<'a>),
     InstanceNormalization(InstanceNormalization),
+    IsInf,
+    IsNaN,
     LayerNormalization(LayerNormalization),
     LeakyRelu(LeakyRelu),
     Less,
@@ -662,6 +664,8 @@ impl<'mb, 'a> GraphBuilder<'mb, 'a> {
                     epsilon: args.epsilon.unwrap_or(1e-5)
                 }
             ),
+            OpType::IsInf => op_with_attrs!(IsInf, IsInfAttrs, sg::IsInfAttrsArgs {}),
+            OpType::IsNaN => op!(IsNaN),
             OpType::LayerNormalization(args) => op_with_attrs!(
                 LayerNormalization,
                 LayerNormalizationAttrs,

--- a/src/op_registry.rs
+++ b/src/op_registry.rs
@@ -135,6 +135,8 @@ impl OpRegistry {
         register_op!(Identity);
         register_op!(If);
         register_op!(InstanceNormalization);
+        register_op!(IsInf);
+        register_op!(IsNaN);
         register_op!(LayerNormalization);
         register_op!(LeakyRelu);
         register_op!(Less);
@@ -663,6 +665,10 @@ impl_read_op!(
         })
     }
 );
+impl_read_op!(IsInf, attrs_as_is_inf_attrs, |_attrs: sg::IsInfAttrs| {
+    Ok(ops::IsInf {})
+});
+impl_read_op!(IsNaN);
 impl_read_op!(
     LayerNormalization,
     attrs_as_layer_normalization_attrs,

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -119,8 +119,8 @@ pub use unary_elementwise::{
     abs, acos, asin, atan, ceil, clip, cos, elu, erf, exp, floor, gelu, hard_sigmoid, hard_swish,
     leaky_relu, log, neg, not, reciprocal, relu, round, sigmoid, sign, silu, sin, softplus, sqrt,
     swish, tan, tanh, Abs, Acos, Asin, Atan, Ceil, Clip, Cos, Elu, Erf, Exp, Floor, Gelu,
-    HardSigmoid, HardSwish, LeakyRelu, Log, Neg, Not, Reciprocal, Relu, Round, Sigmoid, Sign, Silu,
-    Sin, Softplus, Sqrt, Swish, Tan, Tanh,
+    HardSigmoid, HardSwish, IsInf, IsNaN, LeakyRelu, Log, Neg, Not, Reciprocal, Relu, Round,
+    Sigmoid, Sign, Silu, Sin, Softplus, Sqrt, Swish, Tan, Tanh,
 };
 pub use variadic_elementwise::{max, mean, min, sum, Max, Mean, Min, Sum};
 

--- a/src/schema.fbs
+++ b/src/schema.fbs
@@ -127,6 +127,8 @@ enum OperatorType: ubyte {
   CastLike,
   Dropout,
   EyeLike,
+  IsNaN,
+  IsInf,
 }
 
 enum RNNDirection: ubyte {
@@ -226,6 +228,7 @@ union OperatorAttrs {
   ShapeAttrs,
   DropoutAttrs,
   EyeLikeAttrs,
+  IsInfAttrs,
 }
 
 table ArgMaxAttrs {
@@ -279,6 +282,10 @@ table EyeLikeAttrs {
   dtype:DataType = null;
   k:int;
 }
+
+// Not used, but reserved for supporting `detect_negative` and
+// `detect_positive` attrs.
+table IsInfAttrs {}
 
 union Scalar {
   IntScalar,

--- a/src/schema_generated.rs
+++ b/src/schema_generated.rs
@@ -18,13 +18,13 @@ pub const ENUM_MIN_OPERATOR_TYPE: u8 = 0;
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
-pub const ENUM_MAX_OPERATOR_TYPE: u8 = 113;
+pub const ENUM_MAX_OPERATOR_TYPE: u8 = 115;
 #[deprecated(
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 114] = [
+pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 116] = [
     OperatorType::Add,
     OperatorType::ArgMin,
     OperatorType::ArgMax,
@@ -139,6 +139,8 @@ pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 114] = [
     OperatorType::CastLike,
     OperatorType::Dropout,
     OperatorType::EyeLike,
+    OperatorType::IsNaN,
+    OperatorType::IsInf,
 ];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -260,9 +262,11 @@ impl OperatorType {
     pub const CastLike: Self = Self(111);
     pub const Dropout: Self = Self(112);
     pub const EyeLike: Self = Self(113);
+    pub const IsNaN: Self = Self(114);
+    pub const IsInf: Self = Self(115);
 
     pub const ENUM_MIN: u8 = 0;
-    pub const ENUM_MAX: u8 = 113;
+    pub const ENUM_MAX: u8 = 115;
     pub const ENUM_VALUES: &'static [Self] = &[
         Self::Add,
         Self::ArgMin,
@@ -378,6 +382,8 @@ impl OperatorType {
         Self::CastLike,
         Self::Dropout,
         Self::EyeLike,
+        Self::IsNaN,
+        Self::IsInf,
     ];
     /// Returns the variant's name or "" if unknown.
     pub fn variant_name(self) -> Option<&'static str> {
@@ -496,6 +502,8 @@ impl OperatorType {
             Self::CastLike => Some("CastLike"),
             Self::Dropout => Some("Dropout"),
             Self::EyeLike => Some("EyeLike"),
+            Self::IsNaN => Some("IsNaN"),
+            Self::IsInf => Some("IsInf"),
             _ => None,
         }
     }
@@ -1138,13 +1146,13 @@ pub const ENUM_MIN_OPERATOR_ATTRS: u8 = 0;
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
-pub const ENUM_MAX_OPERATOR_ATTRS: u8 = 47;
+pub const ENUM_MAX_OPERATOR_ATTRS: u8 = 48;
 #[deprecated(
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_OPERATOR_ATTRS: [OperatorAttrs; 48] = [
+pub const ENUM_VALUES_OPERATOR_ATTRS: [OperatorAttrs; 49] = [
     OperatorAttrs::NONE,
     OperatorAttrs::ArgMaxAttrs,
     OperatorAttrs::AveragePoolAttrs,
@@ -1193,6 +1201,7 @@ pub const ENUM_VALUES_OPERATOR_ATTRS: [OperatorAttrs; 48] = [
     OperatorAttrs::ShapeAttrs,
     OperatorAttrs::DropoutAttrs,
     OperatorAttrs::EyeLikeAttrs,
+    OperatorAttrs::IsInfAttrs,
 ];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -1248,9 +1257,10 @@ impl OperatorAttrs {
     pub const ShapeAttrs: Self = Self(45);
     pub const DropoutAttrs: Self = Self(46);
     pub const EyeLikeAttrs: Self = Self(47);
+    pub const IsInfAttrs: Self = Self(48);
 
     pub const ENUM_MIN: u8 = 0;
-    pub const ENUM_MAX: u8 = 47;
+    pub const ENUM_MAX: u8 = 48;
     pub const ENUM_VALUES: &'static [Self] = &[
         Self::NONE,
         Self::ArgMaxAttrs,
@@ -1300,6 +1310,7 @@ impl OperatorAttrs {
         Self::ShapeAttrs,
         Self::DropoutAttrs,
         Self::EyeLikeAttrs,
+        Self::IsInfAttrs,
     ];
     /// Returns the variant's name or "" if unknown.
     pub fn variant_name(self) -> Option<&'static str> {
@@ -1352,6 +1363,7 @@ impl OperatorAttrs {
             Self::ShapeAttrs => Some("ShapeAttrs"),
             Self::DropoutAttrs => Some("DropoutAttrs"),
             Self::EyeLikeAttrs => Some("EyeLikeAttrs"),
+            Self::IsInfAttrs => Some("IsInfAttrs"),
             _ => None,
         }
     }
@@ -3364,6 +3376,85 @@ impl core::fmt::Debug for EyeLikeAttrs<'_> {
         let mut ds = f.debug_struct("EyeLikeAttrs");
         ds.field("dtype", &self.dtype());
         ds.field("k", &self.k());
+        ds.finish()
+    }
+}
+pub enum IsInfAttrsOffset {}
+#[derive(Copy, Clone, PartialEq)]
+
+pub struct IsInfAttrs<'a> {
+    pub _tab: flatbuffers::Table<'a>,
+}
+
+impl<'a> flatbuffers::Follow<'a> for IsInfAttrs<'a> {
+    type Inner = IsInfAttrs<'a>;
+    #[inline]
+    unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self {
+            _tab: flatbuffers::Table::new(buf, loc),
+        }
+    }
+}
+
+impl<'a> IsInfAttrs<'a> {
+    #[inline]
+    pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+        IsInfAttrs { _tab: table }
+    }
+    #[allow(unused_mut)]
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
+        _args: &'args IsInfAttrsArgs,
+    ) -> flatbuffers::WIPOffset<IsInfAttrs<'bldr>> {
+        let mut builder = IsInfAttrsBuilder::new(_fbb);
+        builder.finish()
+    }
+}
+
+impl flatbuffers::Verifiable for IsInfAttrs<'_> {
+    #[inline]
+    fn run_verifier(
+        v: &mut flatbuffers::Verifier,
+        pos: usize,
+    ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+        use self::flatbuffers::Verifiable;
+        v.visit_table(pos)?.finish();
+        Ok(())
+    }
+}
+pub struct IsInfAttrsArgs {}
+impl<'a> Default for IsInfAttrsArgs {
+    #[inline]
+    fn default() -> Self {
+        IsInfAttrsArgs {}
+    }
+}
+
+pub struct IsInfAttrsBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+    fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
+    start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> IsInfAttrsBuilder<'a, 'b, A> {
+    #[inline]
+    pub fn new(
+        _fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
+    ) -> IsInfAttrsBuilder<'a, 'b, A> {
+        let start = _fbb.start_table();
+        IsInfAttrsBuilder {
+            fbb_: _fbb,
+            start_: start,
+        }
+    }
+    #[inline]
+    pub fn finish(self) -> flatbuffers::WIPOffset<IsInfAttrs<'a>> {
+        let o = self.fbb_.end_table(self.start_);
+        flatbuffers::WIPOffset::new(o.value())
+    }
+}
+
+impl core::fmt::Debug for IsInfAttrs<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut ds = f.debug_struct("IsInfAttrs");
         ds.finish()
     }
 }
@@ -9385,6 +9476,21 @@ impl<'a> OperatorNode<'a> {
             None
         }
     }
+
+    #[inline]
+    #[allow(non_snake_case)]
+    pub fn attrs_as_is_inf_attrs(&self) -> Option<IsInfAttrs<'a>> {
+        if self.attrs_type() == OperatorAttrs::IsInfAttrs {
+            self.attrs().map(|t| {
+                // Safety:
+                // Created from a valid Table for this object
+                // Which contains a valid union in this slot
+                unsafe { IsInfAttrs::init_from_table(t) }
+            })
+        } else {
+            None
+        }
+    }
 }
 
 impl flatbuffers::Verifiable for OperatorNode<'_> {
@@ -9445,6 +9551,7 @@ impl flatbuffers::Verifiable for OperatorNode<'_> {
           OperatorAttrs::ShapeAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<ShapeAttrs>>("OperatorAttrs::ShapeAttrs", pos),
           OperatorAttrs::DropoutAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<DropoutAttrs>>("OperatorAttrs::DropoutAttrs", pos),
           OperatorAttrs::EyeLikeAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<EyeLikeAttrs>>("OperatorAttrs::EyeLikeAttrs", pos),
+          OperatorAttrs::IsInfAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<IsInfAttrs>>("OperatorAttrs::IsInfAttrs", pos),
           _ => Ok(()),
         }
      })?
@@ -9992,6 +10099,16 @@ impl core::fmt::Debug for OperatorNode<'_> {
             }
             OperatorAttrs::EyeLikeAttrs => {
                 if let Some(x) = self.attrs_as_eye_like_attrs() {
+                    ds.field("attrs", &x)
+                } else {
+                    ds.field(
+                        "attrs",
+                        &"InvalidFlatbuffer: Union discriminant does not match value.",
+                    )
+                }
+            }
+            OperatorAttrs::IsInfAttrs => {
+                if let Some(x) = self.attrs_as_is_inf_attrs() {
                     ds.field("attrs", &x)
                 } else {
                     ds.field(


### PR DESCRIPTION
Add support for the IsInf and IsNaN operators, minus the optional `detect_negative` and `detect_positive` attrs for IsInf.

The Whisper model (and probably many others) exported with optimum 1.27 and transformers 4.53 now uses IsNaN.