### PR TITLE
Check domain when looking up ONNX op deserializer

### DIFF
--- a/rten-onnx/src/onnx.rs
+++ b/rten-onnx/src/onnx.rs
@@ -103,6 +103,7 @@ impl DecodeMessage for AttributeProto {
 
 #[derive(Clone, Debug, Default)]
 pub struct NodeProto {
+    pub domain: Option<String>,
     pub name: Option<String>,
     pub input: Vec<String>,
     pub output: Vec<String>,
@@ -116,6 +117,7 @@ impl NodeProto {
     const NAME: u64 = 3;
     const OP_TYPE: u64 = 4;
     const ATTRIBUTE: u64 = 5;
+    const DOMAIN: u64 = 7;
 }
 
 impl DecodeMessage for NodeProto {
@@ -142,6 +144,9 @@ impl DecodeMessage for NodeProto {
                 Self::ATTRIBUTE => {
                     msg.attribute
                         .push(AttributeProto::decode_field(&mut field)?);
+                }
+                Self::DOMAIN => {
+                    msg.domain = Some(field.read_string()?);
                 }
                 _ => {
                     field.skip()?;

--- a/src/model/onnx_builder.rs
+++ b/src/model/onnx_builder.rs
@@ -91,6 +91,7 @@ pub fn create_node(op_type: &str) -> onnx::NodeProto {
 /// Fluent methods for building an [`onnx::NodeProto`].
 pub trait NodeProtoExt {
     fn with_attr(self, name: &str, value: impl Into<AttrValue>) -> Self;
+    fn with_domain(self, domain: &str) -> Self;
     fn with_name(self, name: &str) -> Self;
     fn with_input(self, name: &str) -> Self;
 }
@@ -98,6 +99,11 @@ pub trait NodeProtoExt {
 impl NodeProtoExt for onnx::NodeProto {
     fn with_attr(mut self, name: &str, value: impl Into<AttrValue>) -> Self {
         self.attribute.push(create_attr(name, value.into()));
+        self
+    }
+
+    fn with_domain(mut self, domain: &str) -> Self {
+        self.domain = Some(domain.to_string());
         self
     }
 


### PR DESCRIPTION
Use (domain, op_type) as the key for ONNX op deserializer functions instead of just op_type. When reading `NodeProto` messages, deserialize the `domain` field and use it as part of the key, defaulting to "ai.onnx" if not present.

This avoids intepreting operators incorrectly if they have an op_type that matches a built-in operator but use a custom domain. The "com.microsoft" domain has several ops with names that overlap with ops from the "ai.onnx" domain [^1].

This will also make it possible to support non-standard ONNX operators. See https://github.com/robertknight/rten/issues/578.

[^1]: https://github.com/microsoft/onnxruntime/blob/main/docs/ContribOperators.md