### PR TITLE
Improve error when ONNX initializer has an unsupported data type

### DIFF
--- a/rten-onnx/src/onnx.rs
+++ b/rten-onnx/src/onnx.rs
@@ -8,6 +8,7 @@
 //! are used by RTen or its associated tools.
 
 use std::cell::RefCell;
+use std::fmt;
 use std::fs::File;
 
 use crate::protobuf::{DecodeMessage, Fields, OwnedValues, ProtobufError, ReadValue, ValueReader};
@@ -266,12 +267,68 @@ pub struct DataType(pub i32);
 
 impl DataType {
     pub const FLOAT: Self = Self(1);
-    pub const INT32: Self = Self(6);
-    pub const INT64: Self = Self(7);
     pub const UINT8: Self = Self(2);
     pub const INT8: Self = Self(3);
+    pub const UINT16: Self = Self(4);
+    pub const INT16: Self = Self(5);
+    pub const INT32: Self = Self(6);
+    pub const INT64: Self = Self(7);
+    pub const STRING: Self = Self(8);
     pub const BOOL: Self = Self(9);
+    pub const FLOAT16: Self = Self(10);
     pub const DOUBLE: Self = Self(11);
+    pub const UINT32: Self = Self(12);
+    pub const UINT64: Self = Self(13);
+    pub const COMPLEX64: Self = Self(14);
+    pub const COMPLEX128: Self = Self(15);
+    pub const BFLOAT16: Self = Self(16);
+    pub const FLOAT8E4M3FN: Self = Self(17);
+    pub const FLOAT8E4M3FNUZ: Self = Self(18);
+    pub const FLOAT8E5M2: Self = Self(19);
+    pub const FLOAT8E5M2FNUZ: Self = Self(20);
+    pub const UINT4: Self = Self(21);
+    pub const INT4: Self = Self(22);
+    pub const FLOAT4E2M1: Self = Self(23);
+    pub const FLOAT8E8M0: Self = Self(24);
+
+    pub fn name(&self) -> Option<&str> {
+        match *self {
+            Self::FLOAT => Some("FLOAT"),
+            Self::UINT8 => Some("UINT8"),
+            Self::INT8 => Some("INT8"),
+            Self::UINT16 => Some("UINT16"),
+            Self::INT16 => Some("INT16"),
+            Self::INT32 => Some("INT32"),
+            Self::INT64 => Some("INT64"),
+            Self::STRING => Some("STRING"),
+            Self::BOOL => Some("BOOL"),
+            Self::FLOAT16 => Some("FLOAT16"),
+            Self::DOUBLE => Some("DOUBLE"),
+            Self::UINT32 => Some("UINT32"),
+            Self::UINT64 => Some("UINT64"),
+            Self::COMPLEX64 => Some("COMPLEX64"),
+            Self::COMPLEX128 => Some("COMPLEX128"),
+            Self::BFLOAT16 => Some("BFLOAT16"),
+            Self::FLOAT8E4M3FN => Some("FLOAT8E4M3FN"),
+            Self::FLOAT8E4M3FNUZ => Some("FLOAT8E4M3FNUZ"),
+            Self::FLOAT8E5M2 => Some("FLOAT8E5M2"),
+            Self::FLOAT8E5M2FNUZ => Some("FLOAT8E5M2FNUZ"),
+            Self::UINT4 => Some("UINT4"),
+            Self::INT4 => Some("INT4"),
+            Self::FLOAT4E2M1 => Some("FLOAT4E2M1"),
+            Self::FLOAT8E8M0 => Some("FLOAT8E8M0"),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for DataType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.name() {
+            Some(name) => write!(f, "{name}"),
+            None => write!(f, "{}", self.0),
+        }
+    }
 }
 
 #[derive(Clone, Debug, Default)]

--- a/src/model/onnx_loader.rs
+++ b/src/model/onnx_loader.rs
@@ -447,7 +447,7 @@ fn load_constant(
                 GraphError,
                 name,
                 "initializer has unsupported data type {}",
-                dtype.0
+                dtype
             ));
         }
         None => {
@@ -1072,6 +1072,27 @@ mod tests {
 
         let floats_vec = model.get_tensor_by_name::<f32>("doubles_vec").unwrap();
         assert_eq!(floats_vec, TensorView::from(&[0.1, 0.2, 0.3]));
+    }
+
+    #[test]
+    fn test_initializer_with_unsupported_dtype() {
+        let tensor = create_tensor(
+            "init",
+            &[],
+            onnx::DataType::FLOAT16,
+            TensorData::Raw((0u16).to_le_bytes().into()),
+        );
+
+        let model_proto = onnx::GraphProto::default()
+            .with_initializer(tensor)
+            .into_model();
+
+        let err = load_model(model_proto).err().unwrap();
+
+        assert_eq!(
+            err.to_string(),
+            "in node \"init\": graph error: initializer has unsupported data type FLOAT16"
+        );
     }
 
     #[test]

--- a/src/op_registry/onnx_registry.rs
+++ b/src/op_registry/onnx_registry.rs
@@ -476,7 +476,10 @@ impl<'a> Attr<'a> {
             onnx::DataType::INT32 | onnx::DataType::INT64 | onnx::DataType::BOOL => {
                 Ok(DataType::Int32)
             }
-            _ => Err(ReadOpError::attr_error(self.name, "unsupported data type")),
+            _ => Err(ReadOpError::attr_error(
+                self.name,
+                format!("unsupported data type {onnx_dtype}"),
+            )),
         }
     }
 


### PR DESCRIPTION
 - Add remaining entries from `DataType` enum in onnx.proto3
 - If an unsupported data type is encountered, include the name in the error if the value is known, otherwise include the numeric value.