### PR TITLE
Add plumbing to support configurable optimizations

### DIFF
--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -315,6 +315,10 @@ fn find_operator_output_used_outside_subgraph(
     None
 }
 
+/// Configuration for [`GraphOptimizer::optimize`].
+#[derive(Clone, Default)]
+pub struct OptimizeOptions {}
+
 /// Applies optimizations to a [`Graph`] to enable faster inference.
 pub struct GraphOptimizer {}
 
@@ -335,6 +339,7 @@ impl GraphOptimizer {
         &self,
         graph: Graph,
         capture_env: Option<&CaptureEnv>,
+        _options: OptimizeOptions,
     ) -> Result<Graph, OptimizeError> {
         let mut graph_mut = GraphMutator::from_graph(graph);
 


### PR DESCRIPTION
This adds some plumbing to support runtime configuration for graph optimizations, rather than just being an on/off switch. There are no new options yet, just the existing on/off toggle.