### PR TITLE
Replace new_pool() with BufferPool::new()

### DIFF
--- a/src/ops/binary_elementwise.rs
+++ b/src/ops/binary_elementwise.rs
@@ -1007,8 +1007,8 @@ mod tests {
         less, less_or_equal, mod_op, mul, mul_in_place, or, pow, pow_in_place, sub, sub_in_place,
         where_op, xor,
     };
+    use crate::buffer_pool::BufferPool;
     use crate::operator::{InputList, OpError, OpRunContext, Operator, OperatorExt};
-    use crate::ops::tests::new_pool;
     use crate::value::Value;
 
     #[test]
@@ -1057,7 +1057,7 @@ mod tests {
 
     #[test]
     fn test_add() -> Result<(), Box<dyn Error>> {
-        let pool = new_pool();
+        let pool = BufferPool::new();
 
         // Float tensor
         let a = Tensor::from_data(&[2, 2], vec![1., 2., 3., 4.]);
@@ -1078,7 +1078,7 @@ mod tests {
 
     #[test]
     fn test_add_broadcasted() -> Result<(), Box<dyn Error>> {
-        let pool = new_pool();
+        let pool = BufferPool::new();
 
         // Simple case where comparing ordering of tensor shapes tells us
         // target shape.
@@ -1120,7 +1120,7 @@ mod tests {
 
     #[test]
     fn test_add_broadcast_first_input() {
-        let pool = new_pool();
+        let pool = BufferPool::new();
         let a: Tensor<i32> = Tensor::zeros(&[1, 1, 10]);
         let b = Tensor::zeros(&[1, 5, 10]);
         let result = add(&pool, a.view(), b.view()).unwrap();
@@ -1129,7 +1129,7 @@ mod tests {
 
     #[test]
     fn test_add_in_place() -> Result<(), Box<dyn Error>> {
-        let pool = new_pool();
+        let pool = BufferPool::new();
 
         // In-place addition with float inputs that have the same shape.
         let mut a = Tensor::from_data(&[2, 2], vec![1., 2., 3., 4.]);
@@ -1199,7 +1199,7 @@ mod tests {
 
     #[test]
     fn test_and() {
-        let pool = new_pool();
+        let pool = BufferPool::new();
         let a = Tensor::from([0, 1, 0, 1]);
         let b = Tensor::from([0, 0, 1, 1]);
         let expected = Tensor::from([0, 0, 0, 1]);
@@ -1209,7 +1209,7 @@ mod tests {
 
     #[test]
     fn test_div() -> Result<(), Box<dyn Error>> {
-        let pool = new_pool();
+        let pool = BufferPool::new();
 
         // Non-scalar a and b
         let a = Tensor::from_data(&[2, 2], vec![10., 20., 30., 40.]);
@@ -1277,7 +1277,7 @@ mod tests {
 
     #[test]
     fn test_equal() {
-        let pool = new_pool();
+        let pool = BufferPool::new();
 
         // Int tensor
         let a = Tensor::from([1, 2]);
@@ -1296,7 +1296,7 @@ mod tests {
 
     #[test]
     fn test_greater() {
-        let pool = new_pool();
+        let pool = BufferPool::new();
 
         // Int tensor
         let a = Tensor::from([1, 2, 5]);
@@ -1315,7 +1315,7 @@ mod tests {
 
     #[test]
     fn test_greater_or_equal() {
-        let pool = new_pool();
+        let pool = BufferPool::new();
 
         // Int tensor
         let a = Tensor::from([1, 2, 5]);
@@ -1334,7 +1334,7 @@ mod tests {
 
     #[test]
     fn test_less() {
-        let pool = new_pool();
+        let pool = BufferPool::new();
 
         // Int tensor
         let a = Tensor::from([1, 2]);
@@ -1353,7 +1353,7 @@ mod tests {
 
     #[test]
     fn test_less_or_equal() {
-        let pool = new_pool();
+        let pool = BufferPool::new();
 
         // Int tensor
         let a = Tensor::from([1, 2, 5]);
@@ -1372,7 +1372,7 @@ mod tests {
 
     #[test]
     fn test_mod_op() {
-        let pool = new_pool();
+        let pool = BufferPool::new();
 
         // Int tensor, floor division (like Python's `%`, `numpy.mod`).
         let a = Tensor::from([10, -10, 10, -10]);
@@ -1401,7 +1401,7 @@ mod tests {
 
     #[test]
     fn test_mul() -> Result<(), Box<dyn Error>> {
-        let pool = new_pool();
+        let pool = BufferPool::new();
 
         // Float tensor
         let a = Tensor::from_data(&[2, 2], vec![1., 2., 3., 4.]);
@@ -1441,7 +1441,7 @@ mod tests {
 
     #[test]
     fn test_or() {
-        let pool = new_pool();
+        let pool = BufferPool::new();
         let a = Tensor::from([0, 1, 0, 1]);
         let b = Tensor::from([0, 0, 1, 1]);
         let expected = Tensor::from([0, 1, 1, 1]);
@@ -1497,7 +1497,7 @@ mod tests {
         ];
 
         cases.test_each(|case| {
-            let pool = new_pool();
+            let pool = BufferPool::new();
 
             macro_rules! test_case {
                 ($a:expr, $b:expr, $expected:expr) => {
@@ -1526,7 +1526,7 @@ mod tests {
 
     #[test]
     fn test_sub() -> Result<(), Box<dyn Error>> {
-        let pool = new_pool();
+        let pool = BufferPool::new();
 
         // Float tensor
         let a = Tensor::from_data(&[2, 2], vec![10., 20., 30., 40.]);
@@ -1549,7 +1549,7 @@ mod tests {
     // both the inner and outer dimensions of the second operand.
     #[test]
     fn test_sub_broadcast() -> Result<(), Box<dyn Error>> {
-        let pool = new_pool();
+        let pool = BufferPool::new();
 
         // [2, 3, 3]
         let a = Tensor::from([
@@ -1593,7 +1593,7 @@ mod tests {
 
     #[test]
     fn test_where() {
-        let pool = new_pool();
+        let pool = BufferPool::new();
 
         // Float tensor with exact matching shapes
         let cond = Tensor::from_data(&[2, 2], vec![1, 0, 0, 1]);
@@ -1640,7 +1640,7 @@ mod tests {
 
     #[test]
     fn test_where_invalid_inputs() {
-        let pool = new_pool();
+        let pool = BufferPool::new();
 
         let cond = Tensor::from([1, 1]);
         let x = Tensor::from([1, 2, 3]);
@@ -1663,7 +1663,7 @@ mod tests {
 
     #[test]
     fn test_xor() {
-        let pool = new_pool();
+        let pool = BufferPool::new();
         let a = Tensor::from([0, 1, 0, 1]);
         let b = Tensor::from([0, 0, 1, 1]);
         let expected = Tensor::from([0, 1, 1, 0]);

--- a/src/ops/concat.rs
+++ b/src/ops/concat.rs
@@ -288,8 +288,8 @@ mod tests {
     use rten_tensor::test_util::expect_equal;
     use rten_testing::TestCases;
 
+    use crate::buffer_pool::BufferPool;
     use crate::ops::OpError;
-    use crate::ops::tests::new_pool;
 
     use super::{concat, concat_in_place, tile};
 
@@ -299,7 +299,7 @@ mod tests {
 
     #[test]
     fn test_concat() -> Result<(), Box<dyn Error>> {
-        let pool = new_pool();
+        let pool = BufferPool::new();
         let a = Tensor::from_data(&[2, 2, 1], vec![0.1, 0.2, 0.3, 0.4]);
         let b = Tensor::from_data(&[2, 2, 1], vec![1.0, 2.0, 3.0, 4.0]);
 
@@ -334,7 +334,7 @@ mod tests {
 
     #[test]
     fn test_concat_in_place() -> Result<(), Box<dyn Error>> {
-        let pool = new_pool();
+        let pool = BufferPool::new();
 
         let dest = Tensor::with_capacity_in(&pool, &[3, 3], 1);
 
@@ -372,7 +372,7 @@ mod tests {
 
     #[test]
     fn test_concat_invalid_inputs() {
-        let pool = new_pool();
+        let pool = BufferPool::new();
 
         // Invalid `dim` attribute
         let input = from_slice(&[1, 2, 3]);
@@ -463,7 +463,7 @@ mod tests {
         ];
 
         cases.test_each(|case| {
-            let pool = new_pool();
+            let pool = BufferPool::new();
             let Case {
                 input,
                 repeats,
@@ -500,7 +500,7 @@ mod tests {
         ];
 
         cases.test_each(|case| {
-            let pool = new_pool();
+            let pool = BufferPool::new();
             let Case {
                 input,
                 repeats,

--- a/src/ops/control_flow.rs
+++ b/src/ops/control_flow.rs
@@ -282,10 +282,10 @@ where
 mod tests {
     use rten_tensor::Tensor;
 
+    use crate::buffer_pool::BufferPool;
     use crate::graph::builder::Expr;
     use crate::graph::{CaptureEnv, Graph, RunError, RunErrorKind};
     use crate::operator::{InputList, OpRunContext, SubgraphOperator};
-    use crate::ops::tests::new_pool;
     use crate::value::{Scalar, Value, ValueView};
 
     use super::Loop;
@@ -318,7 +318,7 @@ mod tests {
                 .chain(inputs.into_iter().cloned().map(Some)),
             );
 
-            let pool = new_pool();
+            let pool = BufferPool::new();
             let ctx = OpRunContext::new(&pool, &input_list);
             let captures = CaptureEnv::empty();
             let weight_caches = None;

--- a/src/ops/conv.rs
+++ b/src/ops/conv.rs
@@ -541,10 +541,10 @@ mod tests {
     use rten_testing::TestCases;
 
     use crate::buffer_pool::AutoReturn;
+    use crate::buffer_pool::BufferPool;
     use crate::operator::{OpError, OperatorExt};
     use crate::ops::pooling::{RoundMode, calc_output_size_and_padding};
     use crate::ops::tests::expect_eq_1e4;
-    use crate::ops::tests::new_pool;
     use crate::ops::{Conv, Padding, conv, conv_integer};
 
     trait ReferenceConvKernel<X, W> {
@@ -700,7 +700,7 @@ mod tests {
         strides: &[usize],
         dilations: &[usize],
     ) -> Result<Tensor<f32>, ExpectEqualError> {
-        let pool = new_pool();
+        let pool = BufferPool::new();
         let result = conv(
             &pool,
             input.view(),
@@ -1183,7 +1183,7 @@ mod tests {
         ];
 
         cases.test_each(|case| {
-            let pool = new_pool();
+            let pool = BufferPool::new();
             let result = conv(
                 &pool,
                 case.input.view(),
@@ -1281,7 +1281,7 @@ mod tests {
         ];
 
         cases.test_each(|case| {
-            let pool = new_pool();
+            let pool = BufferPool::new();
             let result = conv(
                 &pool,
                 case.input.view(),
@@ -1312,7 +1312,7 @@ mod tests {
                     input_zero: Option<TensorView<$input_ty>>,
                     kernel_zero: Option<TensorView<$weight_ty>>,
                 ) -> Result<Tensor<i32>, ExpectEqualError> {
-                    let pool = new_pool();
+                    let pool = BufferPool::new();
                     let result = conv_integer(
                         &pool,
                         input.view(),
@@ -1467,7 +1467,7 @@ mod tests {
         let dilations = [1, 1];
 
         let iters = 100;
-        let pool = new_pool();
+        let pool = BufferPool::new();
 
         let start = std::time::Instant::now();
         for _ in 0..iters {

--- a/src/ops/conv_transpose.rs
+++ b/src/ops/conv_transpose.rs
@@ -400,7 +400,7 @@ mod tests {
     use rten_testing::TestCases;
 
     use super::{conv_transpose, conv_transpose_output_size_and_padding};
-    use crate::ops::tests::new_pool;
+    use crate::buffer_pool::BufferPool;
     use crate::ops::{OpError, Padding};
 
     fn reference_conv_transpose(
@@ -481,7 +481,7 @@ mod tests {
         strides: [usize; 2],
         output_padding: [usize; 2],
     ) -> Result<Tensor<f32>, ExpectEqualError> {
-        let pool = new_pool();
+        let pool = BufferPool::new();
         let result = conv_transpose(
             &pool,
             input.view(),
@@ -502,7 +502,7 @@ mod tests {
 
     #[test]
     fn test_conv_transpose() -> Result<(), Box<dyn Error>> {
-        let pool = new_pool();
+        let pool = BufferPool::new();
         let input = Tensor::from_data(&[1, 1, 2, 2], vec![1.0, 2.0, 3.0, 4.0]);
         let kernel = Tensor::from_data(&[1, 1, 2, 2], vec![0.1, 0.2, 0.3, 0.4]);
 
@@ -555,7 +555,7 @@ mod tests {
 
     #[test]
     fn test_conv_transpose_padding() -> Result<(), Box<dyn Error>> {
-        let pool = new_pool();
+        let pool = BufferPool::new();
         let input = Tensor::from_data(&[1, 1, 2, 2], vec![1.0, 2.0, 3.0, 4.0]);
         let kernel = Tensor::from_data(&[1, 1, 2, 2], vec![0.1, 0.2, 0.3, 0.4]);
 
@@ -608,7 +608,7 @@ mod tests {
 
     #[test]
     fn test_conv_transpose_1d() -> Result<(), Box<dyn Error>> {
-        let pool = new_pool();
+        let pool = BufferPool::new();
         let input = Tensor::from_data(&[1, 1, 2], vec![1., 2.]);
         let kernel = Tensor::from_data(&[1, 1, 2], vec![0.1, 0.2]);
 

--- a/src/ops/einsum.rs
+++ b/src/ops/einsum.rs
@@ -702,8 +702,8 @@ mod tests {
     use rten_testing::TestCases;
 
     use super::{EinsumExpr, EinsumInput, EinsumStep, EinsumTerm, einsum_path};
+    use crate::buffer_pool::BufferPool;
     use crate::operator::OpError;
-    use crate::ops::tests::new_pool;
     use crate::ops::{einsum, matmul, mul, reduce_sum};
 
     #[test]
@@ -715,7 +715,7 @@ mod tests {
             expected: Result<Tensor, OpError>,
         }
 
-        let pool = new_pool();
+        let pool = BufferPool::new();
         let vec_a = Tensor::arange(1., 10., None);
         let vec_b = Tensor::arange(1., 5., None);
 
@@ -1050,7 +1050,7 @@ mod tests {
                 expected,
             } = case;
 
-            let pool = new_pool();
+            let pool = BufferPool::new();
             let output = einsum(&pool, inputs.as_slice(), equation);
             assert_eq!(
                 &output, expected,

--- a/src/ops/gather.rs
+++ b/src/ops/gather.rs
@@ -622,15 +622,15 @@ mod tests {
     use rten_tensor::test_util::expect_equal;
     use rten_testing::TestCases;
 
+    use crate::buffer_pool::BufferPool;
     use crate::operator::OpError;
-    use crate::ops::tests::new_pool;
     use crate::ops::{
         ScatterReduction, gather, gather_elements, gather_nd, scatter_elements, scatter_nd,
     };
 
     #[test]
     fn test_gather_scalar_index() {
-        let pool = new_pool();
+        let pool = BufferPool::new();
 
         // 1D input
         let input = Tensor::from([1, 20, 30]);
@@ -650,7 +650,7 @@ mod tests {
 
     #[test]
     fn test_gather() -> Result<(), Box<dyn Error>> {
-        let pool = new_pool();
+        let pool = BufferPool::new();
 
         // Test case shrunk down from a small BERT model where `gather` is used
         // to lookup embeddings.
@@ -700,7 +700,7 @@ mod tests {
 
     #[test]
     fn test_gather_invalid_axis() {
-        let pool = new_pool();
+        let pool = BufferPool::new();
 
         let mut rng = XorShiftRng::new(1234);
         let input = Tensor::<f32>::rand(&[128, 10], &mut rng);
@@ -735,7 +735,7 @@ mod tests {
         ];
 
         cases.test_each(|case| {
-            let pool = new_pool();
+            let pool = BufferPool::new();
             let result = gather(&pool, case.input.view(), 0, case.indices.view());
             assert_eq!(
                 result.err(),
@@ -816,7 +816,7 @@ mod tests {
         ];
 
         cases.test_each(|case| {
-            let pool = new_pool();
+            let pool = BufferPool::new();
             let result =
                 gather_elements(&pool, case.input.view(), case.indices.view(), case.axis).unwrap();
             assert_eq!(result, case.expected);
@@ -863,7 +863,7 @@ mod tests {
         ];
 
         cases.test_each_value(|case| {
-            let pool = new_pool();
+            let pool = BufferPool::new();
             let result = gather_elements(&pool, case.input.view(), case.indices.view(), case.axis);
             assert_eq!(result.err(), Some(case.expected));
         });
@@ -943,7 +943,7 @@ mod tests {
         ];
 
         cases.test_each(|case| {
-            let pool = new_pool();
+            let pool = BufferPool::new();
             let result = gather_nd(
                 &pool,
                 if case.transpose {
@@ -1017,7 +1017,7 @@ mod tests {
         ];
 
         cases.test_each(|case| {
-            let pool = new_pool();
+            let pool = BufferPool::new();
             let result = scatter_elements(
                 &pool,
                 case.data.view(),
@@ -1032,7 +1032,7 @@ mod tests {
 
     #[test]
     fn test_scatter_elements_reduction() {
-        let pool = new_pool();
+        let pool = BufferPool::new();
 
         let data = Tensor::from([1, 2, 3, 4]);
         let indices = Tensor::from([1, 3]);
@@ -1114,7 +1114,7 @@ mod tests {
         ];
 
         cases.test_each(|case| {
-            let pool = new_pool();
+            let pool = BufferPool::new();
             let result = scatter_nd(
                 &pool,
                 case.data.view(),
@@ -1170,7 +1170,7 @@ mod tests {
         ];
 
         cases.test_each(|case| {
-            let pool = new_pool();
+            let pool = BufferPool::new();
             let result = scatter_nd(
                 &pool,
                 case.data.view(),
@@ -1227,7 +1227,7 @@ mod tests {
         ];
 
         cases.test_each(|case| {
-            let pool = new_pool();
+            let pool = BufferPool::new();
             let result = scatter_nd(
                 &pool,
                 case.data.view(),

--- a/src/ops/grid_sample.rs
+++ b/src/ops/grid_sample.rs
@@ -143,8 +143,9 @@ mod tests {
     use rten_testing::TestCases;
 
     use super::grid_sample;
+    use crate::buffer_pool::BufferPool;
     use crate::operator::OpError;
-    use crate::ops::tests::{IntoNDim, expect_eq_1e4, new_pool};
+    use crate::ops::tests::{IntoNDim, expect_eq_1e4};
 
     #[test]
     fn test_grid_sample() {
@@ -267,7 +268,7 @@ mod tests {
         ];
 
         cases.test_each(|case| {
-            let pool = new_pool();
+            let pool = BufferPool::new();
             let result = grid_sample(
                 &pool,
                 case.input.view(),
@@ -304,7 +305,7 @@ mod tests {
         ];
 
         cases.test_each(|case| {
-            let pool = new_pool();
+            let pool = BufferPool::new();
             let input = NdTensor::zeros(case.input_shape);
             let grid = NdTensor::zeros(case.grid_shape);
             let align_corners = false;

--- a/src/ops/layout.rs
+++ b/src/ops/layout.rs
@@ -641,12 +641,12 @@ mod tests {
     use rten_testing::TestCases;
 
     use super::{DepthToSpaceMode, depth_to_space};
+    use crate::buffer_pool::BufferPool;
     use crate::operator::{OpError, OperatorExt};
     use crate::ops::layout::{
         Reshape, Shape, Size, expand, flatten, reshape, reshape_in_place, squeeze,
         squeeze_in_place, transpose, unsqueeze,
     };
-    use crate::ops::tests::new_pool;
     use crate::value::Value;
 
     #[test]
@@ -711,7 +711,7 @@ mod tests {
         ];
 
         cases.test_each(|case| {
-            let pool = new_pool();
+            let pool = BufferPool::new();
             let result = depth_to_space(&pool, case.input.as_dyn(), case.block_size, case.mode);
             assert_eq!(result, case.expected);
         })
@@ -719,7 +719,7 @@ mod tests {
 
     #[test]
     fn test_expand() {
-        let pool = new_pool();
+        let pool = BufferPool::new();
 
         // Broadcast scalar
         let input = Tensor::from(5.);
@@ -764,7 +764,7 @@ mod tests {
 
     #[test]
     fn test_expand_invalid_inputs() {
-        let pool = new_pool();
+        let pool = BufferPool::new();
 
         // Invalid broadcast shape
         let input = Tensor::from([1, 2, 3]);
@@ -840,7 +840,7 @@ mod tests {
         ];
 
         cases.test_each(|case| {
-            let pool = new_pool();
+            let pool = BufferPool::new();
             let input = Tensor::<f32>::zeros(case.shape.as_slice());
             let result =
                 flatten(&pool, input.view(), case.axis).map(|tensor| tensor.shape().to_vec());
@@ -850,7 +850,7 @@ mod tests {
 
     #[test]
     fn test_reshape_with_unspecified_dim() -> Result<(), Box<dyn Error>> {
-        let pool = new_pool();
+        let pool = BufferPool::new();
 
         // Reshape with an unspecified (-1) dim and nonzero-length input
         let input = Tensor::from_data(&[2, 2], vec![-0.5, 0.5, 3.0, -5.5]);
@@ -883,7 +883,7 @@ mod tests {
 
     #[test]
     fn test_reshape_with_zero_dim() -> Result<(), Box<dyn Error>> {
-        let pool = new_pool();
+        let pool = BufferPool::new();
 
         // When the target shape has a zero dim, the corresponding input dim
         // size should be copied.
@@ -946,7 +946,7 @@ mod tests {
 
     #[test]
     fn test_reshape_with_multiple_unspecified_dims() {
-        let pool = new_pool();
+        let pool = BufferPool::new();
         let input = Tensor::from_data(&[2, 2], vec![-0.5, 0.5, 3.0, -5.5]);
         let shape = NdTensor::from([1, -1, -1]);
         assert_eq!(
@@ -965,7 +965,7 @@ mod tests {
 
     #[test]
     fn test_reshape_with_unsolvable_unspecified_dim() {
-        let pool = new_pool();
+        let pool = BufferPool::new();
         let expected_err = Some(OpError::InvalidValue(
             "Input length must be a multiple of specified dimensions",
         ));
@@ -994,7 +994,7 @@ mod tests {
 
     #[test]
     fn test_reshape_in_place() {
-        let pool = new_pool();
+        let pool = BufferPool::new();
         let mut input = Tensor::from_data(&[2, 2], vec![-0.5, 0.5, 3.0, -5.5]);
         let shape = NdTensor::from([4]);
         let expected = input.to_shape([4].as_slice());
@@ -1105,7 +1105,7 @@ mod tests {
 
     #[test]
     fn test_squeeze() -> Result<(), Box<dyn Error>> {
-        let pool = new_pool();
+        let pool = BufferPool::new();
 
         let mut rng = XorShiftRng::new(5678);
         let input = Tensor::<f32>::rand(&[1, 5, 5, 1], &mut rng);
@@ -1156,7 +1156,7 @@ mod tests {
         let mut rng = XorShiftRng::new(5678);
         let input = Tensor::<f32>::rand(&[1, 5, 5, 1], &mut rng);
 
-        let pool = new_pool();
+        let pool = BufferPool::new();
         let result = squeeze(&pool, input.view(), Some(NdTensor::from([1]).view()));
 
         assert_eq!(
@@ -1169,7 +1169,7 @@ mod tests {
 
     #[test]
     fn test_transpose() -> Result<(), Box<dyn Error>> {
-        let pool = new_pool();
+        let pool = BufferPool::new();
         let mut rng = XorShiftRng::new(5678);
         let input = Tensor::<f32>::rand(&[10, 20], &mut rng);
 
@@ -1193,7 +1193,7 @@ mod tests {
 
     #[test]
     fn test_transpose_invalid_inputs() {
-        let pool = new_pool();
+        let pool = BufferPool::new();
         let mut rng = XorShiftRng::new(5678);
         let input = Tensor::<f32>::rand(&[10, 20], &mut rng);
 
@@ -1228,7 +1228,7 @@ mod tests {
 
     #[test]
     fn test_unsqueeze() {
-        let pool = new_pool();
+        let pool = BufferPool::new();
         let mut rng = XorShiftRng::new(5678);
         let input = Tensor::<f32>::rand(&[3, 4, 5], &mut rng);
 
@@ -1249,7 +1249,7 @@ mod tests {
 
     #[test]
     fn test_unsqueeze_invalid_inputs() {
-        let pool = new_pool();
+        let pool = BufferPool::new();
         let mut rng = XorShiftRng::new(5678);
         let input = Tensor::<f32>::rand(&[10, 20], &mut rng);
 

--- a/src/ops/matmul.rs
+++ b/src/ops/matmul.rs
@@ -634,9 +634,9 @@ mod tests {
     use rten_testing::TestCases;
 
     use crate::buffer_pool::AutoReturn;
+    use crate::buffer_pool::BufferPool;
     use crate::operator::{InputList, Operator};
     use crate::ops::binary_elementwise::broadcast_shapes;
-    use crate::ops::tests::new_pool;
 
     use super::{
         FusedMatMul, MatMul, MatMulInteger, MatmulStrategy, OpError, OpRunContext, cast_scale,
@@ -772,7 +772,7 @@ mod tests {
         ];
 
         cases.test_each(|case| {
-            let pool = new_pool();
+            let pool = BufferPool::new();
             let result = cast_scale(&pool, case.input.clone(), case.scales.view());
             assert_eq!(result, case.expected);
         });
@@ -780,7 +780,7 @@ mod tests {
 
     #[test]
     fn test_gemm_op() -> Result<(), Box<dyn Error>> {
-        let pool = new_pool();
+        let pool = BufferPool::new();
 
         let mut rng = XorShiftRng::new(1234);
         let a = Tensor::rand(&[3, 10], &mut rng);
@@ -798,7 +798,7 @@ mod tests {
 
     #[test]
     fn test_gemm_op_transposed() -> Result<(), Box<dyn Error>> {
-        let pool = new_pool();
+        let pool = BufferPool::new();
 
         let mut rng = XorShiftRng::new(1234);
         let a = Tensor::rand(&[10, 3], &mut rng);
@@ -820,7 +820,7 @@ mod tests {
 
     #[test]
     fn test_gemm_op_adds_c() -> Result<(), Box<dyn Error>> {
-        let pool = new_pool();
+        let pool = BufferPool::new();
 
         let mut rng = XorShiftRng::new(1234);
         let a = Tensor::rand(&[3, 10], &mut rng);
@@ -849,7 +849,7 @@ mod tests {
 
     #[test]
     fn test_gemm_op_invalid_inputs() {
-        let pool = new_pool();
+        let pool = BufferPool::new();
 
         let mut rng = XorShiftRng::new(1234);
         let a = Tensor::rand(&[3, 10], &mut rng);
@@ -954,7 +954,7 @@ mod tests {
                 b_shape,
             } = case;
 
-            let pool = new_pool();
+            let pool = BufferPool::new();
             let mut rng = XorShiftRng::new(1234);
             let a = Tensor::<f32>::rand(a_shape, &mut rng);
             let b = Tensor::<f32>::rand(b_shape, &mut rng);
@@ -1001,7 +1001,7 @@ mod tests {
 
             let expected = reference_matmul(a.view(), packed_b_input.view(), MatMulOpts::default());
 
-            let pool = new_pool();
+            let pool = BufferPool::new();
             let get_prepacked = |idx| {
                 if idx == 1 { Some(&packed_b) } else { None }
             };
@@ -1048,7 +1048,7 @@ mod tests {
         cases.test_each(|case| {
             let Case { bias, alpha } = case;
 
-            let pool = new_pool();
+            let pool = BufferPool::new();
             let expected = reference_matmul(
                 a.view(),
                 b.view(),
@@ -1104,7 +1104,7 @@ mod tests {
                 error,
             } = case;
 
-            let pool = new_pool();
+            let pool = BufferPool::new();
 
             let mut rng = XorShiftRng::new(1234);
             let a = Tensor::<f32>::rand(a_shape, &mut rng);
@@ -1131,7 +1131,7 @@ mod tests {
         ];
 
         cases.test_each_clone(|Case { m, n, k }| {
-            let pool = new_pool();
+            let pool = BufferPool::new();
             let mut rng = XorShiftRng::new(1234);
             let a = Tensor::<f32>::rand(&[m, k], &mut rng);
             let b = Tensor::<f32>::rand(&[k, n], &mut rng);
@@ -1291,7 +1291,7 @@ mod tests {
                 expected_err,
             } = case;
 
-            let pool = new_pool();
+            let pool = BufferPool::new();
             let result = matmul_integer(
                 &pool,
                 a.view(),
@@ -1337,7 +1337,7 @@ mod tests {
 
         let expected = reference_matmul(a.view(), packed_b_input.view(), MatMulOpts::default());
 
-        let pool = new_pool();
+        let pool = BufferPool::new();
         let get_prepacked = |idx| {
             if idx == 1 { Some(&packed_b) } else { None }
         };
@@ -1393,7 +1393,7 @@ mod tests {
                 let desc = format!(
                     "matmul [{a_batch},{a_rows},{a_cols}] x [{a_cols},{b_cols}], strategy={strategy:?}",
                 );
-                let pool = new_pool();
+                let pool = BufferPool::new();
                 run_bench(trials, Some(&desc), || {
                     matmul_impl(
                         &pool,

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -362,16 +362,6 @@ mod tests {
     use rten_tensor::prelude::*;
     use rten_tensor::test_util::{ExpectEqualError, expect_equal_with_tolerance};
 
-    use crate::buffer_pool::BufferPool;
-
-    /// Create an empty tensor pool.
-    ///
-    /// This is a wrapper that provides a place to customize the behavior of
-    /// the pool in tests.
-    pub fn new_pool() -> BufferPool {
-        BufferPool::new()
-    }
-
     /// Compare two f32 tensors with a higher absolute tolerance (1e-4) than
     /// the default (1e-5).
     ///

--- a/src/ops/non_max_suppression.rs
+++ b/src/ops/non_max_suppression.rs
@@ -219,7 +219,7 @@ mod tests {
     use rten_tensor::NdTensor;
     use rten_tensor::prelude::*;
 
-    use crate::ops::tests::new_pool;
+    use crate::buffer_pool::BufferPool;
     use crate::ops::{BoxOrder, OpError, non_max_suppression};
 
     struct NmsBox {
@@ -292,7 +292,7 @@ mod tests {
         let iou_threshold = 0.5;
         let score_threshold = 0.;
 
-        let pool = new_pool();
+        let pool = BufferPool::new();
         let selected = non_max_suppression(
             &pool,
             boxes.view(),
@@ -315,7 +315,7 @@ mod tests {
 
     #[test]
     fn test_non_max_suppression_box_order() {
-        let pool = new_pool();
+        let pool = BufferPool::new();
 
         let (boxes_tlbr, scores) = example_boxes(BoxOrder::TopLeftBottomRight);
         let (boxes_chw, _) = example_boxes(BoxOrder::CenterWidthHeight);
@@ -347,7 +347,7 @@ mod tests {
 
     #[test]
     fn test_non_max_suppression_iou_threshold() {
-        let pool = new_pool();
+        let pool = BufferPool::new();
 
         let (boxes, scores) = example_boxes(BoxOrder::TopLeftBottomRight);
         let iou_threshold = 0.99;
@@ -377,7 +377,7 @@ mod tests {
 
     #[test]
     fn test_non_max_suppression_max_outputs_per_class() {
-        let pool = new_pool();
+        let pool = BufferPool::new();
         let (boxes, scores) = example_boxes(BoxOrder::TopLeftBottomRight);
         let iou_threshold = 1.0;
         let score_threshold = 0.;
@@ -406,7 +406,7 @@ mod tests {
 
     #[test]
     fn test_non_max_suppression_score_threshold() {
-        let pool = new_pool();
+        let pool = BufferPool::new();
         let (boxes, scores) = example_boxes(BoxOrder::TopLeftBottomRight);
         let iou_threshold = 0.5;
         let score_threshold = 0.8;
@@ -431,7 +431,7 @@ mod tests {
 
     #[test]
     fn test_non_max_suppression_invalid() {
-        let pool = new_pool();
+        let pool = BufferPool::new();
         let apply_nms = |boxes, scores| {
             let iou_threshold = 0.5;
             let score_threshold = 0.;

--- a/src/ops/norm.rs
+++ b/src/ops/norm.rs
@@ -685,8 +685,9 @@ mod tests {
         batch_norm, batch_norm_in_place, instance_normalization, layer_normalization, log_softmax,
         rms_normalization, softmax,
     };
+    use crate::buffer_pool::BufferPool;
     use crate::ops::OpError;
-    use crate::ops::tests::{expect_eq_1e4, new_pool};
+    use crate::ops::tests::expect_eq_1e4;
 
     #[test]
     fn test_batch_norm() {
@@ -715,7 +716,7 @@ mod tests {
         ];
 
         cases.test_each(|Case { input }| {
-            let pool = new_pool();
+            let pool = BufferPool::new();
             let scale = &[3.0, 3.0];
             let bias = &[0.1, 0.2];
             let mean = &[0.5, -0.5];
@@ -755,7 +756,7 @@ mod tests {
         let epsilon = 1e-5 as f32;
         let input = Tensor::from(5.0);
 
-        let pool = new_pool();
+        let pool = BufferPool::new();
         let result = batch_norm(
             &pool,
             input.view(),
@@ -824,7 +825,7 @@ mod tests {
             [1.0608, -0.9152],
         ]]);
 
-        let pool = new_pool();
+        let pool = BufferPool::new();
         let result =
             instance_normalization(&pool, input.view(), scale.nd_view(), bias.nd_view(), None)
                 .unwrap();
@@ -919,7 +920,7 @@ mod tests {
                 expected,
             } = case;
 
-            let pool = new_pool();
+            let pool = BufferPool::new();
             let result = layer_normalization(
                 &pool,
                 input.view(),
@@ -956,7 +957,7 @@ mod tests {
         let scale = Tensor::rand(&[10], &mut rng);
         let epsilon = 1e-5;
 
-        let pool = new_pool();
+        let pool = BufferPool::new();
         let result =
             rms_normalization(&pool, input.view(), scale.view(), 0, Some(epsilon)).unwrap();
 
@@ -968,7 +969,7 @@ mod tests {
 
     #[test]
     fn test_log_softmax() -> Result<(), Box<dyn Error>> {
-        let pool = new_pool();
+        let pool = BufferPool::new();
 
         // 1D input
         let mut input = Tensor::from([0.1634, 0.8647, 0.6401, 0.8265, 0.0560, 0.2345]);
@@ -1004,7 +1005,7 @@ mod tests {
 
     #[test]
     fn test_softmax() -> Result<(), Box<dyn Error>> {
-        let pool = new_pool();
+        let pool = BufferPool::new();
 
         // Softmax on a 1D input
         let mut input = Tensor::from([0.1634, 0.8647, 0.6401, 0.8265, 0.0560, 0.2304]);
@@ -1063,7 +1064,7 @@ mod tests {
         );
 
         input.permute(&[1, 0]);
-        let pool = new_pool();
+        let pool = BufferPool::new();
         let result = softmax(&pool, input.view(), 1).unwrap();
 
         expect_eq_1e4(&result, &expected)?;
@@ -1076,7 +1077,7 @@ mod tests {
     // do check the shape and that each lane sums to 1.
     #[test]
     fn test_softmax_sizes() {
-        let pool = new_pool();
+        let pool = BufferPool::new();
 
         let check_result = |result: Tensor<f32>| {
             for lane in result.lanes(1) {

--- a/src/ops/pad.rs
+++ b/src/ops/pad.rs
@@ -290,8 +290,8 @@ mod tests {
     use rten_tensor::{NdTensor, Tensor};
     use rten_testing::TestCases;
 
+    use crate::buffer_pool::BufferPool;
     use crate::operator::{OpError, OperatorExt};
-    use crate::ops::tests::new_pool;
     use crate::ops::{Pad, PadMode, pad};
     use crate::value::{CastError, DataType, Value};
 
@@ -301,7 +301,7 @@ mod tests {
 
     #[test]
     fn test_pad() -> Result<(), Box<dyn Error>> {
-        let pool = new_pool();
+        let pool = BufferPool::new();
 
         // Same padding around each edge.
         let input = Tensor::from_data(&[2, 2], vec![1.0, 2.0, 3.0, 4.0]);
@@ -361,7 +361,7 @@ mod tests {
                 expected,
             } = case;
 
-            let pool = new_pool();
+            let pool = BufferPool::new();
             let result = pad(&pool, input.view(), &pads.view(), *mode, 0.);
             match (result, expected) {
                 (Ok(result), Ok(expected)) => {

--- a/src/ops/pooling.rs
+++ b/src/ops/pooling.rs
@@ -575,8 +575,8 @@ mod tests {
     use rten_testing::TestCases;
 
     use super::{RoundMode, calc_output_size_and_padding};
+    use crate::buffer_pool::BufferPool;
     use crate::ops::tests::expect_eq_1e4;
-    use crate::ops::tests::new_pool;
     use crate::ops::{OpError, Padding, average_pool, global_average_pool, max_pool};
 
     #[test]
@@ -666,7 +666,7 @@ mod tests {
         ];
 
         cases.test_each(|case| {
-            let pool = new_pool();
+            let pool = BufferPool::new();
             let result = average_pool(
                 &pool,
                 case.input.view(),
@@ -683,7 +683,7 @@ mod tests {
 
     #[test]
     fn test_average_pool_padding() -> Result<(), Box<dyn Error>> {
-        let pool = new_pool();
+        let pool = BufferPool::new();
 
         // Exercise both the loop over channel groups and the tail in
         // `pool_impl`.
@@ -745,7 +745,7 @@ mod tests {
 
     #[test]
     fn test_global_average_pool() -> Result<(), Box<dyn Error>> {
-        let pool = new_pool();
+        let pool = BufferPool::new();
         let input = Tensor::from_data(&[1, 2, 2, 2], vec![1., 2., 3., 4., 10., 20., 30., 40.]);
         let expected = Tensor::from_data(&[1, 2, 1, 1], vec![2.5, 25.]);
         let result = global_average_pool(&pool, input.view()).unwrap();
@@ -840,7 +840,7 @@ mod tests {
         ];
 
         cases.test_each(|case| {
-            let pool = new_pool();
+            let pool = BufferPool::new();
             let result = max_pool(
                 &pool,
                 case.input.view(),
@@ -856,7 +856,7 @@ mod tests {
 
     #[test]
     fn test_max_pool_padding() {
-        let pool = new_pool();
+        let pool = BufferPool::new();
         let input = Tensor::zeros(&[1, 1, 9, 9]);
         let rm = RoundMode::default();
 

--- a/src/ops/quantize.rs
+++ b/src/ops/quantize.rs
@@ -430,8 +430,8 @@ mod tests {
     use rten_testing::TestCases;
 
     use super::{dequantize_linear, dynamic_quantize_linear, quantize_linear};
+    use crate::buffer_pool::BufferPool;
     use crate::operator::OpError;
-    use crate::ops::tests::new_pool;
     use crate::value::Value;
 
     // Test dequantization followed by re-quantization. In this order the
@@ -504,7 +504,7 @@ mod tests {
         ];
 
         cases.test_each(|case| {
-            let pool = new_pool();
+            let pool = BufferPool::new();
             let Case {
                 input,
                 scale,
@@ -620,7 +620,7 @@ mod tests {
         cases.test_each(|case| {
             let Case { input, max_error } = case;
 
-            let pool = new_pool();
+            let pool = BufferPool::new();
 
             // Quantize input.
             let output = dynamic_quantize_linear::<u8>(&pool, input.view()).unwrap();

--- a/src/ops/random.rs
+++ b/src/ops/random.rs
@@ -228,9 +228,9 @@ mod tests {
     use rten_tensor::prelude::*;
     use rten_testing::TestCases;
 
+    use crate::buffer_pool::BufferPool;
     use crate::operator::{InputList, OpRunContext, Operator, OperatorExt};
     use crate::ops::operators::{FloatOperators, Operators};
-    use crate::ops::tests::new_pool;
 
     use super::{Dropout, RandomNormal, RandomNormalLike, RandomUniform, RandomUniformLike};
 
@@ -486,7 +486,7 @@ mod tests {
                 ratio_input.as_ref().map(|ri| ri.view().into()),
                 training_mode_input.as_ref().map(|tm| tm.view().into()),
             ]);
-            let pool = new_pool();
+            let pool = BufferPool::new();
             let ctx = OpRunContext::new(&pool, &inputs);
             let mut outputs = op.run(&ctx).unwrap();
             let output: Tensor<f32> = outputs.remove(0).try_into().unwrap();
@@ -535,7 +535,7 @@ mod tests {
                 ratio_input.as_ref().map(|ri| ri.view().into()),
                 Some(training_mode_input.view().into()),
             ]);
-            let pool = new_pool();
+            let pool = BufferPool::new();
             let ctx = OpRunContext::new(&pool, &inputs);
 
             let mut outputs = op.run(&ctx).unwrap();

--- a/src/ops/resize.rs
+++ b/src/ops/resize.rs
@@ -540,9 +540,9 @@ mod tests {
     use rten_tensor::{NdTensor, NdTensorView, Tensor};
     use rten_testing::TestCases;
 
+    use crate::buffer_pool::BufferPool;
     use crate::operator::{InputList, OpError, OpRunContext, Operator};
     use crate::ops::tests::expect_eq_1e4;
-    use crate::ops::tests::new_pool;
     use crate::ops::{CoordTransformMode, NearestMode, Resize, ResizeMode, ResizeTarget, resize};
 
     // Reference values for these tests can be computed with either OpenCV
@@ -622,7 +622,7 @@ mod tests {
         ];
 
         cases.test_each(|case| {
-            let pool = new_pool();
+            let pool = BufferPool::new();
             let result = resize(
                 &pool,
                 case.image.view(),
@@ -688,7 +688,7 @@ mod tests {
         ];
 
         cases.test_each(|case| {
-            let pool = new_pool();
+            let pool = BufferPool::new();
             let result = resize(
                 &pool,
                 image.view(),
@@ -819,7 +819,7 @@ mod tests {
         ];
 
         cases.test_each(|case| {
-            let pool = new_pool();
+            let pool = BufferPool::new();
             let result = resize(
                 &pool,
                 case.image.as_dyn(),
@@ -964,7 +964,7 @@ mod tests {
         ];
 
         cases.test_each(|case| {
-            let pool = new_pool();
+            let pool = BufferPool::new();
             let op = Resize {
                 mode: ResizeMode::Linear,
                 ..Resize::default()

--- a/src/ops/rnn.rs
+++ b/src/ops/rnn.rs
@@ -608,7 +608,7 @@ mod tests {
     use rten_testing::TestCases;
     use serde_json::Value;
 
-    use crate::ops::tests::new_pool;
+    use crate::buffer_pool::BufferPool;
     use crate::ops::{Direction, concat, gru, lstm, split};
 
     /// Read a float tensor from a JSON value.
@@ -700,7 +700,7 @@ mod tests {
 
         cases.test_each_clone(|case| {
             let mut rng = XorShiftRng::new(1234);
-            let pool = new_pool();
+            let pool = BufferPool::new();
             let num_gates = match case.op {
                 Op::Gru => 3,
                 Op::Lstm => 4,
@@ -802,7 +802,7 @@ mod tests {
     /// cell, output) as used by PyTorch to (input, output, forget, cell) as
     /// used by ONNX.
     fn reorder_ifco_to_iofc(x: &Tensor, axis: isize) -> Tensor {
-        let pool = new_pool();
+        let pool = BufferPool::new();
         let size = x.size(axis as usize) / 4;
         let splits = &[size as i32; 4];
 
@@ -826,7 +826,7 @@ mod tests {
     /// Re-order a weight or bias tensor for GRU gates from (reset, update,
     /// hidden) as used by PyTorch to (update, reset, hidden) as used by ONNX.
     fn reorder_ruh_to_urh(x: &Tensor, axis: isize) -> Tensor {
-        let pool = new_pool();
+        let pool = BufferPool::new();
         let size = x.size(axis as usize) / 3;
         let splits = &[size as i32; 3];
 
@@ -864,7 +864,7 @@ mod tests {
 
     /// Read inputs for a PyTorch reference test for RNN ops from a JSON value.
     fn read_pytorch_ref_test(op: Op, case: &Value) -> RNNRefTest {
-        let pool = new_pool();
+        let pool = BufferPool::new();
         let params = &case["params"];
 
         let is_bidirectional = params.get("weight_ih_l0_reverse").is_some();
@@ -991,7 +991,7 @@ mod tests {
         ];
 
         cases.test_each(|case| {
-            let pool = new_pool();
+            let pool = BufferPool::new();
             let op = if case.name.starts_with("lstm") {
                 Op::Lstm
             } else {

--- a/src/ops/slice.rs
+++ b/src/ops/slice.rs
@@ -180,8 +180,8 @@ mod tests {
     use rten_testing::TestCases;
 
     use super::{slice, slice_in_place};
+    use crate::buffer_pool::BufferPool;
     use crate::ops::OpError;
-    use crate::ops::tests::new_pool;
 
     fn from_slice<T: Copy>(data: &[T]) -> Tensor<T> {
         Tensor::from_data(&[data.len()], data.to_vec())
@@ -228,7 +228,7 @@ mod tests {
 
     #[test]
     fn test_slice_first_dim() {
-        let pool = new_pool();
+        let pool = BufferPool::new();
         let mut rng = XorShiftRng::new(5678);
         let input = Tensor::<f32>::rand(&[5, 2, 5, 3], &mut rng);
 
@@ -266,7 +266,7 @@ mod tests {
 
     #[test]
     fn test_slice_inner_dim() {
-        let pool = new_pool();
+        let pool = BufferPool::new();
         let mut rng = XorShiftRng::new(5678);
         let input = Tensor::<f32>::rand(&[2, 2, 5, 3], &mut rng);
 
@@ -307,7 +307,7 @@ mod tests {
 
     #[test]
     fn test_slice_noop() {
-        let pool = new_pool();
+        let pool = BufferPool::new();
         let mut rng = XorShiftRng::new(5678);
         let input = Tensor::<f32>::rand(&[5, 2, 5, 3], &mut rng);
 
@@ -333,7 +333,7 @@ mod tests {
 
     #[test]
     fn test_slice_negative_axes() {
-        let pool = new_pool();
+        let pool = BufferPool::new();
         let input = Tensor::from_data(&[3, 3], vec![1, 2, 3, 4, 5, 6, 7, 8, 9]);
         let starts = &[0];
         let ends = &[2];
@@ -365,7 +365,7 @@ mod tests {
 
     #[test]
     fn test_slice_negative_starts() {
-        let pool = new_pool();
+        let pool = BufferPool::new();
         let input = Tensor::from_data(&[3, 3], vec![1, 2, 3, 4, 5, 6, 7, 8, 9]);
         let axes = &[-1];
         let ends = &[2];
@@ -397,7 +397,7 @@ mod tests {
 
     #[test]
     fn test_slice_negative_ends() {
-        let pool = new_pool();
+        let pool = BufferPool::new();
         let input = Tensor::from_data(&[3, 3], vec![1, 2, 3, 4, 5, 6, 7, 8, 9]);
         let axes = &[-1];
         let starts = &[0];
@@ -429,7 +429,7 @@ mod tests {
 
     #[test]
     fn test_slice_clamps_starts_and_ends() -> Result<(), Box<dyn Error>> {
-        let pool = new_pool();
+        let pool = BufferPool::new();
         let mut rng = XorShiftRng::new(5678);
         let input = Tensor::<f32>::rand(&[20, 20], &mut rng);
 
@@ -505,7 +505,7 @@ mod tests {
         ];
 
         cases.test_each(|case| {
-            let pool = new_pool();
+            let pool = BufferPool::new();
             let starts = &[case.start];
             let ends = &[case.end];
             let axes = &[0];
@@ -573,7 +573,7 @@ mod tests {
         ];
 
         cases.test_each(|case| {
-            let pool = new_pool();
+            let pool = BufferPool::new();
             let input = Tensor::<f32>::zeros(&[1, 2, 3]);
             let err = slice(
                 &pool,

--- a/src/ops/split.rs
+++ b/src/ops/split.rs
@@ -132,8 +132,8 @@ mod tests {
     use rten_tensor::{NdTensor, Tensor};
     use rten_testing::TestCases;
 
+    use crate::buffer_pool::BufferPool;
     use crate::operator::{InputList, OpError, OpRunContext, Operator};
-    use crate::ops::tests::new_pool;
 
     use super::{Split, SplitSizes, split};
 
@@ -215,7 +215,7 @@ mod tests {
                 Some(input.view().into()),
                 case.splits.as_ref().map(|s| s.view().into()),
             ]);
-            let pool = new_pool();
+            let pool = BufferPool::new();
             let mut ctx = OpRunContext::new(&pool, &inputs);
             if let Some(n_outputs) = case.graph_outputs {
                 ctx.set_num_outputs(n_outputs);
@@ -274,7 +274,7 @@ mod tests {
         ];
 
         cases.test_each(|case| {
-            let pool = new_pool();
+            let pool = BufferPool::new();
             let result = split(&pool, input.view(), case.axis, case.splits.clone());
             assert_eq!(result.err().as_ref(), Some(&case.expected));
         })

--- a/src/ops/trilu.rs
+++ b/src/ops/trilu.rs
@@ -86,7 +86,7 @@ mod tests {
     use rten_tensor::prelude::*;
     use rten_testing::TestCases;
 
-    use crate::ops::tests::new_pool;
+    use crate::buffer_pool::BufferPool;
     use crate::ops::{OpError, trilu};
 
     #[test]
@@ -176,7 +176,7 @@ mod tests {
         ];
 
         cases.test_each(|case| {
-            let pool = new_pool();
+            let pool = BufferPool::new();
             let result = trilu(&pool, case.input.view(), case.k, case.upper).unwrap();
             assert_eq!(result, case.expected);
         })
@@ -184,7 +184,7 @@ mod tests {
 
     #[test]
     fn test_trilu_invalid() {
-        let pool = new_pool();
+        let pool = BufferPool::new();
         let input = Tensor::from([1]);
         let result = trilu(&pool, input.view(), 0, true /* upper */);
         assert_eq!(

--- a/src/ops/unary_elementwise.rs
+++ b/src/ops/unary_elementwise.rs
@@ -656,8 +656,8 @@ mod tests {
         Relu, Sigmoid, Sign, Silu, Sin, Softplus, Sqrt, Swish, Tan, Tanh, ceil, clip,
         clip_in_place, erf, floor, hard_sigmoid, hard_swish, leaky_relu, round,
     };
+    use crate::buffer_pool::BufferPool;
     use crate::operator::{OpError, Operator, OperatorExt};
-    use crate::ops::tests::new_pool;
     use crate::value::{CastError, Value, ValueView};
     use rten_tensor::test_util::ApproxEq;
 
@@ -766,7 +766,7 @@ mod tests {
 
     #[test]
     fn test_ceil() {
-        let pool = new_pool();
+        let pool = BufferPool::new();
         let input = Tensor::from([
             1.,
             1.2,
@@ -823,7 +823,7 @@ mod tests {
         ];
 
         cases.test_each(|case| {
-            let pool = new_pool();
+            let pool = BufferPool::new();
             let result = clip(&pool, case.input.view(), case.min, case.max);
             expect_equal(&result, &case.expected).unwrap();
 
@@ -853,7 +853,7 @@ mod tests {
 
     #[test]
     fn test_erf() -> Result<(), Box<dyn Error>> {
-        let pool = new_pool();
+        let pool = BufferPool::new();
         let input = Tensor::from([-2.0, -0.5, 0.5, 2.0]);
         let expected = Tensor::from([
             -0.9953222650189527,
@@ -898,7 +898,7 @@ mod tests {
 
     #[test]
     fn test_floor() {
-        let pool = new_pool();
+        let pool = BufferPool::new();
         let input = Tensor::from([
             1.,
             1.2,
@@ -945,7 +945,7 @@ mod tests {
         let input = Tensor::from([-4., -3., -1., 0., 1., 3., 4.]);
         let alpha = 0.2;
         let beta = 0.5;
-        let pool = new_pool();
+        let pool = BufferPool::new();
         let result = hard_sigmoid(&pool, input.view(), alpha, beta);
         let expected = Tensor::from([0., 0., -1. / 5. + 0.5, 0.5, 1. / 5. + 0.5, 1., 1.]);
         expect_equal(&result, &expected)?;
@@ -954,7 +954,7 @@ mod tests {
 
     #[test]
     fn test_hard_swish() -> Result<(), Box<dyn Error>> {
-        let pool = new_pool();
+        let pool = BufferPool::new();
         let input = Tensor::from([-4., -3., -1., 0., 1., 3., 4.]);
         let result = hard_swish(&pool, input.view());
         let expected = Tensor::from([0., 0., -1. / 3., 0., 2. / 3., 3., 4.]);
@@ -978,7 +978,7 @@ mod tests {
 
     #[test]
     fn test_leaky_relu() -> Result<(), Box<dyn Error>> {
-        let pool = new_pool();
+        let pool = BufferPool::new();
         let input = Tensor::from_data(&[2, 2], vec![-5., -2., 3., 20.]);
         let alpha = 0.1;
         let expected = Tensor::from_data(&[2, 2], vec![-5. * alpha, -2. * alpha, 3., 20.]);
@@ -1019,7 +1019,7 @@ mod tests {
 
     #[test]
     fn test_round() -> Result<(), Box<dyn Error>> {
-        let pool = new_pool();
+        let pool = BufferPool::new();
 
         // Example from ONNX spec.
         let input = Tensor::from([0.9, 2.5, 2.3, 1.5, -4.5]);

--- a/src/ops/variadic_elementwise.rs
+++ b/src/ops/variadic_elementwise.rs
@@ -161,15 +161,15 @@ mod tests {
     use rten_tensor::{Tensor, TensorView};
     use rten_testing::TestCases;
 
+    use crate::buffer_pool::BufferPool;
     use crate::operator::{InputList, OpError, OpRunContext, Operator};
-    use crate::ops::tests::new_pool;
     use crate::ops::{Max, Min, Sum, max, mean, min, sum};
     use crate::value::ValueView;
 
     fn run_operator<Op: Operator>(op: &Op, inputs: &[TensorView]) -> Tensor {
         let inputs: Vec<ValueView> = inputs.iter().cloned().map(|i| i.into()).collect();
         let inputs = InputList::from(inputs.as_slice());
-        let pool = new_pool();
+        let pool = BufferPool::new();
         let ctx = OpRunContext::new(&pool, &inputs);
         let mut outputs = op.run(&ctx).unwrap();
         outputs.remove(0).try_into().unwrap()
@@ -242,7 +242,7 @@ mod tests {
         ];
 
         cases.test_each(|case| {
-            let pool = new_pool();
+            let pool = BufferPool::new();
             let views: Vec<_> = case.inputs.iter().map(|t| t.view()).collect();
             let result = max(&pool, &views);
             match (&result, &case.expected) {
@@ -263,7 +263,7 @@ mod tests {
     fn test_mean() {
         let a = Tensor::from([1., 2., 3., 4.]);
         let b = Tensor::from([5., 6., 7., 8.]);
-        let pool = new_pool();
+        let pool = BufferPool::new();
         assert_eq!(
             mean(&pool, &[a.view(), b.view()]),
             Ok(Tensor::from([3., 4., 5., 6.]))
@@ -272,7 +272,7 @@ mod tests {
 
     #[test]
     fn test_min() {
-        let pool = new_pool();
+        let pool = BufferPool::new();
 
         let (a, b) = (Tensor::from([1., 2., 3.]), Tensor::from([4., 1., 3.]));
         let expected = Tensor::from([1., 1., 3.]);
@@ -291,7 +291,7 @@ mod tests {
 
     #[test]
     fn test_sum() {
-        let pool = new_pool();
+        let pool = BufferPool::new();
         let a = Tensor::from([1., 2., 3., 4.]);
         let b = Tensor::from([5., 6., 7., 8.]);
         let expected = Tensor::from([6., 8., 10., 12.]);


### PR DESCRIPTION
Replace the trivial `new_pool` wrapper with a direct call. The comment states this function was a customization hook but I haven't needed to use it.