### PR TITLE
Allow inputs and outputs to be specified as names rather than IDs

### DIFF
--- a/rten-examples/src/byt5_g2p.rs
+++ b/rten-examples/src/byt5_g2p.rs
@@ -115,14 +115,11 @@ fn main() -> Result<(), Box<dyn Error>> {
     let [encoded_state] = encoder
         .run_n(
             [
-                (encoder.node_id("input_ids")?, input_ids.into()),
-                (
-                    encoder.node_id("attention_mask")?,
-                    attention_mask.view().into(),
-                ),
+                ("input_ids", input_ids.into()),
+                ("attention_mask", attention_mask.view().into()),
             ]
             .into(),
-            [encoder.node_id("last_hidden_state")?],
+            ["last_hidden_state"],
             None,
         )
         .map_err(|e| format!("failed to run encoder: {}", e))?;
@@ -132,14 +129,8 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // Run the decoder to generate phonemes.
     let generator = Generator::from_model(&decoder)?
-        .with_constant_input(
-            decoder.node_id("encoder_attention_mask")?,
-            attention_mask.view().into(),
-        )
-        .with_constant_input(
-            decoder.node_id("encoder_hidden_states")?,
-            encoded_state.view().into(),
-        )
+        .with_constant_input("encoder_attention_mask", attention_mask.view().into())
+        .with_constant_input("encoder_hidden_states", encoded_state.view().into())
         .with_prompt(&[BOS_ID])
         .take(MAX_TOKENS);
 

--- a/rten-examples/src/clip.rs
+++ b/rten-examples/src/clip.rs
@@ -199,19 +199,14 @@ fn main() -> Result<(), Box<dyn Error>> {
         },
     );
 
-    let input_ids_id = model.node_id("input_ids")?;
-    let pixel_values_id = model.node_id("pixel_values")?;
-    let attention_mask_id = model.node_id("attention_mask")?;
-    let logits_per_image_id = model.node_id("logits_per_image")?;
-
     let [logits_per_image] = model.run_n(
         [
-            (input_ids_id, input_ids.into()),
-            (pixel_values_id, pixel_values.into()),
-            (attention_mask_id, attention_mask.into()),
+            ("input_ids", input_ids.into()),
+            ("pixel_values", pixel_values.into()),
+            ("attention_mask", attention_mask.into()),
         ]
         .into(),
-        [logits_per_image_id],
+        ["logits_per_image"],
         None,
     )?;
     let logits_per_image: NdTensor<f32, 2> = logits_per_image.try_into()?;

--- a/rten-examples/src/detr.rs
+++ b/rten-examples/src/detr.rs
@@ -237,13 +237,9 @@ fn main() -> Result<(), Box<dyn Error>> {
         image = image.resize_image([rescaled_height, rescaled_width])?;
     }
 
-    let pixel_input_id = model.node_id("pixel_values")?;
-    let logits_output_id = model.node_id("logits")?;
-    let boxes_output_id = model.node_id("pred_boxes")?;
-
     let [logits, boxes] = model.run_n(
-        vec![(pixel_input_id, image.into())],
-        [logits_output_id, boxes_output_id],
+        vec![("pixel_values", image.into())],
+        ["logits", "pred_boxes"],
         None,
     )?;
     let logits: NdTensor<f32, 3> = logits.try_into()?;

