### PR TITLE
Support `ceil_mode` attribute for AveragePool, MaxPool ops

### DIFF
--- a/rten-convert/rten_convert/converter.py
+++ b/rten-convert/rten_convert/converter.py
@@ -340,7 +340,6 @@ def op_node_from_onnx_operator(
         case "AveragePool":
             kernel_shape = attr_reader.require_attr("kernel_shape", "ints")
             check_ints_length("kernel_shape", kernel_shape, [1, 2])
-            attr_reader.check_attr("ceil_mode", "int", 0)
 
             attrs = sg.AveragePoolAttrsT()
             attrs.kernelSize = kernel_shape
@@ -349,6 +348,7 @@ def op_node_from_onnx_operator(
             attrs.countIncludePad = attr_reader.get_bool_attr(
                 "count_include_pad", False
             )
+            attrs.ceilMode = attr_reader.get_bool_attr("ceil_mode", False)
 
         case "BatchNormalization":
             attrs = sg.BatchNormalizationAttrsT()
@@ -583,8 +583,8 @@ def op_node_from_onnx_operator(
             attrs.kernelSize = kernel_shape
             read_pads(attr_reader, attrs)
             attrs.strides = read_strides(attr_reader)
+            attrs.ceilMode = attr_reader.get_bool_attr("ceil_mode", False)
 
-            attr_reader.check_attr("ceil_mode", "int", 0)
             attr_reader.check_attr("dilations", "ints", ([1], [1, 1]))
             attr_reader.check_attr("storage_order", "int", 0)
 

--- a/rten-convert/rten_convert/schema_generated.py
+++ b/rten-convert/rten_convert/schema_generated.py
@@ -642,8 +642,15 @@ class AveragePoolAttrs(object):
             return bool(self._tab.Get(flatbuffers.number_types.BoolFlags, o + self._tab.Pos))
         return False
 
+    # AveragePoolAttrs
+    def CeilMode(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(14))
+        if o != 0:
+            return bool(self._tab.Get(flatbuffers.number_types.BoolFlags, o + self._tab.Pos))
+        return False
+
 def AveragePoolAttrsStart(builder):
-    builder.StartObject(5)
+    builder.StartObject(6)
 
 def AveragePoolAttrsAddKernelSize(builder, kernelSize):
     builder.PrependUOffsetTRelativeSlot(0, flatbuffers.number_types.UOffsetTFlags.py_type(kernelSize), 0)
@@ -669,6 +676,9 @@ def AveragePoolAttrsStartStridesVector(builder, numElems):
 def AveragePoolAttrsAddCountIncludePad(builder, countIncludePad):
     builder.PrependBoolSlot(4, countIncludePad, 0)
 
+def AveragePoolAttrsAddCeilMode(builder, ceilMode):
+    builder.PrependBoolSlot(5, ceilMode, 0)
+
 def AveragePoolAttrsEnd(builder):
     return builder.EndObject()
 
@@ -687,6 +697,7 @@ class AveragePoolAttrsT(object):
         self.pads = None  # type: List[int]
         self.strides = None  # type: List[int]
         self.countIncludePad = False  # type: bool
+        self.ceilMode = False  # type: bool
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -732,6 +743,7 @@ class AveragePoolAttrsT(object):
             else:
                 self.strides = averagePoolAttrs.StridesAsNumpy()
         self.countIncludePad = averagePoolAttrs.CountIncludePad()
+        self.ceilMode = averagePoolAttrs.CeilMode()
 
     # AveragePoolAttrsT
     def Pack(self, builder):
@@ -768,6 +780,7 @@ class AveragePoolAttrsT(object):
         if self.strides is not None:
             AveragePoolAttrsAddStrides(builder, strides)
         AveragePoolAttrsAddCountIncludePad(builder, self.countIncludePad)
+        AveragePoolAttrsAddCeilMode(builder, self.ceilMode)
         averagePoolAttrs = AveragePoolAttrsEnd(builder)
         return averagePoolAttrs
 
@@ -3707,8 +3720,15 @@ class MaxPoolAttrs(object):
         o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(10))
         return o == 0
 
+    # MaxPoolAttrs
+    def CeilMode(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(12))
+        if o != 0:
+            return bool(self._tab.Get(flatbuffers.number_types.BoolFlags, o + self._tab.Pos))
+        return False
+
 def MaxPoolAttrsStart(builder):
-    builder.StartObject(4)
+    builder.StartObject(5)
 
 def MaxPoolAttrsAddKernelSize(builder, kernelSize):
     builder.PrependUOffsetTRelativeSlot(0, flatbuffers.number_types.UOffsetTFlags.py_type(kernelSize), 0)
@@ -3731,6 +3751,9 @@ def MaxPoolAttrsAddStrides(builder, strides):
 def MaxPoolAttrsStartStridesVector(builder, numElems):
     return builder.StartVector(4, numElems, 4)
 
+def MaxPoolAttrsAddCeilMode(builder, ceilMode):
+    builder.PrependBoolSlot(4, ceilMode, 0)
+
 def MaxPoolAttrsEnd(builder):
     return builder.EndObject()
 
@@ -3748,6 +3771,7 @@ class MaxPoolAttrsT(object):
         self.autoPad = 0  # type: int
         self.pads = None  # type: List[int]
         self.strides = None  # type: List[int]
+        self.ceilMode = False  # type: bool
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -3792,6 +3816,7 @@ class MaxPoolAttrsT(object):
                     self.strides.append(maxPoolAttrs.Strides(i))
             else:
                 self.strides = maxPoolAttrs.StridesAsNumpy()
+        self.ceilMode = maxPoolAttrs.CeilMode()
 
     # MaxPoolAttrsT
     def Pack(self, builder):
@@ -3827,6 +3852,7 @@ class MaxPoolAttrsT(object):
             MaxPoolAttrsAddPads(builder, pads)
         if self.strides is not None:
             MaxPoolAttrsAddStrides(builder, strides)
+        MaxPoolAttrsAddCeilMode(builder, self.ceilMode)
         maxPoolAttrs = MaxPoolAttrsEnd(builder)
         return maxPoolAttrs
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -1374,6 +1374,7 @@ mod tests {
             strides: [2, 2].into(),
             padding: [0, 0, 0, 0].into(),
             count_include_pad: false,
+            ceil_mode: false,
         });
 
         // Dummy value for BatchNormalization inputs which are vectors with
@@ -1559,6 +1560,7 @@ mod tests {
             kernel_size: [2, 2].into(),
             strides: [2, 2].into(),
             padding: [0, 0, 0, 0].into(),
+            ceil_mode: false,
         });
         add_operator!(Mean, [input_node, input_node]);
         add_operator!(Min, [input_node, input_node]);

