### PR TITLE
Recompile FlatBuffers schema with flatc v25.9.23

### DIFF
--- a/rten-convert/rten_convert/converter.py
+++ b/rten-convert/rten_convert/converter.py
@@ -187,7 +187,7 @@ class PadAttrs(Protocol):
     """Common fields for RTen operator attributes which support padding."""
 
     autoPad: int  # sg.AutoPad
-    pads: list[int]
+    pads: list[int] | None
 
 
 def read_pads(attr_reader: AttributeReader, attrs: PadAttrs) -> None:

--- a/rten-convert/rten_convert/schema_generated.py
+++ b/rten-convert/rten_convert/schema_generated.py
@@ -493,9 +493,13 @@ def ArgMaxAttrsEnd(builder):
 class ArgMaxAttrsT(object):
 
     # ArgMaxAttrsT
-    def __init__(self):
-        self.axis = 0  # type: int
-        self.keepDims = False  # type: bool
+    def __init__(
+        self,
+        axis = 0,
+        keepDims = False,
+    ):
+        self.axis = axis  # type: int
+        self.keepDims = keepDims  # type: bool
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -696,13 +700,21 @@ except:
 class AveragePoolAttrsT(object):
 
     # AveragePoolAttrsT
-    def __init__(self):
-        self.kernelSize = None  # type: List[int]
-        self.autoPad = 0  # type: int
-        self.pads = None  # type: List[int]
-        self.strides = None  # type: List[int]
-        self.countIncludePad = False  # type: bool
-        self.ceilMode = False  # type: bool
+    def __init__(
+        self,
+        kernelSize = None,
+        autoPad = 0,
+        pads = None,
+        strides = None,
+        countIncludePad = False,
+        ceilMode = False,
+    ):
+        self.kernelSize = kernelSize  # type: Optional[List[int]]
+        self.autoPad = autoPad  # type: int
+        self.pads = pads  # type: Optional[List[int]]
+        self.strides = strides  # type: Optional[List[int]]
+        self.countIncludePad = countIncludePad  # type: bool
+        self.ceilMode = ceilMode  # type: bool
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -833,8 +845,11 @@ def BatchNormalizationAttrsEnd(builder):
 class BatchNormalizationAttrsT(object):
 
     # BatchNormalizationAttrsT
-    def __init__(self):
-        self.epsilon = 0.0  # type: float
+    def __init__(
+        self,
+        epsilon = 0.0,
+    ):
+        self.epsilon = epsilon  # type: float
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -910,8 +925,11 @@ def CastAttrsEnd(builder):
 class CastAttrsT(object):
 
     # CastAttrsT
-    def __init__(self):
-        self.to = 0  # type: int
+    def __init__(
+        self,
+        to = 0,
+    ):
+        self.to = to  # type: int
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -977,7 +995,9 @@ def CastLikeAttrsEnd(builder):
 class CastLikeAttrsT(object):
 
     # CastLikeAttrsT
-    def __init__(self):
+    def __init__(
+        self,
+    ):
         pass
 
     @classmethod
@@ -1052,8 +1072,11 @@ def ConcatAttrsEnd(builder):
 class ConcatAttrsT(object):
 
     # ConcatAttrsT
-    def __init__(self):
-        self.axis = 0  # type: int
+    def __init__(
+        self,
+        axis = 0,
+    ):
+        self.axis = axis  # type: int
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -1139,9 +1162,13 @@ def ConcatFromSequenceAttrsEnd(builder):
 class ConcatFromSequenceAttrsT(object):
 
     # ConcatFromSequenceAttrsT
-    def __init__(self):
-        self.axis = 0  # type: int
-        self.newAxis = False  # type: bool
+    def __init__(
+        self,
+        axis = 0,
+        newAxis = False,
+    ):
+        self.axis = axis  # type: int
+        self.newAxis = newAxis  # type: bool
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -1229,9 +1256,13 @@ def DepthToSpaceAttrsEnd(builder):
 class DepthToSpaceAttrsT(object):
 
     # DepthToSpaceAttrsT
-    def __init__(self):
-        self.mode = 0  # type: int
-        self.blockSize = 0  # type: int
+    def __init__(
+        self,
+        mode = 0,
+        blockSize = 0,
+    ):
+        self.mode = mode  # type: int
+        self.blockSize = blockSize  # type: int
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -1305,12 +1336,19 @@ def DropoutAttrsEnd(builder):
     return builder.EndObject()
 
 
+try:
+    from typing import Optional
+except:
+    pass
 
 class DropoutAttrsT(object):
 
     # DropoutAttrsT
-    def __init__(self):
-        self.seed = None  # type: Optional[int]
+    def __init__(
+        self,
+        seed = None,
+    ):
+        self.seed = seed  # type: Optional[int]
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -1392,13 +1430,21 @@ def EyeLikeAttrsEnd(builder):
     return builder.EndObject()
 
 
+try:
+    from typing import Optional
+except:
+    pass
 
 class EyeLikeAttrsT(object):
 
     # EyeLikeAttrsT
-    def __init__(self):
-        self.dtype = None  # type: Optional[int]
-        self.k = 0  # type: int
+    def __init__(
+        self,
+        dtype = None,
+        k = 0,
+    ):
+        self.dtype = dtype  # type: Optional[int]
+        self.k = k  # type: int
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -1466,7 +1512,9 @@ def IsInfAttrsEnd(builder):
 class IsInfAttrsT(object):
 
     # IsInfAttrsT
-    def __init__(self):
+    def __init__(
+        self,
+    ):
         pass
 
     @classmethod
@@ -1541,8 +1589,11 @@ def IntScalarEnd(builder):
 class IntScalarT(object):
 
     # IntScalarT
-    def __init__(self):
-        self.value = 0  # type: int
+    def __init__(
+        self,
+        value = 0,
+    ):
+        self.value = value  # type: int
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -1618,8 +1669,11 @@ def FloatScalarEnd(builder):
 class FloatScalarT(object):
 
     # FloatScalarT
-    def __init__(self):
-        self.value = 0.0  # type: float
+    def __init__(
+        self,
+        value = 0.0,
+    ):
+        self.value = value  # type: float
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -1712,9 +1766,13 @@ except:
 class ConstantOfShapeAttrsT(object):
 
     # ConstantOfShapeAttrsT
-    def __init__(self):
-        self.valueType = 0  # type: int
-        self.value = None  # type: Union[None, IntScalarT, FloatScalarT]
+    def __init__(
+        self,
+        valueType = 0,
+        value = None,
+    ):
+        self.valueType = valueType  # type: int
+        self.value = value  # type: Union[None, 'IntScalarT', 'FloatScalarT']
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -1908,12 +1966,19 @@ except:
 class ConvAttrsT(object):
 
     # ConvAttrsT
-    def __init__(self):
-        self.autoPad = 0  # type: int
-        self.pads = None  # type: List[int]
-        self.groups = 0  # type: int
-        self.strides = None  # type: List[int]
-        self.dilations = None  # type: List[int]
+    def __init__(
+        self,
+        autoPad = 0,
+        pads = None,
+        groups = 0,
+        strides = None,
+        dilations = None,
+    ):
+        self.autoPad = autoPad  # type: int
+        self.pads = pads  # type: Optional[List[int]]
+        self.groups = groups  # type: int
+        self.strides = strides  # type: Optional[List[int]]
+        self.dilations = dilations  # type: Optional[List[int]]
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -2155,12 +2220,19 @@ except:
 class ConvTransposeAttrsT(object):
 
     # ConvTransposeAttrsT
