### PR TITLE
Impl Debug for additional exported types

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -447,6 +447,16 @@ impl<'a> NodeInfo<'a> {
     }
 }
 
+impl<'a> std::fmt::Debug for NodeInfo<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("NodeInfo")
+            .field("name", &self.name())
+            .field("shape", &self.shape())
+            .field("dtype", &self.dtype())
+            .finish()
+    }
+}
+
 /// Parse profiling flags from the `RTEN_TIMING` environment variable and
 /// update the graph run configuration `opts`.
 ///
@@ -633,6 +643,15 @@ impl ModelOptions {
             #[cfg(not(feature = "onnx_format"))]
             FileType::Onnx => Err(LoadErrorImpl::FormatNotEnabled.into()),
         }
+    }
+}
+
+impl std::fmt::Debug for ModelOptions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ModelOptions")
+            .field("optimize", &self.optimize)
+            .field("prepack_weights", &self.prepack_weights)
+            .finish()
     }
 }
 

--- a/src/model/metadata.rs
+++ b/src/model/metadata.rs
@@ -51,7 +51,7 @@ impl std::fmt::Display for MetadataField {
 ///
 /// There are methods for standard fields. The [`fields`](Self::fields) method
 /// returns an iterator over all fields.
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct ModelMetadata {
     fields: HashMap<MetadataField, String>,
 }

--- a/src/threading.rs
+++ b/src/threading.rs
@@ -5,6 +5,7 @@ use std::sync::OnceLock;
 ///
 /// On platforms where threads are not supported (eg. WebAssembly) this runs
 /// operations directly on the main thread.
+#[derive(Debug)]
 pub struct ThreadPool {
     /// The wrapped thread pool, or None if we failed to construct one.
     pool: Option<rayon::ThreadPool>,

--- a/src/value.rs
+++ b/src/value.rs
@@ -268,7 +268,7 @@ macro_rules! impl_proxy_layout {
 ///
 /// Views can also be created from an [`NdTensorView`] or [`TensorView`] using
 /// [`Into`].
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 #[non_exhaustive]
 pub enum ValueView<'a> {
     FloatTensor(TensorView<'a, f32>),
@@ -695,7 +695,7 @@ impl From<Sequence> for Value {
 /// These can be created from a shape and data (see
 /// [`ValueView::from_shape`] and [`Value::from_shape`]) or from a
 /// tensor of a supported type ([`Tensor`], [`TensorView`] etc.) using [`Into`].
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum ValueOrView<'a> {
     /// A borrowed view (like a slice).
     ///


### PR DESCRIPTION
Add Debug impls for `ThreadPool` and other types in the public API of the rten crate that didn't have them. See also 33355f0d980294138cee61bc9ccde6914f7f9306.