### PR TITLE
Make ModelProto parsing entry points non-generic

### DIFF
--- a/rten-onnx/src/lib.rs
+++ b/rten-onnx/src/lib.rs
@@ -21,12 +21,10 @@
 //! use std::fs::File;
 //!
 //! use rten_onnx::onnx::ModelProto;
-//! use rten_onnx::protobuf::{DecodeMessage, ReadPos, ValueReader};
 //!
 //! fn main() -> Result<(), Box<dyn Error>> {
 //!     let file = File::open("model.onnx")?;
-//!     let value_reader = ValueReader::from_file(file);
-//!     let model = ModelProto::decode(value_reader)?;
+//!     let model = ModelProto::parse_file(file)?;
 //!
 //!     let op_count = model.graph.as_ref().map(|g| g.node.len()).unwrap_or(0);
 //!     let weight_count = model.graph.as_ref().map(|g| g.initializer.len()).unwrap_or(0);
@@ -40,11 +38,10 @@
 //! To read a model from an in-memory buffer, use:
 //!
 //! ```no_run
-//! # use rten_onnx::{onnx::ModelProto, protobuf::{ValueReader, DecodeMessage}};
+//! # use rten_onnx::onnx::ModelProto;
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! # let buffer = std::fs::read("model.onnx")?;
-//! let value_reader = ValueReader::from_buf(&buffer);
-//! let model = ModelProto::decode(value_reader)?;
+//! let model = ModelProto::parse_buf(&buffer)?;
 //! # Ok(()) }
 //! ```
 //!

--- a/rten-onnx/src/onnx.rs
+++ b/rten-onnx/src/onnx.rs
@@ -8,8 +8,9 @@
 //! are used by RTen or its associated tools.
 
 use std::cell::RefCell;
+use std::fs::File;
 
-use crate::protobuf::{DecodeMessage, Fields, OwnedValues, ProtobufError, ReadValue};
+use crate::protobuf::{DecodeMessage, Fields, OwnedValues, ProtobufError, ReadValue, ValueReader};
 
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub struct AttributeType(pub i32);
@@ -568,6 +569,21 @@ pub struct ModelProto {
 impl ModelProto {
     const IR_VERSION: u64 = 1;
     const GRAPH: u64 = 7;
+
+    // The non-generic `parse_file` and `parse_buf` methods allow the parsing
+    // code to be compiled as part of the rten-onnx crate.
+
+    /// Deserialize a `ModelProto` from a file.
+    pub fn parse_file(file: File) -> Result<Self, ProtobufError> {
+        let reader = ValueReader::from_file(file);
+        ModelProto::decode(reader)
+    }
+
+    /// Deserialize a `ModelProto` from a buffer.
+    pub fn parse_buf(buf: &[u8]) -> Result<Self, ProtobufError> {
+        let reader = ValueReader::from_buf(buf);
+        ModelProto::decode(reader)
+    }
 }
 
 impl DecodeMessage for ModelProto {

--- a/src/model/onnx_loader.rs
+++ b/src/model/onnx_loader.rs
@@ -3,7 +3,6 @@ use std::path::Path;
 
 use rten_base::byte_cast::{Pod, cast_pod_slice};
 use rten_onnx::onnx;
-use rten_onnx::protobuf::{DecodeMessage, ValueReader};
 use rten_tensor::{ArcTensor, Storage, Tensor};
 
 use super::NodeError;
@@ -40,13 +39,9 @@ pub fn load(
     let model = match source {
         Source::Path(path) => {
             let file = File::open(path).map_err(ModelLoadError::ReadFailed)?;
-            let reader = ValueReader::from_file(file);
-            onnx::ModelProto::decode(reader)
+            onnx::ModelProto::parse_file(file)
         }
-        Source::Buffer(buf) => {
-            let reader = ValueReader::from_buf(buf);
-            onnx::ModelProto::decode(reader)
-        }
+        Source::Buffer(buf) => onnx::ModelProto::parse_buf(buf),
         #[cfg(test)]
         Source::Proto(proto) => Ok(proto),
     }


### PR DESCRIPTION
Add non-generic ModelProto parsing entry points to rten-onnx. This allows the parsing code (~24K LLVM lines) to be compiled earlier as part of the rten-onnx crate, rather than as part of the rten crate.

