### PR TITLE
Fix build with `mmap` enabled and `rten_format` or `onnx_format` disabled

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -602,7 +602,7 @@ impl ModelOptions {
                 rten_loader::load(storage, self)
             }
             #[cfg(not(feature = "rten_format"))]
-            FileType::Rten => Err(LoadError::FormatNotEnabled),
+            FileType::Rten => Err(LoadErrorImpl::FormatNotEnabled.into()),
             #[cfg(feature = "onnx_format")]
             FileType::Onnx => {
                 // Safety: By calling `load_mmap` the caller has accepted the
@@ -612,7 +612,7 @@ impl ModelOptions {
                 onnx_loader::load(onnx_loader::Source::Buffer(&mmap), Some(&loader), self)
             }
             #[cfg(not(feature = "onnx_format"))]
-            FileType::Onnx => Err(LoadError::FormatNotEnabled),
+            FileType::Onnx => Err(LoadErrorImpl::FormatNotEnabled.into()),
         }
     }
 }


### PR DESCRIPTION
Fix the build when `mmap` is enabled and at least one model format is disabled. This is an oversight from https://github.com/robertknight/rten/pull/1007.