-    def __init__(self):
-        self.strides = None  # type: List[int]
-        self.autoPad = 1  # type: int
-        self.pads = None  # type: List[int]
-        self.groups = 1  # type: int
-        self.outputPadding = None  # type: List[int]
+    def __init__(
+        self,
+        strides = None,
+        autoPad = 1,
+        pads = None,
+        groups = 1,
+        outputPadding = None,
+    ):
+        self.strides = strides  # type: Optional[List[int]]
+        self.autoPad = autoPad  # type: int
+        self.pads = pads  # type: Optional[List[int]]
+        self.groups = groups  # type: int
+        self.outputPadding = outputPadding  # type: Optional[List[int]]
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -2289,8 +2361,11 @@ def DequantizeLinearAttrsEnd(builder):
 class DequantizeLinearAttrsT(object):
 
     # DequantizeLinearAttrsT
-    def __init__(self):
-        self.axis = 0  # type: int
+    def __init__(
+        self,
+        axis = 0,
+    ):
+        self.axis = axis  # type: int
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -2366,8 +2441,11 @@ def EinsumAttrsEnd(builder):
 class EinsumAttrsT(object):
 
     # EinsumAttrsT
-    def __init__(self):
-        self.equation = None  # type: str
+    def __init__(
+        self,
+        equation = None,
+    ):
+        self.equation = equation  # type: Optional[str]
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -2446,8 +2524,11 @@ def EluAttrsEnd(builder):
 class EluAttrsT(object):
 
     # EluAttrsT
-    def __init__(self):
-        self.alpha = 0.0  # type: float
+    def __init__(
+        self,
+        alpha = 0.0,
+    ):
+        self.alpha = alpha  # type: float
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -2523,8 +2604,11 @@ def FlattenAttrsEnd(builder):
 class FlattenAttrsT(object):
 
     # FlattenAttrsT
-    def __init__(self):
-        self.axis = 0  # type: int
+    def __init__(
+        self,
+        axis = 0,
+    ):
+        self.axis = axis  # type: int
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -2610,9 +2694,13 @@ def LayerNormalizationAttrsEnd(builder):
 class LayerNormalizationAttrsT(object):
 
     # LayerNormalizationAttrsT
-    def __init__(self):
-        self.axis = 0  # type: int
-        self.epsilon = 0.0  # type: float
+    def __init__(
+        self,
+        axis = 0,
+        epsilon = 0.0,
+    ):
+        self.axis = axis  # type: int
+        self.epsilon = epsilon  # type: float
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -2697,8 +2785,11 @@ except:
 class LoopAttrsT(object):
 
     # LoopAttrsT
-    def __init__(self):
-        self.body = None  # type: Optional[GraphT]
+    def __init__(
+        self,
+        body = None,
+    ):
+        self.body = body  # type: Optional[GraphT]
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -2778,8 +2869,11 @@ def GatherAttrsEnd(builder):
 class GatherAttrsT(object):
 
     # GatherAttrsT
-    def __init__(self):
-        self.axis = 0  # type: int
+    def __init__(
+        self,
+        axis = 0,
+    ):
+        self.axis = axis  # type: int
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -2855,8 +2949,11 @@ def GatherNDAttrsEnd(builder):
 class GatherNDAttrsT(object):
 
     # GatherNDAttrsT
-    def __init__(self):
-        self.batchDims = 0  # type: int
+    def __init__(
+        self,
+        batchDims = 0,
+    ):
+        self.batchDims = batchDims  # type: int
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -2932,8 +3029,11 @@ def GeluAttrsEnd(builder):
 class GeluAttrsT(object):
 
     # GeluAttrsT
-    def __init__(self):
-        self.approximate = 0  # type: int
+    def __init__(
+        self,
+        approximate = 0,
+    ):
+        self.approximate = approximate  # type: int
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -3039,11 +3139,17 @@ def GemmAttrsEnd(builder):
 class GemmAttrsT(object):
 
     # GemmAttrsT
-    def __init__(self):
-        self.alpha = 0.0  # type: float
-        self.beta = 0.0  # type: float
-        self.transposeA = False  # type: bool
-        self.transposeB = False  # type: bool
+    def __init__(
+        self,
+        alpha = 0.0,
+        beta = 0.0,
+        transposeA = False,
+        transposeB = False,
+    ):
+        self.alpha = alpha  # type: float
+        self.beta = beta  # type: float
+        self.transposeA = transposeA  # type: bool
+        self.transposeB = transposeB  # type: bool
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -3125,8 +3231,11 @@ def GridSampleAttrsEnd(builder):
 class GridSampleAttrsT(object):
 
     # GridSampleAttrsT
-    def __init__(self):
-        self.alignCorners = False  # type: bool
+    def __init__(
+        self,
+        alignCorners = False,
+    ):
+        self.alignCorners = alignCorners  # type: bool
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -3222,10 +3331,15 @@ def GRUAttrsEnd(builder):
 class GRUAttrsT(object):
 
     # GRUAttrsT
-    def __init__(self):
-        self.direction = 0  # type: int
-        self.hiddenSize = 0  # type: int
-        self.linearBeforeReset = False  # type: bool
+    def __init__(
+        self,
+        direction = 0,
+        hiddenSize = 0,
+        linearBeforeReset = False,
+    ):
+        self.direction = direction  # type: int
+        self.hiddenSize = hiddenSize  # type: int
+        self.linearBeforeReset = linearBeforeReset  # type: bool
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -3315,9 +3429,13 @@ def HardSigmoidAttrsEnd(builder):
 class HardSigmoidAttrsT(object):
 
     # HardSigmoidAttrsT
-    def __init__(self):
-        self.alpha = 0.0  # type: float
-        self.beta = 0.0  # type: float
+    def __init__(
+        self,
+        alpha = 0.0,
+        beta = 0.0,
+    ):
+        self.alpha = alpha  # type: float
+        self.beta = beta  # type: float
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -3415,9 +3533,13 @@ except:
 class IfAttrsT(object):
 
     # IfAttrsT
-    def __init__(self):
-        self.thenBranch = None  # type: Optional[GraphT]
-        self.elseBranch = None  # type: Optional[GraphT]
+    def __init__(
+        self,
+        thenBranch = None,
+        elseBranch = None,
+    ):
+        self.thenBranch = thenBranch  # type: Optional[GraphT]
+        self.elseBranch = elseBranch  # type: Optional[GraphT]
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -3503,8 +3625,11 @@ def LeakyReluAttrsEnd(builder):
 class LeakyReluAttrsT(object):
 
     # LeakyReluAttrsT
-    def __init__(self):
-        self.alpha = 0.0  # type: float
+    def __init__(
+        self,
+        alpha = 0.0,
+    ):
+        self.alpha = alpha  # type: float
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -3590,9 +3715,13 @@ def LSTMAttrsEnd(builder):
 class LSTMAttrsT(object):
 
     # LSTMAttrsT
-    def __init__(self):
-        self.direction = 0  # type: int
-        self.hiddenSize = 0  # type: int
+    def __init__(
+        self,
+        direction = 0,
+        hiddenSize = 0,
+    ):
+        self.direction = direction  # type: int
+        self.hiddenSize = hiddenSize  # type: int
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -3783,12 +3912,19 @@ except:
 class MaxPoolAttrsT(object):
 
     # MaxPoolAttrsT
