### PR TITLE
Support `noop_with_empty_axes` attribute in reduction ops

### DIFF
--- a/rten-convert/rten_convert/converter.py
+++ b/rten-convert/rten_convert/converter.py
@@ -651,8 +651,9 @@ def op_node_from_onnx_operator(
             attrs = sg.ReduceMeanAttrsT()
             attrs.axes = attr_reader.get_attr("axes", "ints", None)
             attrs.keepDims = bool(attr_reader.get_attr("keepdims", "int", 1))
-
-            attr_reader.check_attr("noop_with_empty_axes", "int", 0)
+            attrs.noopWithEmptyAxes = bool(
+                attr_reader.get_attr("noop_with_empty_axes", "int", 0)
+            )
 
         case "Reshape":
             attrs = sg.ReshapeAttrsT()

--- a/rten-convert/rten_convert/schema_generated.py
+++ b/rten-convert/rten_convert/schema_generated.py
@@ -5036,8 +5036,15 @@ class ReduceMeanAttrs(object):
             return bool(self._tab.Get(flatbuffers.number_types.BoolFlags, o + self._tab.Pos))
         return False
 
+    # ReduceMeanAttrs
+    def NoopWithEmptyAxes(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(8))
+        if o != 0:
+            return bool(self._tab.Get(flatbuffers.number_types.BoolFlags, o + self._tab.Pos))
+        return False
+
 def ReduceMeanAttrsStart(builder):
-    builder.StartObject(2)
+    builder.StartObject(3)
 
 def ReduceMeanAttrsAddAxes(builder, axes):
     builder.PrependUOffsetTRelativeSlot(0, flatbuffers.number_types.UOffsetTFlags.py_type(axes), 0)
@@ -5047,6 +5054,9 @@ def ReduceMeanAttrsStartAxesVector(builder, numElems):
 
 def ReduceMeanAttrsAddKeepDims(builder, keepDims):
     builder.PrependBoolSlot(1, keepDims, 0)
+
+def ReduceMeanAttrsAddNoopWithEmptyAxes(builder, noopWithEmptyAxes):
+    builder.PrependBoolSlot(2, noopWithEmptyAxes, 0)
 
 def ReduceMeanAttrsEnd(builder):
     return builder.EndObject()
@@ -5064,9 +5074,11 @@ class ReduceMeanAttrsT(object):
         self,
         axes = None,
         keepDims = False,
+        noopWithEmptyAxes = False,
     ):
         self.axes = axes  # type: Optional[List[int]]
         self.keepDims = keepDims  # type: bool
+        self.noopWithEmptyAxes = noopWithEmptyAxes  # type: bool
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -5097,6 +5109,7 @@ class ReduceMeanAttrsT(object):
             else:
                 self.axes = reduceMeanAttrs.AxesAsNumpy()
         self.keepDims = reduceMeanAttrs.KeepDims()
+        self.noopWithEmptyAxes = reduceMeanAttrs.NoopWithEmptyAxes()
 
     # ReduceMeanAttrsT
     def Pack(self, builder):
@@ -5112,6 +5125,7 @@ class ReduceMeanAttrsT(object):
         if self.axes is not None:
             ReduceMeanAttrsAddAxes(builder, axes)
         ReduceMeanAttrsAddKeepDims(builder, self.keepDims)
+        ReduceMeanAttrsAddNoopWithEmptyAxes(builder, self.noopWithEmptyAxes)
         reduceMeanAttrs = ReduceMeanAttrsEnd(builder)
         return reduceMeanAttrs
 

--- a/rten-model-file/src/schema.fbs
+++ b/rten-model-file/src/schema.fbs
@@ -503,6 +503,7 @@ table RandomUniformLikeAttrs {
 table ReduceMeanAttrs {
   axes:[int];
   keep_dims:bool;
+  noop_with_empty_axes:bool;
 }
 
 table ReshapeAttrs {

--- a/rten-model-file/src/schema_generated.rs
+++ b/rten-model-file/src/schema_generated.rs
@@ -7888,6 +7888,7 @@ impl<'a> flatbuffers::Follow<'a> for ReduceMeanAttrs<'a> {
 impl<'a> ReduceMeanAttrs<'a> {
     pub const VT_AXES: flatbuffers::VOffsetT = 4;
     pub const VT_KEEP_DIMS: flatbuffers::VOffsetT = 6;
+    pub const VT_NOOP_WITH_EMPTY_AXES: flatbuffers::VOffsetT = 8;
 
     #[inline]
     pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
@@ -7902,6 +7903,7 @@ impl<'a> ReduceMeanAttrs<'a> {
         if let Some(x) = args.axes {
             builder.add_axes(x);
         }
+        builder.add_noop_with_empty_axes(args.noop_with_empty_axes);
         builder.add_keep_dims(args.keep_dims);
         builder.finish()
     }
@@ -7930,6 +7932,17 @@ impl<'a> ReduceMeanAttrs<'a> {
                 .unwrap()
         }
     }
+    #[inline]
+    pub fn noop_with_empty_axes(&self) -> bool {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab
+                .get::<bool>(ReduceMeanAttrs::VT_NOOP_WITH_EMPTY_AXES, Some(false))
+                .unwrap()
+        }
+    }
 }
 
 impl flatbuffers::Verifiable for ReduceMeanAttrs<'_> {
@@ -7946,6 +7959,7 @@ impl flatbuffers::Verifiable for ReduceMeanAttrs<'_> {
                 false,
             )?
             .visit_field::<bool>("keep_dims", Self::VT_KEEP_DIMS, false)?
