### PR TITLE
Port rten-cli from lexopt to argh, mention ONNX support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,12 +239,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
-name = "lexopt"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baff4b617f7df3d896f97fe922b64817f6cd9a756bb81d40f8883f2f66dcb401"
-
-[[package]]
 name = "libc"
 version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -456,8 +450,8 @@ version = "0.1.0"
 name = "rten-cli"
 version = "0.22.1"
 dependencies = [
+ "argh",
  "fastrand",
- "lexopt",
  "rten",
  "rten-tensor",
  "rten-testing",

--- a/rten-cli/Cargo.toml
+++ b/rten-cli/Cargo.toml
@@ -10,10 +10,10 @@ repository = "https://github.com/robertknight/rten"
 include = ["/src", "/README.md"]
 
 [dependencies]
+argh = "0.1"
 fastrand = "2.0.2"
 rten = { path = "../", version = "0.22.1", features=["all-ops", "mmap"] }
 rten-tensor = { path = "../rten-tensor", version = "0.22.1" }
-lexopt = "0.3.0"
 safetensors = "0.6.2"
 
 [dev-dependencies]


### PR DESCRIPTION
Replace lexopt with argh for argument parsing in rten-cli. This change follows the same pattern used for porting the examples in rten-examples.  This requires a little less code and also makes CLI argument parsing consistent with the examples.

In the process the CLI docs were updated to mention that `.onnx` models are now supported in addition to `.rten`.

One functional change is that flags can no longer be combined into a single argument so requesting detailed profiling now requires `-p -p` instead of `-pp`.

As with the changes in rten-examples, this is mostly AI generated with touch-ups from me.