### PR TITLE
Change shape type for values from slice to SmallVec

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1047,7 +1047,7 @@ impl Graph {
 
             let op_result = if let Some(input) = in_place_input {
                 let input_dtype = input.dtype();
-                let input_shape: SmallVec<[usize; 4]> = SmallVec::from_slice(input.shape());
+                let input_shape = input.shape();
                 op_node
                     .operator()
                     .run_in_place(input, &ctx)

--- a/src/ops/generate.rs
+++ b/src/ops/generate.rs
@@ -192,7 +192,7 @@ impl Operator for EyeLike {
         let dtype = self.dtype.unwrap_or(input.dtype());
 
         map_dtype!(dtype, T, {
-            let shape: [usize; 2] = input.shape().try_into().map_err(|_| {
+            let shape: [usize; 2] = input.shape().as_ref().try_into().map_err(|_| {
                 OpError::from(DimensionError {
                     actual: input.ndim(),
                     expected: 2,

--- a/src/ops/layout.rs
+++ b/src/ops/layout.rs
@@ -167,8 +167,8 @@ impl Operator for Expand {
     fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<Value, OpError> {
         let shape = ctx.inputs().require_as(0)?;
 
-        let out_shape = expand_output_shape(input.shape(), &shape)?;
-        if input.shape() == out_shape.as_slice() {
+        let out_shape = expand_output_shape(&input.shape(), &shape)?;
+        if input.shape() == out_shape {
             return Ok(input);
         }
 

--- a/src/ops/resize.rs
+++ b/src/ops/resize.rs
@@ -450,10 +450,10 @@ impl Operator for Resize {
 
         let other = ctx.inputs();
         let target = target_from_scale_size_inputs(other, 1)?;
-        let output_size = calc_output_size(input.shape(), target)?;
+        let output_size = calc_output_size(&input.shape(), target)?;
 
         // If this is a no-op resize, just return the input.
-        if input.shape() == output_size {
+        if input.shape().as_slice() == output_size {
             return Ok(input);
         }
 
@@ -898,7 +898,7 @@ mod tests {
             let result = op.run(&ctx);
             match (&case.expected, result) {
                 (CaseOutput::Shape(shape), Ok(out)) => {
-                    assert_eq!(out[0].shape(), *&shape);
+                    assert_eq!(out[0].shape().as_slice(), shape.as_slice());
                 }
                 (CaseOutput::Error(expected_err), Err(err)) => {
                     assert_eq!(&err, expected_err);

--- a/src/wasm_api.rs
+++ b/src/wasm_api.rs
@@ -160,7 +160,7 @@ impl Tensor {
     }
 
     pub fn shape(&self) -> Vec<usize> {
-        self.data.shape().into()
+        self.data.shape().to_vec()
     }
 
     /// Return the elements of a float tensor in their logical order.
@@ -189,7 +189,7 @@ impl Tensor {
 /// Additional constructors and ONNX operators exposed as JS methods.
 #[wasm_bindgen]
 impl Tensor {
-    fn as_float(&self) -> Result<rten_tensor::TensorView<f32>, String> {
+    fn as_float(&self) -> Result<rten_tensor::TensorView<'_, f32>, String> {
         let Value::FloatTensor(ref a) = self.data.borrow() else {
             return Err("Expected a float tensor".to_string());
         };


### PR DESCRIPTION
Change the type returned by `<Value as Layout>::shape` and `<ValueView as Layout>::shape` from `[usize]` to `SmallVec<[usize; 4]>`.

This change will support the addition of new value types (eg. sequences) where the shape is not conveniently stored in a slice or array that we can get a reference to.

This does add overhead to each `shape` call, but this method is not called in performance-sensitive contexts.