### PR TITLE
Support 4-bit weight-only quantization in rten-gemm

### DIFF
--- a/rten-gemm/src/block_quant.rs
+++ b/rten-gemm/src/block_quant.rs
@@ -1,0 +1,202 @@
+use rten_tensor::{Layout, NdTensorView};
+
+use crate::errors::BlockQuantizedError;
+
+/// Matrix which is quantized into blocks along the K dimension.
+///
+/// The data layout and supported bit/block sizes follow ONNX Runtime's MatMulNBits
+/// operator. See <https://github.com/microsoft/onnxruntime/blob/main/docs/ContribOperators.md>.
+#[derive(Copy, Clone)]
+pub struct BlockQuantizedMatrix<'a, T> {
+    /// Quantized data of shape (N, k_blocks, block_size).
+    ///
+    /// The last dimension is guaranteed to have unit stride.
+    quant: NdTensorView<'a, u8, 3>,
+
+    /// Scales of shape (N, k_blocks)
+    ///
+    /// The last dimension is guaranteed to have unit stride.
+    scales: NdTensorView<'a, T, 2>,
+
+    /// Bits per quantized element.
+    ///
+    /// Must be a divisor of `block_size * 8`.
+    bits: u8,
+}
+
+impl<'a, T: Copy> BlockQuantizedMatrix<'a, T> {
+    /// Minimum supported number of elements per block.
+    pub const MIN_BLOCK_SIZE: usize = 16;
+
+    /// Create a block-quantized RHS matrix input.
+    ///
+    /// `quant` is the block-quantized input with shape (cols, k_blocks,
+    /// block_size). `scales` are the per-block scales with shape (cols,
+    /// k_blocks). `bits` specifies the number of bits per element in each
+    /// block.
+    ///
+    /// The number of elements per quantized block must be a power of 2 of at
+    /// least `MIN_BLOCK_SIZE`.
+    pub fn new(
+        quant: NdTensorView<'a, u8, 3>,
+        scales: NdTensorView<'a, T, 2>,
+        bits: u8,
+    ) -> Result<Self, BlockQuantizedError> {
+        // ONNX Runtime currently supports 2, 4 or 8 bits per element. These
+        // values have the convenient property that a byte is a whole number
+        // of elements. We only support 4 bits for the moment.
+        if bits != 4 {
+            return Err(BlockQuantizedError::UnsupportedElementSize);
+        }
+        let n_elem = 8 / bits;
+
+        let [_batch, _k_blocks, block_bytes] = quant.shape();
+
+        let block_size = block_bytes * n_elem as usize;
+        if !block_size.is_power_of_two() || block_size < Self::MIN_BLOCK_SIZE {
+            return Err(BlockQuantizedError::UnsupportedBlockSize);
+        }
+
+        if quant.stride(2) != 1 || scales.stride(1) != 1 {
+            return Err(BlockQuantizedError::NonContiguousInput);
+        }
+
+        Ok(Self {
+            quant,
+            scales,
+            bits,
+        })
+    }
+
+    /// Return the number of rows in the dequantized matrix.
+    pub fn rows(&self) -> usize {
+        self.blocks_per_column() * self.elements_per_block()
+    }
+
+    /// Return the number of columns in the dequantized matrix.
+    pub fn cols(&self) -> usize {
+        self.quant.size(0)
+    }
+
+    /// Return the number of bits per element
+    pub fn n_bits(&self) -> u8 {
+        self.bits
+    }
+
+    /// Return the number of blocks in each column.
+    pub(crate) fn blocks_per_column(&self) -> usize {
+        self.quant.size(1)
+    }
+
+    pub(crate) fn elements_per_block(&self) -> usize {
+        (self.bytes_per_block() * 8) / self.bits as usize
+    }
+
+    pub(crate) fn bytes_per_block(&self) -> usize {
+        self.quant.size(2)
+    }
+
+    /// Return the packed data for a range of blocks in a column.
+    pub(crate) fn column_data(
+        &self,
+        col: usize,
+        start_block: usize,
+        n_blocks: usize,
+    ) -> Option<&[u8]> {
+        if self.quant.size(1) < start_block + n_blocks {
+            return None;
+        }
+        let offset = self.quant.offset([col, start_block, 0])?;
+        let len = self.quant.size(2);
+
+        Some(unsafe {
+            std::slice::from_raw_parts(self.quant.data_ptr().add(offset), len * n_blocks)
+        })
+    }
+
+    /// Return the scale factors for a range of blocks in a column.
+    pub(crate) fn column_scales(
+        &self,
+        col: usize,
+        start_block: usize,
+        n_blocks: usize,
+    ) -> Option<&[T]> {
+        if self.scales.size(1) < start_block + n_blocks {
+            return None;
+        }
+        let offset = self.scales.offset([col, start_block])?;
+
+        Some(unsafe { std::slice::from_raw_parts(self.scales.data_ptr().add(offset), n_blocks) })
+    }
+}
+
+/// Return the default zero point for n-bit quantization.
+///
+/// This is an i16 because the maximum value is 128 (when n_bits=8) and the
+/// value is used in signed subtractions.
+///
+/// See docs for `zero_points` input to MatMulNBits in
+/// https://github.com/microsoft/onnxruntime/blob/main/docs/ContribOperators.md.
+pub const fn nbit_zero_point(n_bits: u8) -> i16 {
+    assert!(n_bits >= 2 && n_bits <= 8);
+    1 << (n_bits - 1)
+}
+
+#[cfg(test)]
+pub fn pack_4bit_elements(vals: &[i8], zero_point: i8) -> Vec<u8> {
+    let (chunks, tail) = vals.as_chunks::<2>();
+    assert!(tail.is_empty());
+    chunks
+        .iter()
+        .copied()
+        .map(|[even, odd]| {
+            let lo = (even + zero_point) as u8;
+            let hi = (odd + zero_point) as u8;
+            (lo & 0x0F) | (hi << 4)
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use rten_tensor::{AsView, NdTensor, NdTensorView};
+
+    use super::{BlockQuantizedMatrix, nbit_zero_point, pack_4bit_elements};
+
+    #[test]
+    fn test_block_quantized_matrix() {
+        let zero_point = nbit_zero_point(4) as i8;
+        let elems: Vec<i8> = (-8..8).cycle().take(256).collect();
+        let packed = pack_4bit_elements(&elems, zero_point);
+
+        let block_bytes = 16;
+        let cols = 4;
+        let k_blocks = 2;
+        let n_bits = 4;
+
+        let quants = NdTensor::from_data([cols, k_blocks, block_bytes], packed);
+        let scales = NdTensorView::from_data([cols, k_blocks], &[1., 2., 3., 4., 5., 6., 7., 8.]);
+        let mat = BlockQuantizedMatrix::new(quants.view(), scales.view(), n_bits).unwrap();
+
+        assert_eq!(mat.rows(), 64);
+        assert_eq!(mat.cols(), cols);
+        assert_eq!(mat.elements_per_block(), 32);
+        assert_eq!(mat.blocks_per_column(), k_blocks);
+
+        assert_eq!(
+            mat.column_data(0, 0, 1).unwrap(),
+            pack_4bit_elements(&elems[..32], zero_point)
+        );
+        assert_eq!(mat.column_scales(0, 0, 2), Some([1.0, 2.0].as_slice()));
+        assert_eq!(
+            mat.column_data(3, 1, 1).unwrap(),
+            pack_4bit_elements(&elems[256 - 32..], zero_point)
+        );
+        assert_eq!(mat.column_scales(3, 1, 1), Some([8.0].as_slice()));
+
+        // Out of bounds column.
+        assert_eq!(mat.column_data(4, 1, 1), None);
+        // Out of bounds K block.
+        assert_eq!(mat.column_data(3, 2, 1), None);
+    }
+}

--- a/rten-gemm/src/errors.rs
+++ b/rten-gemm/src/errors.rs
@@ -21,6 +21,8 @@ pub enum GemmError {
     /// The data was packed with different cache blocking parameters than are
     /// currently being used.
     PackedDataBlockingMismatch,
+    /// Block-quantized inputs are not supported for this data type.
+    BlockQuantizedInputNotSupported,
 }
 
 impl Display for GemmError {
@@ -43,8 +45,34 @@ impl Display for GemmError {
             Self::PackedDataBlockingMismatch => {
                 write!(fmt, "matrix was packed with a different blocking size")
             }
+            Self::BlockQuantizedInputNotSupported => {
+                write!(fmt, "block-quantized inputs not supported for data type")
+            }
         }
     }
 }
 
 impl Error for GemmError {}
+
+/// Errors with block-quantized inputs.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum BlockQuantizedError {
+    /// The block size is unsupported.
+    UnsupportedBlockSize,
+    /// The number of bits per element is unsupported.
+    UnsupportedElementSize,
+    /// The input data or scales are not contiguous.
+    NonContiguousInput,
+}
+
+impl Display for BlockQuantizedError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::UnsupportedBlockSize => write!(f, "block size is unsupported"),
+            Self::UnsupportedElementSize => write!(f, "unsupported bits-per-element"),
+            Self::NonContiguousInput => write!(f, "inputs must have contiguous last dim"),
+        }
+    }
+}
+
+impl Error for BlockQuantizedError {}

