### PR TITLE
Use kernel pattern to reduce generated code size for binary operators

### DIFF
--- a/src/ops/unary_elementwise.rs
+++ b/src/ops/unary_elementwise.rs
@@ -552,14 +552,9 @@ fn prelu<T: Copy + Default + PartialOrd + std::ops::Mul<Output = T>>(
     // Even though PRelu is technically a binary operation in ONNX, it is
     // usually described as elementwise because the slope parameter is normally
     // a constant scalar or vector.
-    binary_op(
-        pool,
-        x,
-        slope,
-        |x, alpha| {
-            if x < T::default() { alpha * x } else { x }
-        },
-    )
+    binary_op(pool, x, slope, &|x, alpha| {
+        if x < T::default() { alpha * x } else { x }
+    })
 }
 
 #[derive(Debug)]

--- a/src/ops/variadic_elementwise.rs
+++ b/src/ops/variadic_elementwise.rs
@@ -23,12 +23,12 @@ fn reduce_elementwise<T: Copy, R: Fn(T, T) -> T + Copy>(
     match inputs {
         [] => Err(OpError::InvalidValue("Expected at least one input")),
         [a] => Ok(a.to_tensor_in(pool)),
-        [a, b] => binary_op(pool, a.view(), b.view(), reduce),
+        [a, b] => binary_op(pool, a.view(), b.view(), &reduce),
         [a, b, c @ ..] => {
-            let mut tmp = binary_op(pool, a.view(), b.view(), reduce)?;
+            let mut tmp = binary_op(pool, a.view(), b.view(), &reduce)?;
             for arg in c {
                 let old_tmp = tmp.auto_return(pool);
-                tmp = binary_op(pool, old_tmp.view(), arg.view(), reduce)?;
+                tmp = binary_op(pool, old_tmp.view(), arg.view(), &reduce)?;
             }
             Ok(tmp)
         }


### PR DESCRIPTION
2c378767b8bb134e7d62b3796293eb130efba7dd separated the kernels and driver loop in unary operations which reduced code size amongst other benefits. This commit does the same for binary operators. This reduces rten CLI binary size by ~65 KB.