### PR TITLE
Add crate features to control which model formats are available

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,9 @@ jobs:
       # nb. wasm-bindgen-cli version must match `wasm-bindgen` version in Cargo.lock
       run: cargo install wasm-bindgen-cli --version 0.2.100
       if: ${{ matrix.os == 'ubuntu-latest' }}
-    - name: Build
+    - name: Build (no default features)
+      run: cargo check --no-default-features
+    - name: Build (default features)
       run: cargo build
     - name: Test
       run: make test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,8 +57,8 @@ flatbuffers = { workspace = true }
 smallvec = { version = "1.10.0", features = ["union", "const_generics", "const_new"] }
 rten-base = { path = "./rten-base", version = "0.22.1" }
 rten-gemm = { path = "./rten-gemm", version = "0.22.1" }
-rten-model-file = { path = "./rten-model-file", version = "0.22.1" }
-rten-onnx = { path = "./rten-onnx", version = "0.22.1" }
+rten-model-file = { path = "./rten-model-file", version = "0.22.1", optional = true }
+rten-onnx = { path = "./rten-onnx", version = "0.22.1", optional = true }
 rten-tensor = { path = "./rten-tensor", version = "0.22.1" }
 rten-vecmath = { path = "./rten-vecmath", version = "0.22.1" }
 rten-simd = { path = "./rten-simd", version = "0.22.1" }
@@ -81,18 +81,24 @@ serde_json = { workspace = true }
 crate-type = ["lib", "cdylib"]
 
 [features]
+default = ["onnx_format", "rten_format"]
+
+# Enable all features that affect supported operators
+all-ops = ["fft", "random"]
 # Enables FFT operators (DFT, STFT etc.)
 fft = ["dep:rustfft"]
 # Enable loading models using memory mapping
 mmap = ["dep:memmap2"]
+# Enable module for building .rten models
+model_builder = []
+# Enable support for loading .onnx models
+onnx_format = ["dep:rten-onnx"]
 # Generate WebAssembly API using wasm-bindgen.
 wasm_api = []
 # Enable operators that generate random numbers.
 random = ["dep:fastrand", "dep:fastrand-contrib"]
-# Enable all features that affect supported operators
-all-ops = ["fft", "random"]
-# Enable module for building .rten models
-model_builder = []
+# Enable support for loading .rten models
+rten_format = ["dep:rten-model-file"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2.100"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,6 +140,18 @@
 //! guide](https://github.com/robertknight/rten/blob/main/docs/performance.md) for
 //! information on profiling and improving model execution performance.
 //!
+//! # Crate features
+//!
+//!  - **all-ops** - Enables all operators which are not enabled by default
+//!  - **fft** - Enables FFT operators
+//!  - **mmap** - Enable loading models with memory mapping via [`Model::load_mmap`]
+//!  - **onnx_format** (enabled by default) - Enables support for loading `.onnx` models.
+//!  - **random** - Enables operators that generate random numbers
+//!  - **rten_format** (enabled by default) - Enables support for loading `.rten` models.
+//!  - **wasm_api** - Generate WebAssembly API using wasm-bindgen
+//!
+//! At least one of the **onnx_format** or **rten_format** features must be enabled.
+//!
 //! [model_formats]: https://github.com/robertknight/rten/blob/main/docs/model-formats.md
 //! [onnx_operators]: https://onnx.ai/onnx/operators/
 //! [rten_examples]: https://github.com/robertknight/rten/tree/main/rten-examples

--- a/src/model/file_type.rs
+++ b/src/model/file_type.rs
@@ -1,9 +1,6 @@
 use std::ffi::OsStr;
 use std::path::Path;
 
-use rten_onnx::onnx::is_onnx_model;
-use rten_onnx::protobuf::ValueReader;
-
 /// File type of a machine learning model.
 #[derive(Debug, PartialEq)]
 pub enum FileType {
@@ -41,10 +38,16 @@ impl FileType {
             return Some(FileType::Rten);
         }
 
-        // ONNX models are serialized Protocol Buffers messages with no file
-        // type identifier, so we attempt some lightweight protobuf parsing.
-        if is_onnx_model(ValueReader::from_buf(data)) {
-            return Some(FileType::Onnx);
+        #[cfg(feature = "onnx_format")]
+        {
+            use rten_onnx::onnx::is_onnx_model;
+            use rten_onnx::protobuf::ValueReader;
+
+            // ONNX models are serialized Protocol Buffers messages with no file
+            // type identifier, so we attempt some lightweight protobuf parsing.
+            if is_onnx_model(ValueReader::from_buf(data)) {
+                return Some(FileType::Onnx);
+            }
         }
 
         // rten files using the v1 format don't have a file type identifier.

--- a/src/model/metadata.rs
+++ b/src/model/metadata.rs
@@ -32,7 +32,7 @@ impl MetadataField {
             Self::RunUrl => "run_url",
             Self::ProducerName => "producer_name",
             Self::ProducerVersion => "producer_version",
-            Self::Custom(value) => &value,
+            Self::Custom(value) => value,
         }
     }
 }

--- a/src/model/onnx_loader.rs
+++ b/src/model/onnx_loader.rs
@@ -55,7 +55,7 @@ pub fn load(
     };
 
     let graph = if let Some(onnx_graph) = &model.graph {
-        load_graph(&onnx_graph, &options.registry, optimize_opts, None, loader)?
+        load_graph(onnx_graph, &options.registry, optimize_opts, None, loader)?
     } else {
         Graph::new()
     };


### PR DESCRIPTION
Both `.rten` and `.onnx` formats are enabled by default. Disabling unused formats can improve build times. Enabling both formats generates ~912K LLVM lines for the rten crate (via `cargo llvm-lines`). Enabling only one format generates ~840K lines (-8%).