### PR TITLE
Cache names of values captured by an operator's subgraphs

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1282,24 +1282,21 @@ impl Graph {
     fn operator_dependencies<'a>(
         &'a self,
         op_node: &'a OperatorNode,
-    ) -> impl Iterator<Item = NodeId> + Clone + 'a {
-        op_node.input_ids().iter().filter_map(|id| *id).chain(
-            op_node
-                .operator()
-                .subgraphs()
-                .into_iter()
-                .flat_map(|sg| sg.capture_names())
-                .filter_map(move |cap_name| {
-                    let cap_id = self.get_node_id(cap_name)?;
-                    if !op_node.input_ids().contains(&Some(cap_id)) {
-                        Some(cap_id)
-                    } else {
-                        // If the captured node is also used as an input,
-                        // only yield it once in the output.
-                        None
-                    }
-                }),
-        )
+    ) -> impl Iterator<Item = NodeId> + 'a {
+        op_node
+            .input_ids()
+            .iter()
+            .filter_map(|id| *id)
+            .chain(op_node.capture_names().filter_map(move |cap_name| {
+                let cap_id = self.get_node_id(cap_name)?;
+                if !op_node.input_ids().contains(&Some(cap_id)) {
+                    Some(cap_id)
+                } else {
+                    // If the captured node is also used as an input,
+                    // only yield it once in the output.
+                    None
+                }
+            }))
     }
 }
 

--- a/src/graph/planner.rs
+++ b/src/graph/planner.rs
@@ -1,4 +1,5 @@
 use rustc_hash::{FxHashMap, FxHashSet};
+use smallvec::SmallVec;
 
 use super::{Graph, Node, NodeId, OperatorNode, RunError};
 
@@ -368,11 +369,12 @@ impl<'a> Planner<'a> {
                 continue;
             };
 
-            let all_inputs = self.graph.operator_dependencies(op_node);
+            let all_inputs: SmallVec<[NodeId; 4]> =
+                self.graph.operator_dependencies(op_node).collect();
 
             let all_inputs_available = all_inputs
-                .clone()
-                .all(|input_id| resolved_values.contains(input_id));
+                .iter()
+                .all(|input_id| resolved_values.contains(*input_id));
 
             // Prune op if:
             //


### PR DESCRIPTION
`Graph::capture_names` was taking up ~1.7% of execution time with a Whisper base model, called via `Graph::run_plan => Graph::operator_dependencies`. Since an operator's subgraphs are immutable after an `OperatorNode` is created, we can cache capture names there. In the process replace some `Vec`s with boxed slices to keep the struct size down.

An alternative approach would be to cache operator dependencies (as `NodeId`s) directly for the whole graph, but that will require a bit more care with invalidation in case a captured value node is replaced.