### PR TITLE
Update infer-shapes.py to work with model files that use external data

### DIFF
--- a/tools/infer-shapes.py
+++ b/tools/infer-shapes.py
@@ -2,16 +2,32 @@ from argparse import ArgumentParser
 
 import onnx
 
-parser = ArgumentParser(description="Apply shape inference to a model")
+parser = ArgumentParser(
+    description="""
+Apply shape inference to a model.
+
+This adds metadata to the model about the shapes of values, potentially
+enabling additional optimizations when running the model.
+"""
+)
 parser.add_argument("input")
-parser.add_argument("output", nargs="?")
+parser.add_argument("output", nargs="?", help="Output file path")
+parser.add_argument(
+    "-i", "--in-place", action="store_true", help="Modify the input model"
+)
 args = parser.parse_args()
 
-output = args.output or args.input.replace(".onnx", ".shaped.onnx")
+if args.in_place:
+    if args.output:
+        raise Exception("Cannot specify both `--in-place` and output path")
+    output = args.input
+else:
+    output = args.output or args.input.replace(".onnx", ".shaped.onnx")
 
-model = onnx.load(args.input)
-
-# See https://onnx.ai/onnx/api/shape_inference.html
-updated_model = onnx.shape_inference.infer_shapes(model, data_prop=True)
-
-onnx.save(updated_model, output)
+# Use `onnx.shape_inference.infer_shapes_path` to support models that
+# are more than 2GB in size. This function will generate a new ".onnx"
+# file that shares the same external data (if any) as the input file.
+#
+# See https://onnx.ai/onnx/api/shape_inference.html#infer-shapes-path and
+# https://github.com/robertknight/rten/issues/851.
+onnx.shape_inference.infer_shapes_path(args.input, output, data_prop=True)


### PR DESCRIPTION
Change this utility script to use `infer_shapes_path`, like the rten format converter. Also add an `--in-place` option as a shorthand way of specifying that the output model path should be the same as the input path.

Related to https://github.com/robertknight/rten/issues/1091.