### PR TITLE
Use VNNI in AVX-512 GEMV kernel if available

### DIFF
--- a/rten-gemm/src/kernels/x86_64.rs
+++ b/rten-gemm/src/kernels/x86_64.rs
@@ -1014,7 +1014,7 @@ unsafe fn avx512_vnni_u8i8i32_dot_product(a: I8x64, b: I8x64, mut c: I32x16) -> 
         b = in(zmm_reg) b.0,
         options(nostack)
     }
-    c.into()
+    c
 }
 
 /// Detect availability of AVX-512 VNNI instructions using cpuid.

--- a/rten-simd/src/arch/x86_64/avx2.rs
+++ b/rten-simd/src/arch/x86_64/avx2.rs
@@ -94,7 +94,7 @@ unsafe impl Isa for Avx2Isa {
         self
     }
 
-    fn u8(self) -> impl NumOps<u8, Simd = Self::U8> + Extend<u8, Output = Self::U16> {
+    fn u8(self) -> impl Extend<u8, Output = Self::U16, Simd = Self::U8> {
         self
     }
 

--- a/rten-simd/src/arch/x86_64/avx512.rs
+++ b/rten-simd/src/arch/x86_64/avx512.rs
@@ -96,7 +96,7 @@ unsafe impl Isa for Avx512Isa {
         self
     }
 
-    fn u8(self) -> impl NumOps<u8, Simd = Self::U8> + Extend<u8, Output = Self::U16> {
+    fn u8(self) -> impl Extend<u8, Output = Self::U16, Simd = Self::U8> {
         self
     }
 


### PR DESCRIPTION
Use VNNI if available for vector-matrix products in int8 AVX-512 matmul kernel. This is faster and fixes a test failure on systems with VNNI enabled. The test failure happened because the kernel reported that it did not suffer from
saturation if VNNI was enabled, and so the test generated inputs using the full int8 range. However if the input had M=1, the GEMV code path would be used which didn't use VNNI and so did encounter saturation.

Note that for the non-GEMV path, VNNI was already used.
