### PR TITLE
Make `RunOptions` a non-exhaustive struct

### DIFF
--- a/rten-cli/src/main.rs
+++ b/rten-cli/src/main.rs
@@ -611,15 +611,14 @@ fn main() {
         println!("Running model with random inputs...");
     }
 
-    let run_opts = RunOptions {
-        timing: profile_mode != ProfileMode::None,
-        timing_by_shape: profile_mode == ProfileMode::Detailed,
-        verbose: args.verbose,
-        thread_pool: args
-            .num_threads
-            .map(|nt| ThreadPool::with_num_threads(nt as usize).into()),
-        ..Default::default()
-    };
+    let thread_pool = args
+        .num_threads
+        .map(|nt| ThreadPool::with_num_threads(nt as usize).into());
+    let run_opts = RunOptions::default()
+        .with_timing(profile_mode != ProfileMode::None)
+        .with_timing_by_shape(profile_mode == ProfileMode::Detailed)
+        .with_verbose(args.verbose)
+        .with_thread_pool(thread_pool);
 
     // Read values for inputs, if provided.
     let mut input_values = HashMap::new();

--- a/rten-examples/src/kokoro.rs
+++ b/rten-examples/src/kokoro.rs
@@ -5,7 +5,7 @@ use std::io::BufWriter;
 
 use argh::FromArgs;
 use hound::{SampleFormat, WavSpec, WavWriter};
-use rten::{Model, RunOptions};
+use rten::Model;
 use rten_tensor::prelude::*;
 use rten_tensor::{NdTensor, Tensor};
 
@@ -230,9 +230,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         ]
         .into(),
         [model.node_id("waveform")?],
-        Some(RunOptions {
-            ..Default::default()
-        }),
+        None,
     )?;
 
     // Either (batch, seq) or (seq) depending on the model variant.

--- a/rten-generate/src/generator.rs
+++ b/rten-generate/src/generator.rs
@@ -1570,10 +1570,7 @@ mod tests {
 
         let generator = Generator::from_model(&model)?;
 
-        let run_opts = RunOptions {
-            verbose: true,
-            ..Default::default()
-        };
+        let run_opts = RunOptions::default().with_verbose(true);
         let output_token_ids: Vec<_> = generator
             .with_prompt(&prompt)
             .with_run_options(Some(run_opts.clone()))

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -90,7 +90,17 @@ impl NodeRefCount {
 
 /// Options that control logging and other behaviors when executing a
 /// [`Model`](crate::Model).
+///
+/// ```
+/// use rten::RunOptions;
+///
+/// let opts = RunOptions::default()
+///     .with_timing(true)
+///     .with_verbose(false)
+///     .with_thread_pool(None);
+/// ```
 #[derive(Clone, Default)]
+#[non_exhaustive]
 pub struct RunOptions {
     /// Whether to log times spent in different operators when run completes.
     pub timing: bool,
@@ -127,6 +137,31 @@ impl RunOptions {
         self.thread_pool
             .as_deref()
             .unwrap_or(threading::thread_pool())
+    }
+
+    pub fn with_timing(mut self, timing: bool) -> Self {
+        self.timing = timing;
+        self
+    }
+
+    pub fn with_timing_filter(mut self, filter: Vec<TimingFilter>) -> Self {
+        self.timing_filter = filter;
+        self
+    }
+
+    pub fn with_timing_by_shape(mut self, timing_by_shape: bool) -> Self {
+        self.timing_by_shape = timing_by_shape;
+        self
+    }
+
+    pub fn with_verbose(mut self, verbose: bool) -> Self {
+        self.verbose = verbose;
+        self
+    }
+
+    pub fn with_thread_pool(mut self, pool: Option<Arc<threading::ThreadPool>>) -> Self {
+        self.thread_pool = pool;
+        self
     }
 }
 


### PR DESCRIPTION
Change `RunOptions` to be a non-exhaustive struct with a builder API. This will make adding new fields a non-breaking change. This change is itself breaking for existing users, but AFAIK there isn't a way around that.