### PR TITLE
Fix typo in `OpId` struct docs and add a useful link

### DIFF
--- a/src/op_registry/onnx_registry.rs
+++ b/src/op_registry/onnx_registry.rs
@@ -232,7 +232,8 @@ impl OnnxOpRegistry {
 
 /// Identifier for an ONNX operator.
 ///
-/// See the `NodeProto` field in the ONNX Protocol Buffers schema.
+/// See https://onnx.ai/onnx/intro/concepts.html#list-of-available-operators-and-domains
+/// and the `NodeProto` message in the ONNX Protocol Buffers schema.
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
 pub struct OpId<'a> {
     /// Reverse DNS domain.


### PR DESCRIPTION
 - `NodeProto` is a message, not a field.
 - Link to section in ONNX docs about operator identifiers