--- a/src/model_builder.rs
+++ b/src/model_builder.rs
@@ -444,6 +444,7 @@ impl<'mb, 'a> GraphBuilder<'mb, 'a> {
                     pads,
                     strides,
                     count_include_pad: args.count_include_pad,
+                    ceil_mode: args.ceil_mode,
                 }
             }),
             OpType::BatchNormalization(args) => op_with_attrs!(
@@ -709,6 +710,7 @@ impl<'mb, 'a> GraphBuilder<'mb, 'a> {
                     auto_pad: pad_args.auto_pad,
                     pads,
                     strides,
+                    ceil_mode: args.ceil_mode,
                 }
             }),
             OpType::Mean => op!(Mean),

--- a/src/op_registry.rs
+++ b/src/op_registry.rs
@@ -451,6 +451,7 @@ impl_read_op!(
             padding,
             count_include_pad: attrs.count_include_pad(),
             strides,
+            ceil_mode: attrs.ceil_mode(),
         })
     }
 );
@@ -777,6 +778,7 @@ impl_read_op!(
             kernel_size,
             padding,
             strides,
+            ceil_mode: attrs.ceil_mode(),
         })
     }
 );

--- a/src/ops/conv.rs
+++ b/src/ops/conv.rs
@@ -10,7 +10,7 @@ use rten_tensor::{CowTensor, NdTensor, NdTensorView, Tensor, TensorView};
 
 use crate::buffer_pool::{AutoReturn, BufferPool, PoolRef};
 use crate::ops::matmul::zero_point_to_vec;
-use crate::ops::pooling::calc_output_size_and_padding;
+use crate::ops::pooling::{calc_output_size_and_padding, RoundMode};
 use crate::ops::{
     static_dims, IntoOpResult, OpError, OpRunContext, Operator, OutputList, Padding, ValueView,
 };
@@ -198,6 +198,7 @@ where
         (stride_y, stride_x),
         padding,
         Some((dilation_y, dilation_x)),
+        RoundMode::default(),
     )?;
 
     let [pad_top, pad_left, pad_bottom, pad_right] = fixed_padding;
