### PR TITLE
Migrate remaining crates to Rust 2024 edition

### DIFF
--- a/rten-bench/Cargo.toml
+++ b/rten-bench/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rten-bench"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 authors = ["Robert Knight"]
 description = "Benchmarking utilities for use in RTen development"
 license = "MIT OR Apache-2.0"

--- a/rten-examples/Cargo.toml
+++ b/rten-examples/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rten-examples"
 version = "0.3.0"
-edition = "2021"
+edition = "2024"
 authors = ["Robert Knight"]
 description = "Examples for using the rten library"
 license = "MIT OR Apache-2.0"

--- a/rten-examples/src/clip.rs
+++ b/rten-examples/src/clip.rs
@@ -4,8 +4,8 @@ use std::error::Error;
 use rten::{FloatOperators, Model};
 use rten_imageio::read_image;
 use rten_imageproc::normalize_image;
-use rten_tensor::prelude::*;
 use rten_tensor::NdTensor;
+use rten_tensor::prelude::*;
 use rten_text::Tokenizer;
 
 struct Args {

--- a/rten-examples/src/deeplab.rs
+++ b/rten-examples/src/deeplab.rs
@@ -3,7 +3,7 @@ use std::error::Error;
 
 use rten::{Dimension, FloatOperators, Model, Operators};
 use rten_imageio::{read_image, write_image};
-use rten_imageproc::{normalize_image, IMAGENET_MEAN, IMAGENET_STD_DEV};
+use rten_imageproc::{IMAGENET_MEAN, IMAGENET_STD_DEV, normalize_image};
 use rten_tensor::prelude::*;
 use rten_tensor::{NdTensor, Tensor};
 

--- a/rten-examples/src/depth_anything.rs
+++ b/rten-examples/src/depth_anything.rs
@@ -3,9 +3,9 @@ use std::error::Error;
 
 use rten::{FloatOperators, Model, Operators};
 use rten_imageio::{read_image, write_image};
-use rten_imageproc::{normalize_image, IMAGENET_MEAN, IMAGENET_STD_DEV};
-use rten_tensor::prelude::*;
+use rten_imageproc::{IMAGENET_MEAN, IMAGENET_STD_DEV, normalize_image};
 use rten_tensor::Tensor;
+use rten_tensor::prelude::*;
 
 struct Args {
     model: String,

--- a/rten-examples/src/detr.rs
+++ b/rten-examples/src/detr.rs
@@ -4,9 +4,9 @@ use std::path::Path;
 
 use rten::{FloatOperators, Model, Operators};
 use rten_imageio::{read_image, write_image};
-use rten_imageproc::{normalize_image, Painter, Rect};
-use rten_tensor::prelude::*;
+use rten_imageproc::{Painter, Rect, normalize_image};
 use rten_tensor::NdTensor;
+use rten_tensor::prelude::*;
 use serde::Deserialize;
 
 struct Args {

--- a/rten-examples/src/distilvit.rs
+++ b/rten-examples/src/distilvit.rs
@@ -5,8 +5,8 @@ use std::io::prelude::*;
 use rten::{FloatOperators, Model};
 use rten_generate::{Generator, GeneratorUtils};
 use rten_imageio::read_image;
-use rten_tensor::prelude::*;
 use rten_tensor::NdTensor;
+use rten_tensor::prelude::*;
 use rten_text::Tokenizer;
 
 struct Args {

--- a/rten-examples/src/modernbert.rs
+++ b/rten-examples/src/modernbert.rs
@@ -2,8 +2,8 @@ use std::collections::VecDeque;
 use std::error::Error;
 
 use rten::{Model, Operators};
-use rten_tensor::prelude::*;
 use rten_tensor::NdTensor;
+use rten_tensor::prelude::*;
 use rten_text::{TokenId, Tokenizer, TokenizerError};
 
 struct Args {

--- a/rten-examples/src/nougat.rs
+++ b/rten-examples/src/nougat.rs
@@ -7,8 +7,8 @@ use rten_generate::metrics::Metrics;
 use rten_generate::{Generator, GeneratorUtils};
 use rten_imageio::read_image;
 use rten_imageproc::normalize_image;
-use rten_tensor::prelude::*;
 use rten_tensor::NdTensor;
+use rten_tensor::prelude::*;
 use rten_text::Tokenizer;
 
 struct Args {

--- a/rten-examples/src/silero.rs
+++ b/rten-examples/src/silero.rs
@@ -3,8 +3,8 @@ use std::error::Error;
 use std::ops::Range;
 
 use rten::Model;
-use rten_tensor::prelude::*;
 use rten_tensor::NdTensor;
+use rten_tensor::prelude::*;
 
 struct Args {
     model: String,

--- a/rten-examples/src/trocr.rs
+++ b/rten-examples/src/trocr.rs
@@ -6,8 +6,8 @@ use rten::{FloatOperators, Model};
 use rten_generate::{Generator, GeneratorUtils};
 use rten_imageio::read_image;
 use rten_imageproc::normalize_image;
-use rten_tensor::prelude::*;
 use rten_tensor::NdTensor;
+use rten_tensor::prelude::*;
 use rten_text::Tokenizer;
 
 struct Args {

--- a/rten-examples/src/wav2vec2.rs
+++ b/rten-examples/src/wav2vec2.rs
@@ -1,8 +1,8 @@
 use std::collections::VecDeque;
 use std::error::Error;
 
-use rten::ctc::CtcDecoder;
 use rten::Model;
+use rten::ctc::CtcDecoder;
 use rten_tensor::prelude::*;
 use rten_tensor::{NdTensor, Tensor};
 

--- a/rten-examples/src/whisper.rs
+++ b/rten-examples/src/whisper.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 
 use microfft::Complex32;
 use rten::{Dimension, FloatOperators, Model};
-use rten_generate::filter::{token_id_filter, LogitsFilter};
+use rten_generate::filter::{LogitsFilter, token_id_filter};
 use rten_generate::{Generator, GeneratorConfig, GeneratorUtils};
 use rten_tensor::prelude::*;
 use rten_tensor::{NdTensor, NdTensorView};
@@ -320,11 +320,7 @@ impl LogitsFilter for TimestampFilter {
                     suppress = true;
                 }
 
-                if !suppress {
-                    logit
-                } else {
-                    f32::NEG_INFINITY
-                }
+                if !suppress { logit } else { f32::NEG_INFINITY }
             })
             .collect();
         Some(NdTensor::from_data([logits.len()], filtered_logits))
@@ -618,7 +614,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!(
         "Transcribed {}s of audio in {:.2}s, {:.1}x real-time (encode: {:.2}s, prompt: {:.2}s, decode: {:.2}s)",
         audio_duration,
-        total_duration, real_time_factor,
+        total_duration,
+        real_time_factor,
         encode_time.as_secs_f32(),
         prompt_time.as_secs_f32(),
         decode_time.as_secs_f32()

--- a/rten-examples/src/yolo.rs
+++ b/rten-examples/src/yolo.rs
@@ -3,12 +3,12 @@ use std::error::Error;
 use std::fs;
 use std::path::PathBuf;
 
-use rten::ops::{non_max_suppression, BoxOrder};
+use rten::ops::{BoxOrder, non_max_suppression};
 use rten::{BufferPool, Dimension, FloatOperators, Model};
 use rten_imageio::{read_image, write_image};
 use rten_imageproc::{Painter, Rect};
-use rten_tensor::prelude::*;
 use rten_tensor::NdTensor;
+use rten_tensor::prelude::*;
 
 struct Args {
     model: String,
@@ -212,12 +212,12 @@ fn main() -> Result<(), Box<dyn Error>> {
 
         if !args.summary {
             println!(
-            "object: {label} score: {score:.3} left: {} top: {} right: {} bottom: {} box index: {box_idx}",
-            int_rect.left(),
-            int_rect.top(),
-            int_rect.right(),
-            int_rect.bottom()
-        );
+                "object: {label} score: {score:.3} left: {} top: {} right: {} bottom: {} box index: {box_idx}",
+                int_rect.left(),
+                int_rect.top(),
+                int_rect.right(),
+                int_rect.bottom()
+            );
         }
     }
 

--- a/rten-gemm/Cargo.toml
+++ b/rten-gemm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rten-gemm"
 version = "0.21.0"
-edition = "2021"
+edition = "2024"
 authors = ["Robert Knight"]
 description = "Machine-learning oriented matrix multiplication"
 license = "MIT OR Apache-2.0"

--- a/rten-gemm/src/im2col.rs
+++ b/rten-gemm/src/im2col.rs
@@ -1,12 +1,12 @@
 use std::mem::MaybeUninit;
 use std::ops::Range;
 
-use rten_base::byte_cast::{cast_uninit_pod_mut_slice, AsBytes};
+use rten_base::byte_cast::{AsBytes, cast_uninit_pod_mut_slice};
 use rten_simd::ops::{MaskOps, NumOps};
 use rten_simd::{Isa, Mask, Simd};
 use rten_tensor::{NdTensorView, Storage};
 
-use super::packing::int8::{shift_cast_i8_u8, PackedBMeta};
+use super::packing::int8::{PackedBMeta, shift_cast_i8_u8};
 
 /// Maps rows of an [`Im2Col`] matrix to locations in the source image.
 ///

--- a/rten-gemm/src/kernels.rs
+++ b/rten-gemm/src/kernels.rs
@@ -1,3 +1,7 @@
+// The GEMM kernels contain many unsafe calls for performance reasons. This
+// lint was suppressed to simplify migration to the 2024 Rust edition.
+#![allow(unsafe_op_in_unsafe_fn)]
+
 use std::mem::MaybeUninit;
 use std::ops::Range;
 

--- a/rten-gemm/src/kernels/aarch64.rs
+++ b/rten-gemm/src/kernels/aarch64.rs
@@ -1,4 +1,4 @@
-use std::arch::aarch64::{int32x4_t, int8x16_t};
+use std::arch::aarch64::{int8x16_t, int32x4_t};
 use std::mem::MaybeUninit;
 use std::ops::Range;
 
@@ -7,11 +7,11 @@ use rten_simd::isa::ArmNeonIsa;
 use rten_tensor::{Matrix, MatrixLayout};
 
 use super::simd_generic::{
-    simd_gemv, simd_int8_gemm, simd_int8_gemm_epilogue, simd_int8_gemv, GemmDispatch,
+    GemmDispatch, simd_gemv, simd_int8_gemm, simd_int8_gemm_epilogue, simd_int8_gemv,
 };
 use super::{Int8DotProduct, Kernel, Lhs, MatVecOutput, PackedLayout, QuantParams, TempTile};
 use crate::packing::{pack_a_block, pack_b_block, packed_a_layout, packed_b_layout};
-use crate::{packing, Im2Col};
+use crate::{Im2Col, packing};
 
 pub struct ArmNeonKernel {
     isa: ArmNeonIsa,
@@ -477,8 +477,8 @@ unsafe impl Kernel<u8, i8, i32> for ArmInt8MlalKernel {
         _b_quant: Option<QuantParams<i8>>,
     ) {
         use rten_simd::{
-            ops::{Extend, NumOps},
             Isa, Simd,
+            ops::{Extend, NumOps},
         };
         use std::arch::aarch64::{vget_low_u16, vmlal_high_laneq_u16, vmlal_laneq_u16};
 
@@ -660,7 +660,7 @@ unsafe impl Int8DotProduct for NeonNativeDotProd {
         #[inline]
         unsafe fn dot_product(a: int8x16_t, b: int8x16_t, c: int32x4_t) -> int32x4_t {
             use core::arch::aarch64::{
-                vreinterpretq_s32_u32, vreinterpretq_u32_s32, vreinterpretq_u8_s8,
+                vreinterpretq_s32_u32, vreinterpretq_u8_s8, vreinterpretq_u32_s32,
             };
             use core::arch::asm;
 
@@ -698,7 +698,7 @@ unsafe impl Int8DotProduct for NeonNativeDotProd {
             c: int32x4_t,
         ) -> int32x4_t {
             use core::arch::aarch64::{
-                vreinterpretq_s32_u32, vreinterpretq_u32_s32, vreinterpretq_u8_s8,
+                vreinterpretq_s32_u32, vreinterpretq_u8_s8, vreinterpretq_u32_s32,
             };
             use core::arch::asm;
 
@@ -738,7 +738,7 @@ unsafe impl Int8DotProduct for NeonDotProd {
         unsafe {
             use core::arch::aarch64::{
                 vaddq_u32, vget_low_u8, vmull_high_u8, vmull_u8, vpaddlq_u16, vpaddq_u32,
-                vreinterpretq_s32_u32, vreinterpretq_u32_s32, vreinterpretq_u8_s8,
+                vreinterpretq_s32_u32, vreinterpretq_u8_s8, vreinterpretq_u32_s32,
             };
 
             let a = vreinterpretq_u8_s8(a);
@@ -882,8 +882,8 @@ unsafe impl Kernel<u8, i8, i32> for ArmInt8MMKernel {
         _b_quant: Option<QuantParams<i8>>,
     ) {
         use rten_simd::{
-            ops::{Concat, NumOps},
             Isa,
+            ops::{Concat, NumOps},
         };
 
         const MR: usize = ArmInt8MMKernel::MR;

--- a/rten-gemm/src/kernels/generic.rs
+++ b/rten-gemm/src/kernels/generic.rs
@@ -2,13 +2,13 @@ use std::mem::MaybeUninit;
 use std::ops::Range;
 
 use rten_base::byte_cast::{cast_pod_slice, cast_uninit_pod_mut_slice};
-use rten_simd::{isa::GenericIsa, Isa};
+use rten_simd::{Isa, isa::GenericIsa};
 use rten_tensor::{Matrix, MatrixLayout};
 
-use super::simd_generic::{simd_gemv, GemmDispatch};
+use super::simd_generic::{GemmDispatch, simd_gemv};
 use super::{Kernel, Lhs, MatVecOutput, PackedLayout, QuantParams, TempTile};
-use crate::packing::{pack_a_block, pack_b_block, packed_a_layout, packed_b_layout};
 use crate::Im2Col;
+use crate::packing::{pack_a_block, pack_b_block, packed_a_layout, packed_b_layout};
 
 /// This is the base kernel that does not use architecture-specific intrinsics
 /// but is autovectorization-friendly. It is expected to perform the same as

--- a/rten-gemm/src/kernels/wasm.rs
+++ b/rten-gemm/src/kernels/wasm.rs
@@ -2,13 +2,13 @@ use std::mem::MaybeUninit;
 use std::ops::Range;
 
 use rten_base::byte_cast::{cast_pod_slice, cast_uninit_pod_mut_slice};
-use rten_simd::{isa::Wasm32Isa, Isa};
+use rten_simd::{Isa, isa::Wasm32Isa};
 use rten_tensor::{Matrix, MatrixLayout};
 
-use super::simd_generic::{simd_gemv, simd_int8_gemm, simd_int8_gemv, GemmDispatch};
+use super::simd_generic::{GemmDispatch, simd_gemv, simd_int8_gemm, simd_int8_gemv};
 use super::{Int8DotProduct, Kernel, Lhs, MatVecOutput, PackedLayout, QuantParams, TempTile};
 use crate::packing::{pack_a_block, pack_b_block, packed_a_layout, packed_b_layout};
-use crate::{packing, Im2Col};
+use crate::{Im2Col, packing};
 
 pub struct WasmKernel {
     isa: Wasm32Isa,

--- a/rten-gemm/src/kernels/x86_64.rs
+++ b/rten-gemm/src/kernels/x86_64.rs
@@ -2,16 +2,16 @@ use std::mem::MaybeUninit;
 use std::ops::Range;
 
 use rten_base::byte_cast::{cast_pod_slice, cast_uninit_pod_mut_slice};
-use rten_simd::{isa::Avx2Isa, Isa};
+use rten_simd::{Isa, isa::Avx2Isa};
 use rten_tensor::{Matrix, MatrixLayout};
 
 use rten_simd::isa::Avx512Isa;
 
-use super::simd_generic::{simd_gemv, simd_int8_gemm, simd_int8_gemv, GemmDispatch};
+use super::simd_generic::{GemmDispatch, simd_gemv, simd_int8_gemm, simd_int8_gemv};
 use super::{Int8DotProduct, Kernel, Lhs, MatVecOutput, PackedLayout, QuantParams, TempTile};
+use crate::Im2Col;
 use crate::packing;
 use crate::packing::{pack_a_block, pack_b_block, packed_a_layout, packed_b_layout};
-use crate::Im2Col;
 
 /// Optimized kernel for x64 CPUs that support AVX + FMA instructions.
 pub struct FmaKernel {

--- a/rten-gemm/src/lib.rs
+++ b/rten-gemm/src/lib.rs
@@ -737,16 +737,16 @@ fn gemm_impl<'a, LhsT: GemmInT, RhsT: GemmInT, OutT: GemmOutT>(
         return Err(GemmError::WrongBiasSize);
     }
 
-    if let Some(a_quant) = a_quant {
-        if a_quant.zero_point.len() != a.rows() {
-            return Err(GemmError::WrongQuantParamSize);
-        }
+    if let Some(a_quant) = a_quant
+        && a_quant.zero_point.len() != a.rows()
+    {
+        return Err(GemmError::WrongQuantParamSize);
     }
 
-    if let Some(b_quant) = b_quant {
-        if b_quant.zero_point.len() != b.cols() {
-            return Err(GemmError::WrongQuantParamSize);
-        }
+    if let Some(b_quant) = b_quant
+        && b_quant.zero_point.len() != b.cols()
+    {
+        return Err(GemmError::WrongQuantParamSize);
     }
 
     // Construct a Matrix from the implied dimensions, to validate the slice length.

--- a/rten-gemm/src/lib.rs
+++ b/rten-gemm/src/lib.rs
@@ -8,7 +8,7 @@ use std::ops::{Add, Mul, Range};
 
 use rayon::prelude::*;
 use rten_base::byte_cast::Pod;
-use rten_base::iter::{range_chunks, MaybeParIter};
+use rten_base::iter::{MaybeParIter, range_chunks};
 use rten_base::num::Identities;
 use rten_tensor::prelude::*;
 use rten_tensor::{
@@ -25,8 +25,8 @@ mod tiles;
 
 pub use errors::GemmError;
 pub use im2col::{ColOffsets, Im2Col, RowOffsets};
-use kernels::generic::GenericKernel;
 pub use kernels::QuantParams;
+use kernels::generic::GenericKernel;
 use kernels::{Kernel, MatVecOutput};
 use packing::PackingBuffer;
 pub use prepack::{PackedAMatrix, PackedBMatrix};

--- a/rten-gemm/src/packing.rs
+++ b/rten-gemm/src/packing.rs
@@ -31,7 +31,7 @@ impl<'a, T> SliceWriter<'a, T> {
     /// length of the slice.
     unsafe fn write_unchecked(&mut self, val: T) {
         debug_assert!(self.offset < self.slice.len());
-        self.slice.get_unchecked_mut(self.offset).write(val);
+        unsafe { self.slice.get_unchecked_mut(self.offset) }.write(val);
         self.offset += 1;
     }
 
@@ -58,7 +58,7 @@ impl<'a, T> SliceWriter<'a, T> {
     {
         debug_assert!(self.offset + len <= self.slice.len());
         for i in 0..len {
-            self.slice.get_unchecked_mut(self.offset + i).write(val);
+            unsafe { self.slice.get_unchecked_mut(self.offset + i) }.write(val);
         }
         self.offset += len;
     }
@@ -283,7 +283,7 @@ impl PackingBuffer {
 
         let buf_len = rounded_len / size_of::<PackElem>();
         assert!(buf_len <= self.buf.capacity());
-        self.buf.set_len(buf_len);
+        unsafe { self.buf.set_len(buf_len) };
         self.used_len = initialized_len;
     }
 

--- a/rten-gemm/src/packing/int8.rs
+++ b/rten-gemm/src/packing/int8.rs
@@ -506,14 +506,14 @@ pub fn extract_packed_b<const NR: usize>(b: &[u8]) -> (&[u8], &PackedBMeta<NR>) 
 
 #[cfg(test)]
 mod tests {
-    use rten_base::byte_cast::{cast_pod_slice, AsBytes};
+    use rten_base::byte_cast::{AsBytes, cast_pod_slice};
     use rten_tensor::prelude::*;
     use rten_tensor::rng::XorShiftRng;
     use rten_tensor::{Matrix, MatrixLayout, NdTensor};
 
     use super::{
-        extract_packed_a, extract_packed_b, pack_a, pack_b, pack_b_cast_i8_u8, packed_a_layout,
-        packed_b_layout, PackedAMeta, PackedBMeta,
+        PackedAMeta, PackedBMeta, extract_packed_a, extract_packed_b, pack_a, pack_b,
+        pack_b_cast_i8_u8, packed_a_layout, packed_b_layout,
     };
 
     // K tile size used by kernels that compute dot product of 4x i8 -> i32.

--- a/rten-gemm/src/prepack.rs
+++ b/rten-gemm/src/prepack.rs
@@ -5,7 +5,7 @@ use rten_base::iter::range_chunks;
 use rten_tensor::{Alloc, Matrix, MatrixLayout};
 
 use super::packing::PackingBuffer;
-use super::{depth_block_size, GemmError, Kernel, LhsBlock, RhsBlock};
+use super::{GemmError, Kernel, LhsBlock, RhsBlock, depth_block_size};
 
 /// Common data and logic for a pre-packed A or B matrix.
 ///

--- a/rten-gemm/src/reduced_range_rng.rs
+++ b/rten-gemm/src/reduced_range_rng.rs
@@ -1,5 +1,5 @@
-use rten_tensor::rng::XorShiftRng;
 use rten_tensor::RandomSource;
+use rten_tensor::rng::XorShiftRng;
 
 /// Random number generator which produces values with an optionally reduced
 /// range.

--- a/rten-gemm/src/tests.rs
+++ b/rten-gemm/src/tests.rs
@@ -4,7 +4,7 @@ use std::time::Instant;
 use rten_bench::run_bench;
 use rten_tensor::prelude::*;
 use rten_tensor::rng::XorShiftRng;
-use rten_tensor::test_util::{expect_equal, ApproxEq};
+use rten_tensor::test_util::{ApproxEq, expect_equal};
 use rten_tensor::{Matrix, MatrixLayout, MatrixMut, NdTensor, NdTensorView, RandomSource};
 use rten_testing::TestCases;
 

--- a/rten-gemm/src/tiles.rs
+++ b/rten-gemm/src/tiles.rs
@@ -62,7 +62,7 @@ impl<'a, T> OutputTiles<'a, T> {
         let start_col = col * self.tile_cols;
 
         OutputTile {
-            ptr: self.data.add(start_row * self.row_stride + start_col),
+            ptr: unsafe { self.data.add(start_row * self.row_stride + start_col) },
             row_stride: self.row_stride,
             used_rows: (self.rows - start_row).min(self.tile_rows),
             used_cols: (self.cols - start_col).min(self.tile_cols),

--- a/rten-simd/Cargo.toml
+++ b/rten-simd/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rten-simd"
 version = "0.21.0"
-edition = "2021"
+edition = "2024"
 authors = ["Robert Knight"]
 description = "Portable SIMD for stable Rust"
 license = "MIT OR Apache-2.0"

--- a/rten-simd/src/arch.rs
+++ b/rten-simd/src/arch.rs
@@ -1,3 +1,7 @@
+// The `arch` module contains many unsafe calls to SIMD intrinsics. Suppress
+// this lint to simplify migration to the 2024 Rust edition.
+#![allow(unsafe_op_in_unsafe_fn)]
+
 #[cfg(target_arch = "aarch64")]
 pub mod aarch64;
 

--- a/rten-simd/src/arch/aarch64.rs
+++ b/rten-simd/src/arch/aarch64.rs
@@ -1,20 +1,20 @@
 use std::arch::aarch64::{
-    float32x4_t, int16x8_t, int32x4_t, int8x16_t, uint16x8_t, uint32x4_t, uint8x16_t, vabsq_f32,
-    vaddq_f32, vaddq_s16, vaddq_s32, vaddq_s8, vaddq_u16, vaddq_u8, vaddvq_f32, vandq_u16,
-    vandq_u32, vandq_u8, vbslq_f32, vbslq_s16, vbslq_s32, vbslq_s8, vbslq_u16, vbslq_u8, vceqq_f32,
-    vceqq_s16, vceqq_s32, vceqq_s8, vceqq_u16, vceqq_u8, vcgeq_f32, vcgeq_s16, vcgeq_s32, vcgeq_s8,
-    vcgeq_u16, vcgeq_u8, vcgtq_f32, vcgtq_s16, vcgtq_s32, vcgtq_s8, vcgtq_u16, vcgtq_u8, vcleq_f32,
-    vcleq_s16, vcleq_s8, vcleq_u16, vcleq_u8, vcltq_f32, vcltq_s16, vcltq_s8, vcltq_u16, vcltq_u8,
-    vcombine_s16, vcombine_s32, vcombine_u8, vcvtnq_s32_f32, vcvtq_s32_f32, vdivq_f32,
-    vdupq_laneq_f32, vdupq_n_f32, vdupq_n_s16, vdupq_n_s32, vdupq_n_s8, vdupq_n_u16, vdupq_n_u8,
-    veorq_u32, vfmaq_f32, vfmsq_f32, vget_high_s32, vget_low_s16, vget_low_s32, vget_low_s8,
-    vget_low_u8, vld1q_f32, vld1q_s16, vld1q_s32, vld1q_s8, vld1q_u16, vld1q_u32, vld1q_u8,
-    vmaxq_f32, vminq_f32, vmovl_high_s16, vmovl_high_s8, vmovl_high_u8, vmovl_s16, vmovl_s8,
-    vmovl_u8, vmulq_f32, vmulq_s16, vmulq_s32, vmulq_s8, vmulq_u16, vmulq_u8, vmvnq_u32, vnegq_f32,
-    vnegq_s16, vnegq_s32, vnegq_s8, vorrq_u32, vqmovn_s32, vqmovun_s16, vrndnq_f32, vshlq_n_s16,
-    vshlq_n_s32, vshlq_n_s8, vshlq_n_u16, vst1q_f32, vst1q_s16, vst1q_s32, vst1q_s8, vst1q_u16,
-    vst1q_u8, vsubq_f32, vsubq_s16, vsubq_s32, vsubq_s8, vsubq_u16, vsubq_u8, vzip1q_s16,
-    vzip1q_s8, vzip2q_s16, vzip2q_s8,
+    float32x4_t, int8x16_t, int16x8_t, int32x4_t, uint8x16_t, uint16x8_t, uint32x4_t, vabsq_f32,
+    vaddq_f32, vaddq_s8, vaddq_s16, vaddq_s32, vaddq_u8, vaddq_u16, vaddvq_f32, vandq_u8,
+    vandq_u16, vandq_u32, vbslq_f32, vbslq_s8, vbslq_s16, vbslq_s32, vbslq_u8, vbslq_u16,
+    vceqq_f32, vceqq_s8, vceqq_s16, vceqq_s32, vceqq_u8, vceqq_u16, vcgeq_f32, vcgeq_s8, vcgeq_s16,
+    vcgeq_s32, vcgeq_u8, vcgeq_u16, vcgtq_f32, vcgtq_s8, vcgtq_s16, vcgtq_s32, vcgtq_u8, vcgtq_u16,
+    vcleq_f32, vcleq_s8, vcleq_s16, vcleq_u8, vcleq_u16, vcltq_f32, vcltq_s8, vcltq_s16, vcltq_u8,
+    vcltq_u16, vcombine_s16, vcombine_s32, vcombine_u8, vcvtnq_s32_f32, vcvtq_s32_f32, vdivq_f32,
+    vdupq_laneq_f32, vdupq_n_f32, vdupq_n_s8, vdupq_n_s16, vdupq_n_s32, vdupq_n_u8, vdupq_n_u16,
+    veorq_u32, vfmaq_f32, vfmsq_f32, vget_high_s32, vget_low_s8, vget_low_s16, vget_low_s32,
+    vget_low_u8, vld1q_f32, vld1q_s8, vld1q_s16, vld1q_s32, vld1q_u8, vld1q_u16, vld1q_u32,
+    vmaxq_f32, vminq_f32, vmovl_high_s8, vmovl_high_s16, vmovl_high_u8, vmovl_s8, vmovl_s16,
+    vmovl_u8, vmulq_f32, vmulq_s8, vmulq_s16, vmulq_s32, vmulq_u8, vmulq_u16, vmvnq_u32, vnegq_f32,
+    vnegq_s8, vnegq_s16, vnegq_s32, vorrq_u32, vqmovn_s32, vqmovun_s16, vrndnq_f32, vshlq_n_s8,
+    vshlq_n_s16, vshlq_n_s32, vshlq_n_u16, vst1q_f32, vst1q_s8, vst1q_s16, vst1q_s32, vst1q_u8,
+    vst1q_u16, vsubq_f32, vsubq_s8, vsubq_s16, vsubq_s32, vsubq_u8, vsubq_u16, vzip1q_s8,
+    vzip1q_s16, vzip2q_s8, vzip2q_s16,
 };
 use std::mem::transmute;
 
@@ -55,17 +55,17 @@ unsafe impl Isa for ArmNeonIsa {
     fn i32(
         self,
     ) -> impl SignedIntOps<i32, Simd = Self::I32>
-           + NarrowSaturate<i32, i16, Output = Self::I16>
-           + Concat<i32> {
+    + NarrowSaturate<i32, i16, Output = Self::I16>
+    + Concat<i32> {
         self
     }
 
     fn i16(
         self,
     ) -> impl SignedIntOps<i16, Simd = Self::I16>
-           + NarrowSaturate<i16, u8, Output = Self::U8>
-           + Extend<i16, Output = Self::I32>
-           + Interleave<i16> {
+    + NarrowSaturate<i16, u8, Output = Self::U8>
+    + Extend<i16, Output = Self::I32>
+    + Interleave<i16> {
         self
     }
 

--- a/rten-simd/src/arch/generic.rs
+++ b/rten-simd/src/arch/generic.rs
@@ -97,17 +97,17 @@ unsafe impl Isa for GenericIsa {
     fn i32(
         self,
     ) -> impl SignedIntOps<i32, Simd = Self::I32>
-           + NarrowSaturate<i32, i16, Output = Self::I16>
-           + Concat<i32> {
+    + NarrowSaturate<i32, i16, Output = Self::I16>
+    + Concat<i32> {
         self
     }
 
     fn i16(
         self,
     ) -> impl SignedIntOps<i16, Simd = Self::I16>
-           + NarrowSaturate<i16, u8, Output = Self::U8>
-           + Extend<i16, Output = Self::I32>
-           + Interleave<i16> {
+    + NarrowSaturate<i16, u8, Output = Self::U8>
+    + Extend<i16, Output = Self::I32>
+    + Interleave<i16> {
         self
     }
 

--- a/rten-simd/src/arch/wasm32.rs
+++ b/rten-simd/src/arch/wasm32.rs
@@ -1,16 +1,16 @@
 use std::arch::wasm32::{
     f32x4_abs, f32x4_add, f32x4_div, f32x4_eq, f32x4_extract_lane, f32x4_ge, f32x4_gt, f32x4_le,
     f32x4_lt, f32x4_max, f32x4_min, f32x4_mul, f32x4_nearest, f32x4_neg, f32x4_splat, f32x4_sub,
-    i16x8_add, i16x8_eq, i16x8_extend_high_i8x16, i16x8_extend_low_i8x16, i16x8_extmul_high_i8x16,
-    i16x8_extmul_low_i8x16, i16x8_ge, i16x8_gt, i16x8_mul, i16x8_narrow_i32x4, i16x8_neg,
-    i16x8_shl, i16x8_shuffle, i16x8_splat, i16x8_sub, i32x4_add, i32x4_eq, i32x4_extend_high_i16x8,
-    i32x4_extend_low_i16x8, i32x4_ge, i32x4_gt, i32x4_mul, i32x4_neg, i32x4_shl, i32x4_shuffle,
-    i32x4_splat, i32x4_sub, i32x4_trunc_sat_f32x4, i8x16_add, i8x16_eq, i8x16_ge, i8x16_gt,
-    i8x16_neg, i8x16_shl, i8x16_shuffle, i8x16_splat, i8x16_sub, u16x8_add, u16x8_eq,
-    u16x8_extend_high_u8x16, u16x8_extend_low_u8x16, u16x8_extmul_high_u8x16,
-    u16x8_extmul_low_u8x16, u16x8_ge, u16x8_gt, u16x8_mul, u16x8_shl, u16x8_splat, u16x8_sub,
-    u8x16_add, u8x16_eq, u8x16_ge, u8x16_gt, u8x16_narrow_i16x8, u8x16_shuffle, u8x16_splat,
-    u8x16_sub, v128, v128_and, v128_bitselect, v128_load, v128_not, v128_or, v128_store, v128_xor,
+    i8x16_add, i8x16_eq, i8x16_ge, i8x16_gt, i8x16_neg, i8x16_shl, i8x16_shuffle, i8x16_splat,
+    i8x16_sub, i16x8_add, i16x8_eq, i16x8_extend_high_i8x16, i16x8_extend_low_i8x16,
+    i16x8_extmul_high_i8x16, i16x8_extmul_low_i8x16, i16x8_ge, i16x8_gt, i16x8_mul,
+    i16x8_narrow_i32x4, i16x8_neg, i16x8_shl, i16x8_shuffle, i16x8_splat, i16x8_sub, i32x4_add,
+    i32x4_eq, i32x4_extend_high_i16x8, i32x4_extend_low_i16x8, i32x4_ge, i32x4_gt, i32x4_mul,
+    i32x4_neg, i32x4_shl, i32x4_shuffle, i32x4_splat, i32x4_sub, i32x4_trunc_sat_f32x4, u8x16_add,
+    u8x16_eq, u8x16_ge, u8x16_gt, u8x16_narrow_i16x8, u8x16_shuffle, u8x16_splat, u8x16_sub,
+    u16x8_add, u16x8_eq, u16x8_extend_high_u8x16, u16x8_extend_low_u8x16, u16x8_extmul_high_u8x16,
+    u16x8_extmul_low_u8x16, u16x8_ge, u16x8_gt, u16x8_mul, u16x8_shl, u16x8_splat, u16x8_sub, v128,
+    v128_and, v128_bitselect, v128_load, v128_not, v128_or, v128_store, v128_xor,
 };
 use std::mem::transmute;
 
@@ -64,17 +64,17 @@ unsafe impl Isa for Wasm32Isa {
     fn i32(
         self,
     ) -> impl SignedIntOps<i32, Simd = Self::I32>
-           + NarrowSaturate<i32, i16, Output = Self::I16>
-           + Concat<i32> {
+    + NarrowSaturate<i32, i16, Output = Self::I16>
+    + Concat<i32> {
         self
     }
 
     fn i16(
         self,
     ) -> impl SignedIntOps<i16, Simd = Self::I16>
-           + NarrowSaturate<i16, u8, Output = Self::U8>
-           + Extend<i16, Output = Self::I32>
-           + Interleave<i16> {
+    + NarrowSaturate<i16, u8, Output = Self::U8>
+    + Extend<i16, Output = Self::I32>
+    + Interleave<i16> {
         self
     }
 

--- a/rten-simd/src/arch/x86_64/avx2.rs
+++ b/rten-simd/src/arch/x86_64/avx2.rs
@@ -1,23 +1,23 @@
 use std::arch::x86_64::{
-    __m128i, __m256, __m256i, _mm256_add_epi16, _mm256_add_epi32, _mm256_add_epi8, _mm256_add_ps,
-    _mm256_and_ps, _mm256_and_si256, _mm256_andnot_ps, _mm256_andnot_si256, _mm256_blendv_epi8,
-    _mm256_blendv_ps, _mm256_castps256_ps128, _mm256_castsi256_si128, _mm256_cmp_ps,
-    _mm256_cmpeq_epi16, _mm256_cmpeq_epi32, _mm256_cmpeq_epi8, _mm256_cmpgt_epi16,
-    _mm256_cmpgt_epi32, _mm256_cmpgt_epi8, _mm256_cvtepi16_epi32, _mm256_cvtepi8_epi16,
-    _mm256_cvtepu8_epi16, _mm256_cvtps_epi32, _mm256_cvttps_epi32, _mm256_div_ps,
-    _mm256_extractf128_ps, _mm256_extracti128_si256, _mm256_fmadd_ps, _mm256_fnmadd_ps,
-    _mm256_insertf128_si256, _mm256_loadu_ps, _mm256_loadu_si256, _mm256_maskload_epi32,
-    _mm256_maskload_ps, _mm256_maskstore_epi32, _mm256_maskstore_ps, _mm256_max_ps, _mm256_min_ps,
+    __m128i, __m256, __m256i, _CMP_EQ_OQ, _CMP_GE_OQ, _CMP_GT_OQ, _CMP_LE_OQ, _CMP_LT_OQ,
+    _MM_FROUND_TO_NEAREST_INT, _MM_HINT_ET0, _MM_HINT_T0, _mm_add_ps, _mm_cvtss_f32, _mm_movehl_ps,
+    _mm_prefetch, _mm_setr_epi8, _mm_shuffle_epi8, _mm_shuffle_ps, _mm_unpacklo_epi64,
+    _mm256_add_epi8, _mm256_add_epi16, _mm256_add_epi32, _mm256_add_ps, _mm256_and_ps,
+    _mm256_and_si256, _mm256_andnot_ps, _mm256_andnot_si256, _mm256_blendv_epi8, _mm256_blendv_ps,
+    _mm256_castps256_ps128, _mm256_castsi256_si128, _mm256_cmp_ps, _mm256_cmpeq_epi8,
+    _mm256_cmpeq_epi16, _mm256_cmpeq_epi32, _mm256_cmpgt_epi8, _mm256_cmpgt_epi16,
+    _mm256_cmpgt_epi32, _mm256_cvtepi8_epi16, _mm256_cvtepi16_epi32, _mm256_cvtepu8_epi16,
+    _mm256_cvtps_epi32, _mm256_cvttps_epi32, _mm256_div_ps, _mm256_extractf128_ps,
+    _mm256_extracti128_si256, _mm256_fmadd_ps, _mm256_fnmadd_ps, _mm256_insertf128_si256,
+    _mm256_loadu_ps, _mm256_loadu_si256, _mm256_maskload_epi32, _mm256_maskload_ps,
+    _mm256_maskstore_epi32, _mm256_maskstore_ps, _mm256_max_ps, _mm256_min_ps,
     _mm256_movemask_epi8, _mm256_mul_ps, _mm256_mullo_epi16, _mm256_mullo_epi32, _mm256_or_ps,
     _mm256_or_si256, _mm256_packs_epi32, _mm256_packus_epi16, _mm256_permute2x128_si256,
-    _mm256_permute4x64_epi64, _mm256_round_ps, _mm256_set1_epi16, _mm256_set1_epi32,
-    _mm256_set1_epi8, _mm256_set1_ps, _mm256_set_m128i, _mm256_setr_m128i, _mm256_setzero_si256,
-    _mm256_slli_epi16, _mm256_slli_epi32, _mm256_storeu_ps, _mm256_storeu_si256, _mm256_sub_epi16,
-    _mm256_sub_epi32, _mm256_sub_epi8, _mm256_sub_ps, _mm256_unpackhi_epi16, _mm256_unpackhi_epi8,
-    _mm256_unpacklo_epi16, _mm256_unpacklo_epi8, _mm256_xor_ps, _mm256_xor_si256, _mm_add_ps,
-    _mm_cvtss_f32, _mm_movehl_ps, _mm_prefetch, _mm_setr_epi8, _mm_shuffle_epi8, _mm_shuffle_ps,
-    _mm_unpacklo_epi64, _CMP_EQ_OQ, _CMP_GE_OQ, _CMP_GT_OQ, _CMP_LE_OQ, _CMP_LT_OQ,
-    _MM_FROUND_TO_NEAREST_INT, _MM_HINT_ET0, _MM_HINT_T0,
+    _mm256_permute4x64_epi64, _mm256_round_ps, _mm256_set_m128i, _mm256_set1_epi8,
+    _mm256_set1_epi16, _mm256_set1_epi32, _mm256_set1_ps, _mm256_setr_m128i, _mm256_setzero_si256,
+    _mm256_slli_epi16, _mm256_slli_epi32, _mm256_storeu_ps, _mm256_storeu_si256, _mm256_sub_epi8,
+    _mm256_sub_epi16, _mm256_sub_epi32, _mm256_sub_ps, _mm256_unpackhi_epi8, _mm256_unpackhi_epi16,
+    _mm256_unpacklo_epi8, _mm256_unpacklo_epi16, _mm256_xor_ps, _mm256_xor_si256,
 };
 use std::is_x86_feature_detected;
 use std::mem::transmute;
@@ -73,17 +73,17 @@ unsafe impl Isa for Avx2Isa {
     fn i32(
         self,
     ) -> impl SignedIntOps<i32, Simd = Self::I32>
-           + NarrowSaturate<i32, i16, Output = Self::I16>
-           + Concat<i32> {
+    + NarrowSaturate<i32, i16, Output = Self::I16>
+    + Concat<i32> {
         self
     }
 
     fn i16(
         self,
     ) -> impl SignedIntOps<i16, Simd = Self::I16>
-           + NarrowSaturate<i16, u8, Output = Self::U8>
-           + Extend<i16, Output = Self::I32>
-           + Interleave<i16> {
+    + NarrowSaturate<i16, u8, Output = Self::U8>
+    + Extend<i16, Output = Self::I32>
+    + Interleave<i16> {
         self
     }
 

--- a/rten-simd/src/arch/x86_64/avx512.rs
+++ b/rten-simd/src/arch/x86_64/avx512.rs
@@ -1,26 +1,26 @@
 use std::arch::x86_64::{
-    __m512, __m512i, __mmask16, __mmask32, __mmask64, _mm512_add_epi16, _mm512_add_epi32,
-    _mm512_add_epi8, _mm512_add_ps, _mm512_and_ps, _mm512_and_si512, _mm512_andnot_ps,
-    _mm512_andnot_si512, _mm512_castsi256_si512, _mm512_castsi512_si256, _mm512_cmp_epi16_mask,
-    _mm512_cmp_epi32_mask, _mm512_cmp_epu16_mask, _mm512_cmp_ps_mask, _mm512_cmpeq_epi8_mask,
-    _mm512_cmpeq_epu8_mask, _mm512_cmpge_epi8_mask, _mm512_cmpge_epu8_mask, _mm512_cmpgt_epi8_mask,
-    _mm512_cmpgt_epu8_mask, _mm512_cvtepi16_epi32, _mm512_cvtepi16_epi8, _mm512_cvtepi8_epi16,
-    _mm512_cvtepu8_epi16, _mm512_cvtps_epi32, _mm512_cvttps_epi32, _mm512_div_ps,
-    _mm512_extracti64x4_epi64, _mm512_fmadd_ps, _mm512_fnmadd_ps, _mm512_inserti64x4,
-    _mm512_loadu_ps, _mm512_loadu_si512, _mm512_mask_blend_epi16, _mm512_mask_blend_epi32,
-    _mm512_mask_blend_epi8, _mm512_mask_blend_ps, _mm512_mask_loadu_epi16, _mm512_mask_loadu_epi32,
-    _mm512_mask_loadu_epi8, _mm512_mask_loadu_ps, _mm512_mask_storeu_epi16,
-    _mm512_mask_storeu_epi32, _mm512_mask_storeu_epi8, _mm512_mask_storeu_ps, _mm512_max_ps,
-    _mm512_min_ps, _mm512_mul_ps, _mm512_mullo_epi16, _mm512_mullo_epi32, _mm512_or_ps,
-    _mm512_or_si512, _mm512_packs_epi32, _mm512_packus_epi16, _mm512_permutex2var_epi32,
-    _mm512_permutexvar_epi64, _mm512_reduce_add_ps, _mm512_roundscale_ps, _mm512_set1_epi16,
-    _mm512_set1_epi32, _mm512_set1_epi8, _mm512_set1_ps, _mm512_setr_epi32, _mm512_setr_epi64,
-    _mm512_setzero_si512, _mm512_sllv_epi16, _mm512_sllv_epi32, _mm512_storeu_ps,
-    _mm512_storeu_si512, _mm512_sub_epi16, _mm512_sub_epi32, _mm512_sub_epi8, _mm512_sub_ps,
-    _mm512_unpackhi_epi16, _mm512_unpackhi_epi8, _mm512_unpacklo_epi16, _mm512_unpacklo_epi8,
-    _mm512_xor_ps, _mm512_xor_si512, _mm_prefetch, _CMP_EQ_OQ, _CMP_GE_OQ, _CMP_GT_OQ, _CMP_LE_OQ,
-    _CMP_LT_OQ, _MM_CMPINT_EQ, _MM_CMPINT_NLE, _MM_CMPINT_NLT, _MM_FROUND_TO_NEAREST_INT,
-    _MM_HINT_ET0, _MM_HINT_T0,
+    __m512, __m512i, __mmask16, __mmask32, __mmask64, _CMP_EQ_OQ, _CMP_GE_OQ, _CMP_GT_OQ,
+    _CMP_LE_OQ, _CMP_LT_OQ, _MM_CMPINT_EQ, _MM_CMPINT_NLE, _MM_CMPINT_NLT,
+    _MM_FROUND_TO_NEAREST_INT, _MM_HINT_ET0, _MM_HINT_T0, _mm_prefetch, _mm512_add_epi8,
+    _mm512_add_epi16, _mm512_add_epi32, _mm512_add_ps, _mm512_and_ps, _mm512_and_si512,
+    _mm512_andnot_ps, _mm512_andnot_si512, _mm512_castsi256_si512, _mm512_castsi512_si256,
+    _mm512_cmp_epi16_mask, _mm512_cmp_epi32_mask, _mm512_cmp_epu16_mask, _mm512_cmp_ps_mask,
+    _mm512_cmpeq_epi8_mask, _mm512_cmpeq_epu8_mask, _mm512_cmpge_epi8_mask, _mm512_cmpge_epu8_mask,
+    _mm512_cmpgt_epi8_mask, _mm512_cmpgt_epu8_mask, _mm512_cvtepi8_epi16, _mm512_cvtepi16_epi8,
+    _mm512_cvtepi16_epi32, _mm512_cvtepu8_epi16, _mm512_cvtps_epi32, _mm512_cvttps_epi32,
+    _mm512_div_ps, _mm512_extracti64x4_epi64, _mm512_fmadd_ps, _mm512_fnmadd_ps,
+    _mm512_inserti64x4, _mm512_loadu_ps, _mm512_loadu_si512, _mm512_mask_blend_epi8,
+    _mm512_mask_blend_epi16, _mm512_mask_blend_epi32, _mm512_mask_blend_ps, _mm512_mask_loadu_epi8,
+    _mm512_mask_loadu_epi16, _mm512_mask_loadu_epi32, _mm512_mask_loadu_ps,
+    _mm512_mask_storeu_epi8, _mm512_mask_storeu_epi16, _mm512_mask_storeu_epi32,
+    _mm512_mask_storeu_ps, _mm512_max_ps, _mm512_min_ps, _mm512_mul_ps, _mm512_mullo_epi16,
+    _mm512_mullo_epi32, _mm512_or_ps, _mm512_or_si512, _mm512_packs_epi32, _mm512_packus_epi16,
+    _mm512_permutex2var_epi32, _mm512_permutexvar_epi64, _mm512_reduce_add_ps,
+    _mm512_roundscale_ps, _mm512_set1_epi8, _mm512_set1_epi16, _mm512_set1_epi32, _mm512_set1_ps,
+    _mm512_setr_epi32, _mm512_setr_epi64, _mm512_setzero_si512, _mm512_sllv_epi16,
+    _mm512_sllv_epi32, _mm512_storeu_ps, _mm512_storeu_si512, _mm512_sub_epi8, _mm512_sub_epi16,
+    _mm512_sub_epi32, _mm512_sub_ps, _mm512_unpackhi_epi8, _mm512_unpackhi_epi16,
+    _mm512_unpacklo_epi8, _mm512_unpacklo_epi16, _mm512_xor_ps, _mm512_xor_si512,
 };
 use std::mem::transmute;
 
@@ -75,17 +75,17 @@ unsafe impl Isa for Avx512Isa {
     fn i32(
         self,
     ) -> impl SignedIntOps<i32, Simd = Self::I32>
-           + NarrowSaturate<i32, i16, Output = Self::I16>
-           + Concat<i32> {
+    + NarrowSaturate<i32, i16, Output = Self::I16>
+    + Concat<i32> {
         self
     }
 
     fn i16(
         self,
     ) -> impl SignedIntOps<i16, Simd = Self::I16>
-           + NarrowSaturate<i16, u8, Output = Self::U8>
-           + Extend<i16, Output = Self::I32>
-           + Interleave<i16> {
+    + NarrowSaturate<i16, u8, Output = Self::U8>
+    + Extend<i16, Output = Self::I32>
+    + Interleave<i16> {
         self
     }
 

--- a/rten-simd/src/dispatch.rs
+++ b/rten-simd/src/dispatch.rs
@@ -1,9 +1,9 @@
 use std::mem::MaybeUninit;
 
+use crate::Isa;
 use crate::functional::simd_map;
 use crate::ops::{GetNumOps, GetSimd};
 use crate::span::SrcDest;
-use crate::Isa;
 
 /// A vectorized operation which can be instantiated for different instruction
 /// sets.
@@ -205,8 +205,8 @@ pub(crate) use test_simd_op;
 #[cfg(test)]
 mod tests {
     use super::SimdUnaryOp;
-    use crate::ops::{FloatOps, GetNumOps, GetSimd, NumOps};
     use crate::Isa;
+    use crate::ops::{FloatOps, GetNumOps, GetSimd, NumOps};
 
     #[test]
     fn test_unary_float_op() {

--- a/rten-simd/src/functional.rs
+++ b/rten-simd/src/functional.rs
@@ -1,8 +1,8 @@
 //! Vectorized higher-order operations (map etc.)
 
+use crate::Elem;
 use crate::ops::NumOps;
 use crate::span::SrcDest;
-use crate::Elem;
 
 /// Transform a slice by applying a vectorized map function to its elements.
 ///

--- a/rten-simd/src/isa_detection.rs
+++ b/rten-simd/src/isa_detection.rs
@@ -37,7 +37,7 @@ pub mod macos {
         use std::os::raw::{c_char, c_int, c_void};
 
         #[link(name = "c")]
-        extern "C" {
+        unsafe extern "C" {
             /// See https://developer.apple.com/documentation/kernel/1387446-sysctlbyname.
             fn sysctlbyname(
                 name: *const c_char,

--- a/rten-simd/src/ops.rs
+++ b/rten-simd/src/ops.rs
@@ -69,16 +69,16 @@ pub unsafe trait Isa: Copy {
     fn i32(
         self,
     ) -> impl SignedIntOps<i32, Simd = Self::I32>
-           + NarrowSaturate<i32, i16, Output = Self::I16>
-           + Concat<i32>;
+    + NarrowSaturate<i32, i16, Output = Self::I16>
+    + Concat<i32>;
 
     /// Operations on SIMD vectors with `i16` elements.
     fn i16(
         self,
     ) -> impl SignedIntOps<i16, Simd = Self::I16>
-           + NarrowSaturate<i16, u8, Output = Self::U8>
-           + Extend<i16, Output = Self::I32>
-           + Interleave<i16>;
+    + NarrowSaturate<i16, u8, Output = Self::U8>
+    + Extend<i16, Output = Self::I32>
+    + Interleave<i16>;
 
     /// Operations on SIMD vectors with `i8` elements.
     fn i8(
@@ -635,15 +635,15 @@ mod tests {
     use crate::ops::{
         Concat, Extend, FloatOps, IntOps, Interleave, MaskOps, NarrowSaturate, NumOps, SignedIntOps,
     };
-    use crate::{assert_simd_eq, assert_simd_ne, test_simd_op, Isa, Mask, Simd, SimdOp};
+    use crate::{Isa, Mask, Simd, SimdOp, assert_simd_eq, assert_simd_ne, test_simd_op};
 
     // Generate tests for operations available on all numeric types.
     macro_rules! test_num_ops {
         ($modname:ident, $elem:ident) => {
             mod $modname {
                 use super::{
-                    assert_simd_eq, assert_simd_ne, test_simd_op, Isa, Mask, NumOps, Simd, SimdOp,
-                    WrappingAdd,
+                    Isa, Mask, NumOps, Simd, SimdOp, WrappingAdd, assert_simd_eq, assert_simd_ne,
+                    test_simd_op,
                 };
 
                 #[test]
@@ -967,7 +967,7 @@ mod tests {
     macro_rules! test_float_ops {
         ($modname:ident, $elem:ident, $int_elem:ident) => {
             mod $modname {
-                use super::{assert_simd_eq, test_simd_op, FloatOps, Isa, NumOps, Simd, SimdOp};
+                use super::{FloatOps, Isa, NumOps, Simd, SimdOp, assert_simd_eq, test_simd_op};
 
                 #[test]
                 fn test_div() {
@@ -1075,7 +1075,7 @@ mod tests {
     macro_rules! test_unsigned_int_ops {
         ($modname:ident, $elem:ident) => {
             mod $modname {
-                use super::{assert_simd_eq, test_simd_op, IntOps, Isa, NumOps, Simd, SimdOp};
+                use super::{IntOps, Isa, NumOps, Simd, SimdOp, assert_simd_eq, test_simd_op};
 
                 #[test]
                 fn test_shift_left() {
@@ -1099,7 +1099,7 @@ mod tests {
         ($modname:ident, $elem:ident) => {
             mod $modname {
                 use super::{
-                    assert_simd_eq, test_simd_op, IntOps, Isa, NumOps, SignedIntOps, Simd, SimdOp,
+                    IntOps, Isa, NumOps, SignedIntOps, Simd, SimdOp, assert_simd_eq, test_simd_op,
                 };
 
                 #[test]

--- a/rten-simd/src/span.rs
+++ b/rten-simd/src/span.rs
@@ -1,6 +1,6 @@
 //! Slice-like types used as inputs and outputs for vectorized operations.
 
-use std::mem::{transmute, MaybeUninit};
+use std::mem::{MaybeUninit, transmute};
 
 enum SrcDestInner<'src, 'dst, T> {
     InOut(&'src [T], &'dst mut [MaybeUninit<T>]),
@@ -59,7 +59,9 @@ impl<'dst, T: Copy> SrcDest<'_, 'dst, T> {
     /// buffer, all elements must have been initialized before this is called.
     pub unsafe fn dest_assume_init(self) -> &'dst mut [T] {
         match self.inner {
-            SrcDestInner::InOut(_src, dest) => transmute::<&mut [MaybeUninit<T>], &mut [T]>(dest),
+            SrcDestInner::InOut(_src, dest) => unsafe {
+                transmute::<&mut [MaybeUninit<T>], &mut [T]>(dest)
+            },
             SrcDestInner::InMut(src) => src,
         }
     }

--- a/rten-simd/src/writer.rs
+++ b/rten-simd/src/writer.rs
@@ -1,7 +1,7 @@
-use std::mem::{transmute, MaybeUninit};
+use std::mem::{MaybeUninit, transmute};
 
-use crate::ops::NumOps;
 use crate::Elem;
+use crate::ops::NumOps;
 
 /// Utility for incrementally filling an uninitialized slice, one SIMD vector
 /// at a time.


### PR DESCRIPTION
The `rten_gemm::kernels` and `rten_simd::arch` modules had a large number of `unsafe_op_in_unsafe_fn` lint violations which have been suppressed to simplify the migration. Otherwise this was straightforward.