### PR TITLE
Use shared ownership for more constants

### DIFF
--- a/src/graph/node.rs
+++ b/src/graph/node.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use rten_tensor::prelude::*;
-use rten_tensor::{DynLayout, Tensor, TensorView};
+use rten_tensor::{ArcTensor, DynLayout, Tensor, TensorView};
 
 use super::NodeId;
 use crate::constant_storage::ArcTensorView;
@@ -272,6 +272,7 @@ impl<T> ConstantNode<T> {
     pub fn view(&self) -> TensorView<'_, T> {
         match &self.data {
             ConstantNodeData::Owned(data) => data.view(),
+            ConstantNodeData::ArcSlice(data) => data.view(),
             ConstantNodeData::Arc(data) => data.view(),
         }
     }
@@ -287,6 +288,7 @@ impl<T> ConstantNode<T> {
     fn layout(&self) -> &DynLayout {
         match &self.data {
             ConstantNodeData::Owned(data) => data.layout(),
+            ConstantNodeData::ArcSlice(data) => data.layout(),
             ConstantNodeData::Arc(data) => data.layout(),
         }
     }
@@ -308,16 +310,34 @@ impl_constant_node!(i8, Int8);
 impl_constant_node!(u8, UInt8);
 
 /// Data for a constant node (ie. model weights) in a [`Graph`].
+///
+/// Constant data can be owned or shared. It is generally preferable to use
+/// shared types when possible as this enables constants to be cheaply cloned
+/// and shared between graphs.
 #[derive(Debug)]
 pub enum ConstantNodeData<T> {
+    /// Uniquely-owned buffer.
     Owned(Tensor<T>),
-    Arc(ArcTensorView<T>),
+
+    /// Slice of a shared, reference-counted buffer that contains data for
+    /// multiple tensors of heterogenous types.
+    ///
+    /// This is used when a file containing suitably aligned weights is read
+    /// into a single buffer or mmap-ed.
+    ArcSlice(ArcTensorView<T>),
+
+    /// Shared, reference-counted buffer.
+    Arc(ArcTensor<T>),
 }
 
 impl<T> ConstantNodeData<T> {
+    /// Perform a cheap copy of this constant data.
+    ///
+    /// This will succeed only for reference-counted types.
     fn clone_ref(&self) -> Option<ConstantNodeData<T>> {
         match self {
             ConstantNodeData::Owned(_) => None,
+            ConstantNodeData::ArcSlice(view) => Some(ConstantNodeData::ArcSlice(view.clone())),
             ConstantNodeData::Arc(view) => Some(ConstantNodeData::Arc(view.clone())),
         }
     }
@@ -331,6 +351,12 @@ impl<T> From<Tensor<T>> for ConstantNodeData<T> {
 
 impl<T> From<ArcTensorView<T>> for ConstantNodeData<T> {
     fn from(val: ArcTensorView<T>) -> ConstantNodeData<T> {
+        ConstantNodeData::ArcSlice(val)
+    }
+}
+
+impl<T> From<ArcTensor<T>> for ConstantNodeData<T> {
+    fn from(val: ArcTensor<T>) -> ConstantNodeData<T> {
         ConstantNodeData::Arc(val)
     }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -12,7 +12,7 @@ use memmap2::Mmap;
 
 use rten_base::byte_cast::{Pod, cast_pod_slice};
 use rten_base::num::LeBytes;
-use rten_tensor::Tensor;
+use rten_tensor::ArcTensor;
 
 use crate::constant_storage::{ArcSlice, ArcTensorView, ConstantStorage};
 use crate::env::str_as_bool;
@@ -598,11 +598,11 @@ fn constant_data_from_storage_offset<T: LeBytes + Pod>(
         let const_data: ConstantNodeData<T> = ArcTensorView::from_data(shape, storage).into();
         Ok(const_data)
     } else {
-        let data: Vec<T> = bytes
+        let data: Arc<_> = bytes
             .chunks(std::mem::size_of::<T>())
             .map(|chunk| T::from_le_bytes(chunk.try_into().unwrap()))
             .collect();
-        Ok(Tensor::from_data(shape, data).into())
+        Ok(ArcTensor::from_data(shape, data).into())
     }
 }
 

--- a/src/model/rten_loader.rs
+++ b/src/model/rten_loader.rs
@@ -7,7 +7,7 @@ use rten_base::byte_cast::Pod;
 use rten_model_file::header::{Header, HeaderError};
 use rten_model_file::schema as sg;
 use rten_model_file::schema::root_as_model;
-use rten_tensor::Tensor;
+use rten_tensor::ArcTensor;
 
 use super::{
     ConstantStorage, Model, ModelLoadError, ModelMetadata, ModelOptions, NodeError, OptimizeMode,
@@ -355,7 +355,7 @@ fn constant_data_from_flatbuffers_vec<'a, T: Pod + flatbuffers::Follow<'a, Inner
             ArcSlice::new(storage.clone(), elements).expect("storage does not contain data");
         ArcTensorView::from_data(shape, storage).into()
     } else {
-        let storage: Vec<T> = fb_vec.iter().collect();
-        Tensor::from_data(shape, storage).into()
+        let storage: Arc<[T]> = fb_vec.iter().collect();
+        ArcTensor::from_data(shape, storage).into()
     }
 }

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -3,13 +3,13 @@ use std::error::Error;
 use std::fmt::{Display, Formatter};
 use std::sync::Arc;
 
-use rten_tensor::Tensor;
 use rustc_hash::FxHashSet;
 use smallvec::SmallVec;
 
 use crate::Value;
 use crate::graph::{
-    CaptureEnv, Constant, ConstantNode, Graph, Node, NodeId, OperatorNode, PlanOptions, RunError,
+    CaptureEnv, Constant, ConstantNode, ConstantNodeData, Graph, Node, NodeId, OperatorNode,
+    PlanOptions, RunError,
 };
 use crate::ops::{Identity, Operator};
 
@@ -57,7 +57,11 @@ impl GraphMutator {
     }
 
     /// Add a new constant value to the graph.
-    fn add_constant<T>(&mut self, name: Option<&str>, value: Tensor<T>) -> NodeId
+    fn add_constant<T>(
+        &mut self,
+        name: Option<&str>,
+        value: impl Into<ConstantNodeData<T>>,
+    ) -> NodeId
     where
         Constant: From<ConstantNode<T>>,
     {


### PR DESCRIPTION
The preferred backing storage for constant data is either an mmap-ed buffer or a slice of a `Vec<u8>` into which the model file was originally loaded, as these options minimize copying when loading a model. When loading weights from a `.rten` file, weights are usually stored this way.

In cases where these options are not available, unique ownersip is currently used. However this prevents sharing of constants between sub-graphs, which in turn limits constant propagation in sub-graphs. To remedy this, allow constants to use an `ArcTensor<T>` as the backing storage and change existing creation of owned constants to use this where possible.

One place where unique ownership cannot be replaced with shared ownership trivially is after constant propagation. `Graph::partial_run` returns a set of owned tensors which we want to turn into constants. Turning these into reference-counted constants would occur an additional copy.