### PR TITLE
Fix loading of zero-length tensors in the ONNX loader

### DIFF
--- a/src/constant_storage.rs
+++ b/src/constant_storage.rs
@@ -128,6 +128,18 @@ impl<T> ArcSlice<T> {
     where
         T: Pod,
     {
+        // Vecs with zero capacity have a non-null dangling pointer which can
+        // have a smaller alignment that the minimum used by the global
+        // allocator. Create a new vec with zero length but non-zero capacity to
+        // ensure the data pointer has the required alignment. This assumes that
+        // `T` has an alignment <= the minimum alignment of the allocator. If
+        // not, this operation will still fail.
+        let buf = if buf.capacity() == 0 {
+            Vec::with_capacity(1)
+        } else {
+            buf
+        };
+
         if !(buf.as_ptr() as usize).is_multiple_of(align_of::<T>())
             || !buf.len().is_multiple_of(size_of::<T>())
         {
@@ -226,6 +238,15 @@ mod tests {
         let bytes = vec_to_ne_bytes(data.clone());
         let slice = ArcSlice::<i32>::from_bytes(bytes).unwrap();
         let tensor = ArcTensorView::from_data(&[16], slice);
+        assert_eq!(tensor.data().unwrap(), data);
+    }
+
+    #[test]
+    fn test_arc_slice_from_empty_bytes() {
+        let data: Vec<i32> = Vec::new();
+        let bytes = vec_to_ne_bytes(data.clone());
+        let slice = ArcSlice::<i32>::from_bytes(bytes).unwrap();
+        let tensor = ArcTensorView::from_data(&[0], slice);
         assert_eq!(tensor.data().unwrap(), data);
     }
 


### PR DESCRIPTION
When a tensor has zero length, the `TensorProto.raw_data` field can be an empty `Vec<u8>` whose data pointer is a dangling pointer with a smaller alignment that the global allocator's minimum (this is the normal behavior of `Vec::new`), causing `ArcSlice::<T>::from_bytes` to return `None`. Address this in `ArcSlice::from_bytes` by creating a dummy Vec with zero length but non-zero capacity which will allocate. The same issue could in principle also happen for tensors with external data when using `FileLoader`. Handle that
be delegating to `ArcSlice::from_bytes` in `tensor_from_external_data`.