-    def __init__(self):
-        self.kernelSize = None  # type: List[int]
-        self.autoPad = 0  # type: int
-        self.pads = None  # type: List[int]
-        self.strides = None  # type: List[int]
-        self.ceilMode = False  # type: bool
+    def __init__(
+        self,
+        kernelSize = None,
+        autoPad = 0,
+        pads = None,
+        strides = None,
+        ceilMode = False,
+    ):
+        self.kernelSize = kernelSize  # type: Optional[List[int]]
+        self.autoPad = autoPad  # type: int
+        self.pads = pads  # type: Optional[List[int]]
+        self.strides = strides  # type: Optional[List[int]]
+        self.ceilMode = ceilMode  # type: bool
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -3917,8 +4053,11 @@ def ModAttrsEnd(builder):
 class ModAttrsT(object):
 
     # ModAttrsT
-    def __init__(self):
-        self.fmod = False  # type: bool
+    def __init__(
+        self,
+        fmod = False,
+    ):
+        self.fmod = fmod  # type: bool
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -3994,8 +4133,11 @@ def NonMaxSuppressionAttrsEnd(builder):
 class NonMaxSuppressionAttrsT(object):
 
     # NonMaxSuppressionAttrsT
-    def __init__(self):
-        self.boxOrder = 0  # type: int
+    def __init__(
+        self,
+        boxOrder = 0,
+    ):
+        self.boxOrder = boxOrder  # type: int
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -4071,8 +4213,11 @@ def OneHotAttrsEnd(builder):
 class OneHotAttrsT(object):
 
     # OneHotAttrsT
-    def __init__(self):
-        self.axis = 0  # type: int
+    def __init__(
+        self,
+        axis = 0,
+    ):
+        self.axis = axis  # type: int
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -4148,8 +4293,11 @@ def PadAttrsEnd(builder):
 class PadAttrsT(object):
 
     # PadAttrsT
-    def __init__(self):
-        self.mode = 0  # type: int
+    def __init__(
+        self,
+        mode = 0,
+    ):
+        self.mode = mode  # type: int
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -4231,13 +4379,21 @@ def QuantizeLinearAttrsEnd(builder):
     return builder.EndObject()
 
 
+try:
+    from typing import Optional
+except:
+    pass
 
 class QuantizeLinearAttrsT(object):
 
     # QuantizeLinearAttrsT
-    def __init__(self):
-        self.axis = 0  # type: int
-        self.outputDtype = None  # type: Optional[int]
+    def __init__(
+        self,
+        axis = 0,
+        outputDtype = None,
+    ):
+        self.axis = axis  # type: int
+        self.outputDtype = outputDtype  # type: Optional[int]
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -4365,18 +4521,24 @@ def RandomNormalAttrsEnd(builder):
 
 
 try:
-    from typing import List
+    from typing import List, Optional
 except:
     pass
 
 class RandomNormalAttrsT(object):
 
     # RandomNormalAttrsT
-    def __init__(self):
-        self.mean = 0.0  # type: float
-        self.scale = 0.0  # type: float
-        self.seed = None  # type: Optional[float]
-        self.shape = None  # type: List[int]
+    def __init__(
+        self,
+        mean = 0.0,
+        scale = 0.0,
+        seed = None,
+        shape = None,
+    ):
+        self.mean = mean  # type: float
+        self.scale = scale  # type: float
+        self.seed = seed  # type: Optional[float]
+        self.shape = shape  # type: Optional[List[int]]
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -4489,14 +4651,23 @@ def RandomNormalLikeAttrsEnd(builder):
     return builder.EndObject()
 
 
+try:
+    from typing import Optional
+except:
+    pass
 
 class RandomNormalLikeAttrsT(object):
 
     # RandomNormalLikeAttrsT
-    def __init__(self):
-        self.mean = 0.0  # type: float
-        self.scale = 0.0  # type: float
-        self.seed = None  # type: Optional[float]
+    def __init__(
+        self,
+        mean = 0.0,
+        scale = 0.0,
+        seed = None,
+    ):
+        self.mean = mean  # type: float
+        self.scale = scale  # type: float
+        self.seed = seed  # type: Optional[float]
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -4626,18 +4797,24 @@ def RandomUniformAttrsEnd(builder):
 
 
 try:
-    from typing import List
+    from typing import List, Optional
 except:
     pass
 
 class RandomUniformAttrsT(object):
 
     # RandomUniformAttrsT
-    def __init__(self):
-        self.shape = None  # type: List[int]
-        self.high = 0.0  # type: float
-        self.low = 0.0  # type: float
-        self.seed = None  # type: Optional[float]
+    def __init__(
+        self,
+        shape = None,
+        high = 0.0,
+        low = 0.0,
+        seed = None,
+    ):
+        self.shape = shape  # type: Optional[List[int]]
+        self.high = high  # type: float
+        self.low = low  # type: float
+        self.seed = seed  # type: Optional[float]
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -4750,14 +4927,23 @@ def RandomUniformLikeAttrsEnd(builder):
     return builder.EndObject()
 
 
+try:
+    from typing import Optional
+except:
+    pass
 
 class RandomUniformLikeAttrsT(object):
 
     # RandomUniformLikeAttrsT
-    def __init__(self):
-        self.high = 0.0  # type: float
-        self.low = 0.0  # type: float
-        self.seed = None  # type: Optional[float]
+    def __init__(
+        self,
+        high = 0.0,
+        low = 0.0,
+        seed = None,
+    ):
+        self.high = high  # type: float
+        self.low = low  # type: float
+        self.seed = seed  # type: Optional[float]
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -4874,9 +5060,13 @@ except:
 class ReduceMeanAttrsT(object):
 
     # ReduceMeanAttrsT
-    def __init__(self):
-        self.axes = None  # type: List[int]
-        self.keepDims = False  # type: bool
+    def __init__(
+        self,
+        axes = None,
+        keepDims = False,
+    ):
+        self.axes = axes  # type: Optional[List[int]]
+        self.keepDims = keepDims  # type: bool
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -4969,8 +5159,11 @@ def ReshapeAttrsEnd(builder):
 class ReshapeAttrsT(object):
 
     # ReshapeAttrsT
-    def __init__(self):
-        self.allowZero = False  # type: bool
+    def __init__(
+        self,
+        allowZero = False,
+    ):
+        self.allowZero = allowZero  # type: bool
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -5066,10 +5259,15 @@ def ResizeAttrsEnd(builder):
 class ResizeAttrsT(object):
 
     # ResizeAttrsT
-    def __init__(self):
-        self.mode = 0  # type: int
-        self.coordMode = 0  # type: int
-        self.nearestMode = 0  # type: int
+    def __init__(
+        self,
+        mode = 0,
+        coordMode = 0,
+        nearestMode = 0,
+    ):
+        self.mode = mode  # type: int
+        self.coordMode = coordMode  # type: int
+        self.nearestMode = nearestMode  # type: int
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -5159,9 +5357,13 @@ def ScatterElementsAttrsEnd(builder):
 class ScatterElementsAttrsT(object):
 
     # ScatterElementsAttrsT
-    def __init__(self):
-        self.axis = 0  # type: int
-        self.reduction = 0  # type: int
+    def __init__(
+        self,
+        axis = 0,
+        reduction = 0,
+    ):
+        self.axis = axis  # type: int
+        self.reduction = reduction  # type: int
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -5239,8 +5441,11 @@ def ScatterNDAttrsEnd(builder):
 class ScatterNDAttrsT(object):
 
     # ScatterNDAttrsT
