### PR TITLE
Add basic support for reference-counted tensors in rten-tensor

### DIFF
--- a/rten-tensor/src/lib.rs
+++ b/rten-tensor/src/lib.rs
@@ -9,6 +9,7 @@
 //! - Owned (like `Vec<T>`)
 //! - Borrowed (like `&[T]` or `&mut [T]`)
 //! - Maybe-owned (like `Cow[T]`)
+//! - Shared / reference-counted (like `Arc<[T]>`)
 //!
 //! The layout determines the number of dimensions (the _rank_) and size of each
 //! (the _shape_) and how indices map to offsets in the storage. The dimension
@@ -21,10 +22,10 @@
 //! directly but instead via a type alias which specifies the data ownership
 //! and layout:
 //!
-//! | Rank    | Owned | Borrowed | Mutably borrowed | Owned or borrowed |
-//! | ----    | ----- | -------- | ---------------- | ----------------- |
-//! | Static  | [NdTensor] | [NdTensorView] | [NdTensorViewMut] | [CowNdTensor] |
-//! | Dynamic | [Tensor]   | [TensorView]   | [TensorViewMut]   | [CowTensor]   |
+//! | Rank    | Owned | Borrowed | Mutably borrowed | Owned or borrowed | Reference counted |
+//! | ----    | ----- | -------- | ---------------- | ----------------- | ----------------- |
+//! | Static  | [NdTensor] | [NdTensorView] | [NdTensorViewMut] | [CowNdTensor] | [ArcNdTensor] |
+//! | Dynamic | [Tensor]   | [TensorView]   | [TensorViewMut]   | [CowTensor]   | [ArcTensor]   |
 //!
 //! All tensors implement the [Layout] trait, which provide methods to query
 //! the shape, dimension count and strides of the tensor. Tensor views provide
@@ -133,8 +134,9 @@ pub use layout::{
 pub use slice_range::{DynSliceItems, IntoSliceItems, SliceItem, SliceRange, to_slice_items};
 
 pub use tensor::{
-    AsView, CowNdTensor, CowTensor, Matrix, MatrixMut, NdTensor, NdTensorView, NdTensorViewMut,
-    Scalar, Tensor, TensorBase, TensorView, TensorViewMut, WeaklyCheckedView,
+    ArcNdTensor, ArcTensor, AsView, CowNdTensor, CowTensor, Matrix, MatrixMut, NdTensor,
+    NdTensorView, NdTensorViewMut, Scalar, Tensor, TensorBase, TensorView, TensorViewMut,
+    WeaklyCheckedView,
 };
 
 pub use storage::{CowData, IntoStorage, Storage, StorageMut, ViewData, ViewMutData};

--- a/rten-tensor/src/tensor.rs
+++ b/rten-tensor/src/tensor.rs
@@ -2,6 +2,7 @@ use std::borrow::Cow;
 use std::fmt::Debug;
 use std::mem::MaybeUninit;
 use std::ops::{Index, IndexMut, Range};
+use std::sync::Arc;
 
 use crate::assume_init::AssumeInit;
 use crate::copy::{
@@ -2334,6 +2335,12 @@ pub type TensorViewMut<'a, T = f32> = TensorBase<ViewMutData<'a, T>, DynLayout>;
 ///
 /// The name comes from [`std::borrow::Cow`].
 pub type CowTensor<'a, T> = TensorBase<CowData<'a, T>, DynLayout>;
+
+/// Reference-counted tensor with a dynamic dimension count.
+pub type ArcTensor<T> = TensorBase<Arc<[T]>, DynLayout>;
+
+/// Reference-counted tensor with N dimensions.
+pub type ArcNdTensor<T, const N: usize> = TensorBase<Arc<[T]>, NdLayout<N>>;
 
 impl<T, S: Storage<Elem = T>, L: TrustedLayout, I: AsIndex<L>> Index<I> for TensorBase<S, L> {
     type Output = T;


### PR DESCRIPTION
These are currently immutable once constructed as there are no equivalents of eg. `Arc::get_mut`. To allow for adding these in future, `Arc<[T]>` has been marked as a mutable form of storage (ie. cannot be used with broadcasting layouts).