### PR TITLE
Add node context to external data errors

### DIFF
--- a/src/model/onnx_loader.rs
+++ b/src/model/onnx_loader.rs
@@ -524,7 +524,9 @@ where
         tensor_from_bytes::<T>(shape, data, name)?.into()
     } else if let Some(loc) = external_data {
         if let Some(loader) = &loader {
-            let data = loader.load(&loc)?;
+            let data = loader
+                .load(&loc)
+                .map_err(|e| load_error!(ExternalDataError, name, e))?;
             tensor_from_external_data::<T>(shape, &data, name)?.into()
         } else {
             return Err(load_error!(


### PR DESCRIPTION
If an error occurs reading an external data file, include the name of the initializer in the error. Example:

> Failed to load model "model-2.onnx": external data error: in node "numeric_proj.0.0.weight": io error: No such file or directory (os error 2)