-    def __init__(self):
-        self.reduction = 0  # type: int
+    def __init__(
+        self,
+        reduction = 0,
+    ):
+        self.reduction = reduction  # type: int
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -5312,12 +5517,19 @@ def SequenceEmptyAttrsEnd(builder):
     return builder.EndObject()
 
 
+try:
+    from typing import Optional
+except:
+    pass
 
 class SequenceEmptyAttrsT(object):
 
     # SequenceEmptyAttrsT
-    def __init__(self):
-        self.dtype = None  # type: Optional[int]
+    def __init__(
+        self,
+        dtype = None,
+    ):
+        self.dtype = dtype  # type: Optional[int]
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -5399,13 +5611,21 @@ def ShapeAttrsEnd(builder):
     return builder.EndObject()
 
 
+try:
+    from typing import Optional
+except:
+    pass
 
 class ShapeAttrsT(object):
 
     # ShapeAttrsT
-    def __init__(self):
-        self.start = None  # type: Optional[int]
-        self.end = None  # type: Optional[int]
+    def __init__(
+        self,
+        start = None,
+        end = None,
+    ):
+        self.start = start  # type: Optional[int]
+        self.end = end  # type: Optional[int]
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -5483,8 +5703,11 @@ def SoftmaxAttrsEnd(builder):
 class SoftmaxAttrsT(object):
 
     # SoftmaxAttrsT
-    def __init__(self):
-        self.axis = 0  # type: int
+    def __init__(
+        self,
+        axis = 0,
+    ):
+        self.axis = axis  # type: int
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -5566,13 +5789,21 @@ def SplitAttrsEnd(builder):
     return builder.EndObject()
 
 
+try:
+    from typing import Optional
+except:
+    pass
 
 class SplitAttrsT(object):
 
     # SplitAttrsT
-    def __init__(self):
-        self.axis = 0  # type: int
-        self.numOutputs = None  # type: Optional[int]
+    def __init__(
+        self,
+        axis = 0,
+        numOutputs = None,
+    ):
+        self.axis = axis  # type: int
+        self.numOutputs = numOutputs  # type: Optional[int]
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -5660,9 +5891,13 @@ def SplitToSequenceAttrsEnd(builder):
 class SplitToSequenceAttrsT(object):
 
     # SplitToSequenceAttrsT
-    def __init__(self):
-        self.axis = 0  # type: int
-        self.keepDims = True  # type: bool
+    def __init__(
+        self,
+        axis = 0,
+        keepDims = True,
+    ):
+        self.axis = axis  # type: int
+        self.keepDims = keepDims  # type: bool
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -5740,8 +5975,11 @@ def STFTAttrsEnd(builder):
 class STFTAttrsT(object):
 
     # STFTAttrsT
-    def __init__(self):
-        self.onesided = True  # type: bool
+    def __init__(
+        self,
+        onesided = True,
+    ):
+        self.onesided = onesided  # type: bool
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -5837,10 +6075,15 @@ def TopKAttrsEnd(builder):
 class TopKAttrsT(object):
 
     # TopKAttrsT
-    def __init__(self):
-        self.axis = 0  # type: int
-        self.largest = False  # type: bool
-        self.sorted = False  # type: bool
+    def __init__(
+        self,
+        axis = 0,
+        largest = False,
+        sorted = False,
+    ):
+        self.axis = axis  # type: int
+        self.largest = largest  # type: bool
+        self.sorted = sorted  # type: bool
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -5947,8 +6190,11 @@ except:
 class TransposeAttrsT(object):
 
     # TransposeAttrsT
-    def __init__(self):
-        self.perm = None  # type: List[int]
+    def __init__(
+        self,
+        perm = None,
+    ):
+        self.perm = perm  # type: Optional[List[int]]
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -6039,8 +6285,11 @@ def TriluAttrsEnd(builder):
 class TriluAttrsT(object):
 
     # TriluAttrsT
-    def __init__(self):
-        self.upper = False  # type: bool
+    def __init__(
+        self,
+        upper = False,
+    ):
+        self.upper = upper  # type: bool
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -6209,12 +6458,19 @@ except:
 class OperatorNodeT(object):
 
     # OperatorNodeT
-    def __init__(self):
-        self.type = 0  # type: int
-        self.attrsType = 0  # type: int
-        self.attrs = None  # type: Union[None, ArgMaxAttrsT, AveragePoolAttrsT, BatchNormalizationAttrsT, CastAttrsT, ConcatAttrsT, ConstantOfShapeAttrsT, ConvAttrsT, ConvTransposeAttrsT, FlattenAttrsT, GatherAttrsT, GemmAttrsT, GRUAttrsT, LeakyReluAttrsT, LSTMAttrsT, MaxPoolAttrsT, ReduceMeanAttrsT, ReshapeAttrsT, ResizeAttrsT, SplitAttrsT, SoftmaxAttrsT, TransposeAttrsT, ModAttrsT, ScatterElementsAttrsT, OneHotAttrsT, TopKAttrsT, HardSigmoidAttrsT, TriluAttrsT, ScatterNDAttrsT, NonMaxSuppressionAttrsT, LayerNormalizationAttrsT, RandomUniformAttrsT, EluAttrsT, RandomUniformLikeAttrsT, RandomNormalAttrsT, RandomNormalLikeAttrsT, GatherNDAttrsT, GeluAttrsT, EinsumAttrsT, IfAttrsT, PadAttrsT, DequantizeLinearAttrsT, QuantizeLinearAttrsT, DepthToSpaceAttrsT, CastLikeAttrsT, ShapeAttrsT, DropoutAttrsT, EyeLikeAttrsT, IsInfAttrsT, LoopAttrsT, SequenceEmptyAttrsT, ConcatFromSequenceAttrsT, SplitToSequenceAttrsT, GridSampleAttrsT, STFTAttrsT]
-        self.inputs = None  # type: List[int]
-        self.outputs = None  # type: List[int]
+    def __init__(
+        self,
+        type = 0,
+        attrsType = 0,
+        attrs = None,
+        inputs = None,
+        outputs = None,
+    ):
+        self.type = type  # type: int
+        self.attrsType = attrsType  # type: int
+        self.attrs = attrs  # type: Union[None, 'ArgMaxAttrsT', 'AveragePoolAttrsT', 'BatchNormalizationAttrsT', 'CastAttrsT', 'ConcatAttrsT', 'ConstantOfShapeAttrsT', 'ConvAttrsT', 'ConvTransposeAttrsT', 'FlattenAttrsT', 'GatherAttrsT', 'GemmAttrsT', 'GRUAttrsT', 'LeakyReluAttrsT', 'LSTMAttrsT', 'MaxPoolAttrsT', 'ReduceMeanAttrsT', 'ReshapeAttrsT', 'ResizeAttrsT', 'SplitAttrsT', 'SoftmaxAttrsT', 'TransposeAttrsT', 'ModAttrsT', 'ScatterElementsAttrsT', 'OneHotAttrsT', 'TopKAttrsT', 'HardSigmoidAttrsT', 'TriluAttrsT', 'ScatterNDAttrsT', 'NonMaxSuppressionAttrsT', 'LayerNormalizationAttrsT', 'RandomUniformAttrsT', 'EluAttrsT', 'RandomUniformLikeAttrsT', 'RandomNormalAttrsT', 'RandomNormalLikeAttrsT', 'GatherNDAttrsT', 'GeluAttrsT', 'EinsumAttrsT', 'IfAttrsT', 'PadAttrsT', 'DequantizeLinearAttrsT', 'QuantizeLinearAttrsT', 'DepthToSpaceAttrsT', 'CastLikeAttrsT', 'ShapeAttrsT', 'DropoutAttrsT', 'EyeLikeAttrsT', 'IsInfAttrsT', 'LoopAttrsT', 'SequenceEmptyAttrsT', 'ConcatFromSequenceAttrsT', 'SplitToSequenceAttrsT', 'GridSampleAttrsT', 'STFTAttrsT']
+        self.inputs = inputs  # type: Optional[List[int]]
+        self.outputs = outputs  # type: Optional[List[int]]
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -6358,8 +6614,11 @@ except:
 class FloatDataT(object):
 
     # FloatDataT
