### PR TITLE
Support custom metadata fields in ONNX loader

### DIFF
--- a/rten-onnx/src/onnx.rs
+++ b/rten-onnx/src/onnx.rs
@@ -564,6 +564,7 @@ impl DecodeMessage for GraphProto {
 pub struct ModelProto {
     pub ir_version: Option<i64>,
     pub graph: Option<GraphProto>,
+    pub metadata_props: Vec<StringStringEntryProto>,
     pub producer_name: Option<String>,
     pub producer_version: Option<String>,
 }
@@ -573,6 +574,7 @@ impl ModelProto {
     const PRODUCER_NAME: u64 = 2;
     const PRODUCER_VERSION: u64 = 3;
     const GRAPH: u64 = 7;
+    const METADATA_PROPS: u64 = 14;
 
     // The non-generic `parse_file` and `parse_buf` methods allow the parsing
     // code to be compiled as part of the rten-onnx crate.
@@ -610,6 +612,10 @@ impl DecodeMessage for ModelProto {
                 }
                 Self::PRODUCER_VERSION => {
                     msg.producer_version = Some(field.read_string()?);
+                }
+                Self::METADATA_PROPS => {
+                    msg.metadata_props
+                        .push(StringStringEntryProto::decode_field(&mut field)?);
                 }
                 _ => {
                     field.skip()?;

--- a/src/model/metadata.rs
+++ b/src/model/metadata.rs
@@ -15,6 +15,8 @@ pub enum MetadataField {
     // Standard fields in ONNX models.
     ProducerName,
     ProducerVersion,
+
+    Custom(String),
 }
 
 impl MetadataField {
@@ -30,6 +32,7 @@ impl MetadataField {
             Self::RunUrl => "run_url",
             Self::ProducerName => "producer_name",
             Self::ProducerVersion => "producer_version",
+            Self::Custom(value) => &value,
         }
     }
 }
@@ -138,6 +141,14 @@ impl ModelMetadata {
     /// Return the version of the framework or tool used to produce the model.
     pub fn producer_version(&self) -> Option<&str> {
         self.field(&MetadataField::ProducerVersion)
+    }
+
+    /// Get the value of a metadata field by name.
+    pub fn get(&self, name: &str) -> Option<&str> {
+        let key = MetadataField::Custom(
+            name.to_string(), // Clone is not ideal, but it makes the types simpler.
+        );
+        self.fields.get(&key).map(|v| v.as_str())
     }
 
     fn field(&self, field: &MetadataField) -> Option<&str> {


### PR DESCRIPTION
Support custom fields in `ModelMetadata` and populate it from the ONNX model's `ModelProto.metadata_props`.