### PR TITLE
Reduce number of bounds checks when indexing a tensor

### DIFF
--- a/rten-gemm/src/packing/int8.rs
+++ b/rten-gemm/src/packing/int8.rs
@@ -314,7 +314,7 @@ impl Layout for RowMajorLayout {
     }
 
     #[inline]
-    fn try_offset(&self, index: [usize; 2]) -> Option<usize> {
+    fn offset(&self, index: [usize; 2]) -> Option<usize> {
         self.index_valid(index)
             .then_some(self.offset_unchecked(index))
     }

--- a/rten-tensor/src/lib.rs
+++ b/rten-tensor/src/lib.rs
@@ -128,7 +128,7 @@ pub use iterators::{
 };
 pub use layout::{
     AsIndex, DynLayout, IntoLayout, Layout, MatrixLayout, MutLayout, NdLayout, OverlapPolicy,
-    ResizeLayout, is_valid_permutation,
+    ResizeLayout, TrustedLayout, is_valid_permutation,
 };
 pub use slice_range::{DynSliceItems, IntoSliceItems, SliceItem, SliceRange, to_slice_items};
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -168,9 +168,9 @@ macro_rules! impl_proxy_layout {
             }
         }
 
-        fn try_offset(&self, index: Self::Index<'_>) -> Option<usize> {
+        fn offset(&self, index: Self::Index<'_>) -> Option<usize> {
             match self.layout() {
-                ValueLayout::Tensor(layout) => layout.try_offset(&index),
+                ValueLayout::Tensor(layout) => layout.offset(&index),
                 ValueLayout::Vector(len) => index
                     .get(0)
                     .and_then(|&idx| if idx < len { Some(idx) } else { None }),


### PR DESCRIPTION
Reduce the number of bounds checks when indexing a tensor from N + 1 (where N is the number of dimensions) to N. Previously each index was checked against the corresponding dimension size, then the offset returned by the layout was checked against the storage length. Remove the check against the storage length, but make it subject to the layout implementing an unsafe `TrustedLayout` trait.

Also remove `Layout::try_offset` in favor of making `offset` return an option, which makes `offset`/`offset_unchecked` consistent with eg. `get`/`get_unchecked` for tensors.