### PR TITLE
Support float16 -> float32 dtype promotion for values and attributes

### DIFF
--- a/rten-convert/rten_convert/converter.py
+++ b/rten-convert/rten_convert/converter.py
@@ -249,6 +249,8 @@ def convert_data_type(onnx_dtype: int) -> int:
     :param onnx_dtype: Data type from `TensorProto.DataType`.
     :return: Value from `sg.DataType`
     """
+
+    dtype_name = TensorProto.DataType.Name(onnx_dtype).lower()
     match onnx_dtype:
         case TensorProto.DataType.FLOAT:  # type:ignore[attr-defined]
             return sg.DataType.Float
@@ -262,6 +264,11 @@ def convert_data_type(onnx_dtype: int) -> int:
             return sg.DataType.Int8
         case TensorProto.DataType.UINT8:  # type:ignore[attr-defined]
             return sg.DataType.UInt8
+        case TensorProto.DataType.FLOAT16:  # type:ignore[attr-defined]
+            warn_once(
+                f"Changing value or attribute data type from {dtype_name} to float32 because {dtype_name} is not supported natively yet."
+            )
+            return sg.DataType.Float
         case _:
             raise ConversionError(f"Unsupported data type {onnx_dtype}")
 


### PR DESCRIPTION
The model converter already promotes weights from float16 to float32 because RTen doesn't support fp16 yet. Do the same for values and attributes (eg. the target type of the Cast operator).