### PR TITLE
Make standalone invocations of rustfmt use 2024 edition

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,4 @@
+# Make rustfmt use same settings as `cargo fmt`.
+#
+# See https://github.com/dense-analysis/ale/issues/3814#issuecomment-958947463
+edition = "2024"


### PR DESCRIPTION
This is a workaround for tools like [ALE](https://github.com/dense-analysis/ale) which invoke rustfmt directly rather than `cargo fmt`.