-    def __init__(self):
-        self.data = None  # type: List[float]
+    def __init__(
+        self,
+        data = None,
+    ):
+        self.data = data  # type: Optional[List[float]]
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -6477,8 +6736,11 @@ except:
 class Int8DataT(object):
 
     # Int8DataT
-    def __init__(self):
-        self.data = None  # type: List[int]
+    def __init__(
+        self,
+        data = None,
+    ):
+        self.data = data  # type: Optional[List[int]]
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -6596,8 +6858,11 @@ except:
 class Int32DataT(object):
 
     # Int32DataT
-    def __init__(self):
-        self.data = None  # type: List[int]
+    def __init__(
+        self,
+        data = None,
+    ):
+        self.data = data  # type: Optional[List[int]]
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -6715,8 +6980,11 @@ except:
 class UInt8DataT(object):
 
     # UInt8DataT
-    def __init__(self):
-        self.data = None  # type: List[int]
+    def __init__(
+        self,
+        data = None,
+    ):
+        self.data = data  # type: Optional[List[int]]
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -6870,19 +7138,26 @@ def ConstantNodeEnd(builder):
 
 
 try:
-    from typing import List, Union
+    from typing import List, Optional, Union
 except:
     pass
 
 class ConstantNodeT(object):
 
     # ConstantNodeT
-    def __init__(self):
-        self.shape = None  # type: List[int]
-        self.dataType = 0  # type: int
-        self.data = None  # type: Union[None, FloatDataT, Int32DataT, Int8DataT, UInt8DataT]
-        self.dtype = None  # type: Optional[int]
-        self.dataOffset = None  # type: Optional[int]
+    def __init__(
+        self,
+        shape = None,
+        dataType = 0,
+        data = None,
+        dtype = None,
+        dataOffset = None,
+    ):
+        self.shape = shape  # type: Optional[List[int]]
+        self.dataType = dataType  # type: int
+        self.data = data  # type: Union[None, 'FloatDataT', 'Int32DataT', 'Int8DataT', 'UInt8DataT']
+        self.dtype = dtype  # type: Optional[int]
+        self.dataOffset = dataOffset  # type: Optional[int]
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -6994,9 +7269,13 @@ def DimEnd(builder):
 class DimT(object):
 
     # DimT
-    def __init__(self):
-        self.value = 0  # type: int
-        self.name = None  # type: str
+    def __init__(
+        self,
+        value = 0,
+        name = None,
+    ):
+        self.value = value  # type: int
+        self.name = name  # type: Optional[str]
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -7104,16 +7383,20 @@ def ValueNodeEnd(builder):
 
 
 try:
-    from typing import List
+    from typing import List, Optional
 except:
     pass
 
 class ValueNodeT(object):
 
     # ValueNodeT
-    def __init__(self):
-        self.shape = None  # type: List[DimT]
-        self.dtype = None  # type: Optional[int]
+    def __init__(
+        self,
+        shape = None,
+        dtype = None,
+    ):
+        self.shape = shape  # type: Optional[List[DimT]]
+        self.dtype = dtype  # type: Optional[int]
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -7234,10 +7517,15 @@ except:
 class NodeT(object):
 
     # NodeT
-    def __init__(self):
-        self.name = None  # type: str
-        self.dataType = 0  # type: int
-        self.data = None  # type: Union[None, OperatorNodeT, ConstantNodeT, ValueNodeT]
+    def __init__(
+        self,
+        name = None,
+        dataType = 0,
+        data = None,
+    ):
+        self.name = name  # type: Optional[str]
+        self.dataType = dataType  # type: int
+        self.data = data  # type: Union[None, 'OperatorNodeT', 'ConstantNodeT', 'ValueNodeT']
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -7446,11 +7734,17 @@ except:
 class GraphT(object):
 
     # GraphT
-    def __init__(self):
-        self.nodes = None  # type: List[NodeT]
-        self.inputs = None  # type: List[int]
-        self.outputs = None  # type: List[int]
-        self.captures = None  # type: List[int]
+    def __init__(
+        self,
+        nodes = None,
+        inputs = None,
+        outputs = None,
+        captures = None,
+    ):
+        self.nodes = nodes  # type: Optional[List[NodeT]]
+        self.inputs = inputs  # type: Optional[List[int]]
+        self.outputs = outputs  # type: Optional[List[int]]
+        self.captures = captures  # type: Optional[List[int]]
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -7663,15 +7957,25 @@ def MetadataEnd(builder):
 class MetadataT(object):
 
     # MetadataT
-    def __init__(self):
-        self.onnxHash = None  # type: str
-        self.description = None  # type: str
-        self.license = None  # type: str
-        self.commit = None  # type: str
-        self.codeRepository = None  # type: str
-        self.modelRepository = None  # type: str
-        self.runId = None  # type: str
-        self.runUrl = None  # type: str
+    def __init__(
+        self,
+        onnxHash = None,
+        description = None,
+        license = None,
+        commit = None,
+        codeRepository = None,
+        modelRepository = None,
+        runId = None,
+        runUrl = None,
+    ):
+        self.onnxHash = onnxHash  # type: Optional[str]
+        self.description = description  # type: Optional[str]
+        self.license = license  # type: Optional[str]
+        self.commit = commit  # type: Optional[str]
+        self.codeRepository = codeRepository  # type: Optional[str]
+        self.modelRepository = modelRepository  # type: Optional[str]
+        self.runId = runId  # type: Optional[str]
+        self.runUrl = runUrl  # type: Optional[str]
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -7815,10 +8119,15 @@ except:
 class ModelT(object):
 
     # ModelT
-    def __init__(self):
-        self.schemaVersion = 0  # type: int
-        self.graph = None  # type: Optional[GraphT]
-        self.metadata = None  # type: Optional[MetadataT]
+    def __init__(
+        self,
+        schemaVersion = 0,
+        graph = None,
+        metadata = None,
+    ):
+        self.schemaVersion = schemaVersion  # type: int
+        self.graph = graph  # type: Optional[GraphT]
+        self.metadata = metadata  # type: Optional[MetadataT]
 
     @classmethod
     def InitFromBuf(cls, buf, pos):

--- a/rten-model-file/src/lib.rs
+++ b/rten-model-file/src/lib.rs
@@ -14,11 +14,10 @@
 ///
 /// See `schema.fbs` for the FlatBuffers source.
 #[allow(
-    clippy::all,
-    dead_code,
-    unused_imports,
+    clippy::extra_unused_lifetimes,
+    clippy::missing_safety_doc,
     mismatched_lifetime_syntaxes,
-    unsafe_op_in_unsafe_fn
+    unused_imports
 )]
 pub mod schema_generated;
 

