### PR TITLE
Detect dependency cycles in execution planner

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -135,7 +135,7 @@ impl fmt::Display for RunError {
         match self {
             RunError::InvalidNodeId => write!(f, "node ID is invalid"),
             RunError::InvalidNodeName(name) => write!(f, "no node found with name {}", name),
-            RunError::PlanningError(err) => write!(f, "planning error {}", err),
+            RunError::PlanningError(err) => write!(f, "planning error: {}", err),
             RunError::OperatorError {
                 name,
                 error: err,


### PR DESCRIPTION
If the operator graph contained a dependency cycle, the planner would recurse indefinitely. Prevent this by tracking the set of operators currently being visited and return an error if attempting to visit an operator already in this set.

It will probably be wise in future to enforce an invariant that the graph does not contain any cycles as part of its construction, so that all downstream code which deals with the graph avoids the possibility of encountering cycles. Adding a check in the planner is simpler to implement for the moment.
