### PR TITLE
Implement GridSample operator

### DIFF
--- a/rten-convert/rten_convert/converter.py
+++ b/rten-convert/rten_convert/converter.py
@@ -497,6 +497,12 @@ def op_node_from_onnx_operator(
             attrs.transposeA = bool(attr_reader.get_attr("transA", "int", 0))
             attrs.transposeB = bool(attr_reader.get_attr("transB", "int", 0))
 
+        case "GridSample":
+            attrs = sg.GridSampleAttrsT()
+            attr_reader.check_attr("align_corners", "int", 0)
+            attr_reader.check_attr("mode", "string", "bilinear")
+            attr_reader.check_attr("padding_mode", "string", "zeros")
+
         case "GRU":
             attrs = sg.GRUAttrsT()
             attrs.direction = attr_reader.get_enum_attr(

--- a/rten-convert/rten_convert/schema_generated.py
+++ b/rten-convert/rten_convert/schema_generated.py
@@ -132,6 +132,7 @@ class OperatorType(object):
     SequenceLength = 122
     SequenceConstruct = 123
     SequenceErase = 124
+    GridSample = 125
 
 
 class RNNDirection(object):
@@ -225,6 +226,7 @@ class OperatorAttrs(object):
     SequenceEmptyAttrs = 50
     ConcatFromSequenceAttrs = 51
     SplitToSequenceAttrs = 52
+    GridSampleAttrs = 53
 
 def OperatorAttrsCreator(unionType, table):
     from flatbuffers.table import Table
@@ -334,6 +336,8 @@ def OperatorAttrsCreator(unionType, table):
         return ConcatFromSequenceAttrsT.InitFromBuf(table.Bytes, table.Pos)
     if unionType == OperatorAttrs.SplitToSequenceAttrs:
         return SplitToSequenceAttrsT.InitFromBuf(table.Bytes, table.Pos)
+    if unionType == OperatorAttrs.GridSampleAttrs:
+        return GridSampleAttrsT.InitFromBuf(table.Bytes, table.Pos)
     return None
 
 
@@ -3058,6 +3062,71 @@ class GemmAttrsT(object):
         GemmAttrsAddTransposeB(builder, self.transposeB)
         gemmAttrs = GemmAttrsEnd(builder)
         return gemmAttrs
+
+
+class GridSampleAttrs(object):
+    __slots__ = ['_tab']
+
+    @classmethod
+    def GetRootAs(cls, buf, offset=0):
+        n = flatbuffers.encode.Get(flatbuffers.packer.uoffset, buf, offset)
+        x = GridSampleAttrs()
+        x.Init(buf, n + offset)
+        return x
+
+    @classmethod
+    def GetRootAsGridSampleAttrs(cls, buf, offset=0):
+        """This method is deprecated. Please switch to GetRootAs."""
+        return cls.GetRootAs(buf, offset)
+    @classmethod
+    def GridSampleAttrsBufferHasIdentifier(cls, buf, offset, size_prefixed=False):
+        return flatbuffers.util.BufferHasIdentifier(buf, offset, b"\x52\x54\x45\x4E", size_prefixed=size_prefixed)
+
+    # GridSampleAttrs
+    def Init(self, buf, pos):
+        self._tab = flatbuffers.table.Table(buf, pos)
+
+def GridSampleAttrsStart(builder):
+    builder.StartObject(0)
+
+def GridSampleAttrsEnd(builder):
+    return builder.EndObject()
+
+
+
+class GridSampleAttrsT(object):
+
+    # GridSampleAttrsT
+    def __init__(self):
+        pass
+
+    @classmethod
+    def InitFromBuf(cls, buf, pos):
+        gridSampleAttrs = GridSampleAttrs()
+        gridSampleAttrs.Init(buf, pos)
+        return cls.InitFromObj(gridSampleAttrs)
+
+    @classmethod
+    def InitFromPackedBuf(cls, buf, pos=0):
+        n = flatbuffers.encode.Get(flatbuffers.packer.uoffset, buf, pos)
+        return cls.InitFromBuf(buf, pos+n)
+
+    @classmethod
+    def InitFromObj(cls, gridSampleAttrs):
+        x = GridSampleAttrsT()
+        x._UnPack(gridSampleAttrs)
+        return x
+
+    # GridSampleAttrsT
+    def _UnPack(self, gridSampleAttrs):
+        if gridSampleAttrs is None:
+            return
+
+    # GridSampleAttrsT
+    def Pack(self, builder):
+        GridSampleAttrsStart(builder)
+        gridSampleAttrs = GridSampleAttrsEnd(builder)
+        return gridSampleAttrs
 
 
 class GRUAttrs(object):
@@ -6023,7 +6092,7 @@ class OperatorNodeT(object):
     def __init__(self):
         self.type = 0  # type: int
         self.attrsType = 0  # type: int
-        self.attrs = None  # type: Union[None, ArgMaxAttrsT, AveragePoolAttrsT, BatchNormalizationAttrsT, CastAttrsT, ConcatAttrsT, ConstantOfShapeAttrsT, ConvAttrsT, ConvTransposeAttrsT, FlattenAttrsT, GatherAttrsT, GemmAttrsT, GRUAttrsT, LeakyReluAttrsT, LSTMAttrsT, MaxPoolAttrsT, ReduceMeanAttrsT, ReshapeAttrsT, ResizeAttrsT, SplitAttrsT, SoftmaxAttrsT, TransposeAttrsT, ModAttrsT, ScatterElementsAttrsT, OneHotAttrsT, TopKAttrsT, HardSigmoidAttrsT, TriluAttrsT, ScatterNDAttrsT, NonMaxSuppressionAttrsT, LayerNormalizationAttrsT, RandomUniformAttrsT, EluAttrsT, RandomUniformLikeAttrsT, RandomNormalAttrsT, RandomNormalLikeAttrsT, GatherNDAttrsT, GeluAttrsT, EinsumAttrsT, IfAttrsT, PadAttrsT, DequantizeLinearAttrsT, QuantizeLinearAttrsT, DepthToSpaceAttrsT, CastLikeAttrsT, ShapeAttrsT, DropoutAttrsT, EyeLikeAttrsT, IsInfAttrsT, LoopAttrsT, SequenceEmptyAttrsT, ConcatFromSequenceAttrsT, SplitToSequenceAttrsT]
+        self.attrs = None  # type: Union[None, ArgMaxAttrsT, AveragePoolAttrsT, BatchNormalizationAttrsT, CastAttrsT, ConcatAttrsT, ConstantOfShapeAttrsT, ConvAttrsT, ConvTransposeAttrsT, FlattenAttrsT, GatherAttrsT, GemmAttrsT, GRUAttrsT, LeakyReluAttrsT, LSTMAttrsT, MaxPoolAttrsT, ReduceMeanAttrsT, ReshapeAttrsT, ResizeAttrsT, SplitAttrsT, SoftmaxAttrsT, TransposeAttrsT, ModAttrsT, ScatterElementsAttrsT, OneHotAttrsT, TopKAttrsT, HardSigmoidAttrsT, TriluAttrsT, ScatterNDAttrsT, NonMaxSuppressionAttrsT, LayerNormalizationAttrsT, RandomUniformAttrsT, EluAttrsT, RandomUniformLikeAttrsT, RandomNormalAttrsT, RandomNormalLikeAttrsT, GatherNDAttrsT, GeluAttrsT, EinsumAttrsT, IfAttrsT, PadAttrsT, DequantizeLinearAttrsT, QuantizeLinearAttrsT, DepthToSpaceAttrsT, CastLikeAttrsT, ShapeAttrsT, DropoutAttrsT, EyeLikeAttrsT, IsInfAttrsT, LoopAttrsT, SequenceEmptyAttrsT, ConcatFromSequenceAttrsT, SplitToSequenceAttrsT, GridSampleAttrsT]
         self.inputs = None  # type: List[int]
         self.outputs = None  # type: List[int]
 

--- a/src/op_registry.rs
+++ b/src/op_registry.rs
@@ -130,6 +130,7 @@ impl OpRegistry {
         register_op!(GlobalAveragePool);
         register_op!(Greater);
         register_op!(GreaterOrEqual);
+        register_op!(GridSample);
         register_op!(GRU);
         register_op!(HardSigmoid);
         register_op!(HardSwish);
@@ -632,6 +633,11 @@ impl_read_op!(Gemm, attrs_as_gemm_attrs, |attrs: sg::GemmAttrs| {
 impl_read_op!(GlobalAveragePool);
 impl_read_op!(Greater);
 impl_read_op!(GreaterOrEqual);
+impl_read_op!(
+    GridSample,
+    attrs_as_grid_sample_attrs,
+    |_attrs: sg::GridSampleAttrs| { Ok(ops::GridSample {}) }
+);
 impl_read_op!(GRU, attrs_as_gruattrs, |attrs: sg::GRUAttrs| {
     let hidden_size = attrs.hidden_size() as usize;
     let direction = match attrs.direction() {

--- a/src/ops/grid_sample.rs
+++ b/src/ops/grid_sample.rs
@@ -1,0 +1,279 @@
+use rten_tensor::prelude::*;
+use rten_tensor::{NdTensor, NdTensorView};
+
+use crate::buffer_pool::BufferPool;
+use crate::ops::{IntoOpResult, OpError, OpRunContext, Operator, OutputList};
+
+/// Interpolate between `x0` and `x1` according to the `factor` in range [0, 1].
+fn lerp(x0: f32, x1: f32, factor: f32) -> f32 {
+    x0 + (x1 - x0) * factor
+}
+
+fn grid_sample(
+    pool: &BufferPool,
+    input: NdTensorView<f32, 4>,
+    grid: NdTensorView<f32, 4>,
+) -> Result<NdTensor<f32, 4>, OpError> {
+    let [batch, h_out, w_out, coord_ndim] = grid.shape();
+    let [in_batch, in_c, in_h, in_w] = input.shape();
+
+    if batch != in_batch {
+        return Err(OpError::IncompatibleInputShapes(
+            "Batch size of input and grid must match",
+        ));
+    }
+
+    if coord_ndim != 2 {
+        return Err(OpError::UnsupportedValue(
+            "Unsupported grid coordinate size",
+        ));
+    }
+
+    let out_shape = [batch, in_c, h_out, w_out];
+
+    if in_h == 0 || in_w == 0 {
+        // If input is empty, all grid coordinates will be out of bounds.
+        return Ok(NdTensor::zeros(out_shape));
+    }
+
+    let mut output = NdTensor::uninit_in(pool, out_shape);
+
+    for n in 0..batch {
+        let grid = grid.slice(n);
+        let input = input.slice(n);
+        let mut output = output.slice_mut(n);
+
+        for y in 0..h_out {
+            for x in 0..w_out {
+                // Get sample coordinates in the range [-1, 1].
+                let grid_x = grid[[y, x, 0]];
+                let grid_y = grid[[y, x, 1]];
+
+                // Scale sample coordinates to [0, 1]
+                let grid_x = (grid_x + 1.) * 0.5;
+                let grid_y = (grid_y + 1.) * 0.5;
+
+                // Scale sample coordinates to image size and subtract 0.5 so
+                // that a grid coordinate of -1 maps to -0.5. The sampled pixels
+                // would have coordinates of -1 and 0 with an interpolation
+                // factor of 0.5. A grid coordinate of 1 maps to `in_w - 0.5`
+                // and the sampled pixels would have coordinates of `in_w - 1`
+                // and `in_w` with an interpolation factor of 0.5.
+                let scaled_x = in_w as f32 * grid_x - 0.5;
+                let scaled_y = in_h as f32 * grid_y - 0.5;
+
+                // Compute coordinates of the 4 pixels to sample and the
+                // interpolation factor along each axis.
+                let x_lerp = scaled_x - scaled_x.floor();
+                let in_x = scaled_x.floor() as i32;
+                let y_lerp = scaled_y - scaled_y.floor();
+                let in_y = scaled_y.floor() as i32;
+
+                for c in 0..in_c {
+                    let get_pixel = |y: i32, x: i32| {
+                        if y < 0 || y >= in_h as i32 || x < 0 || x >= in_w as i32 {
+                            // Out of bounds coordinates are sampled as zero.
+                            0.
+                        } else {
+                            // Safety: c, y and x are all in-bounds here.
+                            unsafe { *input.get_unchecked([c, y as usize, x as usize]) }
+                        }
+                    };
+
+                    let y0x0 = get_pixel(in_y, in_x);
+                    let y0x1 = get_pixel(in_y, in_x + 1);
+                    let y1x0 = get_pixel(in_y + 1, in_x);
+                    let y1x1 = get_pixel(in_y + 1, in_x + 1);
+                    let y0 = lerp(y0x0, y0x1, x_lerp);
+                    let y1 = lerp(y1x0, y1x1, x_lerp);
+                    let val = lerp(y0, y1, y_lerp);
+
+                    // Safety: [c, y, x] coordinates are all in bounds.
+                    unsafe {
+                        output.get_unchecked_mut([c, y, x]).write(val);
+                    }
+                }
+            }
+        }
+    }
+
+    // Safety: We initialized all output values.
+    Ok(unsafe { output.assume_init() })
+}
+
+#[derive(Debug)]
+pub struct GridSample {}
+
+impl Operator for GridSample {
+    fn name(&self) -> &str {
+        "GridSample"
+    }
+
+    fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+        let input = ctx.inputs().require_as(0)?;
+        let grid = ctx.inputs().require_as(1)?;
+        grid_sample(ctx.pool(), input, grid).into_op_result()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rten_tensor::prelude::*;
+    use rten_tensor::NdTensor;
+    use rten_testing::TestCases;
+
+    use super::grid_sample;
+    use crate::ops::tests::{expect_eq_1e4, new_pool};
+    use crate::ops::OpError;
+
+    /// Increase the rank of a tensor by inserting leading 1-sized dimensions.
+    trait IntoNDim<const N: usize> {
+        /// Variant of `Self` with N dimensions.
+        type Output;
+
+        /// Insert leading 1-sized dimensions into the shape of `self` so that
+        /// it has N dimensions.
+        ///
+        /// Panics if `self` already has more than N dimensions.
+        fn into_ndim(self) -> Self::Output;
+    }
+
+    impl<T: Clone, const M: usize, const N: usize> IntoNDim<N> for NdTensor<T, M> {
+        type Output = NdTensor<T, N>;
+
+        fn into_ndim(self) -> Self::Output {
+            assert!(N >= M);
+            let new_dims = N - M;
+            let shape = self.shape();
+            let new_shape =
+                std::array::from_fn(|d| if d < new_dims { 1 } else { shape[d - new_dims] });
+            self.into_shape(new_shape)
+        }
+    }
+
+    #[test]
+    fn test_grid_sample() {
+        #[derive(Debug)]
+        struct Case {
+            input: NdTensor<f32, 4>,
+            grid: NdTensor<f32, 4>,
+            expected: NdTensor<f32, 4>,
+        }
+
+        let row = NdTensor::from([0.1087, 0.9655]).into_ndim();
+        let col = NdTensor::from([[0.1087], [0.9655]]).into_ndim();
+
+        let cases = [
+            // Grid point with center X coordinate.
+            Case {
+                input: row.clone(),
+                grid: NdTensor::from([0., 0.]).into_ndim(),
+                expected: NdTensor::from([0.5371]).into_ndim(),
+            },
+            // Grid point with minimum X coordinate.
+            Case {
+                input: row.clone(),
+                grid: NdTensor::from([-1., 0.]).into_ndim(),
+                expected: NdTensor::from([0.05435]).into_ndim(),
+            },
+            // Grid point with maximum X coordinate.
+            Case {
+                input: row.clone(),
+                grid: NdTensor::from([1., 0.]).into_ndim(),
+                expected: NdTensor::from([0.48275]).into_ndim(),
+            },
+            // Grid point with out of range X coordinate (-ve).
+            Case {
+                input: row.clone(),
+                grid: NdTensor::from([-2., 0.]).into_ndim(),
+                expected: NdTensor::from([0.]).into_ndim(),
+            },
+            // Grid point with out of range X coordinate (+ve).
+            Case {
+                input: row.clone(),
+                grid: NdTensor::from([2., 0.]).into_ndim(),
+                expected: NdTensor::from([0.]).into_ndim(),
+            },
+            // Grid point with center Y coordinate.
+            Case {
+                input: col.clone(),
+                grid: NdTensor::from([0., 0.]).into_ndim(),
+                expected: NdTensor::from([0.5371]).into_ndim(),
+            },
+            // Grid point with minimum Y coordinate.
+            Case {
+                input: col.clone(),
+                grid: NdTensor::from([0., -1.]).into_ndim(),
+                expected: NdTensor::from([0.05435]).into_ndim(),
+            },
+            // Grid point with maximum Y coordinate.
+            Case {
+                input: col.clone(),
+                grid: NdTensor::from([0., 1.]).into_ndim(),
+                expected: NdTensor::from([0.48275]).into_ndim(),
+            },
+            // Test case created with PyTorch's
+            // `torch.nn.functional.grid_sample`
+            Case {
+                input: NdTensor::from([
+                    [0.9942, 0.4255, 0.9730, 0.5230],
+                    [0.8417, 0.1245, 0.2245, 0.0774],
+                    [0.9674, 0.5163, 0.3541, 0.0016],
+                    [0.7593, 0.0594, 0.8754, 0.1339],
+                ])
+                .into_ndim(),
+                grid: NdTensor::from([
+                    [[0.3389, 0.0883], [0.9822, 0.6967], [0.3037, 0.8579]],
+                    [[0.4092, 0.4664], [0.4346, 0.3142], [0.3880, 0.4060]],
+                    [[0.0835, 0.1432], [0.5129, 0.7989], [0.2861, 0.7945]],
+                ])
+                .into_ndim(),
+                expected: NdTensor::from([
+                    [0.2613, 0.0642, 0.6241],
+                    [0.4138, 0.2725, 0.3860],
+                    [0.3618, 0.4381, 0.7487],
+                ])
+                .into_ndim(),
+            },
+        ];
+
+        cases.test_each(|case| {
+            let pool = new_pool();
+            let result = grid_sample(&pool, case.input.view(), case.grid.view()).unwrap();
+            expect_eq_1e4(&result, &case.expected).unwrap();
+        });
+    }
+
+    #[test]
+    fn test_grid_sample_invalid() {
+        #[derive(Debug)]
+        struct Case {
+            input_shape: [usize; 4],
+            grid_shape: [usize; 4],
+            expected: OpError,
+        }
+
+        let cases = [
+            Case {
+                input_shape: [1, 1, 1, 1],
+                grid_shape: [2, 1, 1, 2],
+                expected: OpError::IncompatibleInputShapes(
+                    "Batch size of input and grid must match",
+                ),
+            },
+            Case {
+                input_shape: [1, 1, 1, 1],
+                grid_shape: [1, 1, 1, 3],
+                expected: OpError::UnsupportedValue("Unsupported grid coordinate size"),
+            },
+        ];
+
+        cases.test_each(|case| {
+            let pool = new_pool();
+            let input = NdTensor::zeros(case.input_shape);
+            let grid = NdTensor::zeros(case.grid_shape);
+            let result = grid_sample(&pool, input.view(), grid.view());
+            assert_eq!(result.err().as_ref(), Some(&case.expected));
+        });
+    }
+}

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -40,6 +40,7 @@ mod convert;
 mod einsum;
 mod gather;
 mod generate;
+mod grid_sample;
 mod identity;
 mod layout;
 mod matmul;
@@ -82,6 +83,7 @@ pub use gather::{
     GatherND, ScatterElements, ScatterND, ScatterReduction,
 };
 pub use generate::{constant_of_shape, onehot, range, ConstantOfShape, EyeLike, OneHot, Range};
+pub use grid_sample::GridSample;
 pub use identity::Identity;
 pub use layout::{
     depth_to_space, expand, flatten, reshape, squeeze, DepthToSpace, DepthToSpaceMode, Expand,

--- a/src/schema.fbs
+++ b/src/schema.fbs
@@ -138,6 +138,7 @@ enum OperatorType: ubyte {
   SequenceLength,
   SequenceConstruct,
   SequenceErase,
+  GridSample,
 }
 
 enum RNNDirection: ubyte {
@@ -242,6 +243,7 @@ union OperatorAttrs {
   SequenceEmptyAttrs,
   ConcatFromSequenceAttrs,
   SplitToSequenceAttrs,
+  GridSampleAttrs,
 }
 
 table ArgMaxAttrs {
@@ -394,6 +396,8 @@ table GemmAttrs {
   transpose_a:bool;
   transpose_b:bool;
 }
+
+table GridSampleAttrs {}
 
 table GRUAttrs {
   direction:RNNDirection;

--- a/src/schema_generated.rs
+++ b/src/schema_generated.rs
@@ -18,13 +18,13 @@ pub const ENUM_MIN_OPERATOR_TYPE: u8 = 0;
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
-pub const ENUM_MAX_OPERATOR_TYPE: u8 = 124;
+pub const ENUM_MAX_OPERATOR_TYPE: u8 = 125;
 #[deprecated(
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 125] = [
+pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 126] = [
     OperatorType::Add,
     OperatorType::ArgMin,
     OperatorType::ArgMax,
@@ -150,6 +150,7 @@ pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 125] = [
     OperatorType::SequenceLength,
     OperatorType::SequenceConstruct,
     OperatorType::SequenceErase,
+    OperatorType::GridSample,
 ];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -282,9 +283,10 @@ impl OperatorType {
     pub const SequenceLength: Self = Self(122);
     pub const SequenceConstruct: Self = Self(123);
     pub const SequenceErase: Self = Self(124);
+    pub const GridSample: Self = Self(125);
 
     pub const ENUM_MIN: u8 = 0;
-    pub const ENUM_MAX: u8 = 124;
+    pub const ENUM_MAX: u8 = 125;
     pub const ENUM_VALUES: &'static [Self] = &[
         Self::Add,
         Self::ArgMin,
@@ -411,6 +413,7 @@ impl OperatorType {
         Self::SequenceLength,
         Self::SequenceConstruct,
         Self::SequenceErase,
+        Self::GridSample,
     ];
     /// Returns the variant's name or "" if unknown.
     pub fn variant_name(self) -> Option<&'static str> {
@@ -540,6 +543,7 @@ impl OperatorType {
             Self::SequenceLength => Some("SequenceLength"),
             Self::SequenceConstruct => Some("SequenceConstruct"),
             Self::SequenceErase => Some("SequenceErase"),
+            Self::GridSample => Some("GridSample"),
             _ => None,
         }
     }
@@ -1182,13 +1186,13 @@ pub const ENUM_MIN_OPERATOR_ATTRS: u8 = 0;
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
-pub const ENUM_MAX_OPERATOR_ATTRS: u8 = 52;
+pub const ENUM_MAX_OPERATOR_ATTRS: u8 = 53;
 #[deprecated(
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_OPERATOR_ATTRS: [OperatorAttrs; 53] = [
+pub const ENUM_VALUES_OPERATOR_ATTRS: [OperatorAttrs; 54] = [
     OperatorAttrs::NONE,
     OperatorAttrs::ArgMaxAttrs,
     OperatorAttrs::AveragePoolAttrs,
@@ -1242,6 +1246,7 @@ pub const ENUM_VALUES_OPERATOR_ATTRS: [OperatorAttrs; 53] = [
     OperatorAttrs::SequenceEmptyAttrs,
     OperatorAttrs::ConcatFromSequenceAttrs,
     OperatorAttrs::SplitToSequenceAttrs,
+    OperatorAttrs::GridSampleAttrs,
 ];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -1302,9 +1307,10 @@ impl OperatorAttrs {
     pub const SequenceEmptyAttrs: Self = Self(50);
     pub const ConcatFromSequenceAttrs: Self = Self(51);
     pub const SplitToSequenceAttrs: Self = Self(52);
+    pub const GridSampleAttrs: Self = Self(53);
 
     pub const ENUM_MIN: u8 = 0;
-    pub const ENUM_MAX: u8 = 52;
+    pub const ENUM_MAX: u8 = 53;
     pub const ENUM_VALUES: &'static [Self] = &[
         Self::NONE,
         Self::ArgMaxAttrs,
@@ -1359,6 +1365,7 @@ impl OperatorAttrs {
         Self::SequenceEmptyAttrs,
         Self::ConcatFromSequenceAttrs,
         Self::SplitToSequenceAttrs,
+        Self::GridSampleAttrs,
     ];
     /// Returns the variant's name or "" if unknown.
     pub fn variant_name(self) -> Option<&'static str> {
@@ -1416,6 +1423,7 @@ impl OperatorAttrs {
             Self::SequenceEmptyAttrs => Some("SequenceEmptyAttrs"),
             Self::ConcatFromSequenceAttrs => Some("ConcatFromSequenceAttrs"),
             Self::SplitToSequenceAttrs => Some("SplitToSequenceAttrs"),
+            Self::GridSampleAttrs => Some("GridSampleAttrs"),
             _ => None,
         }
     }
@@ -5609,6 +5617,85 @@ impl core::fmt::Debug for GemmAttrs<'_> {
         ds.field("beta", &self.beta());
         ds.field("transpose_a", &self.transpose_a());
         ds.field("transpose_b", &self.transpose_b());
+        ds.finish()
+    }
+}
+pub enum GridSampleAttrsOffset {}
+#[derive(Copy, Clone, PartialEq)]
+
+pub struct GridSampleAttrs<'a> {
+    pub _tab: flatbuffers::Table<'a>,
+}
+
+impl<'a> flatbuffers::Follow<'a> for GridSampleAttrs<'a> {
+    type Inner = GridSampleAttrs<'a>;
+    #[inline]
+    unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self {
+            _tab: flatbuffers::Table::new(buf, loc),
+        }
+    }
+}
+
+impl<'a> GridSampleAttrs<'a> {
+    #[inline]
+    pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+        GridSampleAttrs { _tab: table }
+    }
+    #[allow(unused_mut)]
+    pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+        _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
+        _args: &'args GridSampleAttrsArgs,
+    ) -> flatbuffers::WIPOffset<GridSampleAttrs<'bldr>> {
+        let mut builder = GridSampleAttrsBuilder::new(_fbb);
+        builder.finish()
+    }
+}
+
+impl flatbuffers::Verifiable for GridSampleAttrs<'_> {
+    #[inline]
+    fn run_verifier(
+        v: &mut flatbuffers::Verifier,
+        pos: usize,
+    ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+        use self::flatbuffers::Verifiable;
+        v.visit_table(pos)?.finish();
+        Ok(())
+    }
+}
+pub struct GridSampleAttrsArgs {}
+impl<'a> Default for GridSampleAttrsArgs {
+    #[inline]
+    fn default() -> Self {
+        GridSampleAttrsArgs {}
+    }
+}
+
+pub struct GridSampleAttrsBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+    fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
+    start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> GridSampleAttrsBuilder<'a, 'b, A> {
+    #[inline]
+    pub fn new(
+        _fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
+    ) -> GridSampleAttrsBuilder<'a, 'b, A> {
+        let start = _fbb.start_table();
+        GridSampleAttrsBuilder {
+            fbb_: _fbb,
+            start_: start,
+        }
+    }
+    #[inline]
+    pub fn finish(self) -> flatbuffers::WIPOffset<GridSampleAttrs<'a>> {
+        let o = self.fbb_.end_table(self.start_);
+        flatbuffers::WIPOffset::new(o.value())
+    }
+}
+
+impl core::fmt::Debug for GridSampleAttrs<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut ds = f.debug_struct("GridSampleAttrs");
         ds.finish()
     }
 }
