### PR TITLE
Support "edge" and "wrap" modes for Pad operator

### DIFF
--- a/rten-convert/rten_convert/schema_generated.py
+++ b/rten-convert/rten_convert/schema_generated.py
@@ -350,6 +350,8 @@ class NMSBoxOrder(object):
 class PadMode(object):
     Constant = 0
     Reflect = 1
+    Edge = 2
+    Wrap = 3
 
 
 class ScatterReduction(object):

--- a/src/op_registry.rs
+++ b/src/op_registry.rs
@@ -761,6 +761,8 @@ impl ReadOp for ops::Pad {
         let mode = match attrs.map(|a| a.mode()).unwrap_or(sg::PadMode::Constant) {
             sg::PadMode::Constant => PadMode::Constant,
             sg::PadMode::Reflect => PadMode::Reflect,
+            sg::PadMode::Edge => PadMode::Edge,
+            sg::PadMode::Wrap => PadMode::Wrap,
             _ => {
                 return Err(ReadOpError::AttrError {
                     attr: "mode",

--- a/src/schema.fbs
+++ b/src/schema.fbs
@@ -425,6 +425,8 @@ table OneHotAttrs {
 enum PadMode: ubyte {
   Constant,
   Reflect,
+  Edge,
+  Wrap,
 }
 
 table PadAttrs {

--- a/src/schema_generated.rs
+++ b/src/schema_generated.rs
@@ -1796,13 +1796,18 @@ pub const ENUM_MIN_PAD_MODE: u8 = 0;
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
-pub const ENUM_MAX_PAD_MODE: u8 = 1;
+pub const ENUM_MAX_PAD_MODE: u8 = 3;
 #[deprecated(
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_PAD_MODE: [PadMode; 2] = [PadMode::Constant, PadMode::Reflect];
+pub const ENUM_VALUES_PAD_MODE: [PadMode; 4] = [
+    PadMode::Constant,
+    PadMode::Reflect,
+    PadMode::Edge,
+    PadMode::Wrap,
+];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
@@ -1811,15 +1816,20 @@ pub struct PadMode(pub u8);
 impl PadMode {
     pub const Constant: Self = Self(0);
     pub const Reflect: Self = Self(1);
+    pub const Edge: Self = Self(2);
+    pub const Wrap: Self = Self(3);
 
     pub const ENUM_MIN: u8 = 0;
-    pub const ENUM_MAX: u8 = 1;
-    pub const ENUM_VALUES: &'static [Self] = &[Self::Constant, Self::Reflect];
+    pub const ENUM_MAX: u8 = 3;
+    pub const ENUM_VALUES: &'static [Self] =
+        &[Self::Constant, Self::Reflect, Self::Edge, Self::Wrap];
     /// Returns the variant's name or "" if unknown.
     pub fn variant_name(self) -> Option<&'static str> {
         match self {
             Self::Constant => Some("Constant"),
             Self::Reflect => Some("Reflect"),
+            Self::Edge => Some("Edge"),
+            Self::Wrap => Some("Wrap"),
             _ => None,
         }
     }


### PR DESCRIPTION
These are similar to "reflect" in that they fill the padding region with elements from the source, but differ in how they compute the source index ([spec](https://onnx.ai/onnx/operators/onnx__Pad.html#summary)).

The initial support for edge and wrap modes shares the same limitations as the reflect mode.

 - Refactor the "reflect" padding mode to use a trait for source index generation and add implementations for "edge" and "wrap" padding.

 - Refactor existing padding tests to use a common test case struct and and add tests for edge/wrap padding.