### PR TITLE
Move subgraph methods into an Operator sub-trait

### DIFF
--- a/src/graph/node.rs
+++ b/src/graph/node.rs
@@ -103,8 +103,8 @@ impl OperatorNode {
         operator: Arc<dyn Operator + Send + Sync>,
     ) -> Self {
         let mut capture_names = Vec::new();
-        if operator.has_subgraph() {
-            for subgraph in operator.subgraphs() {
+        if let Some(subgraph_op) = operator.as_subgraph_op() {
+            for subgraph in subgraph_op.subgraphs() {
                 capture_names.extend(subgraph.capture_names().iter().map(|s| s.to_string()));
             }
         }

--- a/src/graph/tests.rs
+++ b/src/graph/tests.rs
@@ -12,7 +12,7 @@ use super::{CachedPlan, CaptureEnv, PlanOptions};
 use crate::graph::{Dimension, Graph, Node, NodeId, RunError, RunOptions, TypedConstant};
 use crate::ops::{
     Add, Concat, Conv, Identity, If, IntoOpResult, MatMul, Mul, OpError, OpRunContext, Operator,
-    OutputList, PrepackedInput, Relu, Shape,
+    OutputList, PrepackedInput, Relu, Shape, SubgraphOperator,
 };
 use crate::timing::Profiler;
 use crate::value::{DataType, Value, ValueView};
@@ -1057,6 +1057,12 @@ impl Operator for Subgraph {
         ))
     }
 
+    fn as_subgraph_op(&self) -> Option<&dyn SubgraphOperator> {
+        Some(self as &dyn SubgraphOperator)
+    }
+}
+
+impl SubgraphOperator for Subgraph {
     fn subgraphs(&self) -> SmallVec<[&Graph; 2]> {
         SmallVec::from_slice(&[&self.graph])
     }

--- a/src/ops/control_flow.rs
+++ b/src/ops/control_flow.rs
@@ -3,7 +3,7 @@ use rten_tensor::{Tensor, TensorView};
 use smallvec::SmallVec;
 
 use crate::graph::{CaptureEnv, Graph, NodeId, RunError, RunOptions};
-use crate::ops::{OpError, OpRunContext, Operator, OutputList, Value, map_value};
+use crate::ops::{OpError, OpRunContext, Operator, OutputList, SubgraphOperator, Value, map_value};
 use crate::timing::Profiler;
 use crate::value::ValueOrView;
 use crate::weight_cache::WeightCache;
@@ -34,6 +34,12 @@ impl Operator for If {
         ))
     }
 
+    fn as_subgraph_op(&self) -> Option<&dyn SubgraphOperator> {
+        Some(self as &dyn SubgraphOperator)
+    }
+}
+
+impl SubgraphOperator for If {
     fn subgraphs(&self) -> SmallVec<[&Graph; 2]> {
         [&self.then_branch, &self.else_branch].into()
     }
@@ -108,6 +114,12 @@ impl Operator for Loop {
         ))
     }
 
+    fn as_subgraph_op(&self) -> Option<&dyn SubgraphOperator> {
+        Some(self as &dyn SubgraphOperator)
+    }
+}
+
+impl SubgraphOperator for Loop {
     fn subgraphs(&self) -> SmallVec<[&Graph; 2]> {
         SmallVec::from_slice(&[&self.body])
     }
@@ -271,7 +283,7 @@ mod tests {
     use crate::graph::builder::Expr;
     use crate::graph::{CaptureEnv, Graph};
     use crate::ops::tests::new_pool;
-    use crate::ops::{InputList, OpError, OpRunContext, Operator, RunError};
+    use crate::ops::{InputList, OpError, OpRunContext, RunError, SubgraphOperator};
     use crate::value::{Scalar, Value, ValueView};
 
     use super::Loop;


### PR DESCRIPTION
This eliminates the unused code from default impls of `Operator::{has_subgraphs, run_subgraphs}` in operators that don't have subgraphs, which turned out to be quite a lot. It also makes checking whether an operator has subgraphs cheaper.

This reduces rten CLI binary size by 145KB (!)