### PR TITLE
Vectorize Elu activation

### DIFF
--- a/rten-vecmath/src/lib.rs
+++ b/rten-vecmath/src/lib.rs
@@ -115,7 +115,7 @@ mod extend_init;
 
 // Unary functions.
 pub use erf::{ApproxGelu, Erf, Gelu};
-pub use exp::{Exp, Sigmoid, Silu, Swish};
+pub use exp::{Elu, Exp, Sigmoid, Silu, Swish};
 pub use quantize::Quantize;
 pub use relu::LeakyRelu;
 pub use sin_cos::{Cos, Sin};

--- a/rten-vecmath/src/testing.rs
+++ b/rten-vecmath/src/testing.rs
@@ -204,7 +204,17 @@ pub fn benchmark_op<RF: Fn(&[f32], &mut [f32]), VF: Fn(&[f32], &mut [MaybeUninit
     reference: RF,
     vectorized: VF,
 ) {
-    let input: Vec<_> = repeat_with(|| fastrand::f32()).take(1_000_000).collect();
+    // Generate values in [-0.5, 0.5].
+    //
+    // This range is chosen because a) it is a common range for inputs to NN
+    // functions and b) some of the vectorized functions are activations which
+    // change behavior above/below zero. If we used the default `fastrand::f32`
+    // range of [0, 1] this would give misleading results for reference
+    // implementations as they would always take the same branch.
+    let input: Vec<_> = repeat_with(|| -0.5 + fastrand::f32())
+        .take(1_000_000)
+        .collect();
+
     let mut output = vec![0.; input.len()];
     let iters = 100;
 

--- a/src/ops/unary_elementwise.rs
+++ b/src/ops/unary_elementwise.rs
@@ -318,21 +318,7 @@ impl_operator!(Elu, [FloatTensor]);
 
 impl GetKernel<f32> for Elu {
     fn get_kernel(&self) -> impl UnaryKernel<f32> + Sync + Send {
-        |val: f32| {
-            // The ONNX spec and the original paper [1] define Elu in slightly
-            // different, but equivalent ways:
-            //
-            // Original: `f(x) = x if x > 0 else alpha * (exp(x) - 1)`
-            // ONNX: `f(x) = x if x >= 0 else alpha * (exp(x) - 1)`
-            //
-            // [1] https://arxiv.org/pdf/1511.07289
-
-            if val >= 0. {
-                val
-            } else {
-                self.alpha * (val.exp() - 1.)
-            }
-        }
+        SimdKernel(vecmath::Elu { alpha: self.alpha })
     }
 }
 


### PR DESCRIPTION
The vectorized version avoids an unpredictable branch. For inputs where all values are >= 0., the SIMD version is slightly slower (0.8x reference), for random values in [-0.5, 0.5] it is much faster (9x reference).