### PR TITLE
Accept `saturate=1` attribute for Cast op

### DIFF
--- a/rten-convert/rten_convert/converter.py
+++ b/rten-convert/rten_convert/converter.py
@@ -367,6 +367,10 @@ def op_node_from_onnx_operator(
             )
             attrs.to = convert_data_type(to)
 
+            # Note: ONNX's "saturate" attribute only applies to FP8. Conversions
+            # to other types do not saturate, even if this attribute is 1.
+            attr_reader.check_attr("saturate", "int", 1)
+
         case "CastLike":
             attrs = sg.CastLikeAttrsT()
 


### PR DESCRIPTION
The `saturate` attribute only applies to FP8 data types, which RTen does not support. Ignore it during model conversion when set to the default value.

Spec: https://onnx.ai/onnx/operators/onnx__Cast.html#attributes