### PR TITLE
Optimize padding with zero constant in Pad operator

### DIFF
--- a/src/ops/operators.rs
+++ b/src/ops/operators.rs
@@ -68,7 +68,7 @@ pub trait Operators {
         val: Self::Elem,
     ) -> Result<Tensor<Self::Elem>, OpError>
     where
-        Self::Elem: Copy;
+        Self::Elem: Copy + Default + PartialEq;
 
     fn topk(
         &self,
@@ -170,7 +170,7 @@ impl<T: Send, S: Storage<Elem = T>, L: MutLayout> Operators for TensorBase<S, L>
 
     fn pad(&self, padding: NdTensorView<i32, 1>, val: T) -> Result<Tensor<Self::Elem>, OpError>
     where
-        Self::Elem: Copy,
+        Self::Elem: Copy + Default + PartialEq,
     {
         let view = self.as_dyn();
         use_thread_pool(move || pad(&BufferPool::new(), view, &padding, PadMode::Constant, val))


### PR DESCRIPTION
Apply the same special-casing for zero that was used in https://github.com/robertknight/rten/pull/872. From a quick test on the Piper example this provided a modest speedup in that operator (~10%).