--- a/rten-model-file/src/schema_generated.rs
+++ b/rten-model-file/src/schema_generated.rs
@@ -568,7 +568,7 @@ impl<'a> flatbuffers::Follow<'a> for OperatorType {
     type Inner = Self;
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-        let b = flatbuffers::read_scalar_at::<u8>(buf, loc);
+        let b = unsafe { flatbuffers::read_scalar_at::<u8>(buf, loc) };
         Self(b)
     }
 }
@@ -577,7 +577,9 @@ impl flatbuffers::Push for OperatorType {
     type Output = OperatorType;
     #[inline]
     unsafe fn push(&self, dst: &mut [u8], _written_len: usize) {
-        flatbuffers::emplace_scalar::<u8>(dst, self.0);
+        unsafe {
+            flatbuffers::emplace_scalar::<u8>(dst, self.0);
+        }
     }
 }
 
@@ -663,7 +665,7 @@ impl<'a> flatbuffers::Follow<'a> for RNNDirection {
     type Inner = Self;
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-        let b = flatbuffers::read_scalar_at::<u8>(buf, loc);
+        let b = unsafe { flatbuffers::read_scalar_at::<u8>(buf, loc) };
         Self(b)
     }
 }
@@ -672,7 +674,9 @@ impl flatbuffers::Push for RNNDirection {
     type Output = RNNDirection;
     #[inline]
     unsafe fn push(&self, dst: &mut [u8], _written_len: usize) {
-        flatbuffers::emplace_scalar::<u8>(dst, self.0);
+        unsafe {
+            flatbuffers::emplace_scalar::<u8>(dst, self.0);
+        }
     }
 }
 
@@ -752,7 +756,7 @@ impl<'a> flatbuffers::Follow<'a> for AutoPad {
     type Inner = Self;
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-        let b = flatbuffers::read_scalar_at::<u8>(buf, loc);
+        let b = unsafe { flatbuffers::read_scalar_at::<u8>(buf, loc) };
         Self(b)
     }
 }
@@ -761,7 +765,9 @@ impl flatbuffers::Push for AutoPad {
     type Output = AutoPad;
     #[inline]
     unsafe fn push(&self, dst: &mut [u8], _written_len: usize) {
-        flatbuffers::emplace_scalar::<u8>(dst, self.0);
+        unsafe {
+            flatbuffers::emplace_scalar::<u8>(dst, self.0);
+        }
     }
 }
 
@@ -850,7 +856,7 @@ impl<'a> flatbuffers::Follow<'a> for DataType {
     type Inner = Self;
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-        let b = flatbuffers::read_scalar_at::<u8>(buf, loc);
+        let b = unsafe { flatbuffers::read_scalar_at::<u8>(buf, loc) };
         Self(b)
     }
 }
@@ -859,7 +865,9 @@ impl flatbuffers::Push for DataType {
     type Output = DataType;
     #[inline]
     unsafe fn push(&self, dst: &mut [u8], _written_len: usize) {
-        flatbuffers::emplace_scalar::<u8>(dst, self.0);
+        unsafe {
+            flatbuffers::emplace_scalar::<u8>(dst, self.0);
+        }
     }
 }
 
@@ -953,7 +961,7 @@ impl<'a> flatbuffers::Follow<'a> for CoordTransformMode {
     type Inner = Self;
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-        let b = flatbuffers::read_scalar_at::<u8>(buf, loc);
+        let b = unsafe { flatbuffers::read_scalar_at::<u8>(buf, loc) };
         Self(b)
     }
 }
@@ -962,7 +970,9 @@ impl flatbuffers::Push for CoordTransformMode {
     type Output = CoordTransformMode;
     #[inline]
     unsafe fn push(&self, dst: &mut [u8], _written_len: usize) {
-        flatbuffers::emplace_scalar::<u8>(dst, self.0);
+        unsafe {
+            flatbuffers::emplace_scalar::<u8>(dst, self.0);
+        }
     }
 }
 
@@ -1056,7 +1066,7 @@ impl<'a> flatbuffers::Follow<'a> for NearestMode {
     type Inner = Self;
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-        let b = flatbuffers::read_scalar_at::<u8>(buf, loc);
+        let b = unsafe { flatbuffers::read_scalar_at::<u8>(buf, loc) };
         Self(b)
     }
 }
@@ -1065,7 +1075,9 @@ impl flatbuffers::Push for NearestMode {
     type Output = NearestMode;
     #[inline]
     unsafe fn push(&self, dst: &mut [u8], _written_len: usize) {
-        flatbuffers::emplace_scalar::<u8>(dst, self.0);
+        unsafe {
+            flatbuffers::emplace_scalar::<u8>(dst, self.0);
+        }
     }
 }
 
@@ -1145,7 +1157,7 @@ impl<'a> flatbuffers::Follow<'a> for ResizeMode {
     type Inner = Self;
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-        let b = flatbuffers::read_scalar_at::<u8>(buf, loc);
+        let b = unsafe { flatbuffers::read_scalar_at::<u8>(buf, loc) };
         Self(b)
     }
 }
@@ -1154,7 +1166,9 @@ impl flatbuffers::Push for ResizeMode {
     type Output = ResizeMode;
     #[inline]
     unsafe fn push(&self, dst: &mut [u8], _written_len: usize) {
-        flatbuffers::emplace_scalar::<u8>(dst, self.0);
+        unsafe {
+            flatbuffers::emplace_scalar::<u8>(dst, self.0);
+        }
     }
 }
 
@@ -1452,7 +1466,7 @@ impl<'a> flatbuffers::Follow<'a> for OperatorAttrs {
     type Inner = Self;
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-        let b = flatbuffers::read_scalar_at::<u8>(buf, loc);
+        let b = unsafe { flatbuffers::read_scalar_at::<u8>(buf, loc) };
         Self(b)
     }
 }
@@ -1461,7 +1475,9 @@ impl flatbuffers::Push for OperatorAttrs {
     type Output = OperatorAttrs;
     #[inline]
     unsafe fn push(&self, dst: &mut [u8], _written_len: usize) {
-        flatbuffers::emplace_scalar::<u8>(dst, self.0);
+        unsafe {
+            flatbuffers::emplace_scalar::<u8>(dst, self.0);
+        }
     }
 }
 
@@ -1544,7 +1560,7 @@ impl<'a> flatbuffers::Follow<'a> for DepthToSpaceMode {
     type Inner = Self;
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-        let b = flatbuffers::read_scalar_at::<u8>(buf, loc);
+        let b = unsafe { flatbuffers::read_scalar_at::<u8>(buf, loc) };
         Self(b)
     }
 }
@@ -1553,7 +1569,9 @@ impl flatbuffers::Push for DepthToSpaceMode {
     type Output = DepthToSpaceMode;
     #[inline]
     unsafe fn push(&self, dst: &mut [u8], _written_len: usize) {
-        flatbuffers::emplace_scalar::<u8>(dst, self.0);
+        unsafe {
+            flatbuffers::emplace_scalar::<u8>(dst, self.0);
+        }
     }
 }
 
@@ -1635,7 +1653,7 @@ impl<'a> flatbuffers::Follow<'a> for Scalar {
     type Inner = Self;
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-        let b = flatbuffers::read_scalar_at::<u8>(buf, loc);
+        let b = unsafe { flatbuffers::read_scalar_at::<u8>(buf, loc) };
         Self(b)
     }
 }
@@ -1644,7 +1662,9 @@ impl flatbuffers::Push for Scalar {
     type Output = Scalar;
     #[inline]
     unsafe fn push(&self, dst: &mut [u8], _written_len: usize) {
-        flatbuffers::emplace_scalar::<u8>(dst, self.0);
+        unsafe {
+            flatbuffers::emplace_scalar::<u8>(dst, self.0);
+        }
     }
 }
 
