### PR TITLE
Impl `Extend` and `FromIterator` for InputList

### DIFF
--- a/src/ops/control_flow.rs
+++ b/src/ops/control_flow.rs
@@ -295,12 +295,14 @@ mod tests {
             let max_iter_tensor = max_iterations.map(Tensor::from);
             let cond_tensor = cond.map(|c| if c { 1i32 } else { 0i32 }).map(Tensor::from);
 
-            let mut input_list = InputList::new();
-            input_list.push_optional(max_iter_tensor.as_ref().map(ValueView::from));
-            input_list.push_optional(cond_tensor.as_ref().map(ValueView::from));
-            for input in inputs {
-                input_list.push(input.clone());
-            }
+            let input_list = InputList::from_iter(
+                [
+                    max_iter_tensor.as_ref().map(ValueView::from),
+                    cond_tensor.as_ref().map(ValueView::from),
+                ]
+                .into_iter()
+                .chain(inputs.into_iter().cloned().map(Some)),
+            );
 
             let pool = new_pool();
             let ctx = OpRunContext::new(&pool, &input_list);

--- a/src/ops/random.rs
+++ b/src/ops/random.rs
@@ -470,10 +470,11 @@ mod tests {
                 .map(|tm| Tensor::from(if tm { 1i32 } else { 0 }));
 
             let op = Dropout { seed: None };
-            let mut inputs = InputList::new();
-            inputs.push(&data);
-            inputs.push_optional(ratio_input.as_ref());
-            inputs.push_optional(training_mode_input.as_ref());
+            let inputs = InputList::from_iter([
+                Some(data.view().into()),
+                ratio_input.as_ref().map(|ri| ri.view().into()),
+                training_mode_input.as_ref().map(|tm| tm.view().into()),
+            ]);
             let pool = new_pool();
             let ctx = OpRunContext::new(&pool, &inputs);
             let mut outputs = op.run(&ctx).unwrap();
@@ -518,10 +519,11 @@ mod tests {
                 // Seed a fixed seed for consistent results
                 seed: Some(1),
             };
-            let mut inputs = InputList::new();
-            inputs.push(&data);
-            inputs.push_optional(ratio_input.as_ref());
-            inputs.push(&training_mode_input);
+            let inputs = InputList::from_iter([
+                Some(data.view().into()),
+                ratio_input.as_ref().map(|ri| ri.view().into()),
+                Some(training_mode_input.view().into()),
+            ]);
             let pool = new_pool();
             let ctx = OpRunContext::new(&pool, &inputs);
 

--- a/src/ops/sequence.rs
+++ b/src/ops/sequence.rs
@@ -473,9 +473,7 @@ mod tests {
             let op = SequenceErase {};
             let seq = ValueView::Sequence(&case.seq);
             let pos = case.pos.map(Tensor::from);
-            let mut inputs = InputList::new();
-            inputs.push(seq);
-            inputs.push_optional(pos.as_ref().map(|p| p.view()));
+            let inputs = InputList::from_iter([Some(seq), pos.as_ref().map(|p| p.view().into())]);
             let new_seq: Result<Sequence, OpError> = op.run_simple(inputs);
             assert_eq!(new_seq, case.expected);
         });
@@ -545,10 +543,11 @@ mod tests {
             let op = SequenceInsert {};
             let seq = ValueView::Sequence(&case.seq);
             let pos = case.pos.map(Tensor::from);
-            let mut inputs = InputList::new();
-            inputs.push(seq);
-            inputs.push(case.value.as_view());
-            inputs.push_optional(pos.as_ref().map(|p| p.view()));
+            let inputs = InputList::from_iter([
+                Some(seq),
+                Some(case.value.as_view()),
+                pos.as_ref().map(|p| p.view().into()),
+            ]);
             let new_seq: Result<Sequence, OpError> = op.run_simple(inputs);
             assert_eq!(new_seq, case.expected);
         });

--- a/src/ops/split.rs
+++ b/src/ops/split.rs
@@ -211,8 +211,10 @@ mod tests {
                 num_outputs: case.num_outputs,
             };
 
-            let mut inputs: InputList = input.view().into();
-            inputs.push_optional(case.splits.as_ref().map(|s| s.view()));
+            let inputs = InputList::from_iter([
+                Some(input.view().into()),
+                case.splits.as_ref().map(|s| s.view().into()),
+            ]);
             let pool = new_pool();
             let mut ctx = OpRunContext::new(&pool, &inputs);
             if let Some(n_outputs) = case.graph_outputs {


### PR DESCRIPTION
Enable some new ways of constructing and extending operator input lists by implementing these traits. This avoids the need for input lists to be mutable in some tests and/or can make them a little more succinct.