### PR TITLE
Implement PRelu operator

### DIFF
--- a/rten-convert/rten_convert/schema_generated.py
+++ b/rten-convert/rten_convert/schema_generated.py
@@ -133,6 +133,7 @@ class OperatorType(object):
     SequenceConstruct = 123
     SequenceErase = 124
     GridSample = 125
+    PRelu = 126
 
 
 class RNNDirection(object):

--- a/src/op_registry.rs
+++ b/src/op_registry.rs
@@ -163,6 +163,7 @@ impl OpRegistry {
         register_op!(Or);
         register_op!(Pad);
         register_op!(Pow);
+        register_op!(PRelu);
         register_op!(QuantizeLinear);
 
         #[cfg(feature = "random")]
@@ -831,6 +832,7 @@ impl ReadOp for ops::Pad {
 }
 
 impl_read_op!(Pow);
+impl_read_op!(PRelu);
 
 impl_read_op!(
     QuantizeLinear,

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -129,7 +129,7 @@ pub use unary_elementwise::{
     abs, acos, asin, atan, ceil, clip, cos, elu, erf, exp, floor, gelu, hard_sigmoid, hard_swish,
     leaky_relu, log, neg, not, reciprocal, relu, round, sigmoid, sign, silu, sin, softplus, sqrt,
     swish, tan, tanh, Abs, Acos, Asin, Atan, Ceil, Clip, Cos, Elu, Erf, Exp, Floor, Gelu,
-    HardSigmoid, HardSwish, IsInf, IsNaN, LeakyRelu, Log, Neg, Not, Reciprocal, Relu, Round,
+    HardSigmoid, HardSwish, IsInf, IsNaN, LeakyRelu, Log, Neg, Not, PRelu, Reciprocal, Relu, Round,
     Sigmoid, Sign, Silu, Sin, Softplus, Sqrt, Swish, Tan, Tanh,
 };
 pub use variadic_elementwise::{max, mean, min, sum, Max, Mean, Min, Sum};

--- a/src/schema.fbs
+++ b/src/schema.fbs
@@ -139,6 +139,7 @@ enum OperatorType: ubyte {
   SequenceConstruct,
   SequenceErase,
   GridSample,
+  PRelu,
 }
 
 enum RNNDirection: ubyte {

--- a/src/schema_generated.rs
+++ b/src/schema_generated.rs
@@ -18,13 +18,13 @@ pub const ENUM_MIN_OPERATOR_TYPE: u8 = 0;
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
-pub const ENUM_MAX_OPERATOR_TYPE: u8 = 125;
+pub const ENUM_MAX_OPERATOR_TYPE: u8 = 126;
 #[deprecated(
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 126] = [
+pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 127] = [
     OperatorType::Add,
     OperatorType::ArgMin,
     OperatorType::ArgMax,
@@ -151,6 +151,7 @@ pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 126] = [
     OperatorType::SequenceConstruct,
     OperatorType::SequenceErase,
     OperatorType::GridSample,
+    OperatorType::PRelu,
 ];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -284,9 +285,10 @@ impl OperatorType {
     pub const SequenceConstruct: Self = Self(123);
     pub const SequenceErase: Self = Self(124);
     pub const GridSample: Self = Self(125);
+    pub const PRelu: Self = Self(126);
 
     pub const ENUM_MIN: u8 = 0;
-    pub const ENUM_MAX: u8 = 125;
+    pub const ENUM_MAX: u8 = 126;
     pub const ENUM_VALUES: &'static [Self] = &[
         Self::Add,
         Self::ArgMin,
@@ -414,6 +416,7 @@ impl OperatorType {
         Self::SequenceConstruct,
         Self::SequenceErase,
         Self::GridSample,
+        Self::PRelu,
     ];
     /// Returns the variant's name or "" if unknown.
     pub fn variant_name(self) -> Option<&'static str> {
@@ -544,6 +547,7 @@ impl OperatorType {
             Self::SequenceConstruct => Some("SequenceConstruct"),
             Self::SequenceErase => Some("SequenceErase"),
             Self::GridSample => Some("GridSample"),
+            Self::PRelu => Some("PRelu"),
             _ => None,
         }
     }


### PR DESCRIPTION
PRelu is technically a binary operator but is usually described as _elementwise_, with a learnable scalar or per-channel parameter, is is grouped with the unary ops.