### PR TITLE
Use `Arc<Vec<T>>` as the storage type for `ArcTensor`

### DIFF
--- a/rten-tensor/src/storage.rs
+++ b/rten-tensor/src/storage.rs
@@ -1,4 +1,4 @@
-use std::borrow::{Borrow, Cow};
+use std::borrow::Cow;
 use std::marker::PhantomData;
 use std::mem::MaybeUninit;
 use std::ops::Range;
@@ -269,7 +269,7 @@ unsafe impl<T> StorageMut for Vec<T> {
     }
 }
 
-unsafe impl<T> Storage for Arc<[T]> {
+unsafe impl<T> Storage for Arc<Vec<T>> {
     type Elem = T;
 
     // This storage as marked as mutable to allow for adding methods to
@@ -279,13 +279,11 @@ unsafe impl<T> Storage for Arc<[T]> {
     const MUTABLE: bool = true;
 
     fn len(&self) -> usize {
-        let slice: &[T] = self.borrow();
-        slice.len()
+        self.as_ref().len()
     }
 
     fn as_ptr(&self) -> *const T {
-        let slice: &[T] = self.borrow();
-        slice.as_ptr()
+        self.as_ref().as_ptr()
     }
 }
 

--- a/rten-tensor/src/tensor/tests.rs
+++ b/rten-tensor/src/tensor/tests.rs
@@ -89,8 +89,8 @@ fn test_arange() {
 
 #[test]
 fn test_arc_tensor() {
-    let data: Arc<_> = (0..5i32).collect();
-    let tensor_a = ArcTensor::from_data(&[data.len()], data.clone());
+    let data: Vec<_> = (0..5i32).collect();
+    let tensor_a = ArcTensor::from_data(&[data.len()], Arc::new(data));
     let tensor_b = tensor_a.clone();
     assert_eq!(tensor_a, tensor_b);
     assert_eq!(tensor_a, NdTensorView::from_data([5], &[0, 1, 2, 3, 4]));
@@ -689,6 +689,13 @@ fn test_init_from_shape_mismatch() {
     let dest = NdTensor::uninit([2, 3]);
     let dest = dest.init_from(&src);
     assert_eq!(dest.to_vec(), &[0, 1, 2, 3]);
+}
+
+#[test]
+fn test_into_arc() {
+    let tensor = NdTensor::from([2., 3.]);
+    let arc_tensor = tensor.into_arc();
+    assert_eq!(arc_tensor.data().unwrap(), [2., 3.]);
 }
 
 #[test]

--- a/src/model.rs
+++ b/src/model.rs
@@ -598,11 +598,11 @@ fn constant_data_from_storage_offset<T: LeBytes + Pod>(
         let const_data: ConstantNodeData<T> = ArcTensorView::from_data(shape, storage).into();
         Ok(const_data)
     } else {
-        let data: Arc<_> = bytes
+        let data: Vec<_> = bytes
             .chunks(std::mem::size_of::<T>())
             .map(|chunk| T::from_le_bytes(chunk.try_into().unwrap()))
             .collect();
-        Ok(ArcTensor::from_data(shape, data).into())
+        Ok(ArcTensor::from_data(shape, Arc::new(data)).into())
     }
 }
 

--- a/src/model/rten_loader.rs
+++ b/src/model/rten_loader.rs
@@ -355,7 +355,7 @@ fn constant_data_from_flatbuffers_vec<'a, T: Pod + flatbuffers::Follow<'a, Inner
             ArcSlice::new(storage.clone(), elements).expect("storage does not contain data");
         ArcTensorView::from_data(shape, storage).into()
     } else {
-        let storage: Arc<[T]> = fb_vec.iter().collect();
-        ArcTensor::from_data(shape, storage).into()
+        let data: Vec<T> = fb_vec.iter().collect();
+        ArcTensor::from_data(shape, Arc::new(data)).into()
     }
 }


### PR DESCRIPTION
This adds an extra indirection when accessing the data, but it enables cheap conversion between owned and reference-counted tensors. This in turn will enable an upcoming change to use reference-counting for all constants.