### PR TITLE
Add `shift_right` method for int SIMD types

### DIFF
--- a/rten-simd/src/arch/aarch64.rs
+++ b/rten-simd/src/arch/aarch64.rs
@@ -13,9 +13,10 @@ use std::arch::aarch64::{
     vmovl_high_s8, vmovl_high_s16, vmovl_high_u8, vmovl_s8, vmovl_s16, vmovl_u8, vmulq_f32,
     vmulq_s8, vmulq_s16, vmulq_s32, vmulq_u8, vmulq_u16, vmvnq_u32, vnegq_f32, vnegq_s8, vnegq_s16,
     vnegq_s32, vorrq_u32, vqmovn_s32, vqmovun_s16, vrndnq_f32, vshlq_n_s8, vshlq_n_s16,
-    vshlq_n_s32, vshlq_n_u16, vst1q_f32, vst1q_s8, vst1q_s16, vst1q_s32, vst1q_u8, vst1q_u16,
-    vsubq_f32, vsubq_s8, vsubq_s16, vsubq_s32, vsubq_u8, vsubq_u16, vzip1q_s8, vzip1q_s16,
-    vzip2q_s8, vzip2q_s16,
+    vshlq_n_s32, vshlq_n_u8, vshlq_n_u16, vshrq_n_s8, vshrq_n_s16, vshrq_n_s32, vshrq_n_u8,
+    vshrq_n_u16, vst1q_f32, vst1q_s8, vst1q_s16, vst1q_s32, vst1q_u8, vst1q_u16, vsubq_f32,
+    vsubq_s8, vsubq_s16, vsubq_s32, vsubq_u8, vsubq_u16, vzip1q_s8, vzip1q_s16, vzip2q_s8,
+    vzip2q_s16,
 };
 use std::mem::transmute;
 
@@ -77,7 +78,7 @@ unsafe impl Isa for ArmNeonIsa {
         self
     }
 
