### PR TITLE
Revise API for enabling operator subsets

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,7 +187,7 @@ pub mod ops;
 pub use buffer_pool::{BufferPool, ExtractBuffer, PoolRef};
 pub use graph::{Dimension, NodeId, RunError, RunErrorKind, RunOptions};
 pub use model::{LoadError, LoadErrorKind, Model, ModelMetadata, ModelOptions, NodeInfo};
-pub use op_registry::{OpRegistry, ReadOpError};
+pub use op_registry::{OpRegistry, RegisterOp, op_types};
 pub use ops::{FloatOperators, Operators};
 pub use threading::{ThreadPool, thread_pool};
 pub use timing::TimingSort;

--- a/src/model.rs
+++ b/src/model.rs
@@ -638,12 +638,12 @@ mod tests {
     use rten_tensor::prelude::*;
     use rten_tensor::{NdTensor, Tensor};
 
-    use crate::OpRegistry;
     use crate::graph::{Dimension, NodeId, RunErrorKind};
     use crate::model::rten_builder::{
         GraphBuilder, IfArgs, MetadataArgs, ModelBuilder, ModelFormat, OpType,
     };
     use crate::model::{LoadErrorKind, Model, ModelOptions};
+    use crate::op_registry;
     use crate::ops;
     use crate::ops::{
         BoxOrder, CoordTransformMode, DepthToSpaceMode, NearestMode, ResizeMode, Shape,
@@ -733,12 +733,20 @@ mod tests {
     #[test]
     fn test_unsupported_operator() {
         let buffer = generate_model_buffer(ModelFormat::V2);
-        let registry = OpRegistry::new();
+        let registry = op_registry!();
         let result = ModelOptions::with_ops(registry).load(buffer);
         assert_eq!(
             result.err().map(|err| err.to_string()).as_deref(),
             Some("in node \"concat\": operator error: Concat operator not enabled")
         );
+    }
+
+    #[test]
+    fn test_subset_of_ops_enabled() {
+        let buffer = generate_model_buffer(ModelFormat::V2);
+        let registry = op_registry!(Concat, Relu);
+        let result = ModelOptions::with_ops(registry).load(buffer);
+        assert!(result.is_ok());
     }
 
     #[test]

--- a/src/op_registry.rs
+++ b/src/op_registry.rs
@@ -13,13 +13,15 @@ use onnx_registry::OnnxOpRegistry;
 
 /// Registry used to deserialize operators when loading a model.
 ///
-/// New registries have no operators registered by default. To create a registry
-/// with all built-in operators pre-registered, use
-/// [`OpRegistry::with_all_ops`]. Alternatively create a new registry and
-/// selectively register the required operators using
-/// [`OpRegistry::register_op`]. This can be useful to reduce binary size, as
-/// the linker will remove code for unused operators.
-#[derive(Default)]
+/// A registry is created automatically when using APIs such as
+/// [`Model::load_file`](crate::Model::load_file) or
+/// [`ModelOptions::with_all_ops`](crate::ModelOptions::with_all_ops). These
+/// registries have all operators enabled.
+///
+/// Enabling only a subset of operators can reduce binary size, as the linker
+/// will remove code for unused operators. To do this, create a custom registry
+/// using the [`op_registry`](crate::op_registry) macro and pass it to
+/// [`ModelOptions::with_ops`](crate::ModelOptions::with_ops).
 pub struct OpRegistry {
     /// Registry for deserializing operators from .rten model files.
     #[cfg(feature = "rten_format")]
@@ -31,48 +33,29 @@ pub struct OpRegistry {
 }
 
 impl OpRegistry {
-    /// Create a new empty registry.
-    pub fn new() -> OpRegistry {
-        OpRegistry {
+    /// Create a new registry with selected operators enabled.
+    pub fn with_ops(ops: &[&dyn RegisterOp]) -> OpRegistry {
+        let mut reg = OpRegistry {
             #[cfg(feature = "rten_format")]
             rten_registry: RtenOpRegistry::new(),
             #[cfg(feature = "onnx_format")]
             onnx_registry: OnnxOpRegistry::new(),
+        };
+
+        for op in ops {
+            op.register(&mut reg);
         }
+        reg
     }
 
-    /// Register the default/built-in implementation of an operator.
-    ///
-    /// ```no_run
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// use rten::ops::{Conv, Gemm, MaxPool, ReduceMean, Relu};
-    /// use rten::{Model, ModelOptions, OpRegistry};
-    ///
-    /// // Register only the ops needed for the model.
-    /// let mut reg = OpRegistry::new();
-    /// reg.register_op::<Conv>();
-    /// reg.register_op::<Relu>();
-    /// reg.register_op::<MaxPool>();
-    /// reg.register_op::<ReduceMean>();
-    /// reg.register_op::<Gemm>();
-    ///
-    /// let model = ModelOptions::with_ops(reg).load_file("mnist.onnx")?;
-    /// # Ok(()) }
-    /// ```
-    #[cfg(all(feature = "onnx_format", feature = "rten_format"))]
-    pub fn register_op<Op: rten_registry::ReadOp + onnx_registry::ReadOp + 'static>(&mut self) {
-        self.rten_registry.register_op::<Op>();
-        self.onnx_registry.register_op::<Op>();
-    }
-
-    #[cfg(all(not(feature = "onnx_format"), feature = "rten_format"))]
-    pub fn register_op<Op: rten_registry::ReadOp + 'static>(&mut self) {
-        self.rten_registry.register_op::<Op>();
-    }
-
-    #[cfg(all(feature = "onnx_format", not(feature = "rten_format")))]
-    pub fn register_op<Op: onnx_registry::ReadOp + 'static>(&mut self) {
-        self.onnx_registry.register_op::<Op>();
+    /// Create a new registry with all operators enabled.
+    pub fn with_all_ops() -> OpRegistry {
+        OpRegistry {
+            #[cfg(feature = "rten_format")]
+            rten_registry: RtenOpRegistry::with_all_ops(),
+            #[cfg(feature = "onnx_format")]
+            onnx_registry: OnnxOpRegistry::with_all_ops(),
+        }
     }
 
     /// Return the inner registry for deserializing operators from .rten models.
@@ -85,16 +68,6 @@ impl OpRegistry {
     #[cfg(feature = "onnx_format")]
     pub(crate) fn onnx_registry(&self) -> &onnx_registry::OnnxOpRegistry {
         &self.onnx_registry
-    }
-
-    /// Create a new registry with all built-in operators registered.
-    pub fn with_all_ops() -> OpRegistry {
-        OpRegistry {
-            #[cfg(feature = "rten_format")]
-            rten_registry: RtenOpRegistry::with_all_ops(),
-            #[cfg(feature = "onnx_format")]
-            onnx_registry: OnnxOpRegistry::with_all_ops(),
-        }
     }
 }
 
@@ -116,6 +89,7 @@ pub enum ReadOpError {
         name: Option<String>,
     },
     /// The operator requires a crate feature that was not enabled.
+    #[allow(unused)]
     FeatureNotEnabled {
         /// Name of the operator.
         name: String,
@@ -162,3 +136,196 @@ impl Display for ReadOpError {
 }
 
 impl Error for ReadOpError {}
+
+/// Construct an [`OpRegistry`] with a given set of operators enabled.
+///
+/// ```no_run
+/// use rten::{ModelOptions, op_registry};
+///
+/// // Create a registry with four operators enabled.
+/// let registry = op_registry!(Conv, Add, MatMul, Relu);
+/// let model = ModelOptions::with_ops(registry).load_file("model.onnx");
+/// ```
+#[macro_export]
+macro_rules! op_registry {
+    ($($op:ident),*) => {{
+        #[allow(unused_mut)]
+        let ops: &[&dyn $crate::RegisterOp] = &[$(
+            &$crate::op_types::$op,
+        )*];
+        $crate::OpRegistry::with_ops(ops)
+    }}
+}
+
+/// Enable an operator in a registry. See [`OpRegistry`].
+pub trait RegisterOp {
+    fn register(&self, registry: &mut OpRegistry);
+}
+
+/// Types that can be used with [`OpRegistry::with_ops`].
+///
+/// The types in this module act as "keys" that enable an operator to be
+/// deserialized when loading a model.
+pub mod op_types {
+    use super::{OpRegistry, RegisterOp};
+    use crate::ops;
+
+    macro_rules! declare_op {
+        ($op:ident) => {
+            pub struct $op;
+
+            impl RegisterOp for $op {
+                fn register(&self, registry: &mut OpRegistry) {
+                    #[cfg(feature = "rten_format")]
+                    registry.rten_registry.register_op::<ops::$op>();
+                    #[cfg(feature = "onnx_format")]
+                    registry.onnx_registry.register_op::<ops::$op>();
+                }
+            }
+        };
+
+        ($op:ident, feature=$feature:literal) => {
+            #[cfg(feature = $feature)]
+            pub struct $op;
+
+            #[cfg(feature = $feature)]
+            impl RegisterOp for $op {
+                fn register(&self, registry: &mut OpRegistry) {
+                    #[cfg(feature = "rten_format")]
+                    registry.rten_registry.register_op::<ops::$op>();
+                    #[cfg(feature = "onnx_format")]
+                    registry.onnx_registry.register_op::<ops::$op>();
+                }
+            }
+        };
+    }
+
+    declare_op!(Abs);
+    declare_op!(Acos);
+    declare_op!(Add);
+    declare_op!(And);
+    declare_op!(ArgMax);
+    declare_op!(ArgMin);
+    declare_op!(Asin);
+    declare_op!(Atan);
+    declare_op!(AveragePool);
+    declare_op!(BatchNormalization);
+    declare_op!(Cast);
+    declare_op!(CastLike);
+    declare_op!(Ceil);
+    declare_op!(Clip);
+    declare_op!(Concat);
+    declare_op!(ConcatFromSequence);
+    declare_op!(Conv);
+    declare_op!(ConvInteger);
+    declare_op!(ConstantOfShape);
+    declare_op!(ConvTranspose);
+    declare_op!(Cos);
+    declare_op!(CumSum);
+    declare_op!(DequantizeLinear);
+    declare_op!(DepthToSpace);
+    declare_op!(Div);
+    declare_op!(Dropout, feature = "random");
+    declare_op!(DynamicQuantizeLinear);
+    declare_op!(Einsum);
+    declare_op!(Elu);
+    declare_op!(Equal);
+    declare_op!(Erf);
+    declare_op!(Exp);
+    declare_op!(Expand);
+    declare_op!(EyeLike);
+    declare_op!(Flatten);
+    declare_op!(Floor);
+    declare_op!(Gather);
+    declare_op!(GatherElements);
+    declare_op!(GatherND);
+    declare_op!(Gelu);
+    declare_op!(Gemm);
+    declare_op!(GlobalAveragePool);
+    declare_op!(Greater);
+    declare_op!(GreaterOrEqual);
+    declare_op!(GridSample);
+    declare_op!(GRU);
+    declare_op!(HardSigmoid);
+    declare_op!(HardSwish);
+    declare_op!(Identity);
+    declare_op!(If);
+    declare_op!(InstanceNormalization);
+    declare_op!(IsInf);
+    declare_op!(IsNaN);
+    declare_op!(LayerNormalization);
+    declare_op!(LeakyRelu);
+    declare_op!(Less);
+    declare_op!(LessOrEqual);
+    declare_op!(Log);
+    declare_op!(LogSoftmax);
+    declare_op!(Loop);
+    declare_op!(LSTM);
+    declare_op!(MatMul);
+    declare_op!(MatMulInteger);
+    declare_op!(Max);
+    declare_op!(MaxPool);
+    declare_op!(Mean);
+    declare_op!(Min);
+    declare_op!(Mod);
+    declare_op!(Mul);
+    declare_op!(Neg);
+    declare_op!(NonMaxSuppression);
+    declare_op!(NonZero);
+    declare_op!(Not);
+    declare_op!(OneHot);
+    declare_op!(Or);
+    declare_op!(Pad);
+    declare_op!(Pow);
+    declare_op!(PRelu);
+    declare_op!(QuantizeLinear);
+    declare_op!(RandomNormal, feature = "random");
+    declare_op!(RandomNormalLike, feature = "random");
+    declare_op!(RandomUniform, feature = "random");
+    declare_op!(RandomUniformLike, feature = "random");
+    declare_op!(Range);
+    declare_op!(Reciprocal);
+    declare_op!(ReduceL2);
+    declare_op!(ReduceMax);
+    declare_op!(ReduceMean);
+    declare_op!(ReduceMin);
+    declare_op!(ReduceProd);
+    declare_op!(ReduceSum);
+    declare_op!(ReduceSumSquare);
+    declare_op!(Relu);
+    declare_op!(Reshape);
+    declare_op!(Resize);
+    declare_op!(Round);
+    declare_op!(ScatterElements);
+    declare_op!(ScatterND);
+    declare_op!(SequenceAt);
+    declare_op!(SequenceEmpty);
+    declare_op!(SequenceErase);
+    declare_op!(SequenceConstruct);
+    declare_op!(SequenceInsert);
+    declare_op!(SequenceLength);
+    declare_op!(Shape);
+    declare_op!(Sigmoid);
+    declare_op!(Sign);
+    declare_op!(Sin);
+    declare_op!(Size);
+    declare_op!(Slice);
+    declare_op!(Softmax);
+    declare_op!(Softplus);
+    declare_op!(Split);
+    declare_op!(SplitToSequence);
+    declare_op!(Sqrt);
+    declare_op!(Squeeze);
+    declare_op!(STFT, feature = "fft");
+    declare_op!(Sub);
+    declare_op!(Sum);
+    declare_op!(Tan);
+    declare_op!(Tanh);
+    declare_op!(Tile);
+    declare_op!(TopK);
+    declare_op!(Transpose);
+    declare_op!(Trilu);
+    declare_op!(Unsqueeze);
+    declare_op!(Where);
+    declare_op!(Xor);
+}


### PR DESCRIPTION
Revise the API for loading a model with only a subset of operators enabled. The new API is easier to use and decouples the types/traits used to enable an operator from those that implement deserialization and evaluation internally. This is part of a general effort to expose less of rten's internals in the public API.

Usage of the new API looks like so:

```rs
use rten::{ModelOptions, op_registry};

let registry = op_registry!(Conv, Add, Relu, MatMul);
let model = ModelOptions::with_ops(registry).load_file(path)?;
```

A result of this change is that the `ReadOpError` type is no longer exposed in
the crate's public API.

Part of https://github.com/robertknight/rten/issues/911.
