### PR TITLE
Fix rten-text tests when run standalone

### DIFF
--- a/rten-text/src/tokenizer.rs
+++ b/rten-text/src/tokenizer.rs
@@ -838,7 +838,7 @@ mod tests {
     use super::{EncodeOptions, EncoderInput, TokenId, Tokenizer, TokenizerOptions, WordPiece};
     use crate::normalizers::Normalizer;
     use crate::{normalizers, pre_tokenizers};
-    use serde::Deserialize;
+    use serde_derive::Deserialize;
 
     fn make_wordpiece(vocab: &[&str]) -> WordPiece {
         let vocab: HashMap<_, _> = vocab

--- a/rten-text/tests/reftest.rs
+++ b/rten-text/tests/reftest.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 use rten_text::models::{Bpe, BpeOptions, WordPiece, merge_pairs_from_lines};
 use rten_text::tokenizer::{TokenId, Tokenizer, TokenizerOptions};
 use rten_text::{normalizers, pre_tokenizers};
-use serde::Deserialize;
+use serde_derive::Deserialize;
 
 /// Load a vocabulary from a text file with one token per line (ie. the
 /// vocab.txt files that come with Hugging Face models).


### PR DESCRIPTION
This is a follow up to https://github.com/robertknight/rten/pull/1095 which updates some imports that were missed in that PR.

This issue was not found by CI because running tests for all workspace crates via `cargo test --workspace` succeeded, but running tests for rten-text alone using `cargo test -p rten-text` failed. This is presumably due to different features being activated for the serde crate.