### PR TITLE
Add operator type filter in timing report

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -26,7 +26,7 @@ use crate::graph::{
 use crate::model_metadata::ModelMetadata;
 use crate::op_registry::{OpLoadContext, OpRegistry, ReadOpError, convert_dtype};
 use crate::optimize::{GraphOptimizer, OptimizeOptions};
-use crate::timing::TimingSort;
+use crate::timing::{TimingFilter, TimingSort};
 use crate::value::{DataType, Value, ValueOrView};
 use crate::weight_cache::WeightCache;
 
@@ -165,6 +165,12 @@ fn parse_timing_config(config: &str, opts: &mut RunOptions) {
 
             match key {
                 "by-shape" => opts.timing_by_shape = str_as_bool(val),
+                "filter-op" => {
+                    for op_name in val.split(',') {
+                        opts.timing_filter
+                            .push(TimingFilter::Operator(op_name.to_string()));
+                    }
+                }
                 "sort" => match val {
                     "name" => opts.timing_sort = TimingSort::ByName,
                     "time" => opts.timing_sort = TimingSort::ByTime,

--- a/src/value.rs
+++ b/src/value.rs
@@ -74,7 +74,7 @@ impl std::fmt::Display for DataType {
 ///
 /// This is used in profiling and errors which need to contain metadata about
 /// a tensor but not the content.
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ValueMeta {
     pub(crate) dtype: DataType,
     pub(crate) shape: Vec<usize>,


### PR DESCRIPTION
Add a convenient way to filter timing output by operator type.

Setting the `RTEN_TIMING` env var to `by-shape=1 filter-op=Add,Mul` will print a detailed report at the end of the run that includes only Add and Mul operators.