### PR TITLE
Convert BERT QA example to use ONNX format

### DIFF
--- a/rten-examples/src/bert_qa.rs
+++ b/rten-examples/src/bert_qa.rs
@@ -202,24 +202,22 @@ fn extract_nbest_answers<'a>(
 /// answering, such as <https://huggingface.co/deepset/bert-base-cased-squad2> or
 /// <https://huggingface.co/distilbert-base-cased-distilled-squad>.
 ///
-/// You can export a BERT model in ONNX format from Hugging Face and convert
-/// it as follows, using Optimium [^2].
+/// You can export a BERT model in ONNX format using Optimium [^2]:
 ///
 /// ```
 /// optimum-cli export onnx --model distilbert-base-cased-distilled-squad distilbert
-/// rten-convert distilbert/model.onnx distilbert/distilbert.rten
 /// ```
 ///
 /// Then run the example with:
 ///
 /// ```
-/// cargo run -r --bin bert_qa distilbert/distilbert.rten distilbert/tokenizer.json <context> <query>
+/// cargo run -r --bin bert_qa distilbert/model.onnx distilbert/tokenizer.json <context> <query>
 /// ```
 ///
-/// Where `<context>` is a text file to search, and `<query>` is a question.
-/// For example, given a text file containing "My name is Robert and I
-/// live in London" and the query "what am I called" the model should output
-/// the substring "Robert".
+/// Where `<context>` is the path to a text file to search, and `<query>` is a
+/// question. For example, given a text file containing "My name is Robert and I
+/// live in London" and the query "what am I called" the model should output the
+/// substring "Robert".
 ///
 /// [^1]: <https://huggingface.co/tasks/question-answering>
 /// [^2]: <https://huggingface.co/docs/optimum/index>


### PR DESCRIPTION
Simplify running the example by using ONNX format.