### PR TITLE
Fix warnings about unused error variants when `rten_format` feature is disabled

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -901,7 +901,12 @@ mod tests {
         } in cases
         {
             let err = Model::load(buf).err().unwrap();
-            assert!(err.to_string().contains(expected_error));
+            assert!(
+                err.to_string().contains(expected_error),
+                "expected \"{}\" to contain \"{}\"",
+                err,
+                expected_error
+            );
         }
     }
 

--- a/src/model/rten_loader.rs
+++ b/src/model/rten_loader.rs
@@ -44,7 +44,11 @@ pub fn load(storage: Arc<ConstantStorage>, options: &ModelOptions) -> Result<Mod
         .map_err(|err| LoadErrorImpl::ParseFailed(Box::new(err).into()))?;
 
     if model.schema_version() != 1 {
-        return Err(LoadErrorImpl::SchemaVersionUnsupported.into());
+        let err = format!(
+            "unsupported model schema version {}",
+            model.schema_version()
+        );
+        return Err(LoadErrorImpl::ParseFailed(err.into()).into());
     }
 
     let optimize_opts = if options.optimize {

--- a/src/op_registry.rs
+++ b/src/op_registry.rs
@@ -75,6 +75,7 @@ impl OpRegistry {
 #[derive(Debug)]
 pub enum ReadOpError {
     /// The `attrs` field for this operator is not set or has the wrong type.
+    #[cfg(feature = "rten_format")]
     AttrsMissingError,
     /// An attribute has an unsupported or invalid value.
     AttrError {
@@ -113,6 +114,7 @@ impl ReadOpError {
 impl Display for ReadOpError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
+            #[cfg(feature = "rten_format")]
             ReadOpError::AttrsMissingError => write!(f, "attributes are missing"),
             ReadOpError::AttrError { attr, error } => {
                 write!(f, "error in attribute \"{}\": {}", attr, error)


### PR DESCRIPTION
 - Remove `LoadErrorImpl::InvalidHeader` and `ReadOpError::AttrsMissingError` variants when `rten_format` is disabled.
 - Fold `LoadErrorImpl::SchemaVersionUnsupported` error into the more general `ParseFailed` case