### PR TITLE
Switch DETR example to use ONNX format

### DIFF
--- a/rten-examples/src/detr.rs
+++ b/rten-examples/src/detr.rs
@@ -170,12 +170,10 @@ const NO_OBJECT_LABELS: &[&str] = &["N/A"];
 
 /// Detect objects in images using DETR [^1] or RT-DETR.
 ///
-/// The DETR model [^2] can be obtained from Hugging Face and converted to this
-/// library's format using Optimum [^3]:
+/// The DETR model [^2] can be obtained from Hugging Face using Optimum [^3]:
 ///
 /// ```
 /// optimum-cli export onnx --model facebook/detr-resnet-50 detr
-/// rten-convert detr/model.onnx
 /// ```
 ///
 /// [^1]: <https://arxiv.org/abs/2005.12872>
@@ -185,7 +183,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let args = parse_args()?;
 
     let model_dir = Path::new(&args.model_dir);
-    let model_file = model_dir.join("model.rten");
+    let model_file = model_dir.join("model.onnx");
     let config_file = model_dir.join("config.json");
     let preprocessor_config_file = model_dir.join("preprocessor_config.json");
 


### PR DESCRIPTION
This simplifies running the example, with a very minor impact to model load times (~2ms on my M3 Pro with RT-DETR).