### PR TITLE
Update Layout trait docs to mention that tensors implement it

### DIFF
--- a/rten-tensor/src/layout.rs
+++ b/rten-tensor/src/layout.rs
@@ -57,13 +57,16 @@ macro_rules! debug_assert_dim_valid {
     };
 }
 
-/// Layouts describe the shape of a tensor, ie. the number of dimensions and
-/// size of each, and the mapping between indices and offsets in the data
-/// storage.
+/// Describes the shape and strides of a tensor.
 ///
-/// The main implementations are [`NdLayout`], where the dimension count is known
-/// statically, and [`DynLayout`], where the dimension count is only known at
-/// runtime.
+/// The `Layout` trait provides methods to query the shape of a tensor, i.e. the
+/// number of dimensions and size of each, and the strides which determine the
+/// mapping between logical indices in the tensor and offsets in the data storage.
+///
+/// This trait is implemented for tensor types
+/// ([`TensorBase`](crate::TensorBase)), as well as the underlying layout types
+/// such as [`NdLayout`] (for tensors with a static number of dimensions) and
+/// [`DynLayout`] (for tensors with a dynamic number of dimensions).
 pub trait Layout {
     /// Type used to represent indices.
     ///


### PR DESCRIPTION
The frontmatter of the rten-tensor create mentioned that tensors implement the Layout trait, but the documentation for the trait itself did not. This is important since any methods added to layouts become available on tensors as well. This has consequences for which methods can be added to the trait: Methods names which conflict with other traits (eg. AsView) implemented by tensor types should be avoided, as well as methods which make sense for standalone layout types like NdLayout, but not tensor types (eg. `squeezed`).

I'm adding this because I was in the process of moving a bunch of `MutLayout` methods to `Layout` as part of exploring introducing layout types which guarantee contiguous strides, and then remembered why this wasn't a good idea.