### PR TITLE
Update DeepLabv3 example to use ONNX

### DIFF
--- a/rten-examples/src/deeplab.rs
+++ b/rten-examples/src/deeplab.rs
@@ -94,14 +94,13 @@ const PASCAL_VOC_LABELS: [(&str, Rgb); 21] = [
 /// `export-deeplab.py` script:
 ///
 /// ```
-/// python examples/export-deeplab.py
-/// rten-convert deeplab.onnx deeplab.rten
+/// python src/export-deeplab.py
 /// ```
 ///
 /// Run this program on an image with:
 ///
 /// ```
-/// cargo run --release --bin deeplab deeplab.rten image.jpg out.png
+/// cargo run --release --bin deeplab deeplab.onnx image.jpg out.png
 /// ```
 ///
 /// [^1]: <https://arxiv.org/abs/1706.05587>


### PR DESCRIPTION
 - Correct path to export-deeplab.py script
 - Simplify running example by using ONNX format