### PR TITLE
Revise `SimdUnaryOp` to remove the need for `same_cast`s

### DIFF
--- a/rten-vecmath/src/exp.rs
+++ b/rten-vecmath/src/exp.rs
@@ -60,11 +60,9 @@ pub struct Exp {}
 //     into multiple steps to extend the domain.
 impl SimdUnaryOp<f32> for Exp {
     #[inline(always)]
-    fn eval<I: Isa, S: Simd<Elem = f32, Isa = I>>(&self, isa: I, x: S) -> S {
+    fn eval<I: Isa>(&self, isa: I, x: I::F32) -> I::F32 {
         let ops = isa.f32();
         let int_ops = isa.i32();
-
-        let x = x.same_cast();
 
         // Load constants
         let inv_log_2 = ops.splat(INV_LOG2);
@@ -124,7 +122,7 @@ impl SimdUnaryOp<f32> for Exp {
         let overflow_mask = ops.ge(x, ops.splat(104.0));
         let underflow_mask = ops.le(x, ops.splat(-104.0));
         let r = ops.select(ops.splat(f32::INFINITY), r, overflow_mask);
-        ops.select(ops.zero(), r, underflow_mask).same_cast()
+        ops.select(ops.zero(), r, underflow_mask)
     }
 }
 
@@ -141,11 +139,9 @@ pub struct ReducedRangeExp {}
 
 impl SimdUnaryOp<f32> for ReducedRangeExp {
     #[inline(always)]
-    fn eval<I: Isa, S: Simd<Elem = f32, Isa = I>>(&self, isa: I, x: S) -> S {
+    fn eval<I: Isa>(&self, isa: I, x: I::F32) -> I::F32 {
         let ops = isa.f32();
         let int_ops = isa.i32();
-
-        let x = x.same_cast();
 
         // Load constants
         let inv_log_2 = ops.splat(INV_LOG2);
@@ -190,7 +186,7 @@ impl SimdUnaryOp<f32> for ReducedRangeExp {
 
         // Handle underflow. We don't need to handle overflow since x <= 0.
         let underflow_mask = ops.lt(x, ops.splat(EXP_LOWER_CUTOFF));
-        ops.select(ops.zero(), r, underflow_mask).same_cast()
+        ops.select(ops.zero(), r, underflow_mask)
     }
 }
 
@@ -206,13 +202,12 @@ pub struct Sigmoid {}
 
 impl SimdUnaryOp<f32> for Sigmoid {
     #[inline(always)]
-    fn eval<I: Isa, S: Simd<Elem = f32, Isa = I>>(&self, isa: I, x: S) -> S {
+    fn eval<I: Isa>(&self, isa: I, x: I::F32) -> I::F32 {
         let ops = isa.f32();
-        let x = x.same_cast();
 
         // 1. + exp(-x)
         let denom = ops.add(ops.one(), Exp::apply(isa, ops.neg(x)));
-        ops.reciprocal(denom).same_cast()
+        ops.reciprocal(denom)
     }
 }
 
@@ -223,13 +218,12 @@ pub struct Silu {}
 
 impl SimdUnaryOp<f32> for Silu {
     #[inline(always)]
-    fn eval<I: Isa, S: Simd<Elem = f32, Isa = I>>(&self, isa: I, x: S) -> S {
+    fn eval<I: Isa>(&self, isa: I, x: I::F32) -> I::F32 {
         let ops = isa.f32();
-        let x = x.same_cast();
 
         // 1. + exp(-x)
         let denom = ops.add(ops.one(), Exp::apply(isa, ops.neg(x)));
-        ops.div(x, denom).same_cast()
+        ops.div(x, denom)
     }
 }
 
@@ -242,13 +236,11 @@ pub struct Swish {
 
 impl SimdUnaryOp<f32> for Swish {
     #[inline(always)]
-    fn eval<I: Isa, S: Simd<Elem = f32, Isa = I>>(&self, isa: I, x: S) -> S {
+    fn eval<I: Isa>(&self, isa: I, x: I::F32) -> I::F32 {
         let ops = isa.f32();
-        let x = x.same_cast();
 
         let beta = ops.splat(self.beta);
         ops.mul(x, Sigmoid::apply(isa, ops.mul(x, beta)))
-            .same_cast()
     }
 }
 

--- a/rten-vecmath/src/tanh.rs
+++ b/rten-vecmath/src/tanh.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::excessive_precision)]
 
 use rten_simd::ops::{FloatOps, NumOps};
-use rten_simd::{Isa, Simd, SimdUnaryOp};
+use rten_simd::{Isa, SimdUnaryOp};
 
 use crate::Exp;
 
@@ -11,9 +11,8 @@ pub struct Tanh {}
 
 impl SimdUnaryOp<f32> for Tanh {
     #[inline(always)]
-    fn eval<I: Isa, S: Simd<Elem = f32, Isa = I>>(&self, isa: I, x: S) -> S {
+    fn eval<I: Isa>(&self, isa: I, x: I::F32) -> I::F32 {
         let ops = isa.f32();
-        let x = x.same_cast();
 
         let x_negative = ops.le(x, ops.zero());
         let abs_x = ops.abs(x);
@@ -62,7 +61,7 @@ impl SimdUnaryOp<f32> for Tanh {
         let y = ops.select(abs_x, y, x_tiny);
 
         // Flip sign if input was negative.
-        ops.select(ops.neg(y), y, x_negative).same_cast()
+        ops.select(ops.neg(y), y, x_negative)
     }
 }
 


### PR DESCRIPTION
Add a `GetSimd` trait which is implemented for element types and returns the `Simd` vector type that contains that element in a given `Isa`. This is similar to `GetNumOps` etc.

Then use this in the `SimdUnaryOp` definition to allow it to know which of `Isa`'s associated types will be passed and returned according to the element type. This simplifies the implementation of unary operations as they no longer need to use `same_cast`.