### PR TITLE
Support `stash_type=1` attribute for LayerNormalization in rten-convert

### DIFF
--- a/rten-convert/rten_convert/converter.py
+++ b/rten-convert/rten_convert/converter.py
@@ -519,6 +519,7 @@ def op_node_from_onnx_operator(
             attrs = sg.LayerNormalizationAttrsT()
             attrs.axis = attr_reader.get_attr("axis", "int", -1)
             attrs.epsilon = attr_reader.get_attr("epsilon", "float", 1e-5)
+            attr_reader.check_attr("stash_type", "int", 1)
 
         case "LeakyRelu":
             attrs = sg.LeakyReluAttrsT()


### PR DESCRIPTION
Per the docs:

> Depending on stash_type attribute, the actual computation must happen in
> different floating-point precision. For example, if stash_type is 1, this
> operator casts all input variables to 32-bit float, perform the computation, and
> finally cast Normalized back to the original type of X

Since RTen only supports fp32 inputs for LayerNormalization, stash_type=1 is a no-op.