### PR TITLE
Handle non-power-of-2 sized FFT more correctly in Whisper example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,17 +246,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "microfft"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b6673eb0cc536241d6734c2ca45abfdbf90e9e7791c66a36a7ba3c315b76cf"
-dependencies = [
- "cfg-if",
- "num-complex",
- "static_assertions",
-]
-
-[[package]]
 name = "miniz_oxide"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -271,6 +260,15 @@ name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
  "num-traits",
 ]
@@ -311,6 +309,15 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "primal-check"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0d895b311e3af9902528fbb8f928688abbd95872819320517cc24ca6b2bd08"
+dependencies = [
+ "num-integer",
 ]
 
 [[package]]
@@ -430,7 +437,6 @@ dependencies = [
  "hound",
  "image",
  "lexopt",
- "microfft",
  "png",
  "rten",
  "rten-generate",
@@ -438,6 +444,7 @@ dependencies = [
  "rten-imageproc",
  "rten-tensor",
  "rten-text",
+ "rustfft",
  "serde",
  "serde_json",
  "smallvec",
@@ -545,6 +552,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustfft"
+version = "6.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f140db74548f7c9d7cce60912c9ac414e74df5e718dc947d514b051b42f3f4"
+dependencies = [
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "primal-check",
+ "strength_reduce",
+ "transpose",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -616,10 +637,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
-name = "static_assertions"
-version = "1.1.0"
+name = "strength_reduce"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
 name = "syn"
@@ -646,6 +667,16 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "transpose"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad61aed86bc3faea4300c7aee358b4c6d0c8d6ccc36524c96e4c92ccf26e77e"
+dependencies = [
+ "num-integer",
+ "strength_reduce",
+]
 
 [[package]]
 name = "typeid"

--- a/rten-examples/Cargo.toml
+++ b/rten-examples/Cargo.toml
@@ -13,7 +13,6 @@ fastrand = "2.0.2"
 hound = "3.5.1"
 image = { workspace = true }
 lexopt = "0.3.0"
-microfft = { version = "0.6.0", default-features = false, features = ["size-512"] }
 png = "0.17.6"
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
@@ -24,6 +23,7 @@ rten-imageproc = { path = "../rten-imageproc" }
 rten-tensor = { path = "../rten-tensor", features=["serde"] }
 rten-text = { path = "../rten-text" }
 smallvec = "1.13.2"
+rustfft = "6.4.0"
 
 [lints.clippy]
 # Allows use of `..Default::default()` for future compatibility even when not


### PR DESCRIPTION
Previously the Whisper example used microfft to compute the FFT, which only supports power-of-2 FFT sizes. Whisper however uses an FFT of size 400. This was handled by zero-padding the signal to the nearest power of two (512). This is simple, but distorts the result slightly. Switch to using rustfft instead which can handle non-power-of-2 sizes. From brief testing, this improves accuracy a little.

A downside of rustfft is that it doesn't have a built-in real-to-complex FFT, so we do a complex FFT and discard the unused results. See https://github.com/ejmahler/RustFFT/issues/28.