@@ -10134,6 +10221,21 @@ impl<'a> OperatorNode<'a> {
             None
         }
     }
+
+    #[inline]
+    #[allow(non_snake_case)]
+    pub fn attrs_as_grid_sample_attrs(&self) -> Option<GridSampleAttrs<'a>> {
+        if self.attrs_type() == OperatorAttrs::GridSampleAttrs {
+            self.attrs().map(|t| {
+                // Safety:
+                // Created from a valid Table for this object
+                // Which contains a valid union in this slot
+                unsafe { GridSampleAttrs::init_from_table(t) }
+            })
+        } else {
+            None
+        }
+    }
 }
 
 impl flatbuffers::Verifiable for OperatorNode<'_> {
@@ -10199,6 +10301,7 @@ impl flatbuffers::Verifiable for OperatorNode<'_> {
           OperatorAttrs::SequenceEmptyAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<SequenceEmptyAttrs>>("OperatorAttrs::SequenceEmptyAttrs", pos),
           OperatorAttrs::ConcatFromSequenceAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<ConcatFromSequenceAttrs>>("OperatorAttrs::ConcatFromSequenceAttrs", pos),
           OperatorAttrs::SplitToSequenceAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<SplitToSequenceAttrs>>("OperatorAttrs::SplitToSequenceAttrs", pos),
