### PR TITLE
Add `MaskOps::{any, all}` methods

### DIFF
--- a/rten-simd/src/arch/aarch64.rs
+++ b/rten-simd/src/arch/aarch64.rs
@@ -9,12 +9,13 @@ use std::arch::aarch64::{
     vdupq_laneq_f32, vdupq_n_f32, vdupq_n_s8, vdupq_n_s16, vdupq_n_s32, vdupq_n_u8, vdupq_n_u16,
     veorq_u32, vfmaq_f32, vfmsq_f32, vget_high_s32, vget_low_s8, vget_low_s16, vget_low_s32,
     vget_low_u8, vld1q_f32, vld1q_s8, vld1q_s16, vld1q_s32, vld1q_u8, vld1q_u16, vld1q_u32,
-    vmaxq_f32, vminq_f32, vmovl_high_s8, vmovl_high_s16, vmovl_high_u8, vmovl_s8, vmovl_s16,
-    vmovl_u8, vmulq_f32, vmulq_s8, vmulq_s16, vmulq_s32, vmulq_u8, vmulq_u16, vmvnq_u32, vnegq_f32,
-    vnegq_s8, vnegq_s16, vnegq_s32, vorrq_u32, vqmovn_s32, vqmovun_s16, vrndnq_f32, vshlq_n_s8,
-    vshlq_n_s16, vshlq_n_s32, vshlq_n_u16, vst1q_f32, vst1q_s8, vst1q_s16, vst1q_s32, vst1q_u8,
-    vst1q_u16, vsubq_f32, vsubq_s8, vsubq_s16, vsubq_s32, vsubq_u8, vsubq_u16, vzip1q_s8,
-    vzip1q_s16, vzip2q_s8, vzip2q_s16,
+    vmaxq_f32, vmaxvq_u8, vmaxvq_u16, vmaxvq_u32, vminq_f32, vminvq_u8, vminvq_u16, vminvq_u32,
+    vmovl_high_s8, vmovl_high_s16, vmovl_high_u8, vmovl_s8, vmovl_s16, vmovl_u8, vmulq_f32,
+    vmulq_s8, vmulq_s16, vmulq_s32, vmulq_u8, vmulq_u16, vmvnq_u32, vnegq_f32, vnegq_s8, vnegq_s16,
+    vnegq_s32, vorrq_u32, vqmovn_s32, vqmovun_s16, vrndnq_f32, vshlq_n_s8, vshlq_n_s16,
+    vshlq_n_s32, vshlq_n_u16, vst1q_f32, vst1q_s8, vst1q_s16, vst1q_s32, vst1q_u8, vst1q_u16,
+    vsubq_f32, vsubq_s8, vsubq_s16, vsubq_s32, vsubq_u8, vsubq_u16, vzip1q_s8, vzip1q_s16,
+    vzip2q_s8, vzip2q_s16,
 };
 use std::mem::transmute;
 
@@ -843,6 +844,16 @@ unsafe impl MaskOps<uint32x4_t> for ArmNeonIsa {
     fn and(self, x: uint32x4_t, y: uint32x4_t) -> uint32x4_t {
         unsafe { vandq_u32(x, y) }
     }
+
+    #[inline]
+    fn any(self, x: uint32x4_t) -> bool {
+        unsafe { vmaxvq_u32(x) != 0 }
+    }
+
+    #[inline]
+    fn all(self, x: uint32x4_t) -> bool {
+        unsafe { vminvq_u32(x) != 0 }
+    }
 }
 
 unsafe impl MaskOps<uint16x8_t> for ArmNeonIsa {
@@ -850,12 +861,32 @@ unsafe impl MaskOps<uint16x8_t> for ArmNeonIsa {
     fn and(self, x: uint16x8_t, y: uint16x8_t) -> uint16x8_t {
         unsafe { vandq_u16(x, y) }
     }
+
+    #[inline]
+    fn any(self, x: uint16x8_t) -> bool {
+        unsafe { vmaxvq_u16(x) != 0 }
+    }
+
+    #[inline]
+    fn all(self, x: uint16x8_t) -> bool {
+        unsafe { vminvq_u16(x) != 0 }
+    }
 }
 
 unsafe impl MaskOps<uint8x16_t> for ArmNeonIsa {
     #[inline]
     fn and(self, x: uint8x16_t, y: uint8x16_t) -> uint8x16_t {
         unsafe { vandq_u8(x, y) }
+    }
+
+    #[inline]
+    fn any(self, x: uint8x16_t) -> bool {
+        unsafe { vmaxvq_u8(x) != 0 }
+    }
+
+    #[inline]
+    fn all(self, x: uint8x16_t) -> bool {
+        unsafe { vminvq_u8(x) != 0 }
     }
 }
 

--- a/rten-simd/src/arch/generic.rs
+++ b/rten-simd/src/arch/generic.rs
@@ -505,6 +505,16 @@ macro_rules! impl_mask {
                 let xs = array::from_fn(|i| x.0[i] & y.0[i]);
                 $mask(xs)
             }
+
+            #[inline]
+            fn any(self, x: $mask) -> bool {
+                x.0.iter().any(|x| *x != 0)
+            }
+
+            #[inline]
+            fn all(self, x: $mask) -> bool {
+                x.0.iter().all(|x| *x != 0)
+            }
         }
     };
 }

