### PR TITLE
Implement Top-p sampling in rten-generate

### DIFF
--- a/rten-examples/src/llama.rs
+++ b/rten-examples/src/llama.rs
@@ -5,7 +5,7 @@ use std::io::prelude::*;
 use argh::FromArgs;
 use rten::Model;
 use rten_generate::metrics::Metrics;
-use rten_generate::sampler::TopKSampler;
+use rten_generate::sampler::TopPSampler;
 use rten_generate::{Generator, GeneratorUtils};
 use rten_text::{TokenId, Tokenizer, TokenizerError};
 
@@ -80,12 +80,12 @@ fn main() -> Result<(), Box<dyn Error>> {
     }
     let system_prompt = prompt.encode()?;
 
-    // TODO: Adjust sampling settings to match `generation_config.json`.
-    let top_k = 20;
+    // From `generation_config.json`.
+    let top_p = 0.9;
 
     let mut generator = Generator::from_model(&model)?
         .with_prompt(&system_prompt)
-        .with_sampler(TopKSampler::new(top_k, args.temperature));
+        .with_sampler(TopPSampler::new(top_p, args.temperature));
     let mut metrics = Metrics::new();
 
     loop {

--- a/rten-generate/src/sampler.rs
+++ b/rten-generate/src/sampler.rs
@@ -3,8 +3,8 @@
 use std::cell::RefCell;
 
 use rten::{FloatOperators, Operators};
-use rten_tensor::NdTensorView;
 use rten_tensor::prelude::*;
+use rten_tensor::{NdTensor, NdTensorView};
 
 use crate::generator::TokenId;
 
@@ -13,6 +13,10 @@ pub trait Sampler {
     /// Sample a token ID from the output logits of a model.
     ///
     /// `logits` has shape `[n_vocab]`.
+    ///
+    /// # Panics
+    ///
+    /// `sample` will panic if `logits` is empty.
     fn sample(&self, logits: NdTensorView<f32, 1>) -> TokenId;
 }
 
@@ -109,6 +113,104 @@ impl Sampler for TopKSampler {
     }
 }
 
+/// A [`Sampler`] which samples from the smallest set of tokens whose cumulative
+/// probability exceeds a threshold _p_.
+///
+/// See <https://en.wikipedia.org/wiki/Top-p_sampling>.
+pub struct TopPSampler {
+    temperature: f32,
+    p: f32,
+    rng: RefCell<fastrand::Rng>,
+    normalize: bool,
+}
+
+impl TopPSampler {
+    /// Create a sampler with cumulative probability threshold `p`.
+    ///
+    /// `temperature` specifies a scaling factor to apply before normalizing
+    /// logits to probabilities.
+    pub fn new(p: f32, temperature: f32) -> TopPSampler {
+        Self::with_rng(fastrand::Rng::new(), p, temperature)
+    }
+
+    /// Create a sampler with cumulative probability threshold `p` and a
+    /// pre-configured random number generator.
+    pub fn with_rng(rng: fastrand::Rng, p: f32, temperature: f32) -> TopPSampler {
+        assert!(temperature >= 0.);
+        assert!((0. ..=1.0).contains(&p));
+
+        Self {
+            rng: RefCell::new(rng),
+            p,
+            temperature,
+            normalize: true,
+        }
+    }
+
+    // For testing, treat input logits as probabilities and don't normalize.
+    #[cfg(test)]
+    fn with_normalize(mut self, normalize: bool) -> Self {
+        self.normalize = normalize;
+        self
+    }
+}
+
+impl Sampler for TopPSampler {
+    fn sample(&self, logits: NdTensorView<f32, 1>) -> TokenId {
+        if self.temperature == 0. {
+            return ArgMaxSampler::new().sample(logits);
+        }
+
+        let logits = if self.temperature != 1.0 {
+            logits.map(|x| x / self.temperature).into_cow()
+        } else {
+            logits.as_cow()
+        };
+
+        // Convert logits to probabilities.
+        let probs = if self.normalize {
+            logits.softmax(-1).unwrap().into_cow()
+        } else {
+            logits.into_dyn()
+        };
+
+        // Create (token_id, prob) pairs sorted by ascending probability.
+        let mut sorted_probs: Vec<(u32, f32)> = probs
+            .data()
+            .unwrap()
+            .iter()
+            .enumerate()
+            .map(|(idx, prob)| (idx as u32, *prob))
+            .collect();
+        sorted_probs.sort_by(|a, b| {
+            let (_a_idx, a_prob) = a;
+            let (_b_idx, b_prob) = b;
+            a_prob.total_cmp(b_prob).reverse()
+        });
+
+        // Find k such that the top-K logits have a cumulative probability >= self.p.
+        //
+        // The threshold is set to be > 0 so the sampled set is non-empty.
+        let mut cum_prob = 0.;
+        let mut k = 0;
+        let threshold = self.p.max(f32::EPSILON);
+        while cum_prob < threshold && k < sorted_probs.len() {
+            cum_prob += sorted_probs[k].1;
+            k += 1;
+        }
+
+        // Select the top-K logits, re-normalize their probabilities and sample
+        // a token.
+        let topk_logits = NdTensor::from_fn([k], |[i]| sorted_probs[i].1);
+        let probs = topk_logits.softmax(-1).unwrap();
+        let topk_index = multinomial(&mut self.rng.borrow_mut(), probs.nd_view())
+            .expect("probs should be non-empty and sum to 1");
+
+        // Map index in sorted logits back to original index.
+        sorted_probs[topk_index].0
+    }
+}
+
 /// Sample an item from a vector of probabilities.
 ///
 /// Returns the index of the selected item, or `None` if the vector is empty
