### PR TITLE
Improve efficiency of top-K sampling

### DIFF
--- a/rten-generate/src/logits.rs
+++ b/rten-generate/src/logits.rs
@@ -6,7 +6,7 @@ use crate::generator::TokenId;
 /// each token. These are filtered and processed using
 /// [`LogitsFilter`](crate::filter::LogitsFilter)s before a single token is
 /// sampled using a [`Sampler`](crate::sampler::Sampler).
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct Logits {
     logits: Vec<f32>,
     indices: Vec<TokenId>,


### PR DESCRIPTION
Improve top-K sampling by vectorizing comparisons and avoiding allocating a temporary vector of (logit, index) tuples for the complete list of logits. The implementation relies on the assumption that K is likely small relative to the input length and that updates to the running top-K (ie. the K largest visited so far) will be infrequent.

On an M3 Pro for a 380 token generation for Llama 3B this reduced sampling time from ~60ms to ~10ms, or ~0.4% of the total generation time (small, but it adds up).