### PR TITLE
Add `ValueReader::{from_buf, from_file}` convenience methods

### DIFF
--- a/rten-onnx/src/lib.rs
+++ b/rten-onnx/src/lib.rs
@@ -19,15 +19,13 @@
 //! ```no_run
 //! use std::error::Error;
 //! use std::fs::File;
-//! use std::io::BufReader;
 //!
 //! use rten_onnx::onnx::ModelProto;
 //! use rten_onnx::protobuf::{DecodeMessage, ReadPos, ValueReader};
 //!
 //! fn main() -> Result<(), Box<dyn Error>> {
 //!     let file = File::open("model.onnx")?;
-//!     let reader = ReadPos::new(BufReader::new(file));
-//!     let value_reader = ValueReader::new(reader);
+//!     let value_reader = ValueReader::from_file(file);
 //!     let model = ModelProto::decode(value_reader)?;
 //!
 //!     let op_count = model.graph.as_ref().map(|g| g.node.len()).unwrap_or(0);
@@ -45,10 +43,7 @@
 //! # use rten_onnx::{onnx::ModelProto, protobuf::{ValueReader, DecodeMessage}};
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! # let buffer = std::fs::read("model.onnx")?;
-//! use std::io::Cursor;
-//!
-//! let reader = Cursor::new(&buffer);
-//! let value_reader = ValueReader::new(reader);
+//! let value_reader = ValueReader::from_buf(&buffer);
 //! let model = ModelProto::decode(value_reader)?;
 //! # Ok(()) }
 //! ```

--- a/rten-onnx/src/onnx.rs
+++ b/rten-onnx/src/onnx.rs
@@ -610,11 +610,10 @@ impl DecodeMessage for SlimModelProto {
 /// but skipping over the main graph.
 ///
 /// ```
-/// use std::io::Cursor;
 /// use rten_onnx::protobuf::ValueReader;
 /// use rten_onnx::onnx::is_onnx_model;
 ///
-/// let value_reader = ValueReader::new(Cursor::new(b"NOT AN ONNX MODEL"));
+/// let value_reader = ValueReader::from_buf(b"NOT AN ONNX MODEL");
 /// assert!(!is_onnx_model(value_reader));
 /// ```
 pub fn is_onnx_model(reader: impl ReadValue<Types = OwnedValues>) -> bool {
@@ -629,11 +628,10 @@ pub fn is_onnx_model(reader: impl ReadValue<Types = OwnedValues>) -> bool {
 #[cfg(test)]
 mod tests {
     use std::fs::File;
-    use std::io::{BufReader, Cursor};
     use std::path::PathBuf;
 
     use super::{ModelProto, is_onnx_model};
-    use crate::protobuf::{DecodeMessage, ReadPos, ValueReader};
+    use crate::protobuf::{DecodeMessage, ValueReader};
 
     fn test_file_path(path: &str) -> PathBuf {
         let mut abs_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
@@ -646,8 +644,7 @@ mod tests {
     // default ModelProto.
     #[test]
     fn test_decode_empty_model() {
-        let buf = Vec::new();
-        let value_reader = ValueReader::new(Cursor::new(buf));
+        let value_reader = ValueReader::from_buf(Vec::new());
         let model = ModelProto::decode(value_reader).unwrap();
         assert!(model.graph.is_none());
     }
@@ -656,8 +653,7 @@ mod tests {
     fn test_decode_mnist() {
         let model_path = test_file_path("mnist.onnx");
         let file = File::open(model_path).unwrap();
-        let reader = ReadPos::new(BufReader::new(file));
-        let value_reader = ValueReader::new(reader);
+        let value_reader = ValueReader::from_file(file);
         let model = ModelProto::decode(value_reader).unwrap();
 
         let graph = model.graph.unwrap();
@@ -697,11 +693,10 @@ mod tests {
     fn test_is_onnx_model() {
         let model_path = test_file_path("mnist.onnx");
         let file = File::open(model_path).unwrap();
-        let reader = ReadPos::new(BufReader::new(file));
-        let value_reader = ValueReader::new(reader);
+        let value_reader = ValueReader::from_file(file);
         assert!(is_onnx_model(value_reader));
 
-        let value_reader = ValueReader::new(Cursor::new(vec![]));
+        let value_reader = ValueReader::from_buf(vec![]);
         assert!(!is_onnx_model(value_reader));
     }
 }

--- a/rten-onnx/src/protobuf/message.rs
+++ b/rten-onnx/src/protobuf/message.rs
@@ -17,7 +17,7 @@ use crate::protobuf::{Field, FieldTypes, Fields, ProtobufError, ReadValue};
 /// A decoder could be written as follows:
 ///
 /// ```
-/// use std::io::{BufRead, Cursor};
+/// use std::io::BufRead;
 /// use std::sync::Arc;
 /// use rten_onnx::protobuf::{DecodeMessage, Fields, OwnedValues, ReadPos, ProtobufError,
 /// ReadValue, ValueReader};
@@ -69,8 +69,7 @@ use crate::protobuf::{Field, FieldTypes, Fields, ProtobufError, ReadValue};
 ///         0x12, 0x02, 0x68, 0x69, // string_field = "hi"
 ///         0x1A, 0x02, 0x01, 0x02, // bytes_field = [0x01, 0x02]
 ///     ];
-///     let reader = Cursor::new(message);
-///     let value_reader = ValueReader::new(reader);
+///     let value_reader = ValueReader::from_buf(message);
 ///     let msg = Message::decode(value_reader)?;
 ///
 ///     assert_eq!(msg.int_field, 150);


### PR DESCRIPTION
These are shorthands for `ValueReader::new(Cursor::new(buf))` and `ValueReader::new(ReadPos::new(BufReader::new(file)))` respectively.