### PR TITLE
Remove deprecated aliases for Value/View/ValueOrView

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,10 +193,6 @@ pub use threading::{ThreadPool, thread_pool};
 pub use timing::TimingSort;
 pub use value::{DataType, Sequence, Value, ValueOrView, ValueView};
 
-// Deprecated aliases for `ValueView`, `ValueOrView` and `Value`.
-#[allow(deprecated)]
-pub use ops::{Input, InputOrOutput, Output};
-
 #[deprecated = "renamed to `LoadError`"]
 pub type ModelLoadError = LoadError;
 

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -28,7 +28,7 @@ use rten_tensor::{MutLayout, Storage, TensorBase};
 use crate::buffer_pool::BufferPool;
 use crate::graph::{CaptureEnv, Graph, RunError, RunOptions};
 use crate::timing::Profiler;
-use crate::value::{CastError, DataType, DataTypeOf, Value, ValueOrView, ValueView};
+use crate::value::{CastError, DataType, DataTypeOf, Value, ValueView};
 use crate::weight_cache::WeightCache;
 
 mod attention;
@@ -226,15 +226,6 @@ macro_rules! impl_prepacked_input_conversions {
 }
 impl_prepacked_input_conversions!(f32, FloatBMatrix);
 impl_prepacked_input_conversions!(i8, Int8BMatrix);
-
-#[deprecated = "renamed to `ValueOrView`"]
-pub type InputOrOutput<'a> = ValueOrView<'a>;
-
-#[deprecated = "renamed to `ValueView`"]
-pub type Input<'a> = ValueView<'a>;
-
-#[deprecated = "renamed to `Value`"]
-pub type Output = Value;
 
 /// Trait for values that can be converted into the result type used by
 /// [`Operator::run`].


### PR DESCRIPTION
These have been deprecated for several releases now.