### PR TITLE
Check operator input count against maximum supported

### DIFF
--- a/src/graph/tests.rs
+++ b/src/graph/tests.rs
@@ -62,6 +62,10 @@ impl<Op: Operator> Operator for TrackUsage<Op> {
         self.inner.is_commutative()
     }
 
+    fn max_inputs(&self) -> Option<usize> {
+        self.inner.max_inputs()
+    }
+
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         {
             let mut m = self.metrics.lock().unwrap();
@@ -101,6 +105,10 @@ impl<F: Fn(&OpRunContext) -> Result<OutputList, OpError>> std::fmt::Debug for Ru
 impl<F: Fn(&OpRunContext) -> Result<OutputList, OpError>> Operator for RunFn<F> {
     fn name(&self) -> &str {
         "RunFn"
+    }
+
+    fn max_inputs(&self) -> Option<usize> {
+        None
     }
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
@@ -264,6 +272,10 @@ struct AddOne {}
 impl Operator for AddOne {
     fn name(&self) -> &str {
         "AddOne"
+    }
+
+    fn max_inputs(&self) -> Option<usize> {
+        Some(1)
     }
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
@@ -683,6 +695,10 @@ impl Operator for AddOneInPlace {
         "AddOneInPlace"
     }
 
+    fn max_inputs(&self) -> Option<usize> {
+        Some(1)
+    }
+
     fn can_run_in_place(&self) -> bool {
         true
     }
@@ -830,6 +846,10 @@ impl Split {
 impl Operator for Split {
     fn name(&self) -> &str {
         "Split"
+    }
+
+    fn max_inputs(&self) -> Option<usize> {
+        Some(1)
     }
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
@@ -1016,6 +1036,10 @@ impl Operator for Counter {
         "Counter"
     }
 
+    fn max_inputs(&self) -> Option<usize> {
+        Some(0)
+    }
+
     fn is_deterministic(&self) -> bool {
         false
     }
@@ -1096,6 +1120,10 @@ impl std::fmt::Debug for Subgraph {
 impl Operator for Subgraph {
     fn name(&self) -> &str {
         "Subgraph"
+    }
+
+    fn max_inputs(&self) -> Option<usize> {
+        None
     }
 
     fn run(&self, _ctx: &OpRunContext) -> Result<OutputList, OpError> {
@@ -1451,6 +1479,10 @@ impl MatMulExpectPacked {
 impl Operator for MatMulExpectPacked {
     fn name(&self) -> &str {
         "MatMulExpectPacked"
+    }
+
+    fn max_inputs(&self) -> Option<usize> {
+        self.inner.max_inputs()
     }
 
     fn prepack_inputs(&self) -> SmallVec<[usize; 1]> {

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -338,6 +338,11 @@ pub trait Operator: Any + Debug {
     /// [`SubgraphOperator::run_subgraph`] method should be used instead.
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError>;
 
+    /// Return the maximum number of inputs this operator accepts.
+    ///
+    /// This can return `None` for variadic inputs with no limit.
+    fn max_inputs(&self) -> Option<usize>;
+
     /// Return true if this operator supports in-place execution via
     /// `run_in_place`.
     ///

--- a/src/ops/attention.rs
+++ b/src/ops/attention.rs
@@ -64,6 +64,10 @@ impl Operator for AddSoftmax {
         "AddSoftmax"
     }
 
+    fn max_inputs(&self) -> Option<usize> {
+        Some(2)
+    }
+
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let x: TensorView = ctx.inputs().require_as(0)?;
         let y: TensorView = ctx.inputs().require_as(1)?;

--- a/src/ops/binary_elementwise.rs
+++ b/src/ops/binary_elementwise.rs
@@ -469,6 +469,10 @@ impl Operator for Add {
         "Add"
     }
 
+    fn max_inputs(&self) -> Option<usize> {
+        Some(2)
+    }
+
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         run_typed_op!(ctx.pool(), ctx.inputs(), add)
     }
@@ -508,6 +512,10 @@ macro_rules! logical_boolean_op {
         impl Operator for $op {
             fn name(&self) -> &str {
                 stringify!($op)
+            }
+
+            fn max_inputs(&self) -> Option<usize> {
+                Some(2)
             }
 
             fn is_commutative(&self) -> bool {
@@ -575,6 +583,10 @@ impl Operator for Div {
         "Div"
     }
 
+    fn max_inputs(&self) -> Option<usize> {
+        Some(2)
+    }
+
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         run_typed_op!(ctx.pool(), ctx.inputs(), div)
     }
@@ -631,6 +643,10 @@ macro_rules! boolean_cmp_op {
         impl Operator for $name {
             fn name(&self) -> &str {
                 stringify!($name)
+            }
+
+            fn max_inputs(&self) -> Option<usize> {
+                Some(2)
             }
 
             fn is_commutative(&self) -> bool {
@@ -717,6 +733,10 @@ impl Operator for Mod {
         "Mod"
     }
 
+    fn max_inputs(&self) -> Option<usize> {
+        Some(2)
+    }
+
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let inputs = ctx.inputs();
         let a = inputs.require(0)?;
@@ -756,6 +776,10 @@ pub struct Mul {}
 impl Operator for Mul {
     fn name(&self) -> &str {
         "Mul"
+    }
+
+    fn max_inputs(&self) -> Option<usize> {
+        Some(2)
     }
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
@@ -847,6 +871,10 @@ impl Operator for Pow {
         "Pow"
     }
 
+    fn max_inputs(&self) -> Option<usize> {
+        Some(2)
+    }
+
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let inputs = ctx.inputs();
         let base = inputs.require(0)?;
@@ -896,6 +924,10 @@ pub struct Sub {}
 impl Operator for Sub {
     fn name(&self) -> &str {
         "Sub"
+    }
+
+    fn max_inputs(&self) -> Option<usize> {
+        Some(2)
     }
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
@@ -978,6 +1010,10 @@ pub struct Where {}
 impl Operator for Where {
     fn name(&self) -> &str {
         "Where"
+    }
+
+    fn max_inputs(&self) -> Option<usize> {
+        Some(3)
     }
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {

--- a/src/ops/concat.rs
+++ b/src/ops/concat.rs
@@ -108,6 +108,10 @@ impl Operator for Concat {
         "Concat"
     }
 
+    fn max_inputs(&self) -> Option<usize> {
+        None
+    }
+
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let inputs = ctx.inputs();
         let first = inputs.require(0)?;
@@ -249,6 +253,10 @@ pub struct Tile {}
 impl Operator for Tile {
     fn name(&self) -> &str {
         "Tile"
+    }
+
+    fn max_inputs(&self) -> Option<usize> {
+        Some(2)
     }
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {

--- a/src/ops/control_flow.rs
+++ b/src/ops/control_flow.rs
@@ -30,6 +30,10 @@ impl Operator for If {
         "If"
     }
 
+    fn max_inputs(&self) -> Option<usize> {
+        Some(1)
+    }
+
     fn run(&self, _ctx: &OpRunContext) -> Result<OutputList, OpError> {
         Err(OpError::InvalidValue(
             "operator must be run with `run_subgraph`",
@@ -108,6 +112,10 @@ impl std::fmt::Debug for Loop {
 impl Operator for Loop {
     fn name(&self) -> &str {
         "Loop"
+    }
+
+    fn max_inputs(&self) -> Option<usize> {
+        None
     }
 
     fn run(&self, _ctx: &OpRunContext) -> Result<OutputList, OpError> {

--- a/src/ops/conv.rs
+++ b/src/ops/conv.rs
@@ -368,6 +368,10 @@ impl Operator for Conv {
         "Conv"
     }
 
+    fn max_inputs(&self) -> Option<usize> {
+        Some(3)
+    }
+
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let inputs = ctx.inputs();
         let input = inputs.require_as(0)?;
@@ -500,6 +504,10 @@ pub struct ConvInteger {
 impl Operator for ConvInteger {
     fn name(&self) -> &str {
         "ConvInteger"
+    }
+
+    fn max_inputs(&self) -> Option<usize> {
+        Some(4)
     }
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {

--- a/src/ops/conv_transpose.rs
+++ b/src/ops/conv_transpose.rs
@@ -366,6 +366,10 @@ impl Operator for ConvTranspose {
         "ConvTranspose"
     }
 
+    fn max_inputs(&self) -> Option<usize> {
+        Some(3)
+    }
+
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let inputs = ctx.inputs();
         let input = inputs.require_as(0)?;

--- a/src/ops/convert.rs
+++ b/src/ops/convert.rs
@@ -108,6 +108,10 @@ impl Operator for Cast {
         "Cast"
     }
 
+    fn max_inputs(&self) -> Option<usize> {
+        Some(1)
+    }
+
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let input = ctx.inputs().require(0)?;
         cast(ctx.pool(), input, self.to).into_op_result()
@@ -137,6 +141,10 @@ pub struct CastLike {}
 impl Operator for CastLike {
     fn name(&self) -> &str {
         "CastLike"
+    }
+
+    fn max_inputs(&self) -> Option<usize> {
+        Some(2)
     }
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {

--- a/src/ops/einsum.rs
+++ b/src/ops/einsum.rs
@@ -134,6 +134,10 @@ impl Operator for Einsum {
         "Einsum"
     }
 
+    fn max_inputs(&self) -> Option<usize> {
+        None
+    }
+
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let inputs = ctx.inputs();
         let mut typed_inputs: SmallVec<[TensorView; 2]> = SmallVec::with_capacity(inputs.len());

--- a/src/ops/fft.rs
+++ b/src/ops/fft.rs
@@ -127,6 +127,10 @@ impl Operator for STFT {
         "STFT"
     }
 
+    fn max_inputs(&self) -> Option<usize> {
+        Some(4)
+    }
+
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let signal = ctx.inputs().require_as(0)?;
         let frame_step = ctx.inputs().require_as(1)?;

--- a/src/ops/gather.rs
+++ b/src/ops/gather.rs
@@ -172,6 +172,10 @@ impl Operator for Gather {
         "Gather"
     }
 
+    fn max_inputs(&self) -> Option<usize> {
+        Some(2)
+    }
+
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let inputs = ctx.inputs();
         let input = inputs.require(0)?;
@@ -281,6 +285,10 @@ pub struct GatherElements {
 impl Operator for GatherElements {
     fn name(&self) -> &str {
         "GatherElements"
+    }
+
+    fn max_inputs(&self) -> Option<usize> {
+        Some(2)
     }
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
@@ -401,6 +409,10 @@ impl Operator for GatherND {
         "GatherND"
     }
 
+    fn max_inputs(&self) -> Option<usize> {
+        Some(2)
+    }
+
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let inputs = ctx.inputs();
         let input = inputs.require(0)?;
@@ -508,6 +520,10 @@ impl Operator for ScatterElements {
         "ScatterElements"
     }
 
+    fn max_inputs(&self) -> Option<usize> {
+        Some(3)
+    }
+
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let inputs = ctx.inputs();
         let data = inputs.require(0)?;
@@ -598,6 +614,10 @@ pub struct ScatterND {
 impl Operator for ScatterND {
     fn name(&self) -> &str {
         "ScatterND"
+    }
+
+    fn max_inputs(&self) -> Option<usize> {
+        Some(3)
     }
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {

--- a/src/ops/generate.rs
+++ b/src/ops/generate.rs
@@ -29,6 +29,10 @@ impl Operator for ConstantOfShape {
         "ConstantOfShape"
     }
 
+    fn max_inputs(&self) -> Option<usize> {
+        Some(1)
+    }
+
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let pool = ctx.pool();
         let shape = ctx.inputs().require_as(0)?;
@@ -93,6 +97,10 @@ impl Operator for OneHot {
         "OneHot"
     }
 
+    fn max_inputs(&self) -> Option<usize> {
+        Some(3)
+    }
+
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let inputs = ctx.inputs();
         let indices = inputs.require_as(0)?;
@@ -138,6 +146,10 @@ pub struct Range {}
 impl Operator for Range {
     fn name(&self) -> &str {
         "Range"
+    }
+
+    fn max_inputs(&self) -> Option<usize> {
+        Some(3)
     }
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
@@ -189,6 +201,10 @@ pub struct EyeLike {
 impl Operator for EyeLike {
     fn name(&self) -> &str {
         "EyeLike"
+    }
+
+    fn max_inputs(&self) -> Option<usize> {
+        Some(1)
     }
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {

--- a/src/ops/grid_sample.rs
+++ b/src/ops/grid_sample.rs
@@ -129,6 +129,10 @@ impl Operator for GridSample {
         "GridSample"
     }
 
+    fn max_inputs(&self) -> Option<usize> {
+        Some(2)
+    }
+
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let input = ctx.inputs().require_as(0)?;
         let grid = ctx.inputs().require_as(1)?;

--- a/src/ops/identity.rs
+++ b/src/ops/identity.rs
@@ -18,6 +18,10 @@ impl Operator for Identity {
         "Identity"
     }
 
+    fn max_inputs(&self) -> Option<usize> {
+        Some(1)
+    }
+
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let input = ctx.inputs().require(0)?;
         map_value_view!(input, x, { identity(ctx.pool(), x).into_op_result() })

--- a/src/ops/layout.rs
+++ b/src/ops/layout.rs
@@ -68,6 +68,10 @@ impl Operator for DepthToSpace {
         "DepthToSpace"
     }
 
+    fn max_inputs(&self) -> Option<usize> {
+        Some(1)
+    }
+
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let input = ctx.inputs().require_as(0)?;
         depth_to_space::<f32>(ctx.pool(), input, self.block_size, self.mode).into_op_result()
@@ -149,6 +153,10 @@ impl Operator for Expand {
         "Expand"
     }
 
+    fn max_inputs(&self) -> Option<usize> {
+        Some(2)
+    }
+
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let inputs = ctx.inputs();
         let input = inputs.require(0)?;
@@ -219,6 +227,10 @@ pub struct Flatten {
 impl Operator for Flatten {
     fn name(&self) -> &str {
         "Flatten"
+    }
+
+    fn max_inputs(&self) -> Option<usize> {
+        Some(1)
     }
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
@@ -346,6 +358,10 @@ impl Operator for Reshape {
         "Reshape"
     }
 
+    fn max_inputs(&self) -> Option<usize> {
+        Some(2)
+    }
+
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let inputs = ctx.inputs();
         let input = inputs.require(0)?;
@@ -379,6 +395,10 @@ pub struct Shape {
 impl Operator for Shape {
     fn name(&self) -> &str {
         "Shape"
+    }
+
+    fn max_inputs(&self) -> Option<usize> {
+        Some(1)
     }
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
@@ -427,6 +447,10 @@ pub struct Size {}
 impl Operator for Size {
     fn name(&self) -> &str {
         "Size"
+    }
+
+    fn max_inputs(&self) -> Option<usize> {
+        Some(1)
     }
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
@@ -496,6 +520,10 @@ impl Operator for Squeeze {
         "Squeeze"
     }
 
+    fn max_inputs(&self) -> Option<usize> {
+        Some(2)
+    }
+
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let inputs = ctx.inputs();
         let input = inputs.require(0)?;
@@ -551,6 +579,10 @@ impl Operator for Transpose {
         "Transpose"
     }
 
+    fn max_inputs(&self) -> Option<usize> {
+        Some(1)
+    }
+
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let input = ctx.inputs().require(0)?;
         let perm_slice = self.perm.as_deref();
@@ -604,6 +636,10 @@ pub struct Unsqueeze {}
 impl Operator for Unsqueeze {
     fn name(&self) -> &str {
         "Unsqueeze"
+    }
+
+    fn max_inputs(&self) -> Option<usize> {
+        Some(2)
     }
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {

--- a/src/ops/matmul.rs
+++ b/src/ops/matmul.rs
@@ -101,6 +101,10 @@ impl Operator for Gemm {
         "Gemm"
     }
 
+    fn max_inputs(&self) -> Option<usize> {
+        Some(3)
+    }
+
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let inputs = ctx.inputs();
         let a = inputs.require_as(0)?;
@@ -356,6 +360,10 @@ impl Operator for MatMul {
         "MatMul"
     }
 
+    fn max_inputs(&self) -> Option<usize> {
+        Some(2)
+    }
+
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let inputs = ctx.inputs();
         let a = inputs.require_as(0)?;
@@ -414,6 +422,10 @@ pub struct FusedMatMul {
 impl Operator for FusedMatMul {
     fn name(&self) -> &str {
         "FusedMatMul"
+    }
+
+    fn max_inputs(&self) -> Option<usize> {
+        Some(3)
     }
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
@@ -525,6 +537,10 @@ impl Operator for MatMulInteger {
         "MatMulInteger"
     }
 
+    fn max_inputs(&self) -> Option<usize> {
+        Some(4)
+    }
+
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let inputs = ctx.inputs();
         let a = inputs.require(0)?;
@@ -607,6 +623,10 @@ impl Operator for MatMulIntegerToFloat {
         "MatMulIntegerToFloat"
     }
 
+    fn max_inputs(&self) -> Option<usize> {
+        Some(5)
+    }
+
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let output: Tensor<i32> = self.matmul.run(ctx)?.remove(0).try_into().unwrap();
         let scale = ctx.inputs().require_as(4)?;
@@ -679,6 +699,10 @@ pub struct MatMulNBits {
 impl Operator for MatMulNBits {
     fn name(&self) -> &str {
         "MatMulNBits"
+    }
+
+    fn max_inputs(&self) -> Option<usize> {
+        Some(3)
     }
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {

--- a/src/ops/non_max_suppression.rs
+++ b/src/ops/non_max_suppression.rs
@@ -191,6 +191,10 @@ impl Operator for NonMaxSuppression {
         "NonMaxSuppression"
     }
 
+    fn max_inputs(&self) -> Option<usize> {
+        Some(5)
+    }
+
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let inputs = ctx.inputs();
         let boxes = inputs.require_as(0)?;

--- a/src/ops/norm.rs
+++ b/src/ops/norm.rs
@@ -241,6 +241,10 @@ impl Operator for BatchNormalization {
         "BatchNormalization"
     }
 
+    fn max_inputs(&self) -> Option<usize> {
+        Some(5)
+    }
+
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let inputs = ctx.inputs();
         let input = inputs.require_as(0)?;
@@ -325,6 +329,10 @@ pub struct InstanceNormalization {
 impl Operator for InstanceNormalization {
     fn name(&self) -> &str {
         "InstanceNormalization"
+    }
+
+    fn max_inputs(&self) -> Option<usize> {
+        Some(3)
     }
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
@@ -478,6 +486,10 @@ impl Operator for LayerNormalization {
         "LayerNormalization"
     }
 
+    fn max_inputs(&self) -> Option<usize> {
+        Some(3)
+    }
+
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let inputs = ctx.inputs();
         let input = inputs.require_as(0)?;
@@ -505,6 +517,10 @@ pub struct RmsNormalization {
 impl Operator for RmsNormalization {
     fn name(&self) -> &str {
         "RmsNormalization"
+    }
+
+    fn max_inputs(&self) -> Option<usize> {
+        Some(2)
     }
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
@@ -615,6 +631,10 @@ impl Operator for LogSoftmax {
         "LogSoftmax"
     }
 
+    fn max_inputs(&self) -> Option<usize> {
+        Some(1)
+    }
+
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let input = ctx.inputs().require_as(0)?;
         log_softmax(ctx.pool(), input, self.axis).into_op_result()
@@ -652,6 +672,10 @@ pub struct Softmax {
 impl Operator for Softmax {
     fn name(&self) -> &str {
         "Softmax"
+    }
+
+    fn max_inputs(&self) -> Option<usize> {
+        Some(1)
     }
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {

--- a/src/ops/pad.rs
+++ b/src/ops/pad.rs
@@ -262,6 +262,10 @@ impl Operator for Pad {
         "Pad"
     }
 
+    fn max_inputs(&self) -> Option<usize> {
+        Some(4)
+    }
+
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let inputs = ctx.inputs();
         let input = inputs.require(0)?;

--- a/src/ops/pooling.rs
+++ b/src/ops/pooling.rs
@@ -430,6 +430,10 @@ impl Operator for AveragePool {
         "AveragePool"
     }
 
+    fn max_inputs(&self) -> Option<usize> {
+        Some(1)
+    }
+
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let input = ctx.inputs().require_as(0)?;
         average_pool(
@@ -507,6 +511,10 @@ impl Operator for GlobalAveragePool {
         "GlobalAveragePool"
     }
 
+    fn max_inputs(&self) -> Option<usize> {
+        Some(1)
+    }
+
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let input = ctx.inputs().require_as(0)?;
         global_average_pool(ctx.pool(), input).into_op_result()
@@ -545,6 +553,10 @@ pub struct MaxPool {
 impl Operator for MaxPool {
     fn name(&self) -> &str {
         "MaxPool"
+    }
+
+    fn max_inputs(&self) -> Option<usize> {
+        Some(1)
     }
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {

--- a/src/ops/quantize.rs
+++ b/src/ops/quantize.rs
@@ -97,6 +97,10 @@ impl Operator for DequantizeLinear {
         "DequantizeLinear"
     }
 
+    fn max_inputs(&self) -> Option<usize> {
+        Some(3)
+    }
+
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let inputs = ctx.inputs();
         let input = inputs.require(0)?;
@@ -259,6 +263,10 @@ impl Operator for QuantizeLinear {
         "QuantizeLinear"
     }
 
+    fn max_inputs(&self) -> Option<usize> {
+        Some(3)
+    }
+
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let inputs = ctx.inputs();
         let pool = ctx.pool();
@@ -403,6 +411,10 @@ pub struct DynamicQuantizeLinear {}
 impl Operator for DynamicQuantizeLinear {
     fn name(&self) -> &str {
         "DynamicQuantizeLinear"
+    }
+
+    fn max_inputs(&self) -> Option<usize> {
+        Some(1)
     }
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {

--- a/src/ops/random.rs
+++ b/src/ops/random.rs
@@ -24,6 +24,10 @@ impl Operator for RandomUniform {
         "RandomUniform"
     }
 
+    fn max_inputs(&self) -> Option<usize> {
+        Some(0)
+    }
+
     fn is_deterministic(&self) -> bool {
         false
     }
@@ -53,6 +57,10 @@ pub struct RandomUniformLike {
 impl Operator for RandomUniformLike {
     fn name(&self) -> &str {
         "RandomUniformLike"
+    }
+
+    fn max_inputs(&self) -> Option<usize> {
+        Some(1)
     }
 
     fn is_deterministic(&self) -> bool {
@@ -87,6 +95,10 @@ pub struct RandomNormal {
 impl Operator for RandomNormal {
     fn name(&self) -> &str {
         "RandomNormal"
+    }
+
+    fn max_inputs(&self) -> Option<usize> {
+        Some(0)
     }
 
     fn is_deterministic(&self) -> bool {
@@ -130,6 +142,10 @@ impl Operator for RandomNormalLike {
         "RandomNormalLike"
     }
 
+    fn max_inputs(&self) -> Option<usize> {
+        Some(1)
+    }
+
     fn is_deterministic(&self) -> bool {
         false
     }
@@ -154,6 +170,10 @@ pub struct Dropout {
 impl Operator for Dropout {
     fn name(&self) -> &str {
         "Dropout"
+    }
+
+    fn max_inputs(&self) -> Option<usize> {
+        Some(2)
     }
 
     fn is_deterministic(&self) -> bool {

--- a/src/ops/reduce.rs
+++ b/src/ops/reduce.rs
@@ -93,6 +93,10 @@ impl Operator for ArgMax {
         "ArgMax"
     }
 
+    fn max_inputs(&self) -> Option<usize> {
+        Some(1)
+    }
+
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let input = ctx.inputs().require(0)?;
         map_value_view!(input, input, [FloatTensor, Int32Tensor], {
@@ -127,6 +131,10 @@ pub struct ArgMin {
 impl Operator for ArgMin {
     fn name(&self) -> &str {
         "ArgMin"
+    }
+
+    fn max_inputs(&self) -> Option<usize> {
+        Some(1)
     }
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
@@ -174,6 +182,10 @@ impl Operator for CumSum {
         "CumSum"
     }
 
+    fn max_inputs(&self) -> Option<usize> {
+        Some(2)
+    }
+
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let inputs = ctx.inputs();
         let input = inputs.require(0)?;
@@ -218,6 +230,10 @@ pub struct NonZero {}
 impl Operator for NonZero {
     fn name(&self) -> &str {
         "NonZero"
+    }
+
+    fn max_inputs(&self) -> Option<usize> {
+        Some(1)
     }
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
@@ -425,6 +441,10 @@ impl Operator for ReduceMean {
         "ReduceMean"
     }
 
+    fn max_inputs(&self) -> Option<usize> {
+        Some(2)
+    }
+
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let inputs = ctx.inputs();
         let input = inputs.require_as(0)?;
@@ -464,6 +484,10 @@ pub struct ReduceL2 {
 impl Operator for ReduceL2 {
     fn name(&self) -> &str {
         "ReduceL2"
+    }
+
+    fn max_inputs(&self) -> Option<usize> {
+        Some(2)
     }
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
@@ -580,6 +604,10 @@ impl Operator for ReduceMin {
         "ReduceMin"
     }
 
+    fn max_inputs(&self) -> Option<usize> {
+        Some(2)
+    }
+
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let inputs = ctx.inputs();
         let input = inputs.require(0)?;
@@ -625,6 +653,10 @@ impl Operator for ReduceMax {
         "ReduceMax"
     }
 
+    fn max_inputs(&self) -> Option<usize> {
+        Some(2)
+    }
+
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let inputs = ctx.inputs();
         let input = inputs.require(0)?;
@@ -659,6 +691,10 @@ pub struct ReduceProd {
 impl Operator for ReduceProd {
     fn name(&self) -> &str {
         "ReduceProd"
+    }
+
+    fn max_inputs(&self) -> Option<usize> {
+        Some(2)
     }
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
@@ -704,6 +740,10 @@ pub struct ReduceSum {
 impl Operator for ReduceSum {
     fn name(&self) -> &str {
         "ReduceSum"
+    }
+
+    fn max_inputs(&self) -> Option<usize> {
+        Some(2)
     }
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
@@ -752,6 +792,10 @@ pub struct ReduceSumSquare {
 impl Operator for ReduceSumSquare {
     fn name(&self) -> &str {
         "ReduceSumSquare"
+    }
+
+    fn max_inputs(&self) -> Option<usize> {
+        Some(2)
     }
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
@@ -846,6 +890,10 @@ pub struct TopK {
 impl Operator for TopK {
     fn name(&self) -> &str {
         "TopK"
+    }
+
+    fn max_inputs(&self) -> Option<usize> {
+        Some(2)
     }
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {

--- a/src/ops/resize.rs
+++ b/src/ops/resize.rs
@@ -480,6 +480,10 @@ impl Operator for Resize {
         "Resize"
     }
 
+    fn max_inputs(&self) -> Option<usize> {
+        Some(4)
+    }
+
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let inputs = ctx.inputs();
         let input = inputs.require_as(0)?;

--- a/src/ops/rnn.rs
+++ b/src/ops/rnn.rs
@@ -317,6 +317,10 @@ impl Operator for GRU {
         "GRU"
     }
 
+    fn max_inputs(&self) -> Option<usize> {
+        Some(6)
+    }
+
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let inputs = ctx.inputs();
         let input = inputs.require_as(0)?;
@@ -557,6 +561,10 @@ pub fn lstm(
 impl Operator for LSTM {
     fn name(&self) -> &str {
         "LSTM"
+    }
+
+    fn max_inputs(&self) -> Option<usize> {
+        Some(7)
     }
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {

--- a/src/ops/sequence.rs
+++ b/src/ops/sequence.rs
@@ -18,6 +18,10 @@ impl Operator for SequenceEmpty {
         "SequenceEmpty"
     }
 
+    fn max_inputs(&self) -> Option<usize> {
+        Some(0)
+    }
+
     fn run(&self, _ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let dtype = self.dtype.unwrap_or(DataType::Float);
         Value::from(Sequence::new(dtype)).into_op_result()
@@ -30,6 +34,10 @@ pub struct SequenceAt {}
 impl Operator for SequenceAt {
     fn name(&self) -> &str {
         "SequenceAt"
+    }
+
+    fn max_inputs(&self) -> Option<usize> {
+        Some(2)
     }
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
@@ -50,6 +58,10 @@ pub struct SequenceConstruct {}
 impl Operator for SequenceConstruct {
     fn name(&self) -> &str {
         "SequenceConstruct"
+    }
+
+    fn max_inputs(&self) -> Option<usize> {
+        None
     }
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
@@ -98,6 +110,10 @@ pub struct SequenceErase {}
 impl Operator for SequenceErase {
     fn name(&self) -> &str {
         "SequenceErase"
+    }
+
+    fn max_inputs(&self) -> Option<usize> {
+        Some(2)
     }
 
     fn can_run_in_place(&self) -> bool {
@@ -155,6 +171,10 @@ impl Operator for SequenceInsert {
         "SequenceInsert"
     }
 
+    fn max_inputs(&self) -> Option<usize> {
+        Some(3)
+    }
+
     fn can_run_in_place(&self) -> bool {
         true
     }
@@ -184,6 +204,10 @@ impl Operator for SequenceLength {
         "SequenceLength"
     }
 
+    fn max_inputs(&self) -> Option<usize> {
+        Some(1)
+    }
+
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let seq: &Sequence = ctx.inputs().require_as(0)?;
         let len = seq.len() as i32;
@@ -200,6 +224,10 @@ pub struct ConcatFromSequence {
 impl Operator for ConcatFromSequence {
     fn name(&self) -> &str {
         "ConcatFromSequence"
+    }
+
+    fn max_inputs(&self) -> Option<usize> {
+        Some(1)
     }
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
@@ -248,6 +276,10 @@ pub struct SplitToSequence {
 impl Operator for SplitToSequence {
     fn name(&self) -> &str {
         "SplitToSequence"
+    }
+
+    fn max_inputs(&self) -> Option<usize> {
+        Some(2)
     }
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {

--- a/src/ops/slice.rs
+++ b/src/ops/slice.rs
@@ -116,6 +116,10 @@ impl Operator for Slice {
         "Slice"
     }
 
+    fn max_inputs(&self) -> Option<usize> {
+        Some(5)
+    }
+
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let inputs = ctx.inputs();
         let input = inputs.require(0)?;

--- a/src/ops/split.rs
+++ b/src/ops/split.rs
@@ -96,6 +96,10 @@ impl Operator for Split {
         "Split"
     }
 
+    fn max_inputs(&self) -> Option<usize> {
+        Some(2)
+    }
+
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let input = ctx.inputs().require(0)?;
 

--- a/src/ops/transform_inputs.rs
+++ b/src/ops/transform_inputs.rs
@@ -96,6 +96,10 @@ impl Operator for TransformInputs {
         &self.name
     }
 
+    fn max_inputs(&self) -> Option<usize> {
+        self.inner.max_inputs()
+    }
+
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let mut inputs = ctx.inputs().clone();
         for TransformIndex {

--- a/src/ops/trilu.rs
+++ b/src/ops/trilu.rs
@@ -69,6 +69,10 @@ impl Operator for Trilu {
         "Trilu"
     }
 
+    fn max_inputs(&self) -> Option<usize> {
+        Some(2)
+    }
+
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let inputs = ctx.inputs();
         let input = inputs.require(0)?;

--- a/src/ops/unary_elementwise.rs
+++ b/src/ops/unary_elementwise.rs
@@ -122,6 +122,10 @@ macro_rules! impl_operator {
                 stringify!($op_name)
             }
 
+            fn max_inputs(&self) -> Option<usize> {
+                Some(1)
+            }
+
             fn can_run_in_place(&self) -> bool {
                 true
             }
@@ -280,6 +284,10 @@ impl Operator for Clip {
         "Clip"
     }
 
+    fn max_inputs(&self) -> Option<usize> {
+        Some(3)
+    }
+
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let inputs = ctx.inputs();
         let input = inputs.require(0)?;
@@ -418,6 +426,10 @@ impl Operator for IsInf {
         "IsInf"
     }
 
+    fn max_inputs(&self) -> Option<usize> {
+        Some(1)
+    }
+
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let input: TensorView<f32> = ctx.inputs().require_as(0)?;
         let output = input.map_in(ctx.pool(), |x| i32::from(x.is_infinite()));
@@ -431,6 +443,10 @@ pub struct IsNaN {}
 impl Operator for IsNaN {
     fn name(&self) -> &str {
         "IsNaN"
+    }
+
+    fn max_inputs(&self) -> Option<usize> {
+        Some(1)
     }
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
@@ -486,6 +502,10 @@ pub struct Not {}
 impl Operator for Not {
     fn name(&self) -> &str {
         "Not"
+    }
+
+    fn max_inputs(&self) -> Option<usize> {
+        Some(1)
     }
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
@@ -546,6 +566,10 @@ pub struct PRelu {}
 impl Operator for PRelu {
     fn name(&self) -> &str {
         "PRelu"
+    }
+
+    fn max_inputs(&self) -> Option<usize> {
+        Some(2)
     }
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {

--- a/src/ops/variadic_elementwise.rs
+++ b/src/ops/variadic_elementwise.rs
@@ -69,6 +69,10 @@ impl Operator for Max {
         "Max"
     }
 
+    fn max_inputs(&self) -> Option<usize> {
+        None
+    }
+
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let inputs = ctx.inputs();
         let first = inputs.require(0)?;
@@ -91,6 +95,10 @@ pub struct Mean {}
 impl Operator for Mean {
     fn name(&self) -> &str {
         "Mean"
+    }
+
+    fn max_inputs(&self) -> Option<usize> {
+        None
     }
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
@@ -119,6 +127,10 @@ impl Operator for Min {
         "Min"
     }
 
+    fn max_inputs(&self) -> Option<usize> {
+        None
+    }
+
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let inputs = ctx.inputs();
         let first = inputs.require(0)?;
@@ -142,6 +154,10 @@ pub struct Sum {}
 impl Operator for Sum {
     fn name(&self) -> &str {
         "Sum"
+    }
+
+    fn max_inputs(&self) -> Option<usize> {
+        None
     }
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {


### PR DESCRIPTION
Add a required `Operator::max_inputs` method for operators to report how many inputs they support, and check the actual number of inputs against this when loading a model.

For the rten model format, the check happens when the model is loaded rather than when it is converted. This is mainly out of convenience so that it can share logic with the ONNX loader.

If an operator has too _few_ inputs, this is currently only caught during inference. In that case the `Operator::run` impl will return an error.

Fixes https://github.com/robertknight/rten/issues/133