--- a/rten-gemm/src/kernels.rs
+++ b/rten-gemm/src/kernels.rs
@@ -5,8 +5,11 @@
 use std::mem::MaybeUninit;
 use std::ops::Range;
 
-use super::{GemmOutT, Im2Col};
 use rten_tensor::Matrix;
+
+use super::{GemmOutT, Im2Col};
+use crate::block_quant::BlockQuantizedMatrix;
+use crate::packing::Packer;
 
 pub mod generic;
 mod simd_generic;
@@ -246,6 +249,16 @@ pub unsafe trait Kernel<LhsT, RhsT, OutT>: Sync {
         cols: Range<usize>,
         zero_point: Option<RhsT>,
     );
+
+    /// Create a packer for a blockwise-quantized B input.
+    ///
+    /// This may return None if not supported by the kernel.
+    fn pack_block_quant<'a>(
+        &self,
+        #[allow(unused)] mat: BlockQuantizedMatrix<'a, RhsT>,
+    ) -> Option<Box<dyn Packer<'a> + 'a + Send + Sync>> {
+        None
+    }
 
     /// Compute a tile of the output matrix.
     ///

--- a/rten-gemm/src/kernels/wasm.rs
+++ b/rten-gemm/src/kernels/wasm.rs
@@ -7,8 +7,11 @@ use rten_tensor::{Matrix, MatrixLayout};
 
 use super::simd_generic::{GemmDispatch, simd_gemv, simd_int8_gemm, simd_int8_gemv};
 use super::{Int8DotProduct, Kernel, Lhs, MatVecOutput, PackedLayout, QuantParams, TempTile};
