### PR TITLE
Rename `CastError` to `TryFromValueError` and export it

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,7 +192,7 @@ pub use op_registry::{OpRegistry, RegisterOp, op_types};
 pub use ops::{FloatOperators, Operators};
 pub use threading::{ThreadPool, thread_pool};
 pub use timing::TimingSort;
-pub use value::{DataType, Sequence, Value, ValueOrView, ValueView};
+pub use value::{DataType, Sequence, TryFromValueError, Value, ValueOrView, ValueView};
 
 #[deprecated = "renamed to `LoadError`"]
 pub type ModelLoadError = LoadError;

--- a/src/ops/concat.rs
+++ b/src/ops/concat.rs
@@ -8,7 +8,7 @@ use smallvec::SmallVec;
 use crate::buffer_pool::{AutoReturn, BufferPool};
 use crate::operator::{InputList, IntoOpResult, OpError, OpRunContext, Operator, OutputList};
 use crate::ops::{map_value, map_value_view, resolve_axis};
-use crate::value::{CastError, Value, ValueView};
+use crate::value::{TryFromValueError, Value, ValueView};
 
 /// Return the shape formed by concatenating all tensors along a given axis.
 fn concatenated_shape<T: Copy>(
@@ -45,7 +45,7 @@ fn typed_inputs<'a, T>(
     _: TensorView<T>,
 ) -> Result<SmallVec<[TensorView<'a, T>; 4]>, OpError>
 where
-    TensorView<'a, T>: TryFrom<ValueView<'a>, Error = CastError>,
+    TensorView<'a, T>: TryFrom<ValueView<'a>, Error = TryFromValueError>,
 {
     let mut typed_inputs: SmallVec<_> = SmallVec::with_capacity(inputs.len());
     for input in inputs.iter().flatten() {

--- a/src/ops/pad.rs
+++ b/src/ops/pad.rs
@@ -293,7 +293,7 @@ mod tests {
     use crate::buffer_pool::BufferPool;
     use crate::operator::{OpError, OperatorExt};
     use crate::ops::{Pad, PadMode, pad};
-    use crate::value::{CastError, DataType, Value};
+    use crate::value::{DataType, TryFromValueError, Value};
 
     fn from_slice<T: Clone>(data: &[T]) -> Tensor<T> {
         Tensor::from_data(&[data.len()], data.to_vec())
@@ -594,7 +594,7 @@ mod tests {
                 const_val: Some(Tensor::from(1).into()),
                 expected_error: OpError::InputCastFailed {
                     index: 2,
-                    error: CastError::WrongType {
+                    error: TryFromValueError::WrongType {
                         actual: DataType::Int32,
                         expected: DataType::Float,
                     },
@@ -607,7 +607,7 @@ mod tests {
                 const_val: Some(from_slice(&[1.0, 2.0]).into()),
                 expected_error: OpError::InputCastFailed {
                     index: 2,
-                    error: CastError::WrongRank {
+                    error: TryFromValueError::WrongRank {
                         actual: 1,
                         expected: 0,
                     },

--- a/src/ops/resize.rs
+++ b/src/ops/resize.rs
@@ -10,7 +10,7 @@ use crate::buffer_pool::{AutoReturn, BufferPool};
 use crate::operator::{
     InputList, IntoOpResult, OpError, OpRunContext, Operator, OutputList, static_dims,
 };
-use crate::value::{CastError, Value, ValueView};
+use crate::value::{TryFromValueError, Value, ValueView};
 
 /// Specifies an output size for a resize operation.
 pub enum ResizeTarget<'a> {
@@ -443,7 +443,7 @@ fn get_optional_input<'a, T>(
     index: usize,
 ) -> Result<Option<TensorView<'a, T>>, OpError>
 where
-    TensorView<'a, T>: TryFrom<ValueView<'a>, Error = CastError>,
+    TensorView<'a, T>: TryFrom<ValueView<'a>, Error = TryFromValueError>,
 {
     let tensor = inputs
         .get_as::<TensorView<T>>(index)?

--- a/src/ops/sequence.rs
+++ b/src/ops/sequence.rs
@@ -305,7 +305,7 @@ mod tests {
         SequenceInsert, SequenceLength, SplitToSequence,
     };
     use crate::operator::{InputList, OpError, OperatorExt};
-    use crate::value::{CastError, DataType, Sequence, Value, ValueView};
+    use crate::value::{DataType, Sequence, TryFromValueError, Value, ValueView};
 
     #[test]
     fn test_sequence_empty() {
@@ -398,7 +398,7 @@ mod tests {
                     Value::from(Tensor::from(1.0)),
                 ]
                 .into(),
-                expected: Err(OpError::CastFailed(CastError::WrongType {
+                expected: Err(OpError::CastFailed(TryFromValueError::WrongType {
                     actual: DataType::Float,
                     expected: DataType::Int32,
                 })),

--- a/src/ops/unary_elementwise.rs
+++ b/src/ops/unary_elementwise.rs
@@ -658,7 +658,7 @@ mod tests {
     };
     use crate::buffer_pool::BufferPool;
     use crate::operator::{OpError, Operator, OperatorExt};
-    use crate::value::{CastError, Value, ValueView};
+    use crate::value::{TryFromValueError, Value, ValueView};
     use rten_tensor::test_util::ApproxEq;
 
     // Test a unary operator's in-place and non-in-place implementations.
@@ -669,7 +669,7 @@ mod tests {
     ) -> Result<(), Box<dyn Error>>
     where
         for<'a> TensorView<'a, T>: Into<ValueView<'a>>,
-        Tensor<T>: Into<Value> + TryFrom<Value, Error = CastError>,
+        Tensor<T>: Into<Value> + TryFrom<Value, Error = TryFromValueError>,
     {
         let expected = input.map(reference_op);
 
@@ -692,7 +692,7 @@ mod tests {
     ) -> Result<(), Box<dyn Error>>
     where
         for<'a> TensorView<'a, T>: Into<ValueView<'a>>,
-        Tensor<U>: Into<Value> + TryFrom<Value, Error = CastError>,
+        Tensor<U>: Into<Value> + TryFrom<Value, Error = TryFromValueError>,
     {
         let result: Tensor<U> = op.run_simple(input).unwrap();
         expect_equal(&result.view(), &expected.view())?;

--- a/src/ops/variadic_elementwise.rs
+++ b/src/ops/variadic_elementwise.rs
@@ -9,7 +9,7 @@ use crate::operator::{InputList, IntoOpResult, OpError, OpRunContext, Operator, 
 use crate::ops::binary_elementwise::binary_op;
 use crate::ops::map_value_view;
 use crate::ops::reduce::{cmp_nan_greater, cmp_nan_less};
-use crate::value::{CastError, ValueView};
+use crate::value::{TryFromValueError, ValueView};
 
 /// Apply an elementwise reduction to a sequence of tensors.
 ///
@@ -40,7 +40,7 @@ fn typed_views<'a, T>(
     _: TensorView<T>,
 ) -> Result<Vec<TensorView<'a, T>>, OpError>
 where
-    ValueView<'a>: TryInto<TensorView<'a, T>, Error = CastError>,
+    ValueView<'a>: TryInto<TensorView<'a, T>, Error = TryFromValueError>,
 {
     inputs
         .iter()


### PR DESCRIPTION
The `CastError` error type used when converting `Value`/`ValueView`s to tensors is encountered by users but was not exported in the public API so consumers were limited in how they could use it. Rename to `TryFromValueError` to align with similar types in std (eg. `TryFromIntError`) and export it. Also improve the description of each error variant and mark as `non_exhaustive` to enable adding more errors in future (eg. for when ONNX optional or map types are added).