--- a/rten-examples/src/distilvit.rs
+++ b/rten-examples/src/distilvit.rs
@@ -91,8 +91,6 @@ fn main() -> Result<(), Box<dyn Error>> {
         .run_one(image.view().into(), None)?
         .try_into()?;
 
-    let encoder_hidden_states_id = decoder_model.node_id("encoder_hidden_states")?;
-
     // `decoder_start_token_id` value from
     // https://huggingface.co/Mozilla/distilvit/blob/main/config.json.
     let bos_token = 50256;
@@ -104,7 +102,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let prompt = vec![bos_token];
     let generator = Generator::from_model(&decoder_model)?
         .with_prompt(&prompt)
-        .with_constant_input(encoder_hidden_states_id, encoded_image.view().into())
+        .with_constant_input("encoder_hidden_states", encoded_image.view().into())
         .stop_on_tokens([eos_token])
         .take(max_tokens)
         .decode(&tokenizer);

--- a/rten-examples/src/kokoro.rs
+++ b/rten-examples/src/kokoro.rs
@@ -260,12 +260,12 @@ fn main() -> Result<(), Box<dyn Error>> {
     // Run the model and generate audio samples.
     let [output] = model.run_n(
         [
-            (model.node_id("input_ids")?, tokens.into()),
-            (model.node_id("style")?, style.into()),
-            (model.node_id("speed")?, speed.into()),
+            ("input_ids", tokens.into()),
+            ("style", style.into()),
+            ("speed", speed.into()),
         ]
         .into(),
-        [model.node_id("waveform")?],
+        ["waveform"],
         Some(RunOptions {
             ..Default::default()
         }),

--- a/rten-examples/src/nougat.rs
+++ b/rten-examples/src/nougat.rs
@@ -107,8 +107,6 @@ fn main() -> Result<(), Box<dyn Error>> {
         .run_one(image.view().into(), None)?
         .try_into()?;
 
-    let encoder_hidden_states_id = decoder_model.node_id("encoder_hidden_states")?;
-
     // `bos_token_id` from `generation_config.json`.
     // token.
     let decoder_start_token = 0;
@@ -120,7 +118,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut metrics = Metrics::new();
     let generator = Generator::from_model(&decoder_model)?
         .with_prompt(&prompt)
-        .with_constant_input(encoder_hidden_states_id, encoded_image.view().into())
+        .with_constant_input("encoder_hidden_states", encoded_image.view().into())
         .stop_on_tokens([eos_token])
         .profile(&mut metrics)
         .take(max_tokens)

--- a/rten-examples/src/piper.rs
+++ b/rten-examples/src/piper.rs
@@ -189,12 +189,12 @@ fn main() -> Result<(), Box<dyn Error>> {
     // Run inference and generate audio samples as floats.
     let [samples] = model.run_n(
         [
-            (model.node_id("input")?, phoneme_ids.into()),
-            (model.node_id("input_lengths")?, input_lengths.into()),
-            (model.node_id("scales")?, scales.into()),
+            ("input", phoneme_ids.into()),
+            ("input_lengths", input_lengths.into()),
+            ("scales", scales.into()),
         ]
         .into(),
-        [model.node_id("output")?],
+        ["output"],
         None,
     )?;
     let samples: NdTensor<f32, 4> = samples.try_into()?; // (batch, time, 1, sample)

--- a/rten-examples/src/silero.rs
+++ b/rten-examples/src/silero.rs
@@ -205,12 +205,6 @@ fn main() -> Result<(), Box<dyn Error>> {
     let model = Model::load_file(args.model)?;
     let samples = read_wav_file(&args.wav_file)?;
 
-    let sr_id = model.node_id("sr")?;
-    let input_id = model.node_id("input")?;
-    let state_id = model.node_id("state")?;
-    let state_n_id = model.node_id("stateN")?;
-    let output_id = model.node_id("output")?;
-
     // Create initial internal state for the model.
     let mut state: NdTensor<f32, 3> = NdTensor::zeros([2, 1, 128]); // [2, batch, 128]
     let sample_rate = 16_000;
@@ -233,14 +227,14 @@ fn main() -> Result<(), Box<dyn Error>> {
         let [output, next_state] = model.run_n(
             [
                 (
-                    input_id,
+                    "input",
                     NdTensor::from_data([1, samples_per_chunk], padded_chunk).into(),
                 ),
-                (sr_id, NdTensor::from(sample_rate as i32).into()),
-                (state_id, state.view().into()),
+                ("sr", NdTensor::from(sample_rate as i32).into()),
+                ("state", state.view().into()),
             ]
             .into(),
-            [output_id, state_n_id],
+            ["output", "stateN"],
             None,
         )?;
 

--- a/rten-examples/src/trocr.rs
+++ b/rten-examples/src/trocr.rs
@@ -106,8 +106,6 @@ fn main() -> Result<(), Box<dyn Error>> {
         .run_one(image.view().into(), None)?
         .try_into()?;
 
-    let encoder_hidden_states_id = decoder_model.node_id("encoder_hidden_states")?;
-
     // `decoder_start_token_id` from `generation_config.json`. This is the `</s>`
     // token.
     let decoder_start_token = 2;
@@ -118,7 +116,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let prompt = vec![decoder_start_token];
     let generator = Generator::from_model(&decoder_model)?
         .with_prompt(&prompt)
-        .with_constant_input(encoder_hidden_states_id, encoded_image.view().into())
+        .with_constant_input("encoder_hidden_states", encoded_image.view().into())
         .stop_on_tokens([eos_token])
         .take(max_tokens)
         .decode(&tokenizer);

--- a/rten-examples/src/yolo.rs
+++ b/rten-examples/src/yolo.rs
@@ -130,10 +130,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     };
     let image = image.resize_image([input_h, input_w])?;
 
-    let input_id = model.node_id("images")?;
-    let output_id = model.node_id("output0")?;
-
-    let [output] = model.run_n(vec![(input_id, image.view().into())], [output_id], None)?;
+    let [output] = model.run_n(vec![("images", image.view().into())], ["output0"], None)?;
 
     // Output format is [N, 84, B] where `B` is the number of boxes. The second
     // dimension contains `[x, y, w, h, class_0 ... class 79]` where `(x, y)`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,7 +140,7 @@ pub mod ops;
 
 pub use buffer_pool::{BufferPool, ExtractBuffer, PoolRef};
 pub use graph::{Dimension, NodeId, RunError, RunOptions};
-pub use model::{Model, ModelLoadError, ModelOptions, NodeInfo};
+pub use model::{Model, ModelLoadError, ModelOptions, NodeInfo, ResolveName};
 pub use model_metadata::ModelMetadata;
 pub use op_registry::{OpRegistry, ReadOp, ReadOpError};
 pub use ops::{FloatOperators, Operators};


### PR DESCRIPTION
Simplify use of `Model::run` by allowing input and output names to be specified by name rather than node ID. This also makes the API more familiar to someone used to using ORT or LiteRT. Several `Generator::with_*` methods that accept
input node IDs have also been changed to accept names instead.

I am slightly concerned about making the type signature of `Model::run` more complex, so I have revised the docs and examples to be clear that you can pass a node name or ID. Also you'll get a less clear error if you pass an argument to `run` that is not a `NodeId` or `&str`.

**Before:**

```rs
let [encoded_state] = encoder
    .run_n(
        [
            (encoder.node_id("input_ids")?, input_ids.into()),
            (
                encoder.node_id("attention_mask")?,
                attention_mask.view().into(),
            ),
        ]
        .into(),
        [encoder.node_id("last_hidden_state")?],
        None,
    )?;
let encoded_state: NdTensor<f32, 3> = encoded_state.try_into()?; // (batch, seq, dim)
                                                                                      
let generator = Generator::from_model(&decoder)?
    .with_constant_input(
        decoder.node_id("encoder_attention_mask")?,
        attention_mask.view().into(),
    )
    .with_constant_input(
        decoder.node_id("encoder_hidden_states")?,
        encoded_state.view().into(),
    )
    .with_prompt(&[BOS_ID])
    .take(MAX_TOKENS);
```

**After:**

```rs
let [encoded_state] = encoder
    .run_n(
        [
            ("input_ids", input_ids.into()),
            ("attention_mask", attention_mask.view().into()),
        ]
        .into(),
        ["last_hidden_state"],
        None,
    )?;
let encoded_state: NdTensor<f32, 3> = encoded_state.try_into()?; // (batch, seq, dim)
                                                                                      
let generator = Generator::from_model(&decoder)?
    .with_constant_input("encoder_attention_mask", attention_mask.view().into())
    .with_constant_input("encoder_hidden_states", encoded_state.view().into())
    .with_prompt(&[BOS_ID])
    .take(MAX_TOKENS);
```