@@ -540,7 +541,7 @@ mod tests {
     use rten_testing::TestCases;
 
     use crate::buffer_pool::AutoReturn;
-    use crate::ops::pooling::calc_output_size_and_padding;
+    use crate::ops::pooling::{calc_output_size_and_padding, RoundMode};
     use crate::ops::tests::expect_eq_1e4;
     use crate::ops::tests::new_pool;
     use crate::ops::{conv, conv_integer, Conv, OpError, OperatorExt, Padding};
@@ -624,6 +625,7 @@ mod tests {
             (stride_y, stride_x),
             padding.into(),
             Some((dilation_y, dilation_x)),
+            RoundMode::default(),
         )
         .expect("Input too small");
         let [pad_top, pad_left, _pad_bottom, _pad_right] = fixed_pads;

--- a/src/ops/conv/im2col.rs
+++ b/src/ops/conv/im2col.rs
@@ -2,7 +2,7 @@ use rten_gemm::{ColOffsets, Im2Col, RowOffsets};
 use rten_tensor::prelude::*;
 use rten_tensor::NdTensorView;
 
-use crate::ops::pooling::calc_output_size_and_padding;
+use crate::ops::pooling::{calc_output_size_and_padding, RoundMode};
 use crate::ops::Padding;
 
 /// Build a virtual [`Im2Col`] matrix from an image and convolution parameters.
@@ -31,6 +31,7 @@ pub fn build_im2col<T>(
         (stride_h, stride_w),
         Padding::Fixed(padding.into()),
         Some((dilation_y, dilation_x)),
+        RoundMode::default(),
     )
     .expect("invalid im2col params");
 

--- a/src/schema.fbs
+++ b/src/schema.fbs
@@ -261,6 +261,7 @@ table AveragePoolAttrs {
   strides:[uint];
 
   count_include_pad:bool;
+  ceil_mode:bool;
 }
 
 table BatchNormalizationAttrs {
@@ -432,6 +433,7 @@ table MaxPoolAttrs {
   pads:[uint];
 
   strides:[uint];
+  ceil_mode:bool;
 }
 
 table ModAttrs {

--- a/src/schema_generated.rs
+++ b/src/schema_generated.rs
@@ -2506,6 +2506,7 @@ impl<'a> AveragePoolAttrs<'a> {
     pub const VT_PADS: flatbuffers::VOffsetT = 8;
     pub const VT_STRIDES: flatbuffers::VOffsetT = 10;
     pub const VT_COUNT_INCLUDE_PAD: flatbuffers::VOffsetT = 12;
+    pub const VT_CEIL_MODE: flatbuffers::VOffsetT = 14;
 
     #[inline]
     pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
@@ -2526,6 +2527,7 @@ impl<'a> AveragePoolAttrs<'a> {
         if let Some(x) = args.kernel_size {
             builder.add_kernel_size(x);
         }
+        builder.add_ceil_mode(args.ceil_mode);
         builder.add_count_include_pad(args.count_include_pad);
         builder.add_auto_pad(args.auto_pad);
         builder.finish()
@@ -2593,6 +2595,17 @@ impl<'a> AveragePoolAttrs<'a> {
                 .unwrap()
         }
     }
+    #[inline]
+    pub fn ceil_mode(&self) -> bool {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab
+                .get::<bool>(AveragePoolAttrs::VT_CEIL_MODE, Some(false))
+                .unwrap()
+        }
+    }
 }
 
 impl flatbuffers::Verifiable for AveragePoolAttrs<'_> {
@@ -2620,6 +2633,7 @@ impl flatbuffers::Verifiable for AveragePoolAttrs<'_> {
                 false,
             )?
             .visit_field::<bool>("count_include_pad", Self::VT_COUNT_INCLUDE_PAD, false)?
+            .visit_field::<bool>("ceil_mode", Self::VT_CEIL_MODE, false)?
             .finish();
         Ok(())
     }
@@ -2630,6 +2644,7 @@ pub struct AveragePoolAttrsArgs<'a> {
     pub pads: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u32>>>,
     pub strides: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u32>>>,
     pub count_include_pad: bool,
+    pub ceil_mode: bool,
 }
 impl<'a> Default for AveragePoolAttrsArgs<'a> {
     #[inline]
@@ -2640,6 +2655,7 @@ impl<'a> Default for AveragePoolAttrsArgs<'a> {
             pads: None,
             strides: None,
             count_include_pad: false,
+            ceil_mode: false,
         }
     }
 }
