### PR TITLE
Make zero-copy deserialization of BPE merges work as intended

### DIFF
--- a/rten-text/src/lib.rs
+++ b/rten-text/src/lib.rs
@@ -74,6 +74,7 @@ pub mod normalizers;
 pub mod pre_tokenizers;
 pub mod tokenizer;
 
+mod serde;
 mod split;
 
 pub use tokenizer::{TokenId, Tokenizer, TokenizerError};

--- a/rten-text/src/models/bpe.rs
+++ b/rten-text/src/models/bpe.rs
@@ -191,6 +191,8 @@ pub fn merge_pairs_from_lines(
             if line.starts_with("#version") || line.trim().is_empty() {
                 None
             } else {
+                // Cloning the string here is OK since this is a legacy code
+                // path that is rarely used.
                 line.split_once(' ')
                     .map(|(a, b)| (a.to_string().into(), b.to_string().into()))
             }

--- a/rten-text/src/serde.rs
+++ b/rten-text/src/serde.rs
@@ -1,0 +1,65 @@
+//! Internal utilities related to serde deserialization.
+
+use std::borrow::Cow;
+
+use serde::Deserializer;
+
+/// A wrapper around [`Cow<str>`] which implements [`serde::Deserialize`] as
+/// expected.
+///
+/// By default serde_json will always allocate when deserializing into a
+/// `Cow<str>`, instead of borrowing where possible.
+///
+/// Code based on https://github.com/GnomedDev/serde_cow. See also
+/// https://users.rust-lang.org/t/cow-serde-json/72359.
+#[derive(Clone, Debug, PartialEq)]
+pub struct CowStr<'de>(pub Cow<'de, str>);
+
+impl<'de> AsRef<str> for CowStr<'de> {
+    fn as_ref(&self) -> &str {
+        self.0.as_ref()
+    }
+}
+
+impl serde::Serialize for CowStr<'_> {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.0)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for CowStr<'de> {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        deserializer.deserialize_string(CowStrVisitor)
+    }
+}
+
+struct CowStrVisitor;
+
+impl<'de> serde::de::Visitor<'de> for CowStrVisitor {
+    type Value = CowStr<'de>;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("a string")
+    }
+
+    fn visit_borrowed_str<E>(self, val: &'de str) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        Ok(CowStr(Cow::Borrowed(val)))
+    }
+
+    fn visit_str<E>(self, val: &str) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        self.visit_string(val.into())
+    }
+
+    fn visit_string<E>(self, val: String) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        Ok(CowStr(Cow::Owned(val)))
+    }
+}

--- a/rten-text/src/tokenizer.rs
+++ b/rten-text/src/tokenizer.rs
@@ -406,7 +406,9 @@ impl Tokenizer {
                     .unwrap_or_default();
                 let merges: Vec<(Cow<str>, Cow<str>)> = match model.merges {
                     json::models::MergeList::Legacy(lines) => merge_pairs_from_lines(&lines),
-                    json::models::MergeList::Tuple(pairs) => pairs,
+                    json::models::MergeList::Tuple(pairs) => {
+                        pairs.into_iter().map(|(a, b)| (a.0, b.0)).collect()
+                    }
                 };
                 let bpe_opts = BpeOptions {
                     merges: &merges,

--- a/rten-text/src/tokenizer/json.rs
+++ b/rten-text/src/tokenizer/json.rs
@@ -107,13 +107,13 @@ pub(crate) enum PreTokenizer {
 }
 
 pub mod models {
-    use std::borrow::Cow;
     use std::collections::HashMap;
 
     use rustc_hash::FxHashMap;
     use serde_derive::Deserialize;
 
     use crate::TokenId;
+    use crate::serde::CowStr;
 
     #[derive(Deserialize)]
     pub(crate) struct WordPiece {
@@ -126,9 +126,9 @@ pub mod models {
     pub(crate) enum MergeList<'a> {
         /// Pairs represented as a JSON array.
         #[serde(borrow)]
-        Tuple(Vec<(Cow<'a, str>, Cow<'a, str>)>),
+        Tuple(Vec<(CowStr<'a>, CowStr<'a>)>),
         /// Pairs represented as `<token_a> [SPACE] <token_b>`.
-        Legacy(Vec<Cow<'a, str>>),
+        Legacy(Vec<CowStr<'a>>),
     }
 
     #[derive(Deserialize)]


### PR DESCRIPTION
https://github.com/robertknight/rten/pull/1099 made a change to tokenizer deserialization intended to avoid string allocations for most entries in the BPE merge list. While performance did improve for the whole change set, the change to the `MergeList` type didn't actually work as intended. See the users.rust-lang.org post mentioned in this commit. Fix this by using a newtype which does work as expected. With this only ~0.7% of the strings in the merge list require allocations.

This reduces JSON parse times from ~62ms to ~54ms (-12%) for the Llama 3 tokenizer.