@@ -1727,7 +1747,7 @@ impl<'a> flatbuffers::Follow<'a> for GeluApproximation {
     type Inner = Self;
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-        let b = flatbuffers::read_scalar_at::<u8>(buf, loc);
+        let b = unsafe { flatbuffers::read_scalar_at::<u8>(buf, loc) };
         Self(b)
     }
 }
@@ -1736,7 +1756,9 @@ impl flatbuffers::Push for GeluApproximation {
     type Output = GeluApproximation;
     #[inline]
     unsafe fn push(&self, dst: &mut [u8], _written_len: usize) {
-        flatbuffers::emplace_scalar::<u8>(dst, self.0);
+        unsafe {
+            flatbuffers::emplace_scalar::<u8>(dst, self.0);
+        }
     }
 }
 
@@ -1819,7 +1841,7 @@ impl<'a> flatbuffers::Follow<'a> for NMSBoxOrder {
     type Inner = Self;
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-        let b = flatbuffers::read_scalar_at::<u8>(buf, loc);
+        let b = unsafe { flatbuffers::read_scalar_at::<u8>(buf, loc) };
         Self(b)
     }
 }
@@ -1828,7 +1850,9 @@ impl flatbuffers::Push for NMSBoxOrder {
     type Output = NMSBoxOrder;
     #[inline]
     unsafe fn push(&self, dst: &mut [u8], _written_len: usize) {
-        flatbuffers::emplace_scalar::<u8>(dst, self.0);
+        unsafe {
+            flatbuffers::emplace_scalar::<u8>(dst, self.0);
+        }
     }
 }
 
@@ -1918,7 +1942,7 @@ impl<'a> flatbuffers::Follow<'a> for PadMode {
     type Inner = Self;
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-        let b = flatbuffers::read_scalar_at::<u8>(buf, loc);
+        let b = unsafe { flatbuffers::read_scalar_at::<u8>(buf, loc) };
         Self(b)
     }
 }
@@ -1927,7 +1951,9 @@ impl flatbuffers::Push for PadMode {
     type Output = PadMode;
     #[inline]
     unsafe fn push(&self, dst: &mut [u8], _written_len: usize) {
-        flatbuffers::emplace_scalar::<u8>(dst, self.0);
+        unsafe {
+            flatbuffers::emplace_scalar::<u8>(dst, self.0);
+        }
     }
 }
 
@@ -2020,7 +2046,7 @@ impl<'a> flatbuffers::Follow<'a> for ScatterReduction {
     type Inner = Self;
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-        let b = flatbuffers::read_scalar_at::<u8>(buf, loc);
+        let b = unsafe { flatbuffers::read_scalar_at::<u8>(buf, loc) };
         Self(b)
     }
 }
@@ -2029,7 +2055,9 @@ impl flatbuffers::Push for ScatterReduction {
     type Output = ScatterReduction;
     #[inline]
     unsafe fn push(&self, dst: &mut [u8], _written_len: usize) {
-        flatbuffers::emplace_scalar::<u8>(dst, self.0);
+        unsafe {
+            flatbuffers::emplace_scalar::<u8>(dst, self.0);
+        }
     }
 }
 
@@ -2123,7 +2151,7 @@ impl<'a> flatbuffers::Follow<'a> for NodeKind {
     type Inner = Self;
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-        let b = flatbuffers::read_scalar_at::<u8>(buf, loc);
+        let b = unsafe { flatbuffers::read_scalar_at::<u8>(buf, loc) };
         Self(b)
     }
 }
@@ -2132,7 +2160,9 @@ impl flatbuffers::Push for NodeKind {
     type Output = NodeKind;
     #[inline]
     unsafe fn push(&self, dst: &mut [u8], _written_len: usize) {
-        flatbuffers::emplace_scalar::<u8>(dst, self.0);
+        unsafe {
+            flatbuffers::emplace_scalar::<u8>(dst, self.0);
+        }
     }
 }
 
@@ -2232,7 +2262,7 @@ impl<'a> flatbuffers::Follow<'a> for ConstantData {
     type Inner = Self;
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-        let b = flatbuffers::read_scalar_at::<u8>(buf, loc);
+        let b = unsafe { flatbuffers::read_scalar_at::<u8>(buf, loc) };
         Self(b)
     }
 }
@@ -2241,7 +2271,9 @@ impl flatbuffers::Push for ConstantData {
     type Output = ConstantData;
     #[inline]
     unsafe fn push(&self, dst: &mut [u8], _written_len: usize) {
-        flatbuffers::emplace_scalar::<u8>(dst, self.0);
+        unsafe {
+            flatbuffers::emplace_scalar::<u8>(dst, self.0);
+        }
     }
 }
 
@@ -2332,7 +2364,7 @@ impl<'a> flatbuffers::Follow<'a> for ConstantDataType {
     type Inner = Self;
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
-        let b = flatbuffers::read_scalar_at::<u16>(buf, loc);
+        let b = unsafe { flatbuffers::read_scalar_at::<u16>(buf, loc) };
         Self(b)
     }
 }
@@ -2341,7 +2373,9 @@ impl flatbuffers::Push for ConstantDataType {
     type Output = ConstantDataType;
     #[inline]
     unsafe fn push(&self, dst: &mut [u8], _written_len: usize) {
-        flatbuffers::emplace_scalar::<u16>(dst, self.0);
+        unsafe {
+            flatbuffers::emplace_scalar::<u16>(dst, self.0);
+        }
     }
 }
 
