### PR TITLE
Add Infallible -> OpError conversion

### DIFF
--- a/src/ops/convert.rs
+++ b/src/ops/convert.rs
@@ -187,7 +187,7 @@ mod tests {
 
         cases.test_each(|case| {
             let cast_op = Cast { to: case.dtype };
-            let result: Value = cast_op.run_simple_no_cast(&case.input).unwrap();
+            let result: Value = cast_op.run_simple(&case.input).unwrap();
             assert_eq!(result, case.expected);
         })
     }
@@ -215,9 +215,7 @@ mod tests {
 
         cases.test_each(|case| {
             let cast_op = CastLike {};
-            let result = cast_op
-                .run_simple_no_cast((&case.input, &case.other))
-                .unwrap();
+            let result: Value = cast_op.run_simple((&case.input, &case.other)).unwrap();
             assert_eq!(result, case.expected);
         })
     }

--- a/src/ops/generate.rs
+++ b/src/ops/generate.rs
@@ -294,11 +294,11 @@ mod tests {
         ];
 
         cases.test_each(|case| {
-            let result = EyeLike {
+            let result: Value = EyeLike {
                 k: case.k,
                 dtype: case.dtype,
             }
-            .run_simple_no_cast(case.input.as_view())
+            .run_simple(case.input.as_view())
             .unwrap();
             assert_eq!(result, case.expected);
         });

--- a/src/ops/sequence.rs
+++ b/src/ops/sequence.rs
@@ -381,7 +381,7 @@ mod tests {
             let op = SequenceAt {};
             let seq = ValueView::Sequence(&case.seq);
             let pos = Tensor::from(case.pos);
-            let value = op.run_simple_no_cast((seq, pos.view()));
+            let value = op.run_simple((seq, pos.view()));
             assert_eq!(value, case.expected);
         });
     }
@@ -601,7 +601,7 @@ mod tests {
                 axis: case.axis,
                 new_axis: case.new_axis,
             };
-            let result = op.run_simple_no_cast(ValueView::Sequence(&case.seq));
+            let result = op.run_simple(ValueView::Sequence(&case.seq));
             assert_eq!(result, case.expected);
         });
     }


### PR DESCRIPTION
This removes the need for separate `_no_cast` variants of `OperatorExt::run_simple`.