### PR TITLE
Vectorize LeakyRelu operator

### DIFF
--- a/rten-vecmath/src/lib.rs
+++ b/rten-vecmath/src/lib.rs
@@ -99,6 +99,7 @@ mod exp;
 mod min_max;
 mod normalize;
 mod quantize;
+mod relu;
 mod sin_cos;
 mod softmax;
 mod sum;
@@ -116,6 +117,7 @@ mod extend_init;
 pub use erf::{ApproxGelu, Erf, Gelu};
 pub use exp::{Exp, Sigmoid, Silu, Swish};
 pub use quantize::Quantize;
+pub use relu::LeakyRelu;
 pub use sin_cos::{Cos, Sin};
 pub use tanh::Tanh;
 

--- a/rten-vecmath/src/relu.rs
+++ b/rten-vecmath/src/relu.rs
@@ -1,0 +1,48 @@
+//! Activations related to the ReLU activation.
+//!
+//! Vanilla ReLU doesn't really need an explicitly vectorized kernel because it
+//! is just `x.max(0)` which is easy for compilers to auto-vectorize. Variants
+//! such as leaky ReLU however do benefit.
+
+use rten_simd::ops::NumOps;
+use rten_simd::{Isa, SimdUnaryOp};
+
+/// Computes the leaky ReLU activation function.
+///
+/// This evaluates `if x < 0. { alpha * x } else { x }`.
+pub struct LeakyRelu {
+    pub alpha: f32,
+}
+
+impl SimdUnaryOp<f32> for LeakyRelu {
+    fn eval<I: Isa>(&self, isa: I, x: I::F32) -> I::F32 {
+        let ops = isa.f32();
+        let alpha = ops.splat(self.alpha);
+        let x_neg = ops.lt(x, ops.zero());
+        let x_mul_alpha = ops.mul(x, alpha);
+        ops.select(x_mul_alpha, x, x_neg)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::testing::{Tolerance, UnaryOpTester};
+
+    use super::LeakyRelu;
+
+    fn reference_leaky_relu(x: f32, alpha: f32) -> f32 {
+        if x < 0. { alpha * x } else { x }
+    }
+
+    #[test]
+    fn test_leaky_relu() {
+        let alpha = 0.5;
+        let test = UnaryOpTester {
+            reference: |x: f32| reference_leaky_relu(x, alpha),
+            simd: LeakyRelu { alpha },
+            range: [-2., -1., 0., 1., 2.].iter().copied(),
+            tolerance: Tolerance::Ulp(1.0),
+        };
+        test.run();
+    }
+}

--- a/src/ops/unary_elementwise.rs
+++ b/src/ops/unary_elementwise.rs
@@ -464,9 +464,7 @@ impl_operator!(LeakyRelu, [FloatTensor]);
 
 impl GetKernel<f32> for LeakyRelu {
     fn get_kernel(&self) -> impl UnaryKernel<f32> + Send + Sync {
-        |val: f32| {
-            if val < 0.0 { self.alpha * val } else { val }
-        }
+        SimdKernel(vecmath::LeakyRelu { alpha: self.alpha })
     }
 }
 


### PR DESCRIPTION
The scalar version is inefficient due to an unpredictable branch. The vectorized version uses masking + bitwise selection. Time spent in LeakyRelu ops in a NeuFlow v2 model went from ~17ms to ~1.5ms.