### PR TITLE
Make `Value::dtype` return collection and element type

### DIFF
--- a/rten-cli/src/main.rs
+++ b/rten-cli/src/main.rs
@@ -290,7 +290,7 @@ fn run_model(
         for (output, name) in outputs.iter().zip(output_names) {
             // Print basic information about the output.
             println!(
-                "  Output \"{name}\" data type {} shape: {:?}",
+                "  Output \"{name}\" type {} shape: {:?}",
                 output.dtype(),
                 output.shape()
             );

--- a/src/graph/run_error.rs
+++ b/src/graph/run_error.rs
@@ -2,7 +2,7 @@ use std::error::Error;
 use std::fmt::{Display, Formatter};
 
 use crate::operator::{OpError, OpRunContext};
-use crate::value::{DataType, ValueMeta};
+use crate::value::{ValueMeta, ValueType};
 
 /// Errors that occur when running a model.
 #[derive(Debug)]
@@ -44,7 +44,7 @@ impl RunError {
         name: &str,
         error: OpError,
         ctx: &OpRunContext,
-        main_input_dtype: DataType,
+        main_input_dtype: ValueType,
         main_input_shape: &[usize],
     ) -> Self {
         let meta = ValueMeta {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,7 +192,7 @@ pub use op_registry::{OpRegistry, RegisterOp, op_types};
 pub use ops::{FloatOperators, Operators};
 pub use threading::{ThreadPool, thread_pool};
 pub use timing::TimingSort;
-pub use value::{DataType, Sequence, TryFromValueError, Value, ValueOrView, ValueView};
+pub use value::{DataType, Sequence, TryFromValueError, Value, ValueOrView, ValueType, ValueView};
 
 #[deprecated = "renamed to `LoadError`"]
 pub type ModelLoadError = LoadError;

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -15,7 +15,7 @@ use smallvec::SmallVec;
 use crate::BufferPool;
 use crate::graph::{CaptureEnv, Graph, RunError, RunOptions};
 use crate::timing::Profiler;
-use crate::value::{DataType, DataTypeOf, TryFromValueError, Value, ValueView};
+use crate::value::{DataType, DataTypeOf, TryFromValueError, Value, ValueType, ValueView};
 use crate::weight_cache::WeightCache;
 
 /// An operator input which has been pre-packed for more efficient use during
@@ -52,8 +52,8 @@ macro_rules! impl_prepacked_input_conversions {
                 match ppi {
                     PrepackedInput::$variant(packed) => Ok(packed),
                     _ => Err(TryFromValueError::WrongType {
-                        actual: ppi.dtype(),
-                        expected: <$type as DataTypeOf>::dtype_of(),
+                        actual: ValueType::Tensor(ppi.dtype()),
+                        expected: ValueType::Tensor(<$type as DataTypeOf>::dtype_of()),
                     }),
                 }
             }

--- a/src/ops/pad.rs
+++ b/src/ops/pad.rs
@@ -293,7 +293,7 @@ mod tests {
     use crate::buffer_pool::BufferPool;
     use crate::operator::{OpError, OperatorExt};
     use crate::ops::{Pad, PadMode, pad};
-    use crate::value::{DataType, TryFromValueError, Value};
+    use crate::value::{DataType, TryFromValueError, Value, ValueType};
 
     fn from_slice<T: Clone>(data: &[T]) -> Tensor<T> {
         Tensor::from_data(&[data.len()], data.to_vec())
@@ -595,8 +595,8 @@ mod tests {
                 expected_error: OpError::InputCastFailed {
                     index: 2,
                     error: TryFromValueError::WrongType {
-                        actual: DataType::Int32,
-                        expected: DataType::Float,
+                        actual: ValueType::Tensor(DataType::Int32),
+                        expected: ValueType::Tensor(DataType::Float),
                     },
                 },
             },


### PR DESCRIPTION
Change `Value::dtype` and `ValueView::dtype` to return a type which includes both the collection type (tensor or sequence) as well as the element type of tensor elements (f32, i32 etc.).

Adjust consumers of this method to handle the new cases appropriately. As a result the CastLike, EyeLike and SequenceInsert operators will now error if they get a sequence input where a tensor is expected. This aligns better with the ONNX specifications for these operators.