@@ -133,7 +235,7 @@ mod tests {
     use rten_tensor::prelude::*;
     use rten_testing::TestCases;
 
-    use super::{ArgMaxSampler, Sampler, TopKSampler};
+    use super::{ArgMaxSampler, Sampler, TopKSampler, TopPSampler};
 
     #[test]
     fn test_argmax_sampler() {
@@ -217,5 +319,95 @@ mod tests {
             // their probabilities.
             assert_eq!(counts[logits.size(vocab_dim) - k..], *expected);
         })
+    }
+
+    #[test]
+    fn test_topp_sampler() {
+        #[derive(Clone, Debug)]
+        struct Case {
+            // Threshold
+            p: f32,
+            temperature: f32,
+
+            // If false, treat input logits as probabilities.
+            normalize: bool,
+
+            // Logits or probabilities to sample from.
+            probs: Vec<f32>,
+
+            // Minimum probability of sampled token.
+            min_prob: f32,
+        }
+
+        let cases = [
+            // Threshold set so that sampled set has only one token.
+            Case {
+                p: 0.5,
+                temperature: 1.0,
+                normalize: false,
+                probs: [0.5, 0.3, 0.1, 0.05, 0.03, 0.02].into(),
+                min_prob: 0.5,
+            },
+            // Threshold set so that sampled set has two tokens.
+            Case {
+                p: 0.6,
+                temperature: 1.0,
+                normalize: false,
+                probs: [0.5, 0.3, 0.1, 0.05, 0.03, 0.02].into(),
+                min_prob: 0.3,
+            },
+            Case {
+                p: 0.5,
+                temperature: 1.0,
+                normalize: true,
+                // After softmax the probabilities are
+                // [0.2288, 0.1873, 0.1534, 0.1459, 0.1430, 0.1416] so we'll
+                // need to sample 3 tokens to reach the threshold.
+                probs: [0.5, 0.3, 0.1, 0.05, 0.03, 0.02].into(),
+                min_prob: 0.1,
+            },
+            // Temperature of zero, causing fallback to greedy sampling.
+            Case {
+                temperature: 0.,
+                p: 0.6,
+                normalize: true,
+                probs: [0.5, 0.3, 0.1, 0.05, 0.03, 0.02].into(),
+                min_prob: 0.5,
+            },
+            // Probability of zero.
+            Case {
+                p: 0.,
+                temperature: 1.0,
+                normalize: true,
+                probs: [0.5, 0.3, 0.1, 0.05, 0.03, 0.02].into(),
+                min_prob: 0.5,
+            },
+        ];
+
+        cases.test_each_clone(|case| {
+            let Case {
+                p,
+                temperature,
+                normalize,
+                probs,
+                min_prob,
+            } = case;
+
+            let rng = fastrand::Rng::with_seed(1234);
+            let logits = NdTensor::from(probs);
+
+            let sampler = TopPSampler::with_rng(rng, p, temperature).with_normalize(normalize);
+
+            for _ in 0..10 {
+                let token_id = sampler.sample(logits.view()) as usize;
+                let prob = logits[[token_id]];
+                assert!(
+                    prob >= min_prob,
+                    "sampled token prob {} is below threshold {}",
+                    prob,
+                    min_prob
+                );
+            }
+        });
     }
 }


### PR DESCRIPTION
Implement top-p ("nucleus") sampling in rten-generate. Change the Llama 3 example to use it to align with the generation settings specified in generation_config.json.