### PR TITLE
Add `ToFloat` op trait in rten-simd for int-to-float conversion

### DIFF
--- a/rten-simd/src/arch/aarch64.rs
+++ b/rten-simd/src/arch/aarch64.rs
@@ -5,23 +5,24 @@ use std::arch::aarch64::{
     vceqq_f32, vceqq_s8, vceqq_s16, vceqq_s32, vceqq_u8, vceqq_u16, vcgeq_f32, vcgeq_s8, vcgeq_s16,
     vcgeq_s32, vcgeq_u8, vcgeq_u16, vcgtq_f32, vcgtq_s8, vcgtq_s16, vcgtq_s32, vcgtq_u8, vcgtq_u16,
     vcleq_f32, vcleq_s8, vcleq_s16, vcleq_u8, vcleq_u16, vcltq_f32, vcltq_s8, vcltq_s16, vcltq_u8,
-    vcltq_u16, vcombine_s16, vcombine_s32, vcombine_u8, vcvtnq_s32_f32, vcvtq_s32_f32, vdivq_f32,
-    vdupq_laneq_f32, vdupq_n_f32, vdupq_n_s8, vdupq_n_s16, vdupq_n_s32, vdupq_n_u8, vdupq_n_u16,
-    veorq_u32, vfmaq_f32, vfmsq_f32, vget_high_s32, vget_low_s8, vget_low_s16, vget_low_s32,
-    vget_low_u8, vld1q_f32, vld1q_s8, vld1q_s16, vld1q_s32, vld1q_u8, vld1q_u16, vld1q_u32,
-    vmaxq_f32, vmaxvq_u8, vmaxvq_u16, vmaxvq_u32, vminq_f32, vminvq_u8, vminvq_u16, vminvq_u32,
-    vmovl_high_s8, vmovl_high_s16, vmovl_high_u8, vmovl_s8, vmovl_s16, vmovl_u8, vmulq_f32,
-    vmulq_s8, vmulq_s16, vmulq_s32, vmulq_u8, vmulq_u16, vmvnq_u32, vnegq_f32, vnegq_s8, vnegq_s16,
-    vnegq_s32, vorrq_u32, vqmovn_s32, vqmovun_s16, vrndnq_f32, vshlq_n_s8, vshlq_n_s16,
-    vshlq_n_s32, vshlq_n_u8, vshlq_n_u16, vshrq_n_s8, vshrq_n_s16, vshrq_n_s32, vshrq_n_u8,
-    vshrq_n_u16, vst1q_f32, vst1q_s8, vst1q_s16, vst1q_s32, vst1q_u8, vst1q_u16, vsubq_f32,
-    vsubq_s8, vsubq_s16, vsubq_s32, vsubq_u8, vsubq_u16, vzip1q_s8, vzip1q_s16, vzip1q_u8,
-    vzip2q_s8, vzip2q_s16, vzip2q_u8,
+    vcltq_u16, vcombine_s16, vcombine_s32, vcombine_u8, vcvtnq_s32_f32, vcvtq_f32_s32,
+    vcvtq_s32_f32, vdivq_f32, vdupq_laneq_f32, vdupq_n_f32, vdupq_n_s8, vdupq_n_s16, vdupq_n_s32,
+    vdupq_n_u8, vdupq_n_u16, veorq_u32, vfmaq_f32, vfmsq_f32, vget_high_s32, vget_low_s8,
+    vget_low_s16, vget_low_s32, vget_low_u8, vld1q_f32, vld1q_s8, vld1q_s16, vld1q_s32, vld1q_u8,
+    vld1q_u16, vld1q_u32, vmaxq_f32, vmaxvq_u8, vmaxvq_u16, vmaxvq_u32, vminq_f32, vminvq_u8,
+    vminvq_u16, vminvq_u32, vmovl_high_s8, vmovl_high_s16, vmovl_high_u8, vmovl_s8, vmovl_s16,
+    vmovl_u8, vmulq_f32, vmulq_s8, vmulq_s16, vmulq_s32, vmulq_u8, vmulq_u16, vmvnq_u32, vnegq_f32,
+    vnegq_s8, vnegq_s16, vnegq_s32, vorrq_u32, vqmovn_s32, vqmovun_s16, vrndnq_f32, vshlq_n_s8,
+    vshlq_n_s16, vshlq_n_s32, vshlq_n_u8, vshlq_n_u16, vshrq_n_s8, vshrq_n_s16, vshrq_n_s32,
+    vshrq_n_u8, vshrq_n_u16, vst1q_f32, vst1q_s8, vst1q_s16, vst1q_s32, vst1q_u8, vst1q_u16,
+    vsubq_f32, vsubq_s8, vsubq_s16, vsubq_s32, vsubq_u8, vsubq_u16, vzip1q_s8, vzip1q_s16,
+    vzip1q_u8, vzip2q_s8, vzip2q_s16, vzip2q_u8,
 };
 use std::mem::transmute;
 
 use crate::ops::{
     Concat, Extend, FloatOps, IntOps, Interleave, MaskOps, NarrowSaturate, NumOps, SignedIntOps,
+    ToFloat,
 };
 use crate::{Isa, Mask, Simd};
 
@@ -58,7 +59,8 @@ unsafe impl Isa for ArmNeonIsa {
         self,
     ) -> impl SignedIntOps<i32, Simd = Self::I32>
     + NarrowSaturate<i32, i16, Output = Self::I16>
