### PR TITLE
Remove unnecessary MutLayout bounds

### DIFF
--- a/rten-tensor/src/impl_debug.rs
+++ b/rten-tensor/src/impl_debug.rs
@@ -1,6 +1,6 @@
 use std::fmt::{Debug, Error, Formatter};
 
-use crate::{AsView, Layout, MatrixLayout, MutLayout, NdTensorView, Storage, TensorBase};
+use crate::{AsView, Layout, MatrixLayout, NdTensorView, Storage, TensorBase};
 
 /// Entry in the formatted representation of a tensor's data.
 enum Entry<T: Debug> {
@@ -44,12 +44,12 @@ impl Default for FormatOptions {
 
 /// A [`Debug`]-implementing wrapper around a tensor reference with custom
 /// formatting options.
-struct FormatTensor<'a, S: Storage, L: MutLayout> {
+struct FormatTensor<'a, S: Storage, L: Layout> {
     tensor: &'a TensorBase<S, L>,
     opts: FormatOptions,
 }
 
-impl<'a, S: Storage, L: MutLayout> FormatTensor<'a, S, L> {
+impl<'a, S: Storage, L: Layout> FormatTensor<'a, S, L> {
     fn new(tensor: &'a TensorBase<S, L>, opts: FormatOptions) -> Self {
         Self { tensor, opts }
     }
@@ -103,7 +103,7 @@ impl<'a, S: Storage, L: MutLayout> FormatTensor<'a, S, L> {
     }
 }
 
-impl<S: Storage, L: MutLayout> Debug for FormatTensor<'_, S, L>
+impl<S: Storage, L: Layout + Clone> Debug for FormatTensor<'_, S, L>
 where
     S::Elem: Debug,
 {
@@ -151,7 +151,7 @@ where
     }
 }
 
-impl<S: Storage, L: MutLayout> Debug for TensorBase<S, L>
+impl<S: Storage, L: Layout + Clone> Debug for TensorBase<S, L>
 where
     S::Elem: Debug,
 {

--- a/rten-tensor/src/layout.rs
+++ b/rten-tensor/src/layout.rs
@@ -812,7 +812,7 @@ pub trait MutLayout: Layout + Clone {
 }
 
 /// Trait for broadcasting a layout from one shape to another.
-pub trait BroadcastLayout<L: MutLayout> {
+pub trait BroadcastLayout<L: Layout> {
     /// Broadcast the `self` layout to a given shape.
     fn broadcast<S: IntoLayout<Layout = L>>(&self, shape: S) -> Result<L, ExpandError>;
 }

--- a/src/buffer_pool.rs
+++ b/src/buffer_pool.rs
@@ -3,7 +3,7 @@ use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use rten_gemm::{PackedAMatrix, PackedBMatrix};
-use rten_tensor::{Alloc, Contiguous, CowData, MutLayout, TensorBase};
+use rten_tensor::{Alloc, Contiguous, CowData, Layout, TensorBase};
 
 /// A memory buffer that can be used to satisfy a future allocation from
 /// a [`BufferPool`].
@@ -304,25 +304,25 @@ impl<T> ExtractBuffer for Vec<T> {
     }
 }
 
-impl<T, L: MutLayout> ExtractBuffer for TensorBase<Vec<T>, L> {
+impl<T, L: Layout + Clone> ExtractBuffer for TensorBase<Vec<T>, L> {
     fn extract_buffer(self) -> Option<Buffer> {
         Some(self.into_non_contiguous_data().into())
     }
 }
 
-impl<T, L: MutLayout> ExtractBuffer for Contiguous<TensorBase<Vec<T>, L>> {
+impl<T, L: Layout + Clone> ExtractBuffer for Contiguous<TensorBase<Vec<T>, L>> {
     fn extract_buffer(self) -> Option<Buffer> {
         Some(self.into_data().into())
     }
 }
 
-impl<T, L: MutLayout> ExtractBuffer for TensorBase<CowData<'_, T>, L> {
+impl<T, L: Layout + Clone> ExtractBuffer for TensorBase<CowData<'_, T>, L> {
     fn extract_buffer(self) -> Option<Buffer> {
         self.into_non_contiguous_data().map(|data| data.into())
     }
 }
 
-impl<T, L: MutLayout> ExtractBuffer for Contiguous<TensorBase<CowData<'_, T>, L>> {
+impl<T, L: Layout + Clone> ExtractBuffer for Contiguous<TensorBase<CowData<'_, T>, L>> {
     fn extract_buffer(self) -> Option<Buffer> {
         self.into_data().map(|data| data.into())
     }

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -9,7 +9,7 @@ use std::fmt::{Debug, Display};
 
 use rten_gemm::PackedBMatrix;
 use rten_tensor::errors::DimensionError;
-use rten_tensor::{MutLayout, Storage, TensorBase};
+use rten_tensor::{Layout, Storage, TensorBase};
 use smallvec::SmallVec;
 
 use crate::BufferPool;
@@ -81,7 +81,7 @@ impl IntoOpResult for Value {
     }
 }
 
-impl<S: Storage, L: MutLayout> IntoOpResult for TensorBase<S, L>
+impl<S: Storage, L: Layout> IntoOpResult for TensorBase<S, L>
 where
     Value: From<TensorBase<S, L>>,
 {
@@ -91,7 +91,7 @@ where
     }
 }
 
-impl<S: Storage, L: MutLayout> IntoOpResult for Result<TensorBase<S, L>, OpError>
+impl<S: Storage, L: Layout> IntoOpResult for Result<TensorBase<S, L>, OpError>
 where
     Value: From<TensorBase<S, L>>,
 {

--- a/src/value.rs
+++ b/src/value.rs
@@ -6,8 +6,8 @@ use std::fmt::Display;
 
 use rten_tensor::errors::DimensionError;
 use rten_tensor::{
-    Alloc, AsView, DynIndices, DynLayout, GlobalAlloc, Layout, MutLayout, NdTensor, NdTensorView,
-    Storage, Tensor, TensorBase, TensorView, ViewData,
+    Alloc, AsView, DynIndices, DynLayout, GlobalAlloc, Layout, NdTensor, NdTensorView, Storage,
+    Tensor, TensorBase, TensorView, ViewData,
 };
 use smallvec::SmallVec;
 
@@ -747,7 +747,7 @@ impl<'a> From<ValueView<'a>> for ValueOrView<'a> {
     }
 }
 