@@ -2383,7 +2417,7 @@ impl<'a> flatbuffers::Follow<'a> for ArgMaxAttrs<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -2506,7 +2540,7 @@ impl<'a> flatbuffers::Follow<'a> for AveragePoolAttrs<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -2757,7 +2791,7 @@ impl<'a> flatbuffers::Follow<'a> for BatchNormalizationAttrs<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -2861,7 +2895,7 @@ impl<'a> flatbuffers::Follow<'a> for CastAttrs<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -2965,7 +2999,7 @@ impl<'a> flatbuffers::Follow<'a> for CastLikeAttrs<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -3044,7 +3078,7 @@ impl<'a> flatbuffers::Follow<'a> for ConcatAttrs<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -3143,7 +3177,7 @@ impl<'a> flatbuffers::Follow<'a> for ConcatFromSequenceAttrs<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -3271,7 +3305,7 @@ impl<'a> flatbuffers::Follow<'a> for DepthToSpaceAttrs<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -3402,7 +3436,7 @@ impl<'a> flatbuffers::Follow<'a> for DropoutAttrs<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -3504,7 +3538,7 @@ impl<'a> flatbuffers::Follow<'a> for EyeLikeAttrs<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -3622,7 +3656,7 @@ impl<'a> flatbuffers::Follow<'a> for IsInfAttrs<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -3701,7 +3735,7 @@ impl<'a> flatbuffers::Follow<'a> for IntScalar<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -3798,7 +3832,7 @@ impl<'a> flatbuffers::Follow<'a> for FloatScalar<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -3902,7 +3936,7 @@ impl<'a> flatbuffers::Follow<'a> for ConstantOfShapeAttrs<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -4110,7 +4144,7 @@ impl<'a> flatbuffers::Follow<'a> for ConvAttrs<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -4324,7 +4358,7 @@ impl<'a> flatbuffers::Follow<'a> for ConvTransposeAttrs<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -4547,7 +4581,7 @@ impl<'a> flatbuffers::Follow<'a> for DequantizeLinearAttrs<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -4651,7 +4685,7 @@ impl<'a> flatbuffers::Follow<'a> for EinsumAttrs<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -4760,7 +4794,7 @@ impl<'a> flatbuffers::Follow<'a> for EluAttrs<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -4857,7 +4891,7 @@ impl<'a> flatbuffers::Follow<'a> for FlattenAttrs<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -4960,7 +4994,7 @@ impl<'a> flatbuffers::Follow<'a> for LayerNormalizationAttrs<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -5088,7 +5122,7 @@ impl<'a> flatbuffers::Follow<'a> for LoopAttrs<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -5191,7 +5225,7 @@ impl<'a> flatbuffers::Follow<'a> for GatherAttrs<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -5290,7 +5324,7 @@ impl<'a> flatbuffers::Follow<'a> for GatherNDAttrs<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -5394,7 +5428,7 @@ impl<'a> flatbuffers::Follow<'a> for GeluAttrs<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -5501,7 +5535,7 @@ impl<'a> flatbuffers::Follow<'a> for GemmAttrs<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -5665,7 +5699,7 @@ impl<'a> flatbuffers::Follow<'a> for GridSampleAttrs<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -5771,7 +5805,7 @@ impl<'a> flatbuffers::Follow<'a> for GRUAttrs<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -5922,7 +5956,7 @@ impl<'a> flatbuffers::Follow<'a> for HardSigmoidAttrs<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -6050,7 +6084,7 @@ impl<'a> flatbuffers::Follow<'a> for IfAttrs<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -6190,7 +6224,7 @@ impl<'a> flatbuffers::Follow<'a> for LeakyReluAttrs<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -6294,7 +6328,7 @@ impl<'a> flatbuffers::Follow<'a> for LSTMAttrs<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -6423,7 +6457,7 @@ impl<'a> flatbuffers::Follow<'a> for MaxPoolAttrs<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -6649,7 +6683,7 @@ impl<'a> flatbuffers::Follow<'a> for ModAttrs<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -6750,7 +6784,7 @@ impl<'a> flatbuffers::Follow<'a> for NonMaxSuppressionAttrs<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -6862,7 +6896,7 @@ impl<'a> flatbuffers::Follow<'a> for OneHotAttrs<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -6961,7 +6995,7 @@ impl<'a> flatbuffers::Follow<'a> for PadAttrs<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -7065,7 +7099,7 @@ impl<'a> flatbuffers::Follow<'a> for QuantizeLinearAttrs<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -7194,7 +7228,7 @@ impl<'a> flatbuffers::Follow<'a> for RandomNormalAttrs<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -7372,7 +7406,7 @@ impl<'a> flatbuffers::Follow<'a> for RandomNormalLikeAttrs<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -7520,7 +7554,7 @@ impl<'a> flatbuffers::Follow<'a> for RandomUniformAttrs<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -7698,7 +7732,7 @@ impl<'a> flatbuffers::Follow<'a> for RandomUniformLikeAttrs<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -7846,7 +7880,7 @@ impl<'a> flatbuffers::Follow<'a> for ReduceMeanAttrs<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -7982,7 +8016,7 @@ impl<'a> flatbuffers::Follow<'a> for ReshapeAttrs<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -8086,7 +8120,7 @@ impl<'a> flatbuffers::Follow<'a> for ResizeAttrs<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -8245,7 +8279,7 @@ impl<'a> flatbuffers::Follow<'a> for ScatterElementsAttrs<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -8379,7 +8413,7 @@ impl<'a> flatbuffers::Follow<'a> for ScatterNDAttrs<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -8488,7 +8522,7 @@ impl<'a> flatbuffers::Follow<'a> for SequenceEmptyAttrs<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -8593,7 +8627,7 @@ impl<'a> flatbuffers::Follow<'a> for ShapeAttrs<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -8716,7 +8750,7 @@ impl<'a> flatbuffers::Follow<'a> for SoftmaxAttrs<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -8819,7 +8853,7 @@ impl<'a> flatbuffers::Follow<'a> for SplitAttrs<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -8940,7 +8974,7 @@ impl<'a> flatbuffers::Follow<'a> for SplitToSequenceAttrs<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -9068,7 +9102,7 @@ impl<'a> flatbuffers::Follow<'a> for STFTAttrs<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -9170,7 +9204,7 @@ impl<'a> flatbuffers::Follow<'a> for TopKAttrs<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -9313,7 +9347,7 @@ impl<'a> flatbuffers::Follow<'a> for TransposeAttrs<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -9425,7 +9459,7 @@ impl<'a> flatbuffers::Follow<'a> for TriluAttrs<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -9529,7 +9563,7 @@ impl<'a> flatbuffers::Follow<'a> for OperatorNode<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -11149,7 +11183,7 @@ impl<'a> flatbuffers::Follow<'a> for FloatData<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -11263,7 +11297,7 @@ impl<'a> flatbuffers::Follow<'a> for Int8Data<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -11377,7 +11411,7 @@ impl<'a> flatbuffers::Follow<'a> for Int32Data<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -11491,7 +11525,7 @@ impl<'a> flatbuffers::Follow<'a> for UInt8Data<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -11605,7 +11639,7 @@ impl<'a> flatbuffers::Follow<'a> for ConstantNode<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -11947,7 +11981,7 @@ impl<'a> flatbuffers::Follow<'a> for Dim<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -12069,7 +12103,7 @@ impl<'a> flatbuffers::Follow<'a> for ValueNode<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -12204,7 +12238,7 @@ impl<'a> flatbuffers::Follow<'a> for Node<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -12456,7 +12490,7 @@ impl<'a> flatbuffers::Follow<'a> for Graph<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -12661,7 +12695,7 @@ impl<'a> flatbuffers::Follow<'a> for Metadata<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -12947,7 +12981,7 @@ impl<'a> flatbuffers::Follow<'a> for Model<'a> {
     #[inline]
     unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
         Self {
-            _tab: flatbuffers::Table::new(buf, loc),
+            _tab: unsafe { flatbuffers::Table::new(buf, loc) },
         }
     }
 }
@@ -13142,14 +13176,14 @@ pub fn size_prefixed_root_as_model_with_opts<'b, 'o>(
 /// # Safety
 /// Callers must trust the given bytes do indeed contain a valid `Model`.
 pub unsafe fn root_as_model_unchecked(buf: &[u8]) -> Model {
-    flatbuffers::root_unchecked::<Model>(buf)
+    unsafe { flatbuffers::root_unchecked::<Model>(buf) }
 }
 #[inline]
 /// Assumes, without verification, that a buffer of bytes contains a size prefixed Model and returns it.
 /// # Safety
 /// Callers must trust the given bytes do indeed contain a valid size prefixed `Model`.
 pub unsafe fn size_prefixed_root_as_model_unchecked(buf: &[u8]) -> Model {
-    flatbuffers::size_prefixed_root_unchecked::<Model>(buf)
+    unsafe { flatbuffers::size_prefixed_root_unchecked::<Model>(buf) }
 }
 pub const MODEL_IDENTIFIER: &str = "RTEN";
 


### PR DESCRIPTION
With flatc version 25.9.23 installed this is the result of:

```
touch rten-model-file/src/schema.fbs
make schema
```

Plus manual edits in rten-model-file/src/lib.rs to remove unused lint suppressions.