### PR TITLE
Scale K block size with inverse element size

### DIFF
--- a/rten-gemm/src/prepack.rs
+++ b/rten-gemm/src/prepack.rs
@@ -173,7 +173,7 @@ pub fn prepack_a<A: Alloc, LhsT, RhsT, OutT>(
     alloc: A,
     a: Matrix<LhsT>,
 ) -> PackedAMatrix<LhsT> {
-    let depth_block = depth_block_size(a.cols());
+    let depth_block = depth_block_size::<RhsT>(a.cols());
 
     let layout = kernel.packed_a_layout(a, a.rows(), depth_block, None);
     let tail_layout = if a.cols() % depth_block != 0 {
@@ -229,7 +229,7 @@ pub fn prepack_b<A: Alloc, LhsT, RhsT, OutT>(
     alloc: A,
     b: Matrix<RhsT>,
 ) -> PackedBMatrix<RhsT> {
-    let depth_block = depth_block_size(b.rows());
+    let depth_block = depth_block_size::<RhsT>(b.rows());
 
     let layout = kernel.packed_b_layout(depth_block, b.cols(), None);
     let tail_layout = if b.rows() % depth_block != 0 {


### PR DESCRIPTION
Given the stated rationale for choosing the `kc` block size, it makes sense to choose a 4x larger value for an i8/u8 RHS than f32. This brings the peak flops reported by `bench_gemm_mix` for a single thread closer to the kernel peak reported by `bench_kernel_int8`.

```
$ set -x RAYON_NUM_THREADS 1
$ cargo test -p rten-gemm -r -- --ignored bench_gemm_mix --nocapture

# Before (M3 Pro)
Testing kernel aarch64-u8i8i32-i8mm
m 512 n 512 k 512 iters 512. Duration 402.160ms (0.785ms/iter). GFLOPS 341.8
m 1024 n 1024 k 1024 iters 64. Duration 371.713ms (5.808ms/iter). GFLOPS 369.7
m 128 n 2048 k 512 iters 512. Duration 487.530ms (0.952ms/iter). GFLOPS 281.9
m 2048 n 128 k 512 iters 512. Duration 449.805ms (0.879ms/iter). GFLOPS 305.6

# After
Testing kernel aarch64-u8i8i32-i8mm
m 512 n 512 k 512 iters 512. Duration 378.298ms (0.739ms/iter). GFLOPS 363.3
m 1024 n 1024 k 1024 iters 64. Duration 327.953ms (5.124ms/iter). GFLOPS 419.1
m 128 n 2048 k 512 iters 512. Duration 466.703ms (0.912ms/iter). GFLOPS 294.5
m 2048 n 128 k 512 iters 512. Duration 422.993ms (0.826ms/iter). GFLOPS 324.9
```