### PR TITLE
Support `ignore_merges` option for BPE tokenizers

### DIFF
--- a/rten-text/src/tokenizer.rs
+++ b/rten-text/src/tokenizer.rs
@@ -415,6 +415,7 @@ impl Tokenizer {
                     vocab: Some(model.vocab),
                     added_tokens,
                     end_of_word_suffix: model.end_of_word_suffix,
+                    ignore_merges: model.ignore_merges,
                 };
                 let model = Bpe::new(bpe_opts).map_err(FromJsonError::BpeError)?;
 

--- a/rten-text/src/tokenizer/json.rs
+++ b/rten-text/src/tokenizer/json.rs
@@ -142,6 +142,10 @@ pub mod models {
         /// This originated from CLIP's tokenizer.
         /// See https://github.com/openai/CLIP/blob/main/clip/simple_tokenizer.py.
         pub end_of_word_suffix: Option<String>,
+
+        /// When encoding a string piece, look up the piece in the vocabulary
+        /// before applying merge rules.
+        pub ignore_merges: bool,
     }
 }
 


### PR DESCRIPTION
Support the `ignore_merges` option that was introduced in the tokenizers library in https://github.com/huggingface/tokenizers/pull/1493. This causes string pieces being encoded (after pre-tokenization) to be matched against the vocabulary before applying merge rules. For Llama 3 this affects a very small number of tokens (<0.5%). The downside of enabling this option is that it requires extra memory/copies to keep the vocab around, so we only do this when needed.

Fixes https://github.com/robertknight/rten/issues/453.