### PR TITLE
Use `is_multiple_of` for multiple-checks

### DIFF
--- a/rten-base/src/byte_cast.rs
+++ b/rten-base/src/byte_cast.rs
@@ -65,12 +65,12 @@ impl_pod!(u64);
 /// Return the length of a slice transmuted from `Src` to `Dst`, or `None` if
 /// the transmute is not possible.
 fn transmuted_slice_len<Src, Dst>(src: &[Src]) -> Option<usize> {
-    if (src.as_ptr() as usize) % align_of::<Dst>() != 0 {
+    if !(src.as_ptr() as usize).is_multiple_of(align_of::<Dst>()) {
         return None;
     }
 
     let src_byte_len = std::mem::size_of_val(src);
-    if src_byte_len % size_of::<Dst>() != 0 {
+    if !src_byte_len.is_multiple_of(size_of::<Dst>()) {
         return None;
     }
 
@@ -180,7 +180,8 @@ pub unsafe trait FromBytes: Sized {
     /// for `self`.
     fn from_bytes(bytes: &[u8]) -> &Self {
         assert!(
-            bytes.len() == size_of::<Self>() && bytes.as_ptr() as usize % align_of::<Self>() == 0
+            bytes.len() == size_of::<Self>()
+                && (bytes.as_ptr() as usize).is_multiple_of(align_of::<Self>())
         );
         unsafe { &*bytes.as_ptr().cast::<Self>() }
     }

--- a/rten-gemm/src/prepack.rs
+++ b/rten-gemm/src/prepack.rs
@@ -176,7 +176,7 @@ pub fn prepack_a<A: Alloc, LhsT, RhsT, OutT>(
     let depth_block = depth_block_size::<RhsT>(a.cols());
 
     let layout = kernel.packed_a_layout(a, a.rows(), depth_block, None);
-    let tail_layout = if a.cols() % depth_block != 0 {
+    let tail_layout = if !a.cols().is_multiple_of(depth_block) {
         Some(kernel.packed_a_layout(a, a.rows(), a.cols() % depth_block, None))
     } else {
         None
@@ -232,7 +232,7 @@ pub fn prepack_b<A: Alloc, LhsT, RhsT, OutT>(
     let depth_block = depth_block_size::<RhsT>(b.rows());
 
     let layout = kernel.packed_b_layout(depth_block, b.cols(), None);
-    let tail_layout = if b.rows() % depth_block != 0 {
+    let tail_layout = if !b.rows().is_multiple_of(depth_block) {
         Some(kernel.packed_b_layout(b.rows() % depth_block, b.cols(), None))
     } else {
         None

--- a/rten-simd/src/iter.rs
+++ b/rten-simd/src/iter.rs
@@ -223,7 +223,7 @@ impl<'a, T: Elem, O: NumOps<T>> IterPad<'a, T, O> {
     #[inline]
     fn new(ops: O, xs: &'a [T]) -> Self {
         let iter = Iter::new(ops, xs);
-        let has_tail = xs.len() % ops.len() != 0;
+        let has_tail = !xs.len().is_multiple_of(ops.len());
         Self { iter, has_tail }
     }
 }

--- a/rten-tensor/src/copy.rs
+++ b/rten-tensor/src/copy.rs
@@ -184,7 +184,7 @@ pub fn copy_into_slice<'a, T: Clone>(
     // to cache conflicts. Otherwise a simple direct copy is probably going to
     // be faster. With a better optimized blocked copy path, we might be able to
     // use it all the time.
-    let use_blocked_copy = src.stride(3) % 16 == 0 && src.stride(3) >= 32;
+    let use_blocked_copy = src.stride(3).is_multiple_of(16) && src.stride(3) >= 32;
 
     // Threshold for copying contiguous inner lane using bulk-copying methods
     // (eg. memcpy).

--- a/rten-text/src/split.rs
+++ b/rten-text/src/split.rs
@@ -76,7 +76,7 @@ impl<T> SliceExt for [T] {
 
         let byte_start = subslice_start.wrapping_sub(self_start);
 
-        if byte_start % core::mem::size_of::<T>() != 0 {
+        if !byte_start.is_multiple_of(core::mem::size_of::<T>()) {
             return None;
         }
 

--- a/src/ops/concat.rs
+++ b/src/ops/concat.rs
@@ -180,7 +180,7 @@ fn tile_inner<T: Copy>(
             }
         }
         ([size, inner_size @ ..], [repeats, inner_repeats @ ..]) => {
-            assert!(output.len() % repeats == 0);
+            assert!(output.len().is_multiple_of(*repeats));
             let out_chunk_len = output.len() / repeats;
             let inner_input_len = input.len() / size;
             let inner_output_len = out_chunk_len / size;


### PR DESCRIPTION
This is the result of `cargo clippy --workspace --fix` after updating to Rust v1.90. For reference the implementation of `is_multiple_of` is:

```rs
match rhs {
  0 => self == 0,
  _ => self % rhs == 0,
}
```

The readability benefit is dubious in places where the rhs is obviously non-zero, but at least it avoids forgetting to account for this possibility.