### PR TITLE
Depend on serde_derive directly instead of via serde crate feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -475,6 +475,7 @@ dependencies = [
  "rten-text",
  "rustfft",
  "serde",
+ "serde_derive",
  "serde_json",
  "smallvec",
 ]
@@ -521,6 +522,7 @@ dependencies = [
  "rten-tensor",
  "rten-testing",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -565,6 +567,7 @@ dependencies = [
  "fancy-regex",
  "rten-testing",
  "serde",
+ "serde_derive",
  "serde_json",
  "unicode-normalization",
  "unicode_categories",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,8 +37,9 @@ image = { version = "0.25.1", default-features = false, features = ["png", "jpeg
 libm = "0.2.6"
 rayon = "1.7.0"
 rustfft = { version = "6.4.0" }
-serde = { version = "1.0.202" }
-serde_json = { version = "1.0.117" }
+serde = { version = "1" }
+serde_derive = { version = "1" }
+serde_json = { version = "1" }
 smallvec = { version = "1.10.0", features = ["union", "const_generics", "const_new"] }
 typeid = "1.0.3"
 

--- a/rten-examples/Cargo.toml
+++ b/rten-examples/Cargo.toml
@@ -14,7 +14,8 @@ fastrand = { workspace = true }
 hound = "3.5.1"
 image = { workspace = true }
 png = "0.17.6"
-serde = { workspace = true, features = ["derive"] }
+serde = { workspace = true }
+serde_derive = { workspace = true }
 serde_json = { workspace = true }
 rten = { path = "../", version = "0.23.0", features = ["all-ops", "mmap"] }
 rten-generate = { path = "../rten-generate", features=["text-decoder"] }

--- a/rten-examples/src/detr.rs
+++ b/rten-examples/src/detr.rs
@@ -8,7 +8,7 @@ use rten_imageio::{read_image, write_image};
 use rten_imageproc::{Painter, Rect, normalize_image};
 use rten_tensor::NdTensor;
 use rten_tensor::prelude::*;
-use serde::Deserialize;
+use serde_derive::Deserialize;
 
 /// Detect objects in images.
 #[derive(FromArgs)]

--- a/rten-examples/src/piper.rs
+++ b/rten-examples/src/piper.rs
@@ -8,7 +8,7 @@ use hound::{SampleFormat, WavSpec, WavWriter};
 use rten::Model;
 use rten_tensor::NdTensor;
 use rten_tensor::prelude::*;
-use serde::Deserialize;
+use serde_derive::Deserialize;
 
 /// Deserialized JSON config for a voice model.
 ///

--- a/rten-examples/src/whisper.rs
+++ b/rten-examples/src/whisper.rs
@@ -11,7 +11,7 @@ use rten_tensor::prelude::*;
 use rten_tensor::{NdTensor, NdTensorView};
 use rten_text::Tokenizer;
 use rustfft::{FftPlanner, num_complex::Complex32};
-use serde::Deserialize;
+use serde_derive::Deserialize;
 
 /// Recognize speech in an audio file using OpenAI's Whisper.
 #[derive(FromArgs)]

--- a/rten-imageproc/Cargo.toml
+++ b/rten-imageproc/Cargo.toml
@@ -11,7 +11,8 @@ include = ["/src", "/README.md"]
 
 [dependencies]
 rten-tensor = { path = "../rten-tensor", version = "0.23.0" }
-serde = { workspace = true, features = ["derive"], optional = true }
+serde = { workspace = true, optional = true }
+serde_derive = { workspace = true, optional = true }
 
 [dev-dependencies]
 rten-bench = { path = "../rten-bench" }
@@ -22,7 +23,7 @@ crate-type = ["lib"]
 
 [features]
 # Implement serde Serialize and Deserialize traits on items where it makes sense
-serde_traits = ["serde"]
+serde_traits = ["serde", "serde_derive"]
 
 [lints.clippy]
 uninlined_format_args = "allow"

--- a/rten-imageproc/src/math.rs
+++ b/rten-imageproc/src/math.rs
@@ -1,7 +1,10 @@
 use crate::Point;
 
 #[derive(Copy, Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "serde_traits", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "serde_traits",
+    derive(serde_derive::Serialize, serde_derive::Deserialize)
+)]
 pub struct Vec2 {
     pub x: f32,
     pub y: f32,

--- a/rten-imageproc/src/shapes.rs
+++ b/rten-imageproc/src/shapes.rs
@@ -56,7 +56,10 @@ fn max_or_lhs<T: PartialOrd>(a: T, b: T) -> T {
 
 /// A point defined by X and Y coordinates.
 #[derive(Copy, Clone, Default, Eq, PartialEq)]
-#[cfg_attr(feature = "serde_traits", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "serde_traits",
+    derive(serde_derive::Serialize, serde_derive::Deserialize)
+)]
 pub struct Point<T: Coord = i32> {
     pub x: T,
     pub y: T,
@@ -189,7 +192,10 @@ fn sort_pair<T: PartialOrd>(pair: (T, T)) -> (T, T) {
 
 /// A bounded line segment defined by a start and end point.
 #[derive(Copy, Clone, PartialEq)]
-#[cfg_attr(feature = "serde_traits", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "serde_traits",
+    derive(serde_derive::Serialize, serde_derive::Deserialize)
+)]
 pub struct Line<T: Coord = i32> {
     pub start: Point<T>,
     pub end: Point<T>,
@@ -439,7 +445,10 @@ impl<T: Coord> BoundingRect for Line<T> {
 /// The left and top coordinates are inclusive. The right and bottom coordinates
 /// are exclusive.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "serde_traits", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "serde_traits",
+    derive(serde_derive::Serialize, serde_derive::Deserialize)
+)]
 pub struct Rect<T: Coord = i32> {
     top_left: Point<T>,
     bottom_right: Point<T>,
@@ -702,7 +711,10 @@ impl<T: Coord> BoundingRect for Rect<T> {
 /// orientation, width (extent along axis perpendicular to the up axis) and
 /// height (extent along up axis).
 #[derive(Copy, Clone, Debug)]
-#[cfg_attr(feature = "serde_traits", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "serde_traits",
+    derive(serde_derive::Serialize, serde_derive::Deserialize)
+)]
 pub struct RotatedRect {
     // Centroid of the rect.
     center: PointF,
@@ -905,7 +917,10 @@ where
 /// Depending on the storage type `S`, a Polygon can own its vertices
 /// (eg. `Vec<Point>`) or they can borrowed (eg. `&[Point]`).
 #[derive(Copy, Clone, Debug)]
-#[cfg_attr(feature = "serde_traits", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "serde_traits",
+    derive(serde_derive::Serialize, serde_derive::Deserialize)
+)]
 pub struct Polygon<T: Coord = i32, S: AsRef<[Point<T>]> = Vec<Point<T>>> {
     points: S,
 
@@ -1069,7 +1084,10 @@ impl_bounding_rect_for_polygon!(f32);
 /// `Polygons` is primarily useful when building up collections of many polygons
 /// as it stores all points in a single Vec, which is more efficient than
 /// allocating a separate Vec for each polygon's points.
-#[cfg_attr(feature = "serde_traits", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "serde_traits",
+    derive(serde_derive::Serialize, serde_derive::Deserialize)
+)]
 pub struct Polygons {
     points: Vec<Point>,
 

--- a/rten-text/Cargo.toml
+++ b/rten-text/Cargo.toml
@@ -16,7 +16,8 @@ crate-type = ["lib"]
 fancy-regex = { version = "0.14.0", default-features = false, features = ["std", "unicode"] }
 unicode_categories = "0.1.1"
 unicode-normalization = "0.1.22"
-serde = { workspace = true, features = ["derive"] }
+serde = { workspace = true }
+serde_derive = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]

--- a/rten-text/src/tokenizer/json.rs
+++ b/rten-text/src/tokenizer/json.rs
@@ -2,7 +2,7 @@
 //! format.
 
 use super::TokenId;
-use serde::Deserialize;
+use serde_derive::Deserialize;
 
 #[derive(Deserialize)]
 pub(crate) struct AddedToken {
@@ -17,7 +17,7 @@ pub(crate) enum Pattern {
 }
 
 pub mod normalizers {
-    use serde::Deserialize;
+    use serde_derive::Deserialize;
 
     use super::{Normalizer, Pattern};
 
@@ -58,7 +58,7 @@ pub(crate) enum Normalizer {
 }
 
 pub mod pre_tokenizers {
-    use serde::Deserialize;
+    use serde_derive::Deserialize;
 
     use super::{Pattern, PreTokenizer};
 
@@ -109,7 +109,7 @@ pub(crate) enum PreTokenizer {
 pub mod models {
     use std::collections::HashMap;
 
-    use serde::Deserialize;
+    use serde_derive::Deserialize;
 
     use crate::TokenId;
 


### PR DESCRIPTION
This can improve build times a little by enabling the `serde` and `serde_json` crates to be compiled earlier in the build process.

See https://stackoverflow.com/a/79340137/434243