### PR TITLE
Add CLI options to read inputs from Safetensors file and print outputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,6 +419,7 @@ dependencies = [
  "rten",
  "rten-tensor",
  "rten-testing",
+ "safetensors",
 ]
 
 [[package]]
@@ -553,6 +554,16 @@ name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
+name = "safetensors"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "172dd94c5a87b5c79f945c863da53b2ebc7ccef4eca24ac63cca66a41aab2178"
+dependencies = [
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "semver"

--- a/rten-cli/Cargo.toml
+++ b/rten-cli/Cargo.toml
@@ -14,6 +14,7 @@ fastrand = "2.0.2"
 rten = { path = "../", version = "0.21.0", features=["mmap", "random"] }
 rten-tensor = { path = "../rten-tensor", version = "0.21.0" }
 lexopt = "0.3.0"
+safetensors = "0.6.2"
 
 [dev-dependencies]
 rten-testing = { path = "../rten-testing" }


### PR DESCRIPTION
Add a `--data` option which specifies the path to a Safetensors file from which the CLI should read input tensor values and a `--print-outputs` option which prints the debug representation of output tensors.

Together these options are useful to verify that the outputs of running a model in RTen matches that produced by another system (PyTorch, ONNX Runtime etc.). The general workflow is:

 1. Modify reference implementation of model in Python to save model inputs to a Safetensors file just before running the model, and print the outputs immediately after running.

 2. Run `rten model.rten --data inputs.safetensors --print-outputs` and verify that the outputs match the reference implementation.

The `--print-outputs` option only prints an abbreviated tensor representation, so is only useful as a quick sanity check. An option to save the full outputs for a more thorough comparison will come later.