### PR TITLE
Support i8/u8 inputs in ort-infer.py

### DIFF
--- a/tools/ort-infer.py
+++ b/tools/ort-infer.py
@@ -86,11 +86,13 @@ def run_model(
     print("Inputs:")
     for node in session.get_inputs():
         type_map = {
+            "tensor(bool)": np.bool_,
             "tensor(float)": np.float32,
             "tensor(float16)": np.float16,
-            "tensor(int64)": np.int64,
             "tensor(int32)": np.int32,
-            "tensor(bool)": np.bool_,
+            "tensor(int64)": np.int64,
+            "tensor(int8)": np.int8,
+            "tensor(uint8)": np.uint8,
         }
 
         resolved_shape = []


### PR DESCRIPTION
Encountered while testing [driving_vision.onnx](https://github.com/haraschax/filedump/raw/refs/heads/master/driving_vision.onnx) from openpilot.