### PR TITLE
Refactor mask types and operations in rten-simd

### DIFF
--- a/rten-gemm/src/im2col.rs
+++ b/rten-gemm/src/im2col.rs
@@ -116,7 +116,7 @@ impl<T: Copy + Default> Im2Col<'_, T> {
         cols: Range<usize>,
     ) {
         let ops = isa.i32();
-        let mask_ops = ops.mask_ops();
+        let mask_ops = isa.m32();
 
         assert_eq!(panel_width, ops.len() * NR_REGS);
 
@@ -278,7 +278,7 @@ impl Im2Col<'_, i8> {
         let ops = isa.i32();
         assert_eq!(ops.len() * NR_REGS, NR);
 
-        let mask_ops = ops.mask_ops();
+        let mask_ops = isa.m32();
 
         debug_assert!(rows.end <= self.rows());
         debug_assert!(cols.end <= self.cols());

--- a/rten-simd/src/arch/aarch64.rs
+++ b/rten-simd/src/arch/aarch64.rs
@@ -36,6 +36,9 @@ impl ArmNeonIsa {
 
 // Safety: Neon is supported, as it is a required feature of aarch64.
 unsafe impl Isa for ArmNeonIsa {
+    type M32 = uint32x4_t;
+    type M16 = uint16x8_t;
+    type M8 = uint8x16_t;
     type F32 = float32x4_t;
     type I32 = int32x4_t;
     type I16 = int16x8_t;
@@ -80,6 +83,18 @@ unsafe impl Isa for ArmNeonIsa {
     fn u16(self) -> impl IntOps<u16, Simd = Self::U16> {
         self
     }
+
+    fn m32(self) -> impl MaskOps<Self::M32> {
+        self
+    }
+
+    fn m16(self) -> impl MaskOps<Self::M16> {
+        self
+    }
+
+    fn m8(self) -> impl MaskOps<Self::M8> {
+        self
+    }
 }
 
 macro_rules! simd_ops_common {
@@ -121,11 +136,6 @@ macro_rules! simd_ops_common {
                     *ptr.add(i) = x_array[i];
                 }
             }
-        }
-
-        #[inline]
-        fn mask_ops(self) -> impl MaskOps<$mask> {
-            self
         }
 
         // Since bitwise ops work on individual bits, we can use the same

--- a/rten-simd/src/arch/generic.rs
+++ b/rten-simd/src/arch/generic.rs
@@ -56,6 +56,9 @@ impl Default for GenericIsa {
 
 // Safety: Instructions used by generic ISA are always supported.
 unsafe impl Isa for GenericIsa {
+    type M32 = M32;
+    type M16 = M16;
+    type M8 = M8;
     type F32 = F32x4;
     type I32 = I32x4;
     type I16 = I16x8;
@@ -100,15 +103,22 @@ unsafe impl Isa for GenericIsa {
     fn u16(self) -> impl IntOps<u16, Simd = Self::U16> {
         self
     }
+
+    fn m32(self) -> impl MaskOps<Self::M32> {
+        self
+    }
+
+    fn m16(self) -> impl MaskOps<Self::M16> {
+        self
+    }
+
+    fn m8(self) -> impl MaskOps<Self::M8> {
+        self
+    }
 }
 
 macro_rules! simd_ops_common {
     ($simd:ident, $elem:ty, $len:expr, $mask:ident) => {
-        #[inline]
-        fn mask_ops(self) -> impl MaskOps<$mask> {
-            self
-        }
-
         #[inline]
         fn len(self) -> usize {
             $len

--- a/rten-simd/src/arch/wasm32.rs
+++ b/rten-simd/src/arch/wasm32.rs
@@ -45,6 +45,9 @@ impl Wasm32Isa {
 // Safety: This module is only compiled if WASM SIMD is enabled at compile
 // time, hence this module can treat SIMD as always-available.
 unsafe impl Isa for Wasm32Isa {
+    type M32 = M32;
+    type M16 = M16;
+    type M8 = M8;
     type F32 = F32x4;
     type I32 = I32x4;
     type I16 = I16x8;
@@ -89,16 +92,23 @@ unsafe impl Isa for Wasm32Isa {
     fn u16(self) -> impl IntOps<u16, Simd = Self::U16> {
         self
     }
+
+    fn m32(self) -> impl MaskOps<Self::M32> {
+        self
+    }
+
+    fn m16(self) -> impl MaskOps<Self::M16> {
+        self
+    }
+
+    fn m8(self) -> impl MaskOps<Self::M8> {
+        self
+    }
 }
 
 macro_rules! simd_ops_common {
     ($simd:ident, $mask:ident, $mask_elem:ty) => {
         type Simd = $simd;
-
-        #[inline]
-        fn mask_ops(self) -> impl MaskOps<<$simd as Simd>::Mask> {
-            self
-        }
 
         #[inline]
         fn len(self) -> usize {

--- a/rten-simd/src/arch/x86_64/avx512.rs
+++ b/rten-simd/src/arch/x86_64/avx512.rs
@@ -55,6 +55,9 @@ impl Avx512Isa {
 
 // Safety: AVX-512 is supported as `Avx512Isa::new` checks this.
 unsafe impl Isa for Avx512Isa {
+    type M32 = __mmask16;
+    type M16 = __mmask32;
+    type M8 = __mmask64;
     type F32 = F32x16;
     type I32 = I32x16;
     type I16 = I16x32;
@@ -99,6 +102,18 @@ unsafe impl Isa for Avx512Isa {
     fn u16(self) -> impl IntOps<u16, Simd = Self::U16> {
         self
     }
+
+    fn m32(self) -> impl MaskOps<Self::M32> {
+        self
+    }
+
+    fn m16(self) -> impl MaskOps<Self::M16> {
+        self
+    }
+
+    fn m8(self) -> impl MaskOps<Self::M8> {
+        self
+    }
 }
 
 macro_rules! simd_ops_common {
@@ -108,11 +123,6 @@ macro_rules! simd_ops_common {
         #[inline]
         fn len(self) -> usize {
             lanes::<$simd>()
-        }
-
-        #[inline]
-        fn mask_ops(self) -> impl MaskOps<$mask> {
-            self
         }
 
         #[inline]

--- a/rten-simd/src/simd.rs
+++ b/rten-simd/src/simd.rs
@@ -9,7 +9,7 @@ use crate::ops::Isa;
 ///
 /// Most operations on masks are available via the
 /// [`MaskOps`](crate::ops::MaskOps) trait. Implementations are obtained via
-/// [`NumOps::mask_ops`](crate::ops::NumOps::mask_ops).
+/// methods of [`Isa`].
 pub trait Mask: Copy + Debug {
     type Array: AsRef<[bool]>
         + Copy


### PR DESCRIPTION
Change the APIs for working with masks to be more like other SIMD vectors:

 - Add `M32`, `M16`, `M8` associated types to `Isa` trait. These are types of masks for lanes with 32, 16 and 8-bit elements respectively.

 - Add `m32`, `m16`, `m8` methods to `Isa` trait for getting operations on these mask types.

 - Define the mask type of other `Isa` associated types to be M32, M16 or M8 according to the SIMD vector element width.

This makes the APIs more coherent and allows relating the masks used for different SIMD vectors. The compiler can now understand for example that vectors of f32, i32 and u32 elements all use the same mask type.

In order to implement this for AVX2, the mask types had to be changed so that all vectors of a given lane width use the same mask type. This aligns the AVX2 implementation with how masks are handled for other ISAs.