### PR TITLE
Return `None` for ratio metrics if no tokens have been generated

### DIFF
--- a/rten-examples/src/gpt2.rs
+++ b/rten-examples/src/gpt2.rs
@@ -84,8 +84,8 @@ fn main() -> Result<(), Box<dyn Error>> {
             .warmup_duration()
             .map(|dur| dur.as_secs_f32())
             .unwrap_or(0.),
-        metrics.tokens_per_second(),
-        metrics.mean_duration()
+        metrics.tokens_per_second().unwrap_or(0.),
+        metrics.mean_duration().unwrap_or(0.)
     );
 
     Ok(())

--- a/rten-examples/src/llama.rs
+++ b/rten-examples/src/llama.rs
@@ -130,12 +130,16 @@ fn main() -> Result<(), Box<dyn Error>> {
         println!();
     }
 
-    println!(
-        "\n\nmetrics: tokens {}, {:.0}ms/token, {:.1} tok/s",
-        metrics.token_count(),
-        metrics.mean_duration(),
-        metrics.tokens_per_second(),
-    );
+    if let Some(mean_dur) = metrics.mean_duration()
+        && let Some(tps) = metrics.tokens_per_second()
+    {
+        println!(
+            "\n\nmetrics: tokens {}, {:.0}ms/token, {:.1} tok/s",
+            metrics.token_count(),
+            mean_dur,
+            tps,
+        );
+    }
 
     Ok(())
 }

--- a/rten-examples/src/nougat.rs
+++ b/rten-examples/src/nougat.rs
@@ -101,7 +101,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         "Generated {} tokens in {:.2}s ({:.2} tokens/sec).",
         metrics.token_count(),
         metrics.total_duration().as_secs_f64(),
-        metrics.tokens_per_second()
+        metrics.tokens_per_second().unwrap_or(0.),
     );
 
     Ok(())


### PR DESCRIPTION
Change several `Metrics` methods to return `None` rather than NaN if called when no tokens have been generated. The caller can then decide how to handle this case appropriately.

In the Llama 3 example, skip printing metrics if the user presses "Ctrl+D" to exit before any tokens have been generated.