### PR TITLE
Add round_ties_even, mul_sub_from SIMD ops

### DIFF
--- a/rten-simd/src/arch/aarch64.rs
+++ b/rten-simd/src/arch/aarch64.rs
@@ -7,14 +7,14 @@ use std::arch::aarch64::{
     vcleq_s16, vcleq_s8, vcleq_u16, vcleq_u8, vcltq_f32, vcltq_s16, vcltq_s8, vcltq_u16, vcltq_u8,
     vcombine_s16, vcombine_s32, vcombine_u8, vcvtnq_s32_f32, vcvtq_s32_f32, vdivq_f32,
     vdupq_laneq_f32, vdupq_n_f32, vdupq_n_s16, vdupq_n_s32, vdupq_n_s8, vdupq_n_u16, vdupq_n_u8,
-    veorq_u32, vfmaq_f32, vget_high_s32, vget_low_s16, vget_low_s32, vget_low_s8, vget_low_u8,
-    vld1q_f32, vld1q_s16, vld1q_s32, vld1q_s8, vld1q_u16, vld1q_u32, vld1q_u8, vmaxq_f32,
-    vminq_f32, vmovl_high_s16, vmovl_high_s8, vmovl_high_u8, vmovl_s16, vmovl_s8, vmovl_u8,
-    vmulq_f32, vmulq_s16, vmulq_s32, vmulq_s8, vmulq_u16, vmulq_u8, vmvnq_u32, vnegq_f32,
-    vnegq_s16, vnegq_s32, vnegq_s8, vorrq_u32, vqmovn_s32, vqmovun_s16, vshlq_n_s16, vshlq_n_s32,
-    vshlq_n_s8, vshlq_n_u16, vst1q_f32, vst1q_s16, vst1q_s32, vst1q_s8, vst1q_u16, vst1q_u8,
-    vsubq_f32, vsubq_s16, vsubq_s32, vsubq_s8, vsubq_u16, vsubq_u8, vzip1q_s16, vzip1q_s8,
-    vzip2q_s16, vzip2q_s8,
+    veorq_u32, vfmaq_f32, vfmsq_f32, vget_high_s32, vget_low_s16, vget_low_s32, vget_low_s8,
+    vget_low_u8, vld1q_f32, vld1q_s16, vld1q_s32, vld1q_s8, vld1q_u16, vld1q_u32, vld1q_u8,
+    vmaxq_f32, vminq_f32, vmovl_high_s16, vmovl_high_s8, vmovl_high_u8, vmovl_s16, vmovl_s8,
+    vmovl_u8, vmulq_f32, vmulq_s16, vmulq_s32, vmulq_s8, vmulq_u16, vmulq_u8, vmvnq_u32, vnegq_f32,
+    vnegq_s16, vnegq_s32, vnegq_s8, vorrq_u32, vqmovn_s32, vqmovun_s16, vrndnq_f32, vshlq_n_s16,
+    vshlq_n_s32, vshlq_n_s8, vshlq_n_u16, vst1q_f32, vst1q_s16, vst1q_s32, vst1q_s8, vst1q_u16,
+    vst1q_u8, vsubq_f32, vsubq_s16, vsubq_s32, vsubq_s8, vsubq_u16, vsubq_u8, vzip1q_s16,
+    vzip1q_s8, vzip2q_s16, vzip2q_s8,
 };
 use std::mem::transmute;
 
