### PR TITLE
Use ONNX format for DistilViT example

### DIFF
--- a/rten-examples/src/distilvit.rs
+++ b/rten-examples/src/distilvit.rs
@@ -63,20 +63,15 @@ Args:
 
 /// Generates captions for an image using Mozilla's DistilViT.
 ///
-/// 1. Download the `onnx/encoder.onnx` and `onnx/decoder_with_past.onnx` ONNX
-///    models from https://huggingface.co/Mozilla/distilvit/tree/main, as well
-///    as the `tokenizer.json` file.
-/// 2. Convert the models
+/// 1. Download the `onnx/encoder_model.onnx` and
+///    `onnx/decoder_model_merged.onnx` ONNX models from
+///    https://huggingface.co/Mozilla/distilvit/tree/main, as well as the
+///    `tokenizer.json` file.
+///
+/// 2. Run the model, specifying the image to caption:
 ///
 /// ```sh
-/// rten-convert encoder_model.onnx
-/// rten-convert decoder_model_with_past.onnx
-/// ```
-///
-/// 3. Run the converted model, specifying the image to caption:
-///
-/// ```sh
-/// cargo run --release --bin distilvit encoder_model.rten decoder_model.rten tokenizer.json <image>
+/// cargo run --release --bin distilvit encoder_model.onnx decoder_model_merged.onnx tokenizer.json <image>
 /// ```
 fn main() -> Result<(), Box<dyn Error>> {
     let args = parse_args()?;


### PR DESCRIPTION
Simplify running the example by using ONNX format.