@@ -2683,6 +2699,11 @@ impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> AveragePoolAttrsBuilder<'a, 'b,
         );
     }
     #[inline]
+    pub fn add_ceil_mode(&mut self, ceil_mode: bool) {
+        self.fbb_
+            .push_slot::<bool>(AveragePoolAttrs::VT_CEIL_MODE, ceil_mode, false);
+    }
+    #[inline]
     pub fn new(
         _fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
     ) -> AveragePoolAttrsBuilder<'a, 'b, A> {
@@ -2709,6 +2730,7 @@ impl core::fmt::Debug for AveragePoolAttrs<'_> {
         ds.field("pads", &self.pads());
         ds.field("strides", &self.strides());
         ds.field("count_include_pad", &self.count_include_pad());
+        ds.field("ceil_mode", &self.ceil_mode());
         ds.finish()
     }
 }
@@ -6373,6 +6395,7 @@ impl<'a> MaxPoolAttrs<'a> {
     pub const VT_AUTO_PAD: flatbuffers::VOffsetT = 6;
     pub const VT_PADS: flatbuffers::VOffsetT = 8;
     pub const VT_STRIDES: flatbuffers::VOffsetT = 10;
+    pub const VT_CEIL_MODE: flatbuffers::VOffsetT = 12;
 
     #[inline]
     pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
@@ -6393,6 +6416,7 @@ impl<'a> MaxPoolAttrs<'a> {
         if let Some(x) = args.kernel_size {
             builder.add_kernel_size(x);
         }
+        builder.add_ceil_mode(args.ceil_mode);
         builder.add_auto_pad(args.auto_pad);
         builder.finish()
     }
@@ -6448,6 +6472,17 @@ impl<'a> MaxPoolAttrs<'a> {
                 )
         }
     }
+    #[inline]
+    pub fn ceil_mode(&self) -> bool {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab
+                .get::<bool>(MaxPoolAttrs::VT_CEIL_MODE, Some(false))
+                .unwrap()
+        }
+    }
 }
 
 impl flatbuffers::Verifiable for MaxPoolAttrs<'_> {
@@ -6474,6 +6509,7 @@ impl flatbuffers::Verifiable for MaxPoolAttrs<'_> {
                 Self::VT_STRIDES,
                 false,
             )?
+            .visit_field::<bool>("ceil_mode", Self::VT_CEIL_MODE, false)?
             .finish();
         Ok(())
     }
@@ -6483,6 +6519,7 @@ pub struct MaxPoolAttrsArgs<'a> {
     pub auto_pad: AutoPad,
     pub pads: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u32>>>,
     pub strides: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u32>>>,
+    pub ceil_mode: bool,
 }
 impl<'a> Default for MaxPoolAttrsArgs<'a> {
     #[inline]
@@ -6492,6 +6529,7 @@ impl<'a> Default for MaxPoolAttrsArgs<'a> {
             auto_pad: AutoPad::Same,
             pads: None,
             strides: None,
+            ceil_mode: false,
         }
     }
 }
@@ -6527,6 +6565,11 @@ impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> MaxPoolAttrsBuilder<'a, 'b, A> 
             .push_slot_always::<flatbuffers::WIPOffset<_>>(MaxPoolAttrs::VT_STRIDES, strides);
     }
     #[inline]
+    pub fn add_ceil_mode(&mut self, ceil_mode: bool) {
+        self.fbb_
+            .push_slot::<bool>(MaxPoolAttrs::VT_CEIL_MODE, ceil_mode, false);
+    }
+    #[inline]
     pub fn new(
         _fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
     ) -> MaxPoolAttrsBuilder<'a, 'b, A> {
@@ -6552,6 +6595,7 @@ impl core::fmt::Debug for MaxPoolAttrs<'_> {
         ds.field("auto_pad", &self.auto_pad());
         ds.field("pads", &self.pads());
         ds.field("strides", &self.strides());
+        ds.field("ceil_mode", &self.ceil_mode());
         ds.finish()
     }
 }


### PR DESCRIPTION
For the case of "same" padding there is a quirk that two different but equivalent formulas are given for the output shape in the spec. The main ML frameworks on which ONNX is based (TensorFlow and PyTorch) individually support either "same" padding or a `ceil_mode` argument but not both, so this looks like a corner case that is unimportant.

 - Add `ceil_mode` attribute to MaxPool, AveragePool
 - Implement ceil mode support in `calc_output_size_and_padding`
 - Refactor `calc_output_size_and_padding` tests to use a Default impl to save some repetition