### PR TITLE
Support in-place casts when both element types have same size

### DIFF
--- a/rten-base/src/num.rs
+++ b/rten-base/src/num.rs
@@ -227,6 +227,29 @@ pub fn div_ceil(x: isize, y: isize) -> isize {
     }
 }
 
+/// Provides Rust's `as` conversions as a trait.
+///
+/// See <https://doc.rust-lang.org/reference/expressions/operator-expr.html#type-cast-expressions>
+/// for details.
+pub trait Cast<T> {
+    /// Convert `self` to type T using `self as T`.
+    fn cast(self) -> T;
+}
+
+macro_rules! impl_cast {
+    ($src:ty, $dest:ty) => {
+        impl Cast<$dest> for $src {
+            fn cast(self) -> $dest {
+                self as $dest
+            }
+        }
+    };
+}
+impl_cast!(i32, f32);
+impl_cast!(f32, i32);
+impl_cast!(i8, u8);
+impl_cast!(u8, i8);
+
 #[cfg(test)]
 mod tests {
     use super::div_ceil;

--- a/src/value.rs
+++ b/src/value.rs
@@ -22,6 +22,16 @@ pub enum DataType {
     UInt8,
 }
 
+impl DataType {
+    /** Return the size of elements of this type in bytes. */
+    pub fn size(self) -> u8 {
+        match self {
+            DataType::Int32 | DataType::Float => 4,
+            DataType::Int8 | DataType::UInt8 => 1,
+        }
+    }
+}
+
 /// Get the [`DataType`] that corresponds to a given type.
 pub trait DataTypeOf {
     /// Return the data type that corresponds to the `Self` type.


### PR DESCRIPTION
In-place casts were already supported when the source and destination types were the same. Extend this to also support cases where the source and destination types are different, but have the same size.