### PR TITLE
Remove outdated comment about PoolRef not being Sync

### DIFF
--- a/src/buffer_pool.rs
+++ b/src/buffer_pool.rs
@@ -347,10 +347,6 @@ impl<EB: ExtractBuffer> AutoReturn for EB {
 
 /// A smart pointer which wraps a tensor or other container and returns it to
 /// a pool when dropped.
-///
-/// [`PoolRef`] is not currently [`Sync`], so if you want to wrap a container and
-/// then reference it inside a parallel block, you will need to deref the
-/// [`PoolRef`] outside the parallel block.
 pub struct PoolRef<'a, T: ExtractBuffer> {
     pool: &'a BufferPool,
     container: Option<T>,


### PR DESCRIPTION
This used to be because the internal `&BufferPool` was not Sync, but that changed in 8f39fffc8effb82f8ae771c2f05cb256876f9a92.