### PR TITLE
Improve errors if crate feature is not enabled

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -1042,9 +1042,7 @@ mod tests {
         let result = ModelOptions::with_ops(registry).load(buffer);
         assert_eq!(
             result.err().map(|err| err.to_string()).as_deref(),
-            Some(
-                "operator error: in node \"concat\": operator Concat is not supported or not enabled"
-            )
+            Some("operator error: in node \"concat\": Concat operator not enabled")
         );
     }
 


### PR DESCRIPTION
Improve error message when loading a model which uses an operator that is unavailable because the rten crate was compiled without a certain feature.

Fixes https://github.com/robertknight/rten/issues/154