### PR TITLE
Remove operator types from public API of crate

### DIFF
--- a/src/ops/fft.rs
+++ b/src/ops/fft.rs
@@ -116,6 +116,7 @@ pub fn stft(
     Ok(output)
 }
 
+#[allow(clippy::upper_case_acronyms)]
 #[derive(Debug)]
 pub struct STFT {
     pub onesided: bool,

--- a/src/ops/rnn.rs
+++ b/src/ops/rnn.rs
@@ -91,8 +91,11 @@ const PREPACK_MIN_SEQ_LEN: usize = 5;
 
 /// Gated Recurrent Unit operator.
 #[derive(Debug)]
+#[allow(clippy::upper_case_acronyms)]
 pub struct GRU {
     pub direction: Direction,
+
+    #[allow(unused)] // Currently inferred from operator inputs.
     pub hidden_size: usize,
 
     /// When computing the output of the hidden gate, apply the linear
@@ -347,9 +350,12 @@ impl Operator for GRU {
 
 /// Long Short-Term Memory operator.
 #[derive(Debug)]
+#[allow(clippy::upper_case_acronyms)]
 pub struct LSTM {
     pub direction: Direction,
-    pub hidden_size: usize,
+
+    #[allow(unused)]
+    pub hidden_size: usize, // Currently inferred from operator inputs.
 }
 
 /// Compute the output for a single LSTM layer.


### PR DESCRIPTION
These types were previously exposed as part of the API for enabling subsets of operators. Following https://github.com/robertknight/rten/pull/1011 this is no longer necessary, as a separate set of types are used for this purpose.

The operator functions are still exposed in the public API. A very small number of them are still used by examples as they don't have equivalent methods on the `Operators` trait.

Part of https://github.com/robertknight/rten/issues/1014.
Related to https://github.com/robertknight/rten/issues/911.