### PR TITLE
Fix default for `dilations` attribute in Conv operator

### DIFF
--- a/src/op_registry/onnx_registry.rs
+++ b/src/op_registry/onnx_registry.rs
@@ -746,7 +746,7 @@ fn get_common_conv_attrs(attrs: &Attrs) -> Result<ConvAttrs, ReadOpError> {
         .get("dilations")
         .map(|v| v.cast_ints())
         .transpose()?
-        .unwrap_or_default();
+        .unwrap_or_else(|| vec![1; n_spatial_dims]);
 
     let pads = attrs
         .get("pads")
@@ -1652,6 +1652,7 @@ mod tests {
 
         assert_eq!(conv_op.padding, Padding::Fixed([0, 0, 0, 0].into()));
         assert_eq!(conv_op.strides, vec![1, 1]);
+        assert_eq!(conv_op.dilations, vec![1, 1]);
     }
 
     #[test]


### PR DESCRIPTION
In the ONNX loader, set the default value for the `dilations` attribute to 1 along each spatial axis, instead of an empty list.

This fixes loading of the BiRefNet_lite model from https://huggingface.co/onnx-community/BiRefNet_lite-ONNX.