### PR TITLE
Simplify model input/output creation/extraction

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -301,7 +301,7 @@ impl<'a> ValueView<'a> {
     }
 
     /// Extract shape and data type information from this tensor.
-    pub fn to_meta(&self) -> ValueMeta {
+    pub(crate) fn to_meta(&self) -> ValueMeta {
         ValueMeta {
             shape: self.shape().to_vec(),
             dtype: self.dtype(),
@@ -500,7 +500,7 @@ impl Value {
     }
 
     /// Extract shape and data type information from this tensor.
-    pub fn to_meta(&self) -> ValueMeta {
+    pub(crate) fn to_meta(&self) -> ValueMeta {
         ValueMeta {
             shape: self.shape().to_vec(),
             dtype: self.dtype(),


### PR DESCRIPTION
Add methods to create `Value`s and `ValueView`s directly from shape and data, as well as to extract the shape and data from a value. This enables projects to use rten without a direct dependency on rten-tensor. Also improve the documentation around creating values and extracting the shape/data from them.

The names of the new methods follow conventions from ndarray: `View::from_shape`, `ValueView::from_shape`, `Value::into_shape_vec`, as that is what consumers will probably be most used to.