### PR TITLE
Align features for rten, rten-tensor deps in rten-cli, rten-examples

### DIFF
--- a/rten-cli/Cargo.toml
+++ b/rten-cli/Cargo.toml
@@ -13,8 +13,15 @@ include = ["/src", "/README.md"]
 argh = "0.1"
 fastrand = "2.0.2"
 rten = { path = "../", version = "0.23.0", features=["all-ops", "mmap"] }
-rten-tensor = { path = "../rten-tensor", version = "0.23.0" }
 safetensors = "0.6.2"
+
+[dependencies.rten-tensor]
+path = "../rten-tensor"
+version = "0.23.0"
+# rten-cli doesn't need the "serde" feature, but aligning the features with
+# rten-examples avoids a rebuild of the rten crate when switching between
+# building examples and building the CLI.
+features = ["serde"]
 
 [dev-dependencies]
 rten-testing = { path = "../rten-testing" }

--- a/rten-examples/Cargo.toml
+++ b/rten-examples/Cargo.toml
@@ -16,7 +16,7 @@ image = { workspace = true }
 png = "0.17.6"
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-rten = { path = "../", features = ["fft", "mmap", "random"] }
+rten = { path = "../", version = "0.23.0", features = ["all-ops", "mmap"] }
 rten-generate = { path = "../rten-generate", features=["text-decoder"] }
 rten-imageio = { path = "../rten-imageio" }
 rten-imageproc = { path = "../rten-imageproc" }


### PR DESCRIPTION
Make the rten-cli and rten-examples crates enable the same set of features for the rten-tensor and rten dependencies. This avoids rebuilding the main rten crate when switching between building the CLI and building an example binary.