### PR TITLE
Inline `Model::node_id` calls in examples

### DIFF
--- a/rten-examples/src/clip.rs
+++ b/rten-examples/src/clip.rs
@@ -199,19 +199,14 @@ fn main() -> Result<(), Box<dyn Error>> {
         },
     );
 
-    let input_ids_id = model.node_id("input_ids")?;
-    let pixel_values_id = model.node_id("pixel_values")?;
-    let attention_mask_id = model.node_id("attention_mask")?;
-    let logits_per_image_id = model.node_id("logits_per_image")?;
-
     let [logits_per_image] = model.run_n(
         [
-            (input_ids_id, input_ids.into()),
-            (pixel_values_id, pixel_values.into()),
-            (attention_mask_id, attention_mask.into()),
+            (model.node_id("input_ids")?, input_ids.into()),
+            (model.node_id("pixel_values")?, pixel_values.into()),
+            (model.node_id("attention_mask")?, attention_mask.into()),
         ]
         .into(),
-        [logits_per_image_id],
+        [model.node_id("logits_per_image")?],
         None,
     )?;
     let logits_per_image: NdTensor<f32, 2> = logits_per_image.try_into()?;

--- a/rten-examples/src/detr.rs
+++ b/rten-examples/src/detr.rs
@@ -237,13 +237,9 @@ fn main() -> Result<(), Box<dyn Error>> {
         image = image.resize_image([rescaled_height, rescaled_width])?;
     }
 
-    let pixel_input_id = model.node_id("pixel_values")?;
-    let logits_output_id = model.node_id("logits")?;
-    let boxes_output_id = model.node_id("pred_boxes")?;
-
     let [logits, boxes] = model.run_n(
-        vec![(pixel_input_id, image.into())],
-        [logits_output_id, boxes_output_id],
+        vec![(model.node_id("pixel_values")?, image.into())],
+        [model.node_id("logits")?, model.node_id("pred_boxes")?],
         None,
     )?;
     let logits: NdTensor<f32, 3> = logits.try_into()?;

--- a/rten-examples/src/jina_similarity.rs
+++ b/rten-examples/src/jina_similarity.rs
@@ -117,12 +117,12 @@ fn embed_sentence_batch(
             .fill(1i32);
     }
 
-    let input_ids_id = model.node_id("input_ids")?;
-    let attention_mask_id = model.node_id("attention_mask")?;
-
     let mut inputs: Vec<(NodeId, ValueOrView)> = vec![
-        (input_ids_id, input_ids.view().into()),
-        (attention_mask_id, attention_mask.view().into()),
+        (model.node_id("input_ids")?, input_ids.view().into()),
+        (
+            model.node_id("attention_mask")?,
+            attention_mask.view().into(),
+        ),
     ];
 
     // Generate token type IDs if this model needs them. These are all zeros
@@ -133,8 +133,7 @@ fn embed_sentence_batch(
         inputs.push((type_ids_id, type_ids.view().into()));
     }
 
-    let output_id = model.node_id("last_hidden_state")?;
-    let [last_hidden_state] = model.run_n(inputs, [output_id], None)?;
+    let [last_hidden_state] = model.run_n(inputs, [model.node_id("last_hidden_state")?], None)?;
     let last_hidden_state: Tensor = last_hidden_state.try_into()?;
 
     // Mean pool each item in the batch. We process each batch item separately

--- a/rten-examples/src/modernbert.rs
+++ b/rten-examples/src/modernbert.rs
@@ -138,13 +138,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     let input_ids = NdTensor::from_data([1, input_ids.len()], input_ids).map(|id| *id as i32);
     let attention_mask = NdTensor::full(input_ids.shape(), 1);
 
-    let input_ids_id = model.node_id("input_ids")?;
-    let attention_mask_id = model.node_id("attention_mask")?;
-    let logits_id = model.node_id("logits")?;
-
     let mut model_inputs = Vec::from([
-        (input_ids_id, input_ids.view().into()),
-        (attention_mask_id, attention_mask.into()),
+        (model.node_id("input_ids")?, input_ids.view().into()),
+        (model.node_id("attention_mask")?, attention_mask.into()),
     ]);
 
     // ModernBERT doesn't have a `token_type_ids` input, but this example also
@@ -156,7 +152,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     }
 
     // Run model and predict masked words.
-    let [logits] = model.run_n(model_inputs, [logits_id], None)?;
+    let [logits] = model.run_n(model_inputs, [model.node_id("logits")?], None)?;
 
     // Get the most likely token for each position, filter out special tokens
     // and decode into text.

--- a/rten-examples/src/trocr.rs
+++ b/rten-examples/src/trocr.rs
@@ -106,8 +106,6 @@ fn main() -> Result<(), Box<dyn Error>> {
         .run_one(image.view().into(), None)?
         .try_into()?;
 
-    let encoder_hidden_states_id = decoder_model.node_id("encoder_hidden_states")?;
-
     // `decoder_start_token_id` from `generation_config.json`. This is the `</s>`
     // token.
     let decoder_start_token = 2;
@@ -118,7 +116,10 @@ fn main() -> Result<(), Box<dyn Error>> {
     let prompt = vec![decoder_start_token];
     let generator = Generator::from_model(&decoder_model)?
         .with_prompt(&prompt)
-        .with_constant_input(encoder_hidden_states_id, encoded_image.view().into())
+        .with_constant_input(
+            decoder_model.node_id("encoder_hidden_states")?,
+            encoded_image.view().into(),
+        )
         .stop_on_tokens([eos_token])
         .take(max_tokens)
         .decode(&tokenizer);

--- a/rten-examples/src/yolo.rs
+++ b/rten-examples/src/yolo.rs
@@ -130,10 +130,11 @@ fn main() -> Result<(), Box<dyn Error>> {
     };
     let image = image.resize_image([input_h, input_w])?;
 
-    let input_id = model.node_id("images")?;
-    let output_id = model.node_id("output0")?;
-
-    let [output] = model.run_n(vec![(input_id, image.view().into())], [output_id], None)?;
+    let [output] = model.run_n(
+        vec![(model.node_id("images")?, image.view().into())],
+        [model.node_id("output0")?],
+        None,
+    )?;
 
     // Output format is [N, 84, B] where `B` is the number of boxes. The second
     // dimension contains `[x, y, w, h, class_0 ... class 79]` where `(x, y)`


### PR DESCRIPTION
Reduce the boilerplate in looking up the node IDs of model inputs and outputs by inlining `Model::node_id` calls. I did experiment with an alternative in https://github.com/robertknight/rten/pull/933 which would allow `Model::run` to accept names directly. However that has the downside of making the type signature more complex and errors harder to understand if an incorrect value passed as a node name.