### PR TITLE
Support loading i64 and bool tensors from external data in ONNX loader

### DIFF
--- a/src/model/external_data.rs
+++ b/src/model/external_data.rs
@@ -19,7 +19,7 @@ use crate::constant_storage::ConstantStorage;
 
 /// Specifies the location of tensor data which is stored externally from the
 /// main model file.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct DataLocation {
     /// Name of the external data file.
     pub path: String,


### PR DESCRIPTION
Fix an oversight in the ONNX loader where loading tensors from external data files was not implemented for i64 and bool tensors. i64 and bool tensors are different from most other types as they are converted to i32 when the data is loaded.

**TODO:**

- [x] Tests