-impl<'a, T: 'static, S: Storage<Elem = T>, L: MutLayout> From<&'a TensorBase<S, L>>
+impl<'a, T: 'static, S: Storage<Elem = T>, L: Layout + Clone> From<&'a TensorBase<S, L>>
     for ValueOrView<'a>
 where
     ValueView<'a>: From<TensorView<'a, T>>,
@@ -757,7 +757,7 @@ where
     }
 }
 
-impl<'a, T, L: MutLayout> From<TensorBase<ViewData<'a, T>, L>> for ValueOrView<'a>
+impl<'a, T, L: Layout + Clone> From<TensorBase<ViewData<'a, T>, L>> for ValueOrView<'a>
 where
     ValueView<'a>: From<TensorView<'a, T>>,
 {
@@ -766,7 +766,7 @@ where
     }
 }
 
-impl<T, L: MutLayout> From<TensorBase<Vec<T>, L>> for ValueOrView<'static>
+impl<T, L: Layout + Clone> From<TensorBase<Vec<T>, L>> for ValueOrView<'static>
 where
     Value: From<Tensor<T>>,
     DynLayout: From<L>,


### PR DESCRIPTION
Use the weaker `Layout` or `Layout + Clone` bounds where possible. This will allow using tensors with immutable or otherwise restricted layouts in more contexts.