+          OperatorAttrs::GridSampleAttrs => v.verify_union_variant::<flatbuffers::ForwardsUOffset<GridSampleAttrs>>("OperatorAttrs::GridSampleAttrs", pos),
           _ => Ok(()),
         }
      })?
@@ -10796,6 +10899,16 @@ impl core::fmt::Debug for OperatorNode<'_> {
             }
             OperatorAttrs::SplitToSequenceAttrs => {
                 if let Some(x) = self.attrs_as_split_to_sequence_attrs() {
+                    ds.field("attrs", &x)
+                } else {
+                    ds.field(
+                        "attrs",
+                        &"InvalidFlatbuffer: Union discriminant does not match value.",
+                    )
+                }
+            }
+            OperatorAttrs::GridSampleAttrs => {
+                if let Some(x) = self.attrs_as_grid_sample_attrs() {
                     ds.field("attrs", &x)
                 } else {
                     ds.field(


### PR DESCRIPTION
Add an initial implementation of the [GridSample](https://onnx.ai/onnx/operators/onnx__GridSample.html) operator, used by models such as [RT-DETR](https://huggingface.co/docs/transformers/en/model_doc/rt_detr).

This initial implementation only supports 4D inputs with default values for attributes: align_corners=0, mode=linear, padding_mode=zeros. The supported attribute values align with PyTorch's defaults for `torch.nn.functional.grid_sample`.