--- a/rten-simd/src/arch/wasm32.rs
+++ b/rten-simd/src/arch/wasm32.rs
@@ -1,16 +1,17 @@
 use std::arch::wasm32::{
     f32x4_abs, f32x4_add, f32x4_div, f32x4_eq, f32x4_extract_lane, f32x4_ge, f32x4_gt, f32x4_le,
     f32x4_lt, f32x4_max, f32x4_min, f32x4_mul, f32x4_nearest, f32x4_neg, f32x4_splat, f32x4_sub,
-    i8x16_add, i8x16_eq, i8x16_ge, i8x16_gt, i8x16_neg, i8x16_shl, i8x16_shuffle, i8x16_splat,
-    i8x16_sub, i16x8_add, i16x8_eq, i16x8_extend_high_i8x16, i16x8_extend_low_i8x16,
-    i16x8_extmul_high_i8x16, i16x8_extmul_low_i8x16, i16x8_ge, i16x8_gt, i16x8_mul,
-    i16x8_narrow_i32x4, i16x8_neg, i16x8_shl, i16x8_shuffle, i16x8_splat, i16x8_sub, i32x4_add,
-    i32x4_eq, i32x4_extend_high_i16x8, i32x4_extend_low_i16x8, i32x4_ge, i32x4_gt, i32x4_mul,
-    i32x4_neg, i32x4_shl, i32x4_shuffle, i32x4_splat, i32x4_sub, i32x4_trunc_sat_f32x4, u8x16_add,
-    u8x16_eq, u8x16_ge, u8x16_gt, u8x16_narrow_i16x8, u8x16_shuffle, u8x16_splat, u8x16_sub,
-    u16x8_add, u16x8_eq, u16x8_extend_high_u8x16, u16x8_extend_low_u8x16, u16x8_extmul_high_u8x16,
-    u16x8_extmul_low_u8x16, u16x8_ge, u16x8_gt, u16x8_mul, u16x8_shl, u16x8_splat, u16x8_sub, v128,
-    v128_and, v128_bitselect, v128_load, v128_not, v128_or, v128_store, v128_xor,
+    i8x16_add, i8x16_all_true, i8x16_eq, i8x16_ge, i8x16_gt, i8x16_neg, i8x16_shl, i8x16_shuffle,
+    i8x16_splat, i8x16_sub, i16x8_add, i16x8_all_true, i16x8_eq, i16x8_extend_high_i8x16,
+    i16x8_extend_low_i8x16, i16x8_extmul_high_i8x16, i16x8_extmul_low_i8x16, i16x8_ge, i16x8_gt,
+    i16x8_mul, i16x8_narrow_i32x4, i16x8_neg, i16x8_shl, i16x8_shuffle, i16x8_splat, i16x8_sub,
+    i32x4_add, i32x4_all_true, i32x4_eq, i32x4_extend_high_i16x8, i32x4_extend_low_i16x8, i32x4_ge,
+    i32x4_gt, i32x4_mul, i32x4_neg, i32x4_shl, i32x4_shuffle, i32x4_splat, i32x4_sub,
+    i32x4_trunc_sat_f32x4, u8x16_add, u8x16_eq, u8x16_ge, u8x16_gt, u8x16_narrow_i16x8,
+    u8x16_shuffle, u8x16_splat, u8x16_sub, u16x8_add, u16x8_eq, u16x8_extend_high_u8x16,
+    u16x8_extend_low_u8x16, u16x8_extmul_high_u8x16, u16x8_extmul_low_u8x16, u16x8_ge, u16x8_gt,
+    u16x8_mul, u16x8_shl, u16x8_splat, u16x8_sub, v128, v128_and, v128_any_true, v128_bitselect,
+    v128_load, v128_not, v128_or, v128_store, v128_xor,
 };
 use std::mem::transmute;
 