-use crate::packing::{pack_a_block, pack_b_block, packed_a_layout, packed_b_layout};
-use crate::{Im2Col, packing};
+use crate::packing::{
+    BlockQuantizedMatrixPacker, Packer, pack_a_block, pack_b_block, packed_a_layout,
+    packed_b_layout,
+};
+use crate::{BlockQuantizedMatrix, Im2Col, packing};
 
 pub struct WasmKernel {
     isa: Wasm32Isa,
@@ -103,6 +106,15 @@ unsafe impl Kernel<f32, f32, f32> for WasmKernel {
         // Safety: WASM SIMD types are supported
         let out = cast_uninit_pod_mut_slice(out).unwrap();
         image.pack_block::<_, NR_REGS>(self.isa, out, Self::NR, rows, cols);
+    }
+
+    fn pack_block_quant<'a>(
+        &self,
+        mat: BlockQuantizedMatrix<'a, f32>,
+    ) -> Option<Box<dyn Packer<'a> + 'a + Send + Sync>> {
+        Some(Box::new(
+            BlockQuantizedMatrixPacker::<f32, { Self::NR }>::new(mat),
+        ))
     }
 
     unsafe fn kernel(

--- a/rten-gemm/src/prepack.rs
+++ b/rten-gemm/src/prepack.rs
@@ -173,7 +173,7 @@ pub fn prepack_a<A: Alloc, LhsT, RhsT, OutT>(
     alloc: A,
     a: Matrix<LhsT>,
 ) -> PackedAMatrix<LhsT> {
-    let depth_block = depth_block_size::<RhsT>(a.cols());
+    let depth_block = depth_block_size::<RhsT>(a.cols(), None);
 
     let layout = kernel.packed_a_layout(a, a.rows(), depth_block, None);
     let tail_layout = if !a.cols().is_multiple_of(depth_block) {
@@ -229,7 +229,7 @@ pub fn prepack_b<A: Alloc, LhsT, RhsT, OutT>(
     alloc: A,
     b: Matrix<RhsT>,
 ) -> PackedBMatrix<RhsT> {
-    let depth_block = depth_block_size::<RhsT>(b.rows());
+    let depth_block = depth_block_size::<RhsT>(b.rows(), None);
 
     let layout = kernel.packed_b_layout(depth_block, b.cols(), None);
     let tail_layout = if !b.rows().is_multiple_of(depth_block) {


### PR DESCRIPTION
Support a new type of RHS input in rten-gemm where the LHS input is f32 and the RHS input is quantized to 4-bits in blocks along the K dimension. The 4-bit weights are dequantized during the existing packing stage.

The input format aligns with the `MatMulNBits` contrib operator described at https://github.com/microsoft/onnxruntime/blob/main/docs/ContribOperators.md#com.microsoft.MatMulNBits.

The initial implementation only supports the default zero point of 2^(n_bits - 1) (ie. 8 for 4-bit elements).

There is no GEMV kernel yet, which will be important for auto-regressive models (ie. LLMs) and more performance work will be needed after the initial `MatMulNBits` implementation lands.

Part of https://github.com/robertknight/rten/issues/578.