### PR TITLE
Remove model_builder crate feature and associated public API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,8 +89,6 @@ all-ops = ["fft", "random"]
 fft = ["dep:rustfft"]
 # Enable loading models using memory mapping
 mmap = ["dep:memmap2"]
-# Enable module for building .rten models
-model_builder = []
 # Enable support for loading .onnx models
 onnx_format = ["dep:rten-onnx"]
 # Generate WebAssembly API using wasm-bindgen.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,9 +196,3 @@ pub use value::{DataType, Sequence, Value, ValueOrView, ValueView};
 
 #[deprecated = "renamed to `LoadError`"]
 pub type ModelLoadError = LoadError;
-
-// This is currently exposed for use in ocrs tests. That crate should probably
-// create an abstraction around model execution instead.
-#[doc(hidden)]
-#[cfg(any(test, feature = "model_builder"))]
-pub use model::rten_builder as model_builder;

--- a/src/model.rs
+++ b/src/model.rs
@@ -35,7 +35,7 @@ pub use metadata::ModelMetadata;
 use file_type::FileType;
 use load_error::LoadErrorImpl;
 
-#[cfg(any(test, feature = "model_builder"))]
+#[cfg(test)]
 pub mod rten_builder;
 
 #[cfg(all(test, feature = "onnx_format"))]

--- a/src/model/rten_builder.rs
+++ b/src/model/rten_builder.rs
@@ -55,7 +55,9 @@ pub enum OpType<'a> {
     Div,
     #[cfg(feature = "random")]
     Dropout(Dropout),
+    #[allow(dead_code)]
     DynamicQuantizeLinear,
+    #[allow(dead_code)]
     Einsum(Einsum),
     Elu(Elu),
     Equal,
@@ -67,6 +69,7 @@ pub enum OpType<'a> {
     Floor,
     Gather(Gather),
     GatherElements(GatherElements),
+    #[allow(dead_code)]
     GatherND(GatherND),
     Gelu(Gelu),
     Gemm(Gemm),
@@ -126,8 +129,11 @@ pub enum OpType<'a> {
     Round,
     QuantizeLinear(QuantizeLinear),
     ScatterElements(ScatterElements),
+    #[allow(dead_code)]
     SequenceAt,
+    #[allow(dead_code)]
     SequenceEmpty(SequenceEmpty),
+    #[allow(dead_code)]
     SequenceInsert,
     Shape(Shape),
     Sigmoid,


### PR DESCRIPTION
Downstream usage of the model builder API (that I know about) was removed in https://github.com/robertknight/ocrs/pull/206. The API is still used internally for tests but no longer needs to be exposed.

An upside of this change is that the linter can now identify that some `rten_builder::OpType` variants are not currently used. These have been marked as `#[allow(dead_code)]` for now as a reminder.

Part of https://github.com/robertknight/rten/issues/1014.