### PR TITLE
Implement GlobalMaxPool operator

### DIFF
--- a/rten-convert/rten_convert/schema_generated.py
+++ b/rten-convert/rten_convert/schema_generated.py
@@ -135,6 +135,7 @@ class OperatorType(object):
     GridSample = 125
     PRelu = 126
     STFT = 127
+    GlobalMaxPool = 128
 
 
 class RNNDirection(object):

--- a/rten-model-file/src/schema.fbs
+++ b/rten-model-file/src/schema.fbs
@@ -141,6 +141,7 @@ enum OperatorType: ubyte {
   GridSample,
   PRelu,
   STFT,
+  GlobalMaxPool,
 }
 
 enum RNNDirection: ubyte {

--- a/rten-model-file/src/schema_generated.rs
+++ b/rten-model-file/src/schema_generated.rs
@@ -17,13 +17,13 @@ pub const ENUM_MIN_OPERATOR_TYPE: u8 = 0;
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
-pub const ENUM_MAX_OPERATOR_TYPE: u8 = 127;
+pub const ENUM_MAX_OPERATOR_TYPE: u8 = 128;
 #[deprecated(
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 128] = [
+pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 129] = [
     OperatorType::Add,
     OperatorType::ArgMin,
     OperatorType::ArgMax,
@@ -152,6 +152,7 @@ pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 128] = [
     OperatorType::GridSample,
     OperatorType::PRelu,
     OperatorType::STFT,
+    OperatorType::GlobalMaxPool,
 ];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -287,9 +288,10 @@ impl OperatorType {
     pub const GridSample: Self = Self(125);
     pub const PRelu: Self = Self(126);
     pub const STFT: Self = Self(127);
+    pub const GlobalMaxPool: Self = Self(128);
 
     pub const ENUM_MIN: u8 = 0;
-    pub const ENUM_MAX: u8 = 127;
+    pub const ENUM_MAX: u8 = 128;
     pub const ENUM_VALUES: &'static [Self] = &[
         Self::Add,
         Self::ArgMin,
@@ -419,6 +421,7 @@ impl OperatorType {
         Self::GridSample,
         Self::PRelu,
         Self::STFT,
+        Self::GlobalMaxPool,
     ];
     /// Returns the variant's name or "" if unknown.
     pub fn variant_name(self) -> Option<&'static str> {
@@ -551,6 +554,7 @@ impl OperatorType {
             Self::GridSample => Some("GridSample"),
             Self::PRelu => Some("PRelu"),
             Self::STFT => Some("STFT"),
+            Self::GlobalMaxPool => Some("GlobalMaxPool"),
             _ => None,
         }
     }

--- a/src/model.rs
+++ b/src/model.rs
@@ -1242,6 +1242,7 @@ mod tests {
             transpose_b: false,
         });
         add_operator!(GlobalAveragePool, [input_node]);
+        add_operator!(GlobalMaxPool, [input_node]);
         add_operator!(Greater, [input_node, input_node]);
         add_operator!(GreaterOrEqual, [input_node, input_node]);
         add_operator!(HardSigmoid, [input_node], {

--- a/src/model/rten_builder.rs
+++ b/src/model/rten_builder.rs
@@ -74,6 +74,7 @@ pub enum OpType<'a> {
     Gelu(Gelu),
     Gemm(Gemm),
     GlobalAveragePool,
+    GlobalMaxPool,
     Greater,
     GreaterOrEqual,
     HardSigmoid(HardSigmoid),
@@ -652,6 +653,7 @@ impl<'mb, 'a> GraphBuilder<'mb, 'a> {
                 }
             ),
             OpType::GlobalAveragePool => op!(GlobalAveragePool),
+            OpType::GlobalMaxPool => op!(GlobalMaxPool),
             OpType::Greater => op!(Greater),
             OpType::GreaterOrEqual => op!(GreaterOrEqual),
             OpType::HardSigmoid(args) => op_with_attrs!(

--- a/src/op_registry/onnx_registry.rs
+++ b/src/op_registry/onnx_registry.rs
@@ -139,6 +139,7 @@ impl OnnxOpRegistry {
         register_op!(Gelu);
         register_op!(Gemm);
         register_op!(GlobalAveragePool);
+        register_op!(GlobalMaxPool);
         register_op!(Greater);
         register_op!(GreaterOrEqual);
         register_op!(GridSample);
@@ -1021,6 +1022,7 @@ impl_read_op!(Gemm, |attrs: &Attrs| {
 });
 
 impl_read_op!(GlobalAveragePool);
+impl_read_op!(GlobalMaxPool);
 impl_read_op!(Greater);
 impl_read_op!(GreaterOrEqual);
 

--- a/src/op_registry/rten_registry.rs
+++ b/src/op_registry/rten_registry.rs
@@ -134,6 +134,7 @@ impl RtenOpRegistry {
         register_op!(Gelu);
         register_op!(Gemm);
         register_op!(GlobalAveragePool);
+        register_op!(GlobalMaxPool);
         register_op!(Greater);
         register_op!(GreaterOrEqual);
         register_op!(GridSample);
@@ -597,6 +598,7 @@ impl_read_op!(Gemm, attrs_as_gemm_attrs, |attrs: sg::GemmAttrs| {
     })
 });
 impl_read_op!(GlobalAveragePool);
+impl_read_op!(GlobalMaxPool);
 impl_read_op!(Greater);
 impl_read_op!(GreaterOrEqual);
 impl_read_op!(

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -90,7 +90,7 @@ pub(crate) use {
         RmsNormalization, Softmax,
     },
     pad::Pad,
-    pooling::{AveragePool, GlobalAveragePool, MaxPool},
+    pooling::{AveragePool, GlobalAveragePool, GlobalMaxPool, MaxPool},
     quantize::{DequantizeLinear, DynamicQuantizeLinear, QuantizeLinear},
     reduce::{
         ArgMax, ArgMin, CumSum, NonZero, ReduceL2, ReduceMax, ReduceMean, ReduceMin, ReduceProd,


### PR DESCRIPTION
Replace the GlobalAveragePool implementation with a general global pooling function which is parametrized by a kernel and implement both GlobalAveragePool and GlobalMaxPool using this. The new global pooling operators follow the same implementation design as the reduction ops, where the input is divided into contiguous chunks to which a kernel is applied.

In addition to better efficiency, the new implementation also supports all inputs with at least 2 dimensions, instead of just NCHW tensors.