### PR TITLE
Don't print timing stats if `--n_evals` is set to zero

### DIFF
--- a/tools/ort-infer.py
+++ b/tools/ort-infer.py
@@ -130,6 +130,9 @@ def run_model(
         durations.append(elapsed * 1000.0)
         print("Model eval time: {:.2f}ms".format(elapsed * 1000))
 
+    if n_evals == 0:
+        return
+
     # Print duration statistics
     mean = sum(durations) / n_evals
     variance = sum((dur - mean) ** 2 for dur in durations) / n_evals


### PR DESCRIPTION
Fix division by zero when invoking ort-infer.py with `--n_evals 0`. Setting `n_evals=0` is useful to test/benchmark only loading the model, not running it.