+            .visit_field::<bool>("noop_with_empty_axes", Self::VT_NOOP_WITH_EMPTY_AXES, false)?
             .finish();
         Ok(())
     }
@@ -7953,6 +7967,7 @@ impl flatbuffers::Verifiable for ReduceMeanAttrs<'_> {
 pub struct ReduceMeanAttrsArgs<'a> {
     pub axes: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, i32>>>,
     pub keep_dims: bool,
+    pub noop_with_empty_axes: bool,
 }
 impl<'a> Default for ReduceMeanAttrsArgs<'a> {
     #[inline]
@@ -7960,6 +7975,7 @@ impl<'a> Default for ReduceMeanAttrsArgs<'a> {
         ReduceMeanAttrsArgs {
             axes: None,
             keep_dims: false,
+            noop_with_empty_axes: false,
         }
     }
 }
@@ -7978,6 +7994,14 @@ impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> ReduceMeanAttrsBuilder<'a, 'b, 
     pub fn add_keep_dims(&mut self, keep_dims: bool) {
         self.fbb_
             .push_slot::<bool>(ReduceMeanAttrs::VT_KEEP_DIMS, keep_dims, false);
+    }
+    #[inline]
+    pub fn add_noop_with_empty_axes(&mut self, noop_with_empty_axes: bool) {
+        self.fbb_.push_slot::<bool>(
+            ReduceMeanAttrs::VT_NOOP_WITH_EMPTY_AXES,
+            noop_with_empty_axes,
+            false,
+        );
     }
     #[inline]
     pub fn new(
@@ -8001,6 +8025,7 @@ impl core::fmt::Debug for ReduceMeanAttrs<'_> {
         let mut ds = f.debug_struct("ReduceMeanAttrs");
         ds.field("axes", &self.axes());
         ds.field("keep_dims", &self.keep_dims());
+        ds.field("noop_with_empty_axes", &self.noop_with_empty_axes());
         ds.finish()
     }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -1392,26 +1392,32 @@ mod tests {
         add_operator!(ReduceMean, [input_node], {
             axes: None,
             keep_dims: false,
+            noop_with_empty_axes: false,
         });
         add_operator!(ReduceMax, [input_node], {
             axes: None,
             keep_dims: false,
+            noop_with_empty_axes: false,
         });
         add_operator!(ReduceMin, [input_node], {
             axes: None,
             keep_dims: false,
+            noop_with_empty_axes: false,
         });
         add_operator!(ReduceProd, [input_node], {
             axes: None,
             keep_dims: false,
+            noop_with_empty_axes: false,
         });
         add_operator!(ReduceSum, [input_node], {
             axes: None,
             keep_dims: false,
+            noop_with_empty_axes: false,
         });
         add_operator!(ReduceSumSquare, [input_node], {
             axes: None,
             keep_dims: false,
+            noop_with_empty_axes: false,
         });
         add_operator!(Relu, [input_node]);
 

--- a/src/model/rten_builder.rs
+++ b/src/model/rten_builder.rs
@@ -414,6 +414,7 @@ impl<'mb, 'a> GraphBuilder<'mb, 'a> {
                 sg::ReduceMeanAttrsArgs {
                     axes,
                     keep_dims: $args.keep_dims,
+                    noop_with_empty_axes: $args.noop_with_empty_axes,
                 }
             }};
         }

--- a/src/op_registry/onnx_registry.rs
+++ b/src/op_registry/onnx_registry.rs
@@ -1366,8 +1366,12 @@ macro_rules! impl_read_op_for_reduce_op {
         impl_read_op!($op, |attrs: &Attrs| {
             let axes = attrs.get("axes").map(|v| v.cast_ints()).transpose()?;
             let keep_dims = attrs.get_as("keepdims").unwrap_or(true);
-            attrs.check_eq("noop_with_empty_axes", 0)?;
-            Ok(ops::$op { axes, keep_dims })
+            let noop_with_empty_axes = attrs.get_as("noop_with_empty_axes").unwrap_or(false);
+            Ok(ops::$op {
+                axes,
+                keep_dims,
+                noop_with_empty_axes,
+            })
         });
     };
 }

--- a/src/op_registry/rten_registry.rs
+++ b/src/op_registry/rten_registry.rs
@@ -372,6 +372,7 @@ macro_rules! impl_read_op {
                 let op = ops::$op {
                     axes,
                     keep_dims: attrs.keep_dims(),
+                    noop_with_empty_axes: attrs.noop_with_empty_axes(),
                 };
                 Ok(op)
             }

--- a/src/optimize/fusions.rs
+++ b/src/optimize/fusions.rs
@@ -297,6 +297,7 @@ impl PatternFusion for ReduceMeanAxesFusion {
         Some(ReduceMean {
             axes: Some(axes.to_vec()),
             keep_dims: mean_op.keep_dims,
+            noop_with_empty_axes: false,
         })
     }
 }

--- a/src/optimize/tests.rs
+++ b/src/optimize/tests.rs
@@ -78,6 +78,7 @@ impl OpExprs for Expr {
         self.unary(ReduceMean {
             axes: Some(vec![-1]),
             keep_dims: false,
+            noop_with_empty_axes: false,
         })
     }
 
@@ -86,6 +87,7 @@ impl OpExprs for Expr {
             ReduceMean {
                 axes: None,
                 keep_dims: false,
+                noop_with_empty_axes: false,
             },
             axes,
         )


### PR DESCRIPTION
Support the `noop_with_empty_axes` attribute that was added to `Reduce*` operators in opset 18.

**TODO:**

- [x] Tests
- [x] Correct handling for operators which are fusions of reductions and pointwise ops (eg. ReduceSumSquare)
- [x] Support attribute in .rten format