### PR TITLE
Support SmolLM v3 in the Qwen chat example

### DIFF
--- a/rten-examples/README.md
+++ b/rten-examples/README.md
@@ -95,7 +95,8 @@ The examples have been chosen to cover common tasks and popular models.
 - **jina_similarity** - Sentence similarity using vector embeddings of sentences
 - **llama** - Chatbot using [Llama 3](https://huggingface.co/meta-llama/Llama-3.2-3B-Instruct)
 - **modernbert** - Masked word prediction using [ModernBERT](https://huggingface.co/blog/modernbert). Also works with the base version of the original BERT model.
-- **qwen2_chat** - Chatbot using [Qwen2](https://github.com/QwenLM/Qwen2)
+- **qwen2_chat** - Chatbot using [Qwen2](https://github.com/QwenLM/Qwen2). Also works with some other
+  chat models that use the same prompt format such as [SmolLM](https://huggingface.co/HuggingFaceTB/SmolLM3-3B).
 
 ### Audio
 


### PR DESCRIPTION
Make a minor change to the Qwen chat example so that it works with other models that use the same prompt format. So far only SmolLM v3 has been tested.

This is only "basic" support in the sense that there isn't any special handling of thinking tokens or other new capabilities of this model.