### PR TITLE
Eliminate Identity operations during graph optimization

### DIFF
--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -363,9 +363,9 @@ impl GraphOptimizer {
         // match is found.
         let mut fusions = FusionList::new();
 
-        // Replace no-op operators with an `Identity` op.
-        fusions.push(IdentityFusion {});
+        // Remove operators which return inputs unmodified.
         fusions.push(CastElimination {});
+        fusions.push(IdentityFusion {});
 
         // Canonicalizations to make other fusions support a wider range of
         // patterns.

--- a/src/optimize/fusions.rs
+++ b/src/optimize/fusions.rs
@@ -320,6 +320,7 @@ impl PatternFusion for GeluFusion {
     }
 }
 
+/// Remove operations such as `Identity(x)` or `Add(x, 0)` which have no effect.
 pub struct IdentityFusion {}
 
 impl FusionVisitor for IdentityFusion {
@@ -335,6 +336,8 @@ impl FusionVisitor for IdentityFusion {
 
         Pattern::any_of(
             [
+                // Unary op identities
+                Pattern::unary_op("Identity", x.clone()),
                 // Binary op identities
                 x.clone() + zero.clone(),
                 x.clone() - zero.clone(),


### PR DESCRIPTION
There was already a fusion to match identity patterns like `Add(x, 0)`.  Extend this to eliminate `Identity(x)` where possible. Identity ops are cheap, but eliminating them can unlock other fusions.