-    fn u8(self) -> impl Extend<u8, Output = Self::U16, Simd = Self::U8> {
+    fn u8(self) -> impl IntOps<u8, Simd = Self::U8> + Extend<u8, Output = Self::U16> {
         self
     }
 
@@ -388,6 +389,11 @@ impl IntOps<i32> for ArmNeonIsa {
     fn shift_left<const SHIFT: i32>(self, x: int32x4_t) -> int32x4_t {
         unsafe { vshlq_n_s32::<SHIFT>(x) }
     }
+
+    #[inline]
+    fn shift_right<const SHIFT: i32>(self, x: int32x4_t) -> int32x4_t {
+        unsafe { vshrq_n_s32::<SHIFT>(x) }
+    }
 }
 
 impl SignedIntOps<i32> for ArmNeonIsa {
@@ -518,6 +524,11 @@ impl IntOps<i16> for ArmNeonIsa {
     fn shift_left<const SHIFT: i32>(self, x: int16x8_t) -> int16x8_t {
         unsafe { vshlq_n_s16::<SHIFT>(x) }
     }
+
+    #[inline]
+    fn shift_right<const SHIFT: i32>(self, x: int16x8_t) -> int16x8_t {
+        unsafe { vshrq_n_s16::<SHIFT>(x) }
+    }
 }
 
 impl SignedIntOps<i16> for ArmNeonIsa {
@@ -626,6 +637,11 @@ impl IntOps<i8> for ArmNeonIsa {
     #[inline]
     fn shift_left<const SHIFT: i32>(self, x: int8x16_t) -> int8x16_t {
         unsafe { vshlq_n_s8::<SHIFT>(x) }
+    }
+
+    #[inline]
+    fn shift_right<const SHIFT: i32>(self, x: int8x16_t) -> int8x16_t {
+        unsafe { vshrq_n_s8::<SHIFT>(x) }
     }
 }
 
@@ -744,6 +760,18 @@ impl Extend<u8> for ArmNeonIsa {
     }
 }
 
+impl IntOps<u8> for ArmNeonIsa {
+    #[inline]
+    fn shift_left<const SHIFT: i32>(self, x: uint8x16_t) -> uint8x16_t {
+        unsafe { vshlq_n_u8::<SHIFT>(x) }
+    }
+
+    #[inline]
+    fn shift_right<const SHIFT: i32>(self, x: uint8x16_t) -> uint8x16_t {
+        unsafe { vshrq_n_u8::<SHIFT>(x) }
+    }
+}
+
 unsafe impl NumOps<u16> for ArmNeonIsa {
     simd_ops_common!(uint16x8_t, uint16x8_t);
 
@@ -818,6 +846,11 @@ impl IntOps<u16> for ArmNeonIsa {
     #[inline]
     fn shift_left<const SHIFT: i32>(self, x: uint16x8_t) -> uint16x8_t {
         unsafe { vshlq_n_u16::<SHIFT>(x) }
+    }
+
+    #[inline]
+    fn shift_right<const SHIFT: i32>(self, x: uint16x8_t) -> uint16x8_t {
+        unsafe { vshrq_n_u16::<SHIFT>(x) }
     }
 }
 

--- a/rten-simd/src/arch/generic.rs
+++ b/rten-simd/src/arch/generic.rs
@@ -118,7 +118,7 @@ unsafe impl Isa for GenericIsa {
         self
     }
 
-    fn u8(self) -> impl Extend<u8, Output = Self::U16, Simd = Self::U8> {
+    fn u8(self) -> impl IntOps<u8, Simd = Self::U8> + Extend<u8, Output = Self::U16> {
         self
     }
 
@@ -353,6 +353,11 @@ macro_rules! impl_simd_int_ops {
             #[inline]
             fn shift_left<const SHIFT: i32>(self, x: $simd) -> $simd {
                 x.map(|x| x << SHIFT)
+            }
+
+            #[inline]
+            fn shift_right<const SHIFT: i32>(self, x: $simd) -> $simd {
+                x.map(|x| x >> SHIFT)
             }
         }
     };

--- a/rten-simd/src/arch/wasm32.rs
+++ b/rten-simd/src/arch/wasm32.rs
@@ -1,17 +1,18 @@
 use std::arch::wasm32::{
     f32x4_abs, f32x4_add, f32x4_div, f32x4_eq, f32x4_extract_lane, f32x4_ge, f32x4_gt, f32x4_le,
     f32x4_lt, f32x4_max, f32x4_min, f32x4_mul, f32x4_nearest, f32x4_neg, f32x4_splat, f32x4_sub,
-    i8x16_add, i8x16_all_true, i8x16_eq, i8x16_ge, i8x16_gt, i8x16_neg, i8x16_shl, i8x16_shuffle,
-    i8x16_splat, i8x16_sub, i16x8_add, i16x8_all_true, i16x8_eq, i16x8_extend_high_i8x16,
-    i16x8_extend_low_i8x16, i16x8_extmul_high_i8x16, i16x8_extmul_low_i8x16, i16x8_ge, i16x8_gt,
-    i16x8_mul, i16x8_narrow_i32x4, i16x8_neg, i16x8_shl, i16x8_shuffle, i16x8_splat, i16x8_sub,
-    i32x4_add, i32x4_all_true, i32x4_eq, i32x4_extend_high_i16x8, i32x4_extend_low_i16x8, i32x4_ge,
-    i32x4_gt, i32x4_mul, i32x4_neg, i32x4_shl, i32x4_shuffle, i32x4_splat, i32x4_sub,
-    i32x4_trunc_sat_f32x4, u8x16_add, u8x16_eq, u8x16_ge, u8x16_gt, u8x16_narrow_i16x8,
+    i8x16_add, i8x16_all_true, i8x16_eq, i8x16_ge, i8x16_gt, i8x16_neg, i8x16_shl, i8x16_shr,
+    i8x16_shuffle, i8x16_splat, i8x16_sub, i16x8_add, i16x8_all_true, i16x8_eq,
+    i16x8_extend_high_i8x16, i16x8_extend_low_i8x16, i16x8_extmul_high_i8x16,
+    i16x8_extmul_low_i8x16, i16x8_ge, i16x8_gt, i16x8_mul, i16x8_narrow_i32x4, i16x8_neg,
+    i16x8_shl, i16x8_shr, i16x8_shuffle, i16x8_splat, i16x8_sub, i32x4_add, i32x4_all_true,
+    i32x4_eq, i32x4_extend_high_i16x8, i32x4_extend_low_i16x8, i32x4_ge, i32x4_gt, i32x4_mul,
+    i32x4_neg, i32x4_shl, i32x4_shr, i32x4_shuffle, i32x4_splat, i32x4_sub, i32x4_trunc_sat_f32x4,
+    u8x16_add, u8x16_eq, u8x16_ge, u8x16_gt, u8x16_narrow_i16x8, u8x16_shl, u8x16_shr,
     u8x16_shuffle, u8x16_splat, u8x16_sub, u16x8_add, u16x8_eq, u16x8_extend_high_u8x16,
     u16x8_extend_low_u8x16, u16x8_extmul_high_u8x16, u16x8_extmul_low_u8x16, u16x8_ge, u16x8_gt,
-    u16x8_mul, u16x8_shl, u16x8_splat, u16x8_sub, v128, v128_and, v128_any_true, v128_bitselect,
-    v128_load, v128_not, v128_or, v128_store, v128_xor,
+    u16x8_mul, u16x8_shl, u16x8_shr, u16x8_splat, u16x8_sub, v128, v128_and, v128_any_true,
+    v128_bitselect, v128_load, v128_not, v128_or, v128_store, v128_xor,
 };
 use std::mem::transmute;
 
@@ -86,7 +87,7 @@ unsafe impl Isa for Wasm32Isa {
         self
     }
 
-    fn u8(self) -> impl NumOps<u8, Simd = Self::U8> + Extend<u8, Output = Self::U16> {
+    fn u8(self) -> impl IntOps<u8, Simd = Self::U8> + Extend<u8, Output = Self::U16> {
         self
     }
 
@@ -364,6 +365,11 @@ impl IntOps<i32> for Wasm32Isa {
     fn shift_left<const SHIFT: i32>(self, x: I32x4) -> I32x4 {
         I32x4(i32x4_shl(x.0, SHIFT as u32))
     }
+
+    #[inline]
+    fn shift_right<const SHIFT: i32>(self, x: I32x4) -> I32x4 {
+        I32x4(i32x4_shr(x.0, SHIFT as u32))
+    }
 }
 
 impl SignedIntOps<i32> for Wasm32Isa {
@@ -437,6 +443,11 @@ impl IntOps<i16> for Wasm32Isa {
     #[inline]
     fn shift_left<const SHIFT: i32>(self, x: I16x8) -> I16x8 {
         I16x8(i16x8_shl(x.0, SHIFT as u32))
+    }
+
+    #[inline]
+    fn shift_right<const SHIFT: i32>(self, x: I16x8) -> I16x8 {
+        I16x8(i16x8_shr(x.0, SHIFT as u32))
     }
 }
 
@@ -531,6 +542,11 @@ impl IntOps<i8> for Wasm32Isa {
     #[inline]
     fn shift_left<const SHIFT: i32>(self, x: I8x16) -> I8x16 {
         I8x16(i8x16_shl(x.0, SHIFT as u32))
+    }
+
+    #[inline]
+    fn shift_right<const SHIFT: i32>(self, x: I8x16) -> I8x16 {
+        I8x16(i8x16_shr(x.0, SHIFT as u32))
     }
 }
 
@@ -657,6 +673,11 @@ impl IntOps<u16> for Wasm32Isa {
     fn shift_left<const SHIFT: i32>(self, x: U16x8) -> U16x8 {
         U16x8(u16x8_shl(x.0, SHIFT as u32))
     }
+
+    #[inline]
+    fn shift_right<const SHIFT: i32>(self, x: U16x8) -> U16x8 {
+        U16x8(u16x8_shr(x.0, SHIFT as u32))
+    }
 }
 
 impl Extend<u8> for Wasm32Isa {
@@ -667,6 +688,18 @@ impl Extend<u8> for Wasm32Isa {
         let low = u16x8_extend_low_u8x16(x.0);
         let high = u16x8_extend_high_u8x16(x.0);
         (low.into(), high.into())
+    }
+}
+
+impl IntOps<u8> for Wasm32Isa {
+    #[inline]
+    fn shift_left<const SHIFT: i32>(self, x: U8x16) -> U8x16 {
+        U8x16(u8x16_shl(x.0, SHIFT as u32))
+    }
+
+    #[inline]
+    fn shift_right<const SHIFT: i32>(self, x: U8x16) -> U8x16 {
+        U8x16(u8x16_shr(x.0, SHIFT as u32))
     }
 }
 


### PR DESCRIPTION
Add `IntOps::shift_right` to complement the existing `shift_left` method, and implement `IntOps` for u8 SIMD vectors.

This will be needed for unpacking 4-bit integers from u8 values.