### PR TITLE
Support `output_padding` attribute for ConvTranspose

### DIFF
--- a/rten-convert/rten_convert/converter.py
+++ b/rten-convert/rten_convert/converter.py
@@ -430,7 +430,9 @@ def op_node_from_onnx_operator(
             # The kernel shape is inferred at runtime from the input weight tensor.
             attr_reader.ignore_attr("kernel_shape")
 
-            attr_reader.check_attr("output_padding", "ints", [0, 0, 0, 0])
+            attrs.outputPadding = attr_reader.get_attr(
+                "output_padding", "ints", default=None
+            )
             read_pads(attr_reader, attrs)
 
         case "CumSum":

--- a/rten-tensor/src/tensor/tests.rs
+++ b/rten-tensor/src/tensor/tests.rs
@@ -1033,7 +1033,7 @@ fn test_reshape() {
 }
 
 #[test]
-#[should_panic(expected = "reshape failed")]
+#[should_panic(expected = "element count mismatch reshaping [16] to [2, 2]")]
 fn test_reshape_invalid() {
     let mut tensor = Tensor::arange(0, 16, None);
     tensor.reshape(&[2, 2]);

--- a/src/model.rs
+++ b/src/model.rs
@@ -1420,6 +1420,7 @@ mod tests {
             strides: vec![2, 2],
             padding: [0, 0, 0, 0].into(),
             groups: 1,
+            output_padding: None,
         });
         add_operator!(Cos, [input_node]);
 

--- a/src/model_builder.rs
+++ b/src/model_builder.rs
@@ -526,8 +526,10 @@ impl<'mb, 'a> GraphBuilder<'mb, 'a> {
                 let pad_args = pad_args_from_padding(args.padding);
                 let pads = self.create_vec(pad_args.pads, |pad| pad as u32);
                 let strides = self.create_vec(Some(args.strides), |s| s as u32);
+                let output_padding = self.create_vec(args.output_padding, |s| s as u32);
                 sg::ConvTransposeAttrsArgs {
                     strides,
+                    output_padding,
                     auto_pad: pad_args.auto_pad,
                     pads,
                     groups: args.groups as u32,

--- a/src/op_registry.rs
+++ b/src/op_registry.rs
@@ -293,6 +293,10 @@ fn vec_from_attr(attr: Option<flatbuffers::Vector<u32>>, default: &[usize]) -> V
         .unwrap_or_else(|| default.to_vec())
 }
 
+fn opt_vec_from_attr(attr: Option<flatbuffers::Vector<u32>>) -> Option<Vec<usize>> {
+    attr.map(|val| val.iter().map(|x| x as usize).collect())
+}
+
 /// Result of deserializing an operator node from a model file.
 pub type ReadOpResult = Result<Arc<dyn Operator + Send + Sync>, ReadOpError>;
 
@@ -505,11 +509,13 @@ impl_read_op!(
     |attrs: sg::ConvTransposeAttrs| {
         let padding = padding_from_attrs(attrs.auto_pad(), attrs.pads());
         let strides = vec_from_attr(attrs.strides(), &[1, 1]);
+        let output_padding = opt_vec_from_attr(attrs.output_padding());
         let groups = attrs.groups() as usize;
         Ok(ops::ConvTranspose {
             padding,
             strides,
             groups,
+            output_padding,
         })
     }
 );

--- a/src/schema.fbs
+++ b/src/schema.fbs
@@ -324,6 +324,8 @@ table ConvTransposeAttrs {
   // Padding for spatial axes as [left, right] or [top, left, bottom, right]
   pads:[uint];
   groups:uint = 1;
+
+  output_padding:[uint];
 }
 
 table DequantizeLinearAttrs {

--- a/src/schema_generated.rs
+++ b/src/schema_generated.rs
@@ -4113,6 +4113,7 @@ impl<'a> ConvTransposeAttrs<'a> {
     pub const VT_AUTO_PAD: flatbuffers::VOffsetT = 6;
     pub const VT_PADS: flatbuffers::VOffsetT = 8;
     pub const VT_GROUPS: flatbuffers::VOffsetT = 10;
+    pub const VT_OUTPUT_PADDING: flatbuffers::VOffsetT = 12;
 
     #[inline]
     pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
@@ -4124,6 +4125,9 @@ impl<'a> ConvTransposeAttrs<'a> {
         args: &'args ConvTransposeAttrsArgs<'args>,
     ) -> flatbuffers::WIPOffset<ConvTransposeAttrs<'bldr>> {
         let mut builder = ConvTransposeAttrsBuilder::new(_fbb);
+        if let Some(x) = args.output_padding {
+            builder.add_output_padding(x);
+        }
         builder.add_groups(args.groups);
         if let Some(x) = args.pads {
             builder.add_pads(x);
@@ -4183,6 +4187,19 @@ impl<'a> ConvTransposeAttrs<'a> {
                 .unwrap()
         }
     }
+    #[inline]
+    pub fn output_padding(&self) -> Option<flatbuffers::Vector<'a, u32>> {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab
+                .get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u32>>>(
+                    ConvTransposeAttrs::VT_OUTPUT_PADDING,
+                    None,
+                )
+        }
+    }
 }
 
 impl flatbuffers::Verifiable for ConvTransposeAttrs<'_> {
@@ -4205,6 +4222,11 @@ impl flatbuffers::Verifiable for ConvTransposeAttrs<'_> {
                 false,
             )?
             .visit_field::<u32>("groups", Self::VT_GROUPS, false)?
+            .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, u32>>>(
+                "output_padding",
+                Self::VT_OUTPUT_PADDING,
+                false,
+            )?
             .finish();
         Ok(())
     }
@@ -4214,6 +4236,7 @@ pub struct ConvTransposeAttrsArgs<'a> {
     pub auto_pad: AutoPad,
     pub pads: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u32>>>,
     pub groups: u32,
+    pub output_padding: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u32>>>,
 }
 impl<'a> Default for ConvTransposeAttrsArgs<'a> {
     #[inline]
@@ -4223,6 +4246,7 @@ impl<'a> Default for ConvTransposeAttrsArgs<'a> {
             auto_pad: AutoPad::NotSet,
             pads: None,
             groups: 1,
+            output_padding: None,
         }
     }
 }
@@ -4253,6 +4277,16 @@ impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> ConvTransposeAttrsBuilder<'a, '
             .push_slot::<u32>(ConvTransposeAttrs::VT_GROUPS, groups, 1);
     }
     #[inline]
+    pub fn add_output_padding(
+        &mut self,
+        output_padding: flatbuffers::WIPOffset<flatbuffers::Vector<'b, u32>>,
+    ) {
+        self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(
+            ConvTransposeAttrs::VT_OUTPUT_PADDING,
+            output_padding,
+        );
+    }
+    #[inline]
     pub fn new(
         _fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
     ) -> ConvTransposeAttrsBuilder<'a, 'b, A> {
@@ -4276,6 +4310,7 @@ impl core::fmt::Debug for ConvTransposeAttrs<'_> {
         ds.field("auto_pad", &self.auto_pad());
         ds.field("pads", &self.pads());
         ds.field("groups", &self.groups());
+        ds.field("output_padding", &self.output_padding());
         ds.finish()
     }
 }


### PR DESCRIPTION
Support the [`output_padding`](https://onnx.ai/onnx/operators/onnx__ConvTranspose.html#attributes) attribute for ConvTranspose.