### PR TITLE
Implement MatMulNBits operator

### DIFF
--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -81,7 +81,7 @@ pub(crate) use {
     grid_sample::GridSample,
     identity::Identity,
     layout::{DepthToSpace, Expand, Flatten, Reshape, Shape, Size, Squeeze, Transpose, Unsqueeze},
-    matmul::{FusedMatMul, Gemm, MatMul, MatMulInteger, MatMulIntegerToFloat},
+    matmul::{FusedMatMul, Gemm, MatMul, MatMulInteger, MatMulIntegerToFloat, MatMulNBits},
     non_max_suppression::NonMaxSuppression,
     norm::{
         BatchNormalization, InstanceNormalization, LayerNormalization, LogSoftmax,


### PR DESCRIPTION
Implement the MatMulNBits operator for weight-only quantized matrix multiplication. This is a non-standard operator but nevertheless widely used, eg. by the `*_q4.onnx` models published to https://huggingface.co/onnx-community.

Initially this is only supported for ONNX format models.

Part of https://github.com/robertknight/rten/issues/578.