### PR TITLE
Move undocumented `model_builder` module behind a feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,8 @@ wasm_api = []
 random = ["dep:fastrand", "dep:fastrand-contrib"]
 # Enable all features that affect supported operators
 all-ops = ["fft", "random"]
+# Enable module for building .rten models
+model_builder = []
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2.100"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,4 +167,5 @@ mod schema_generated;
 // This is currently exposed for use in ocrs tests. That crate should probably
 // create an abstraction around model execution instead.
 #[doc(hidden)]
+#[cfg(any(test, feature = "model_builder"))]
 pub mod model_builder;


### PR DESCRIPTION
The only external consumer of this undocumented module that I know of are Ocrs tests. Avoid compiling this code in release builds unless a hidden feature is enabled.