### PR TITLE
Optimize ScatterElements

### DIFF
--- a/rten-tensor/src/iterators.rs
+++ b/rten-tensor/src/iterators.rs
@@ -665,6 +665,11 @@ impl<'a, T> Lane<'a, T> {
     pub fn get(&self, idx: usize) -> Option<&'a T> {
         self.view.get([idx])
     }
+
+    /// Return the entire lane as a 1D tensor view.
+    pub fn as_view(&self) -> NdTensorView<'a, T, 1> {
+        self.view
+    }
 }
 
 impl<'a, T> From<NdTensorView<'a, T, 1>> for Lane<'a, T> {
@@ -899,6 +904,11 @@ impl<'a, T> LaneMut<'a, T> {
     /// Return the remaining part of the lane as a slice, if it is contiguous.
     pub fn as_slice_mut(&mut self) -> Option<&mut [T]> {
         self.view.data_mut().map(|data| &mut data[self.index..])
+    }
+
+    /// Return the entire lane as a mutable 1D tensor view.
+    pub fn into_view(self) -> NdTensorViewMut<'a, T, 1> {
+        self.view
     }
 }
 

--- a/src/ops/gather.rs
+++ b/src/ops/gather.rs
@@ -4,7 +4,8 @@ use std::mem::MaybeUninit;
 use rten_base::num::IsNaN;
 use rten_tensor::prelude::*;
 use rten_tensor::{
-    Lane, ResizeLayout, SliceItem, StorageMut, Tensor, TensorView, TensorViewMut, to_slice_items,
+    NdTensorView, ResizeLayout, SliceItem, StorageMut, Tensor, TensorView, TensorViewMut,
+    to_slice_items,
 };
 use smallvec::SmallVec;
 
@@ -37,7 +38,7 @@ impl<T> GetItem for &[T] {
     }
 }
 
-impl<T> GetItem for Lane<'_, T> {
+impl<T> GetItem for NdTensorView<'_, T, 1> {
     type Item = T;
 
     fn get(&self, index: usize) -> Option<&T> {
@@ -45,7 +46,7 @@ impl<T> GetItem for Lane<'_, T> {
     }
 
     fn len(&self) -> usize {
-        <Self as ExactSizeIterator>::len(self)
+        self.size(0)
     }
 }
 
@@ -263,7 +264,7 @@ pub fn gather_elements<T: Copy + Default + Send + Sync + std::fmt::Debug>(
             .zip(indices.lanes(axis))
             .zip(output.lanes_mut(axis))
         {
-            gather_lane(data_lane, index_lane, out_lane)?;
+            gather_lane(data_lane.as_view(), index_lane, out_lane)?;
         }
     }
 

--- a/src/ops/gather.rs
+++ b/src/ops/gather.rs
@@ -986,6 +986,34 @@ mod tests {
                 axis: 1,
                 expected: Ok(Tensor::from([[1., 1.1, 3., 2.1, 5.]])),
             },
+            // Invalid index
+            Case {
+                data: Tensor::from([1., 2., 3.]),
+                indices: Tensor::from([4]),
+                updates: Tensor::from([1.]),
+                axis: 0,
+                expected: Err(OpError::InvalidValue("Index is invalid")),
+            },
+            // Rank mismatch
+            Case {
+                data: Tensor::from([1., 2., 3.]),
+                indices: Tensor::from([[4]]),
+                updates: Tensor::from([[1.]]),
+                axis: 0,
+                expected: Err(OpError::InvalidValue(
+                    "`data` and `indices` must have same rank",
+                )),
+            },
+            // `indices` and `updates` shape mismatch
+            Case {
+                data: Tensor::from([1., 2., 3.]),
+                indices: Tensor::from([4]),
+                updates: Tensor::from([1., 2.]),
+                axis: 0,
+                expected: Err(OpError::InvalidValue(
+                    "`indices` and `updates` must have same shape",
+                )),
+            },
         ];
 
         cases.test_each(|case| {


### PR DESCRIPTION
Change ScatterElements to iterate over 1D lanes of data/indices/updates in
lock-step and then scatter all updates in that lane. This is much more efficient
than creating, modifying and indexing with dynamically-sized index vectors. It
also mirrors how GatherElements is implemented.

In a SageConv [^1] model, this reduced time in ScatterElements ops from
~55ms to ~12ms.

[^1]: https://huggingface.co/onnxmodelzoo/legacy_models/blob/main/Graph_Machine_Learning/sageconv_Opset16_graph_convolutions/sageconv_Opset16.onnx