-    + Concat<i32> {
+    + Concat<i32>
+    + ToFloat<i32, Output = Self::F32> {
         self
     }
 
@@ -435,6 +437,15 @@ impl Concat<i32> for ArmNeonIsa {
             let high = vget_high_s32(b);
             vcombine_s32(low, high)
         }
+    }
+}
+
+impl ToFloat<i32> for ArmNeonIsa {
+    type Output = float32x4_t;
+
+    #[inline]
+    fn to_float(self, x: int32x4_t) -> float32x4_t {
+        unsafe { vcvtq_f32_s32(x) }
     }
 }
 

--- a/rten-simd/src/arch/generic.rs
+++ b/rten-simd/src/arch/generic.rs
@@ -3,6 +3,7 @@ use std::mem::transmute;
 
 use crate::ops::{
     Concat, Extend, FloatOps, IntOps, Interleave, MaskOps, NarrowSaturate, NumOps, SignedIntOps,
+    ToFloat,
 };
 use crate::{Isa, Mask, Simd};
 
@@ -98,7 +99,8 @@ unsafe impl Isa for GenericIsa {
         self,
     ) -> impl SignedIntOps<i32, Simd = Self::I32>
     + NarrowSaturate<i32, i16, Output = Self::I16>
-    + Concat<i32> {
+    + Concat<i32>
+    + ToFloat<i32, Output = Self::F32> {
         self
     }
 
@@ -459,6 +461,14 @@ impl_interleave!(u8, U8x16);
 
 impl_simd_int_ops!(U8x16, u8, 16, M8);
 impl_simd_int_ops!(U16x8, u16, 8, M16);
+
+impl ToFloat<i32> for GenericIsa {
+    type Output = F32x4;
+
+    fn to_float(self, x: I32x4) -> Self::Output {
+        F32x4(x.0.map(|x| x as f32))
+    }
+}
 
 trait NarrowSaturateElem<T> {
     fn narrow_saturate(self) -> T;

--- a/rten-simd/src/arch/wasm32.rs
+++ b/rten-simd/src/arch/wasm32.rs
@@ -1,9 +1,9 @@
 use std::arch::wasm32::{
-    f32x4_abs, f32x4_add, f32x4_div, f32x4_eq, f32x4_extract_lane, f32x4_ge, f32x4_gt, f32x4_le,
-    f32x4_lt, f32x4_max, f32x4_min, f32x4_mul, f32x4_nearest, f32x4_neg, f32x4_splat, f32x4_sub,
-    i8x16_add, i8x16_all_true, i8x16_eq, i8x16_ge, i8x16_gt, i8x16_neg, i8x16_shl, i8x16_shr,
-    i8x16_shuffle, i8x16_splat, i8x16_sub, i16x8_add, i16x8_all_true, i16x8_eq,
-    i16x8_extend_high_i8x16, i16x8_extend_low_i8x16, i16x8_extmul_high_i8x16,
+    f32x4_abs, f32x4_add, f32x4_convert_i32x4, f32x4_div, f32x4_eq, f32x4_extract_lane, f32x4_ge,
+    f32x4_gt, f32x4_le, f32x4_lt, f32x4_max, f32x4_min, f32x4_mul, f32x4_nearest, f32x4_neg,
+    f32x4_splat, f32x4_sub, i8x16_add, i8x16_all_true, i8x16_eq, i8x16_ge, i8x16_gt, i8x16_neg,
+    i8x16_shl, i8x16_shr, i8x16_shuffle, i8x16_splat, i8x16_sub, i16x8_add, i16x8_all_true,
+    i16x8_eq, i16x8_extend_high_i8x16, i16x8_extend_low_i8x16, i16x8_extmul_high_i8x16,
     i16x8_extmul_low_i8x16, i16x8_ge, i16x8_gt, i16x8_mul, i16x8_narrow_i32x4, i16x8_neg,
     i16x8_shl, i16x8_shr, i16x8_shuffle, i16x8_splat, i16x8_sub, i32x4_add, i32x4_all_true,
     i32x4_eq, i32x4_extend_high_i16x8, i32x4_extend_low_i16x8, i32x4_ge, i32x4_gt, i32x4_mul,
@@ -22,6 +22,7 @@ use std::arch::wasm32::f32x4_relaxed_madd;
 use super::{lanes, simd_type};
 use crate::ops::{
     Concat, Extend, FloatOps, IntOps, Interleave, MaskOps, NarrowSaturate, NumOps, SignedIntOps,
+    ToFloat,
 };
 use crate::{Isa, Mask, Simd};
 
@@ -67,7 +68,8 @@ unsafe impl Isa for Wasm32Isa {
         self,
     ) -> impl SignedIntOps<i32, Simd = Self::I32>
     + NarrowSaturate<i32, i16, Output = Self::I16>
-    + Concat<i32> {
+    + Concat<i32>
+    + ToFloat<i32, Output = Self::F32> {
         self
     }
 
@@ -399,6 +401,15 @@ impl Concat<i32> for Wasm32Isa {
     #[inline]
     fn concat_high(self, a: I32x4, b: I32x4) -> I32x4 {
         I32x4(i32x4_shuffle::<2, 3, 6, 7>(a.0, b.0))
+    }
+}
+
+impl ToFloat<i32> for Wasm32Isa {
+    type Output = F32x4;
+
+    #[inline]
+    fn to_float(self, x: I32x4) -> F32x4 {
+        F32x4(f32x4_convert_i32x4(x.0))
     }
 }
 


### PR DESCRIPTION
This will be used in dequantization of n-bit integers.