### PR TITLE
Update remaining examples to recommend using models in ONNX format

### DIFF
--- a/rten-examples/README.md
+++ b/rten-examples/README.md
@@ -4,36 +4,38 @@ This crate contains example projects showing how to convert and run models for
 common tasks across various modalities. See [Example
 descriptions](#example-descriptions) for a summary of what each example does.
 
+## ONNX format support
+
+The example instructions use models in `.onnx` format. This is only supported
+by rten v0.23 and later. To run examples with earlier versions of rten, you
+will need to convert the models to `.rten` format first:
+
+```sh
+$ pip install rten-convert
+$ rten-convert model.onnx
+```
+
+This will create a `model.rten` file in the same directory as the model.
+
 ## Running an example
 
 Each example has a `main` function with a comment above it describing the steps
-to fetch the ONNX model, convert it to the format used by this library and run
-the example.
+to fetch the ONNX model and run the example.
 
 The general steps to run an example are:
 
 1. Download the ONNX model. These usually come from [Hugging
    Face](https://huggingface.co/docs/optimum/exporters/onnx/overview),
-   the [ONNX Model Zoo](https://github.com/onnx/models) or pre-created ONNX
-   models by the model authors.
-2. Convert the ONNX model to this library's format using the `rten-convert`
-   package:
+   or ONNX format models pre-created by the model authors or community members.
+
+2. Run the example from the `rten-examples` directory using:
 
    ```sh
-   $ pip install rten-convert
-   $ rten-convert model.onnx
+   $ cargo run -r --bin <example_name> -- <...args>
    ```
 
-   This will create a `model.rten` file in the same directory as the ONNX
-   model.
-
-3. Run the example from the `rten-examples` directory using:
-
-   ```sh
-   $ cargo run -r --bin <example_name> <model_path> <...args>
-   ```
-
-   Where `...args` refers to the example-specific arguments, such as input data.
+   Where `...args` refers to the example-specific arguments, such as model
+   path(s), tokenizer configuration and input data.
 
    Note the `-r` flag to create a **release build**. This is required as the
    examples will run very slowly in debug builds.

--- a/rten-examples/src/byt5_g2p.rs
+++ b/rten-examples/src/byt5_g2p.rs
@@ -80,14 +80,12 @@ Options:
 ///
 /// ```
 /// optimum-cli export onnx --model fdemelo/g2p-mbyt5-12l-ipa-childes-espeak g2p --task text2text-generation-with-past
-/// rten-convert g2p/encoder_model.onnx
-/// rten-convert g2p/decoder_model_merged.onnx
 /// ```
 ///
 /// To run the example:
 ///
 /// ```
-/// cargo run -p rten-examples --release --bin byt5_g2p -- g2p/encoder_model.rten g2p/decoder_model_merged.rten "This is some text to convert."
+/// cargo run -p rten-examples --release --bin byt5_g2p -- g2p/encoder_model.onnx g2p/decoder_model_merged.onnx "This is some text to convert."
 /// ```
 ///
 /// The example assumes US English text. To use a different language, specify

--- a/rten-examples/src/clip.rs
+++ b/rten-examples/src/clip.rs
@@ -130,13 +130,12 @@ fn preprocess_image(
 ///
 /// ```
 /// optimum-cli export onnx --model openai/clip-vit-base-patch32 clip-vit-base-patch32
-/// rten-convert clip-vit-base-patch32/model.onnx
 /// ```
 ///
 /// Run this program specifying at least one image and at least one caption:
 ///
 /// ```
-/// cargo run --release --bin clip clip-vit-base-patch32/model.rten clip-vit-base-patch32/tokenizer.json -i ../tools/test-images/horses.jpeg -c "horses" -c "ducks"
+/// cargo run --release --bin clip clip-vit-base-patch32/model.onnx clip-vit-base-patch32/tokenizer.json -i ../tools/test-images/horses.jpeg -c "horses" -c "ducks"
 /// ```
 ///
 /// [^1]: https://github.com/openai/CLIP

--- a/rten-examples/src/depth_anything.rs
+++ b/rten-examples/src/depth_anything.rs
@@ -66,8 +66,7 @@ Args:
 /// After downloading the model, it can be run on an image using:
 ///
 /// ```
-/// rten-convert depth_anything.onnx
-/// cargo run --release --bin depth_anything depth_anything.rten image.jpg
+/// cargo run --release --bin depth_anything depth_anything.onnx image.jpg
 /// ```
 ///
 /// This will generate a depth map as `depth-map.png`.

--- a/rten-examples/src/detr.rs
+++ b/rten-examples/src/detr.rs
@@ -39,7 +39,7 @@ Arguments:
 
     This should contain:
 
-    - `model.rten` - The DETR or RT-DETR model
+    - `model.onnx` - The DETR or RT-DETR model
     - `config.json` - JSON file containing class ID to label mappings
     - `preprocessor_config.json` - JSON file containing preprocessor configuration
 

--- a/rten-examples/src/imagenet.rs
+++ b/rten-examples/src/imagenet.rs
@@ -215,13 +215,9 @@ Options:
 ///
 ///    ./tools/export-timm-model.py timm/convnext_base.fb_in1k --dynamo
 ///
-/// 2. Convert the model to .rten format using:
+/// 2. Run this example specifying the path to the converted image:
 ///
-///    rten-convert resnet-50/model.onnx
-///
-/// 3. Run this example specifying the path to the converted image:
-///
-///    cargo run --release --bin imagenet resnet-50/model.rten image.jpg
+///    cargo run --release --bin imagenet resnet-50/model.onnx image.jpg
 ///
 /// By default the example assumes the model expects 224x224 RGB input with
 /// standard ImageNet normalization applied. You can change these using CLI

--- a/rten-examples/src/kokoro.rs
+++ b/rten-examples/src/kokoro.rs
@@ -194,23 +194,20 @@ const BOS_ID: i32 = 0;
 
 /// Convert text to speech using Kokoro.
 ///
-/// Download the ONNX model from https://huggingface.co/robertknight/kokoro-onnx/tree/main
-/// and convert it using rten-convert:
-///
-/// ```
-/// rten-convert kokoro.onnx
-/// ```
+/// Download the ONNX model from https://huggingface.co/robertknight/kokoro-onnx/tree/main.
 ///
 /// Then run with:
 ///
 /// ```txt
-/// cargo run -p rten-examples -r --bin kokoro -- kokoro.rten voice.bin [<phonemes>]
+/// cargo run -p rten-examples -r --bin kokoro -- kokoro.onnx voice.bin [<phonemes>]
 /// ```
 ///
 /// The voice files can be downloaded from
 /// https://huggingface.co/onnx-community/Kokoro-82M-v1.0-ONNX/tree/main/voices.
 ///
-/// (Note: Don't use the version of the ONNX model from the onnx-community repository).
+/// (Note: Don't use the version of the ONNX model from the onnx-community repository.
+///  It relies on some particular behaviors of ONNX Runtime which do not work
+///  in other runtimes)
 ///
 /// _phonemes_ is an optional argument that specifies the text to read as a
 /// sequence of phonemes. See [`Args::phonemes`].

--- a/rten-examples/src/modernbert.rs
+++ b/rten-examples/src/modernbert.rs
@@ -70,16 +70,10 @@ Options:
 /// https://huggingface.co/answerdotai/ModernBERT-base/tree/main, as well
 /// as the `tokenizer.json` file.
 ///
-/// Convert the model using `rten-convert`:
-///
-/// ```
-/// rten-convert modernbert.onnx
-/// ```
-///
 /// Run the example using:
 ///
 /// ```
-/// cargo run --release --bin modernbert modernbert.rten tokenizer.json "Earth is a [MASK]."
+/// cargo run --release --bin modernbert modernbert.onnx tokenizer.json "Earth is a [MASK]."
 /// ```
 ///
 /// This should print "Earth is a planet." Note the period at the end of the

--- a/rten-examples/src/piper.rs
+++ b/rten-examples/src/piper.rs
@@ -142,12 +142,11 @@ fn phonemes_to_ids(phonemes: &str, config: &ModelConfig) -> NdTensor<i32, 1> {
 ///    Other voice models should also work, but have not been tested
 ///    extensively.
 ///
-/// 2. Convert the model to `.rten` format using `rten-convert`
-/// 3. Run the demo with:
+/// 2. Run the demo with:
 ///
 ///    ```
 ///    cargo run -p rten-examples -r --bin piper \
-///      en_US-lessac-medium.rten en_US-lessac-medium.onnx.json
+///      en_US-lessac-medium.onnx en_US-lessac-medium.onnx.json
 ///    ```
 ///
 ///    This will generate an `output.wav` file, which you can play using

--- a/rten-examples/src/rmbg.rs
+++ b/rten-examples/src/rmbg.rs
@@ -78,8 +78,7 @@ fn fill_mask(mut image: NdTensorViewMut<f32, 3>, mask: NdTensorView<bool, 2>, co
 /// run on an image using:
 ///
 /// ```
-/// rten-convert rmbg.onnx
-/// cargo run --release --bin rmbg rmbg.rten image.jpg
+/// cargo run --release --bin rmbg rmbg.onnx image.jpg
 /// ```
 ///
 /// This will generate `output.png`, a copy of the input image with the

--- a/rten-examples/src/silero.rs
+++ b/rten-examples/src/silero.rs
@@ -173,13 +173,8 @@ impl VadState {
 
 /// Detect speech in .wav audio files using Silero VAD [^1].
 ///
-/// Download the ONNX model from the Silero VAD repository at
-/// https://github.com/snakers4/silero-vad/tree/master/src/silero_vad/data,
-/// then convert it using:
-///
-/// ```
-/// rten-convert silero_vad.onnx
-/// ```
+/// First, download the ONNX model from the Silero VAD repository at
+/// https://github.com/snakers4/silero-vad/tree/master/src/silero_vad/data.
 ///
 /// To record a .wav file and run this example:
 ///
@@ -195,7 +190,7 @@ impl VadState {
 /// 3. Run this program on the generated .wav file:
 ///
 ///    ```
-///    cargo run --release --bin silero_vad silero.rten output.wav
+///    cargo run --release --bin silero_vad silero.onnx output.wav
 ///    ```
 ///
 /// [^1]: <https://github.com/snakers4/silero-vad>

--- a/rten-examples/src/wav2vec2.rs
+++ b/rten-examples/src/wav2vec2.rs
@@ -95,7 +95,6 @@ fn read_wav_file(path: &str, expected_sample_rate: u32) -> Result<Vec<f32>, houn
 ///
 /// ```
 /// optimum-cli export onnx --model facebook/wav2vec2-base-960h wav2vec2
-/// rten-convert wav2vec2/model.onnx wav2vec2.rten
 /// ```
 ///
 /// For better accuracy at the cost of slower transcription, you can use larger
@@ -115,7 +114,7 @@ fn read_wav_file(path: &str, expected_sample_rate: u32) -> Result<Vec<f32>, houn
 /// 3. Run this program on the generated .wav file:
 ///
 ///    ```
-///    cargo run --release --bin wav2vec2 wav2vec.rten output.wav
+///    cargo run --release --bin wav2vec2 wav2vec.onnx output.wav
 ///    ```
 ///
 /// [^1]: <https://ai.meta.com/blog/wav2vec-20-learning-the-structure-of-speech-from-raw-audio/>

--- a/rten-examples/src/whisper.rs
+++ b/rten-examples/src/whisper.rs
@@ -355,14 +355,6 @@ fn format_timestamp(sec: f32) -> String {
 /// optimum-cli export onnx --model openai/whisper-base whisper-base
 /// ```
 ///
-/// Convert the models to `.rten` format. For the decoder you need to use the
-/// "merged" model.
-///
-/// ```
-/// rten-convert whisper-base/encoder_model.onnx
-/// rten-convert whisper-base/decoder_model_merged.onnx
-/// ```
-///
 /// The audio input must be a 16 kHz WAV file. To convert an existing audio
 /// file to this format you can use ffmpeg:
 ///
@@ -373,7 +365,7 @@ fn format_timestamp(sec: f32) -> String {
 /// Run the model, specifying the audio file to recognize.
 ///
 /// ```sh
-/// cargo run --release --bin whisper whisper-base/encoder_model.rten whisper-base/decoder_model_merged.rten whisper-base/tokenizer.json audio.wav
+/// cargo run --release --bin whisper whisper-base/encoder_model.onnx whisper-base/decoder_model_merged.onnx whisper-base/tokenizer.json audio.wav
 /// ```
 ///
 /// [^1]: https://arxiv.org/abs/2212.04356


### PR DESCRIPTION
Using the models in ONNX format simplifies getting started by removing a conversion step, at the cost of slightly slower load times.

Part of https://github.com/robertknight/rten/issues/141.