### PR TITLE
Refactor and parallelize unary op kernels

### DIFF
--- a/rten-simd/src/dispatch.rs
+++ b/rten-simd/src/dispatch.rs
@@ -117,14 +117,13 @@ pub trait SimdUnaryOp<T: GetSimd> {
     ///
     /// This reads elements from `input` in SIMD vector-sized chunks, applies
     /// the operation and writes the results to `output`.
-    #[allow(private_bounds)]
-    fn map(&self, input: &[T], output: &mut [MaybeUninit<T>])
+    fn map<'dst>(&self, input: &[T], output: &'dst mut [MaybeUninit<T>]) -> &'dst mut [T]
     where
         Self: Sized,
         T: GetNumOps,
     {
         let wrapped_op = SimdMapOp::wrap((input, output).into(), self);
-        dispatch(wrapped_op);
+        dispatch(wrapped_op)
     }
 
     /// Apply a vectorized unary function to a mutable slice.
@@ -142,7 +141,6 @@ pub trait SimdUnaryOp<T: GetSimd> {
     }
 
     /// Apply this operation to a single element.
-    #[allow(private_bounds)]
     fn scalar_eval(&self, x: T) -> T
     where
         Self: Sized,

--- a/rten-vecmath/src/erf.rs
+++ b/rten-vecmath/src/erf.rs
@@ -181,7 +181,9 @@ mod tests {
                     .zip(ys.iter_mut())
                     .for_each(|(x, y)| *y = libm::erff(*x))
             },
-            |xs, ys| Erf {}.map(xs, ys),
+            |xs, ys| {
+                Erf {}.map(xs, ys);
+            },
         );
     }
 }

--- a/rten-vecmath/src/exp.rs
+++ b/rten-vecmath/src/exp.rs
@@ -377,7 +377,9 @@ mod tests {
     fn bench_exp() {
         benchmark_op(
             |xs, ys| xs.iter().zip(ys.iter_mut()).for_each(|(x, y)| *y = x.exp()),
-            |xs, ys| Exp {}.map(xs, ys),
+            |xs, ys| {
+                Exp {}.map(xs, ys);
+            },
         );
     }
 
@@ -390,7 +392,9 @@ mod tests {
                     .zip(ys.iter_mut())
                     .for_each(|(x, y)| *y = reference_sigmoid(*x))
             },
-            |xs, ys| Sigmoid {}.map(xs, ys),
+            |xs, ys| {
+                Sigmoid {}.map(xs, ys);
+            },
         );
     }
 }

--- a/rten-vecmath/src/tanh.rs
+++ b/rten-vecmath/src/tanh.rs
@@ -107,7 +107,9 @@ mod tests {
                     .zip(ys.iter_mut())
                     .for_each(|(x, y)| *y = x.tanh())
             },
-            |xs, ys| Tanh {}.map(xs, ys),
+            |xs, ys| {
+                Tanh {}.map(xs, ys);
+            },
         );
     }
 }

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -128,9 +128,7 @@ pub use trilu::{Trilu, trilu};
 pub use unary_elementwise::{
     Abs, Acos, Asin, Atan, Ceil, Clip, Cos, Elu, Erf, Exp, Floor, Gelu, HardSigmoid, HardSwish,
     IsInf, IsNaN, LeakyRelu, Log, Neg, Not, PRelu, Reciprocal, Relu, Round, Sigmoid, Sign, Silu,
-    Sin, Softplus, Sqrt, Swish, Tan, Tanh, abs, acos, asin, atan, ceil, clip, cos, elu, erf, exp,
-    floor, gelu, hard_sigmoid, hard_swish, leaky_relu, log, neg, not, reciprocal, relu, round,
-    sigmoid, sign, silu, sin, softplus, sqrt, swish, tan, tanh,
+    Sin, Softplus, Sqrt, Swish, Tan, Tanh,
 };
 pub use variadic_elementwise::{Max, Mean, Min, Sum, max, mean, min, sum};
 


### PR DESCRIPTION
Refactor unary op kernels to make the implementation approach more consistent across different operations, and make it easier to support additional data types in future.

Previously some operations were vectorized and parallelized with kernels that operated on slices of input, while others used `Tensor::{map_in, apply}` to apply a scalar operation on a single thread. Now all ops have kernels that apply the operation to a contiguous slice of the input. The kernel is invoked on chunks of the input by a parallel iterator.  This parallelizes the remaining unary ops that don't yet have vectorized implementations. For some ops this will have minimal benefit, since they are memory bound. For others (eg. trig ops) this will be much faster.

Aside from improving performance and consistency, the volume of generated code is also reduced (~974K => ~911K lines of IR reported by `cargo llvm-lines`), as kernels operating on slices generate much less code than `Tensor::{map_in, apply}` instantiations.

The downside of this change is that calls to unary ops with non-contiguous inputs will copy their input into a contiguous buffer first. This overhead is balanced by operations on contiguous inputs being more efficient, and also it means that the output of the unary op will always be contiguous which benefits downstream ops.

Finally the standalone operator functions that were not used outside of tests have been removed to make future refactoring easier.