### PR TITLE
Implement `Interleave` trait for u8 SIMD vectors

### DIFF
--- a/rten-simd/src/arch/aarch64.rs
+++ b/rten-simd/src/arch/aarch64.rs
@@ -15,8 +15,8 @@ use std::arch::aarch64::{
     vnegq_s32, vorrq_u32, vqmovn_s32, vqmovun_s16, vrndnq_f32, vshlq_n_s8, vshlq_n_s16,
     vshlq_n_s32, vshlq_n_u8, vshlq_n_u16, vshrq_n_s8, vshrq_n_s16, vshrq_n_s32, vshrq_n_u8,
     vshrq_n_u16, vst1q_f32, vst1q_s8, vst1q_s16, vst1q_s32, vst1q_u8, vst1q_u16, vsubq_f32,
-    vsubq_s8, vsubq_s16, vsubq_s32, vsubq_u8, vsubq_u16, vzip1q_s8, vzip1q_s16, vzip2q_s8,
-    vzip2q_s16,
+    vsubq_s8, vsubq_s16, vsubq_s32, vsubq_u8, vsubq_u16, vzip1q_s8, vzip1q_s16, vzip1q_u8,
+    vzip2q_s8, vzip2q_s16, vzip2q_u8,
 };
 use std::mem::transmute;
 
@@ -78,7 +78,9 @@ unsafe impl Isa for ArmNeonIsa {
         self
     }
 
-    fn u8(self) -> impl IntOps<u8, Simd = Self::U8> + Extend<u8, Output = Self::U16> {
+    fn u8(
+        self,
+    ) -> impl IntOps<u8, Simd = Self::U8> + Extend<u8, Output = Self::U16> + Interleave<u8> {
         self
     }
 
@@ -769,6 +771,18 @@ impl IntOps<u8> for ArmNeonIsa {
     #[inline]
     fn shift_right<const SHIFT: i32>(self, x: uint8x16_t) -> uint8x16_t {
         unsafe { vshrq_n_u8::<SHIFT>(x) }
+    }
+}
+
+impl Interleave<u8> for ArmNeonIsa {
+    #[inline]
+    fn interleave_low(self, a: uint8x16_t, b: uint8x16_t) -> uint8x16_t {
+        unsafe { vzip1q_u8(a, b) }
+    }
+
+    #[inline]
+    fn interleave_high(self, a: uint8x16_t, b: uint8x16_t) -> uint8x16_t {
+        unsafe { vzip2q_u8(a, b) }
     }
 }
 

--- a/rten-simd/src/arch/generic.rs
+++ b/rten-simd/src/arch/generic.rs
@@ -118,7 +118,9 @@ unsafe impl Isa for GenericIsa {
         self
     }
 
-    fn u8(self) -> impl IntOps<u8, Simd = Self::U8> + Extend<u8, Output = Self::U16> {
+    fn u8(
+        self,
+    ) -> impl IntOps<u8, Simd = Self::U8> + Extend<u8, Output = Self::U16> + Interleave<u8> {
         self
     }
 
@@ -453,6 +455,7 @@ macro_rules! impl_interleave {
 }
 impl_interleave!(i8, I8x16);
 impl_interleave!(i16, I16x8);
+impl_interleave!(u8, U8x16);
 
 impl_simd_int_ops!(U8x16, u8, 16, M8);
 impl_simd_int_ops!(U16x8, u16, 8, M16);

--- a/rten-simd/src/arch/wasm32.rs
+++ b/rten-simd/src/arch/wasm32.rs
@@ -87,7 +87,9 @@ unsafe impl Isa for Wasm32Isa {
         self
     }
 
-    fn u8(self) -> impl IntOps<u8, Simd = Self::U8> + Extend<u8, Output = Self::U16> {
+    fn u8(
+        self,
+    ) -> impl IntOps<u8, Simd = Self::U8> + Extend<u8, Output = Self::U16> + Interleave<u8> {
         self
     }
 
@@ -700,6 +702,19 @@ impl IntOps<u8> for Wasm32Isa {
     #[inline]
     fn shift_right<const SHIFT: i32>(self, x: U8x16) -> U8x16 {
         U8x16(u8x16_shr(x.0, SHIFT as u32))
+    }
+}
+
+impl Interleave<u8> for Wasm32Isa {
+    #[inline]
+    fn interleave_low(self, a: U8x16, b: U8x16) -> U8x16 {
+        u8x16_shuffle::<0, 16, 1, 17, 2, 18, 3, 19, 4, 20, 5, 21, 6, 22, 7, 23>(a.0, b.0).into()
+    }
+
+    #[inline]
+    fn interleave_high(self, a: U8x16, b: U8x16) -> U8x16 {
+        u8x16_shuffle::<8, 24, 9, 25, 10, 26, 11, 27, 12, 28, 13, 29, 14, 30, 15, 31>(a.0, b.0)
+            .into()
     }
 }
 

--- a/rten-simd/src/ops.rs
+++ b/rten-simd/src/ops.rs
@@ -86,7 +86,9 @@ pub unsafe trait Isa: Copy {
     ) -> impl SignedIntOps<i8, Simd = Self::I8> + Extend<i8, Output = Self::I16> + Interleave<i8>;
 
     /// Operations on SIMD vectors with `u8` elements.
-    fn u8(self) -> impl IntOps<u8, Simd = Self::U8> + Extend<u8, Output = Self::U16>;
+    fn u8(
+        self,
+    ) -> impl IntOps<u8, Simd = Self::U8> + Extend<u8, Output = Self::U16> + Interleave<u8>;
 
     /// Operations on SIMD vectors with `u16` elements.
     fn u16(self) -> impl IntOps<u16, Simd = Self::U16>;
@@ -1383,6 +1385,7 @@ mod tests {
     }
     test_interleave!(test_interleave_i16, i16);
     test_interleave!(test_interleave_i8, i8);
+    test_interleave!(test_interleave_u8, u8);
 
     #[test]
     fn test_concat_i32() {


### PR DESCRIPTION
This will be needed for dequantization of 4-bit weights.