### PR TITLE
Add fusion that eliminates no-op Cast operations

### DIFF
--- a/rten-cli/src/main.rs
+++ b/rten-cli/src/main.rs
@@ -555,18 +555,24 @@ impl RandomInputGenerator {
         match name {
             // If this is a mask, use all ones on the assumption that we
             // don't want to mask anything out.
-            name if name.ends_with("_mask") => Value::from(Tensor::full(&resolved_shape, 1i32)),
+            name if name.ends_with("_mask") && matches!(dtype, Some(DataType::Int32) | None) => {
+                Value::from(Tensor::full(&resolved_shape, 1i32))
+            }
 
             // Inputs such as `token_type_ids`, `position_ids`, `input_ids`.
             // We use zero as a value that is likely to be valid for all
             // of these.
-            name if name.ends_with("_ids") => Value::from(Tensor::<i32>::zeros(&resolved_shape)),
+            name if name.ends_with("_ids") && matches!(dtype, Some(DataType::Int32) | None) => {
+                Value::from(Tensor::<i32>::zeros(&resolved_shape))
+            }
 
             // Optimum can export "merged" transformer models which have two
             // branches. One accepts KV-cache inputs and the other does not.
             // Set this to false as a "safer" value because we don't have
             // cached outputs from a previous run.
-            "use_cache_branch" => Value::from(Tensor::from(0i32)),
+            "use_cache_branch" if matches!(dtype, Some(DataType::Int32) | None) => {
+                Value::from(Tensor::from(0i32))
+            }
 
             // For anything else, random values.
             _ => match dtype {

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -17,10 +17,10 @@ mod fusions;
 mod pattern_matcher;
 
 use fusions::{
-    AddSoftmaxFusion, ApproxGeluFusion, Fusion, FusionVisitor, GeluFusion, IdentityFusion,
-    LayerNormalizationFusion, MatMulAddFusion, MatMulIntegerToFloatFusion, MatMulScaleFusion,
-    PatternFusion, ReciprocalFusion, ReduceMeanAxesFusion, RmsNormalizationFusion,
-    ShapeSliceToConstant, SiluFusion, SwishFusion, TransposeFusion,
+    AddSoftmaxFusion, ApproxGeluFusion, CastElimination, Fusion, FusionVisitor, GeluFusion,
+    IdentityFusion, LayerNormalizationFusion, MatMulAddFusion, MatMulIntegerToFloatFusion,
+    MatMulScaleFusion, PatternFusion, ReciprocalFusion, ReduceMeanAxesFusion,
+    RmsNormalizationFusion, ShapeSliceToConstant, SiluFusion, SwishFusion, TransposeFusion,
 };
 
 /// Errors that occur while applying graph optimizations.
@@ -365,6 +365,7 @@ impl GraphOptimizer {
 
         // Replace no-op operators with an `Identity` op.
         fusions.push(IdentityFusion {});
+        fusions.push(CastElimination {});
 
         // Canonicalizations to make other fusions support a wider range of
         // patterns.


### PR DESCRIPTION
Add an optimization step that eliminates Cast operations where the output dtype is the same as the input dtype. Such casts are already cheap as they can run in place and just return their input, but eliminating the op entirely can unlock other fusions.

When testing this I encountered a case where the CLI was generating inputs of the wrong type for an input named `attention_mask` with dtype float, so there is a fix for that as well.