@@ -289,6 +289,16 @@ impl FloatOps<f32> for ArmNeonIsa {
     #[inline]
     fn div(self, x: float32x4_t, y: float32x4_t) -> float32x4_t {
         unsafe { vdivq_f32(x, y) }
+    }
+
+    #[inline]
+    fn mul_sub_from(self, a: float32x4_t, b: float32x4_t, c: float32x4_t) -> float32x4_t {
+        unsafe { vfmsq_f32(c, a, b) }
+    }
+
+    #[inline]
+    fn round_ties_even(self, x: float32x4_t) -> float32x4_t {
+        unsafe { vrndnq_f32(x) }
     }
 
     #[inline]

--- a/rten-simd/src/arch/generic.rs
+++ b/rten-simd/src/arch/generic.rs
@@ -302,6 +302,12 @@ impl FloatOps<f32> for GenericIsa {
     }
 
     #[inline]
+    fn round_ties_even(self, x: F32x4) -> F32x4 {
+        let xs = array::from_fn(|i| x.0[i].round_ties_even());
+        F32x4(xs)
+    }
+
+    #[inline]
     fn neg(self, x: F32x4) -> F32x4 {
         let xs = array::from_fn(|i| -x.0[i]);
         F32x4(xs)

--- a/rten-simd/src/arch/wasm32.rs
+++ b/rten-simd/src/arch/wasm32.rs
@@ -292,6 +292,23 @@ impl FloatOps<f32> for Wasm32Isa {
     }
 
     #[inline]
+    fn mul_sub_from(self, a: F32x4, b: F32x4, c: F32x4) -> F32x4 {
+        #[cfg(target_feature = "relaxed-simd")]
+        {
+            F32x4(f32x4_relaxed_nmadd(a.0, b.0, c.0))
+        }
+        #[cfg(not(target_feature = "relaxed-simd"))]
+        {
+            F32x4(f32x4_sub(c.0, f32x4_mul(a.0, b.0)))
+        }
+    }
+
+    #[inline]
+    fn round_ties_even(self, x: F32x4) -> F32x4 {
+        F32x4(f32x4_nearest(x.0))
+    }
+
+    #[inline]
     fn to_int_trunc(self, x: F32x4) -> Self::Int {
         I32x4(i32x4_trunc_sat_f32x4(x.0))
     }

--- a/rten-simd/src/arch/x86_64/avx2.rs
+++ b/rten-simd/src/arch/x86_64/avx2.rs
@@ -5,19 +5,19 @@ use std::arch::x86_64::{
     _mm256_cmpeq_epi16, _mm256_cmpeq_epi32, _mm256_cmpeq_epi8, _mm256_cmpgt_epi16,
     _mm256_cmpgt_epi32, _mm256_cmpgt_epi8, _mm256_cvtepi16_epi32, _mm256_cvtepi8_epi16,
     _mm256_cvtepu8_epi16, _mm256_cvtps_epi32, _mm256_cvttps_epi32, _mm256_div_ps,
-    _mm256_extractf128_ps, _mm256_extracti128_si256, _mm256_fmadd_ps, _mm256_insertf128_si256,
-    _mm256_loadu_ps, _mm256_loadu_si256, _mm256_maskload_epi32, _mm256_maskload_ps,
-    _mm256_maskstore_epi32, _mm256_maskstore_ps, _mm256_max_ps, _mm256_min_ps,
+    _mm256_extractf128_ps, _mm256_extracti128_si256, _mm256_fmadd_ps, _mm256_fnmadd_ps,
+    _mm256_insertf128_si256, _mm256_loadu_ps, _mm256_loadu_si256, _mm256_maskload_epi32,
+    _mm256_maskload_ps, _mm256_maskstore_epi32, _mm256_maskstore_ps, _mm256_max_ps, _mm256_min_ps,
     _mm256_movemask_epi8, _mm256_mul_ps, _mm256_mullo_epi16, _mm256_mullo_epi32, _mm256_or_ps,
     _mm256_or_si256, _mm256_packs_epi32, _mm256_packus_epi16, _mm256_permute2x128_si256,
-    _mm256_permute4x64_epi64, _mm256_set1_epi16, _mm256_set1_epi32, _mm256_set1_epi8,
-    _mm256_set1_ps, _mm256_set_m128i, _mm256_setr_m128i, _mm256_setzero_si256, _mm256_slli_epi16,
-    _mm256_slli_epi32, _mm256_storeu_ps, _mm256_storeu_si256, _mm256_sub_epi16, _mm256_sub_epi32,
-    _mm256_sub_epi8, _mm256_sub_ps, _mm256_unpackhi_epi16, _mm256_unpackhi_epi8,
+    _mm256_permute4x64_epi64, _mm256_round_ps, _mm256_set1_epi16, _mm256_set1_epi32,
+    _mm256_set1_epi8, _mm256_set1_ps, _mm256_set_m128i, _mm256_setr_m128i, _mm256_setzero_si256,
+    _mm256_slli_epi16, _mm256_slli_epi32, _mm256_storeu_ps, _mm256_storeu_si256, _mm256_sub_epi16,
+    _mm256_sub_epi32, _mm256_sub_epi8, _mm256_sub_ps, _mm256_unpackhi_epi16, _mm256_unpackhi_epi8,
     _mm256_unpacklo_epi16, _mm256_unpacklo_epi8, _mm256_xor_ps, _mm256_xor_si256, _mm_add_ps,
     _mm_cvtss_f32, _mm_movehl_ps, _mm_prefetch, _mm_setr_epi8, _mm_shuffle_epi8, _mm_shuffle_ps,
-    _mm_unpacklo_epi64, _CMP_EQ_OQ, _CMP_GE_OQ, _CMP_GT_OQ, _CMP_LE_OQ, _CMP_LT_OQ, _MM_HINT_ET0,
-    _MM_HINT_T0,
+    _mm_unpacklo_epi64, _CMP_EQ_OQ, _CMP_GE_OQ, _CMP_GT_OQ, _CMP_LE_OQ, _CMP_LT_OQ,
+    _MM_FROUND_TO_NEAREST_INT, _MM_HINT_ET0, _MM_HINT_T0,
 };
 use std::is_x86_feature_detected;
 use std::mem::transmute;
@@ -309,6 +309,16 @@ impl FloatOps<f32> for Avx2Isa {
     #[inline]
     fn neg(self, x: F32x8) -> F32x8 {
         unsafe { _mm256_xor_ps(x.0, _mm256_set1_ps(-0.0)) }.into()
+    }
+
+    #[inline]
+    fn mul_sub_from(self, a: F32x8, b: F32x8, c: F32x8) -> F32x8 {
+        unsafe { _mm256_fnmadd_ps(a.0, b.0, c.0) }.into()
+    }
+
+    #[inline]
+    fn round_ties_even(self, x: F32x8) -> F32x8 {
+        unsafe { _mm256_round_ps(x.0, _MM_FROUND_TO_NEAREST_INT) }.into()
     }
 
     #[inline]

--- a/rten-simd/src/arch/x86_64/avx512.rs
+++ b/rten-simd/src/arch/x86_64/avx512.rs
@@ -6,19 +6,20 @@ use std::arch::x86_64::{
     _mm512_cmpeq_epu8_mask, _mm512_cmpge_epi8_mask, _mm512_cmpge_epu8_mask, _mm512_cmpgt_epi8_mask,
     _mm512_cmpgt_epu8_mask, _mm512_cvtepi16_epi32, _mm512_cvtepi16_epi8, _mm512_cvtepi8_epi16,
     _mm512_cvtepu8_epi16, _mm512_cvtps_epi32, _mm512_cvttps_epi32, _mm512_div_ps,
-    _mm512_extracti64x4_epi64, _mm512_fmadd_ps, _mm512_inserti64x4, _mm512_loadu_ps,
-    _mm512_loadu_si512, _mm512_mask_blend_epi16, _mm512_mask_blend_epi32, _mm512_mask_blend_epi8,
-    _mm512_mask_blend_ps, _mm512_mask_loadu_epi16, _mm512_mask_loadu_epi32, _mm512_mask_loadu_epi8,
-    _mm512_mask_loadu_ps, _mm512_mask_storeu_epi16, _mm512_mask_storeu_epi32,
-    _mm512_mask_storeu_epi8, _mm512_mask_storeu_ps, _mm512_max_ps, _mm512_min_ps, _mm512_mul_ps,
-    _mm512_mullo_epi16, _mm512_mullo_epi32, _mm512_or_ps, _mm512_or_si512, _mm512_packs_epi32,
-    _mm512_packus_epi16, _mm512_permutex2var_epi32, _mm512_permutexvar_epi64, _mm512_reduce_add_ps,
-    _mm512_set1_epi16, _mm512_set1_epi32, _mm512_set1_epi8, _mm512_set1_ps, _mm512_setr_epi32,
-    _mm512_setr_epi64, _mm512_setzero_si512, _mm512_sllv_epi16, _mm512_sllv_epi32,
-    _mm512_storeu_ps, _mm512_storeu_si512, _mm512_sub_epi16, _mm512_sub_epi32, _mm512_sub_epi8,
-    _mm512_sub_ps, _mm512_unpackhi_epi16, _mm512_unpackhi_epi8, _mm512_unpacklo_epi16,
-    _mm512_unpacklo_epi8, _mm512_xor_ps, _mm512_xor_si512, _mm_prefetch, _CMP_EQ_OQ, _CMP_GE_OQ,
-    _CMP_GT_OQ, _CMP_LE_OQ, _CMP_LT_OQ, _MM_CMPINT_EQ, _MM_CMPINT_NLE, _MM_CMPINT_NLT,
+    _mm512_extracti64x4_epi64, _mm512_fmadd_ps, _mm512_fnmadd_ps, _mm512_inserti64x4,
+    _mm512_loadu_ps, _mm512_loadu_si512, _mm512_mask_blend_epi16, _mm512_mask_blend_epi32,
+    _mm512_mask_blend_epi8, _mm512_mask_blend_ps, _mm512_mask_loadu_epi16, _mm512_mask_loadu_epi32,
+    _mm512_mask_loadu_epi8, _mm512_mask_loadu_ps, _mm512_mask_storeu_epi16,
+    _mm512_mask_storeu_epi32, _mm512_mask_storeu_epi8, _mm512_mask_storeu_ps, _mm512_max_ps,
+    _mm512_min_ps, _mm512_mul_ps, _mm512_mullo_epi16, _mm512_mullo_epi32, _mm512_or_ps,
+    _mm512_or_si512, _mm512_packs_epi32, _mm512_packus_epi16, _mm512_permutex2var_epi32,
+    _mm512_permutexvar_epi64, _mm512_reduce_add_ps, _mm512_roundscale_ps, _mm512_set1_epi16,
+    _mm512_set1_epi32, _mm512_set1_epi8, _mm512_set1_ps, _mm512_setr_epi32, _mm512_setr_epi64,
+    _mm512_setzero_si512, _mm512_sllv_epi16, _mm512_sllv_epi32, _mm512_storeu_ps,
+    _mm512_storeu_si512, _mm512_sub_epi16, _mm512_sub_epi32, _mm512_sub_epi8, _mm512_sub_ps,
+    _mm512_unpackhi_epi16, _mm512_unpackhi_epi8, _mm512_unpacklo_epi16, _mm512_unpacklo_epi8,
+    _mm512_xor_ps, _mm512_xor_si512, _mm_prefetch, _CMP_EQ_OQ, _CMP_GE_OQ, _CMP_GT_OQ, _CMP_LE_OQ,
+    _CMP_LT_OQ, _MM_CMPINT_EQ, _MM_CMPINT_NLE, _MM_CMPINT_NLT, _MM_FROUND_TO_NEAREST_INT,
     _MM_HINT_ET0, _MM_HINT_T0,
 };
 use std::mem::transmute;
@@ -301,6 +302,16 @@ impl FloatOps<f32> for Avx512Isa {
     #[inline]
     fn neg(self, x: F32x16) -> F32x16 {
         unsafe { _mm512_xor_ps(x.0, _mm512_set1_ps(-0.0)) }.into()
+    }
+
+    #[inline]
+    fn mul_sub_from(self, a: F32x16, b: F32x16, c: F32x16) -> F32x16 {
+        unsafe { _mm512_fnmadd_ps(a.0, b.0, c.0) }.into()
+    }
+
+    #[inline]
+    fn round_ties_even(self, x: F32x16) -> F32x16 {
+        unsafe { _mm512_roundscale_ps(x.0, _MM_FROUND_TO_NEAREST_INT) }.into()
     }
 
     #[inline]

--- a/rten-simd/src/ops.rs
+++ b/rten-simd/src/ops.rs
@@ -506,6 +506,16 @@ pub trait FloatOps<T: Elem>: NumOps<T> {
         self.select(self.neg(x), x, self.lt(x, self.zero()))
     }
 
+    /// Round `x` to the nearest integer value, with ties to even.
+    ///
+    /// This is like [`f32::round_ties_even`].
+    fn round_ties_even(self, x: Self::Simd) -> Self::Simd;
+
+    /// Compute `c - a * b`.
+    fn mul_sub_from(self, a: Self::Simd, b: Self::Simd, c: Self::Simd) -> Self::Simd {
+        self.sub(c, self.mul(a, b))
+    }
+
     /// Convert each lane to an integer of the same width, rounding towards zero.
     fn to_int_trunc(self, x: Self::Simd) -> Self::Int;
 
@@ -987,6 +997,35 @@ mod tests {
 
                         let expected = ops.splat(-3 as $elem);
                         let actual = ops.neg(x);
+                        assert_simd_eq!(actual, expected);
+                    })
+                }
+
+                #[test]
+                fn test_mul_sub_from() {
+                    test_simd_op!(isa, {
+                        let ops = isa.$elem();
+
+                        let a = ops.splat(2 as $elem);
+                        let b = ops.splat(3 as $elem);
+                        let c = ops.splat(4 as $elem);
+
+                        let actual = ops.mul_sub_from(a, b, c);
+                        let expected = ops.splat((-(2. * 3.) + 4.) as $elem);
+
+                        assert_simd_eq!(actual, expected);
+                    })
+                }
+
+                #[test]
+                fn test_round_ties_even() {
+                    test_simd_op!(isa, {
+                        let ops = isa.$elem();
+
+                        let x = ops.splat(3.5 as $elem);
+
+                        let expected = ops.splat(4 as $elem);
+                        let actual = ops.round_ties_even(x);
                         assert_simd_eq!(actual, expected);
                     })
                 }


### PR DESCRIPTION
Add two operations that will be useful for a sine and cosine implementation. Extracted from https://github.com/robertknight/rten/pull/879.