@@ -670,7 +671,7 @@ impl Extend<u8> for Wasm32Isa {
 }
 
 macro_rules! mask_type {
-    ($mask:ident, $elem:ty, $len: expr) => {
+    ($mask:ident, $elem:ty, $len: expr, $all_true_fn:ident) => {
         #[derive(Copy, Clone, Debug)]
         #[repr(transparent)]
         pub struct $mask(v128);
@@ -690,11 +691,21 @@ macro_rules! mask_type {
             fn and(self, x: $mask, y: $mask) -> $mask {
                 $mask(v128_and(x.0, y.0))
             }
+
+            #[inline]
+            fn any(self, x: $mask) -> bool {
+                unsafe { v128_any_true(x.0) }
+            }
+
+            #[inline]
+            fn all(self, x: $mask) -> bool {
+                unsafe { $all_true_fn(x.0) }
+            }
         }
     };
 }
 
 // Define mask vector types. `Mn` is a mask for a vector with n-bit lanes.
-mask_type!(M32, i32, 4);
-mask_type!(M16, i16, 8);
-mask_type!(M8, i8, 16);
+mask_type!(M32, i32, 4, i32x4_all_true);
+mask_type!(M16, i16, 8, i16x8_all_true);
+mask_type!(M8, i8, 16, i8x16_all_true);

--- a/rten-simd/src/arch/x86_64/avx2.rs
+++ b/rten-simd/src/arch/x86_64/avx2.rs
@@ -1012,6 +1012,16 @@ macro_rules! impl_mask_ops {
             fn and(self, x: $mask, y: $mask) -> $mask {
                 $mask(unsafe { _mm256_and_si256(x.0, y.0) })
             }
+
+            #[inline]
+            fn any(self, x: $mask) -> bool {
+                unsafe { _mm256_movemask_epi8(x.0) != 0 }
+            }
+
+            #[inline]
+            fn all(self, x: $mask) -> bool {
+                unsafe { _mm256_movemask_epi8(x.0) == -1 }
+            }
         }
     };
 }

--- a/rten-simd/src/arch/x86_64/avx512.rs
+++ b/rten-simd/src/arch/x86_64/avx512.rs
@@ -928,6 +928,16 @@ macro_rules! impl_mask {
             fn and(self, x: $mask, y: $mask) -> $mask {
                 x & y
             }
+
+            #[inline]
+            fn any(self, x: $mask) -> bool {
+                x != 0
+            }
+
+            #[inline]
+            fn all(self, x: $mask) -> bool {
+                x == !0
+            }
         }
     };
 }

--- a/rten-simd/src/simd.rs
+++ b/rten-simd/src/simd.rs
@@ -20,16 +20,6 @@ pub trait Mask: Copy + Debug {
 
     /// Convert this mask to a bool array.
     fn to_array(self) -> Self::Array;
-
-    /// Return true if all lanes in the mask are one.
-    fn all_true(self) -> bool {
-        self.to_array().as_ref().iter().all(|&x| x)
-    }
-
-    /// Return true if all lanes in the mask are false.
-    fn all_false(self) -> bool {
-        self.to_array().as_ref().iter().all(|&x| !x)
-    }
 }
 
 /// SIMD vector type.


### PR DESCRIPTION
These replace the existing `Mask::{all_true, all_false}` methods with vectorized alternatives which are suitable for use in kernels rather than just tests.