### PR TITLE
Add ComputeShape operator and fusion

### DIFF
--- a/src/ops/layout.rs
+++ b/src/ops/layout.rs
@@ -666,6 +666,63 @@ impl Operator for Unsqueeze {
     }
 }
 
+/// Specifies the source for a tensor shape computed by [`ComputeShape`].
+#[derive(Debug, Clone, PartialEq)]
+pub enum DimSpec {
+    /// Output a fixed value.
+    Static(u32),
+    /// Copy the size of a tensor dimension from an input.
+    Dynamic { input: u32, dim: u32 },
+}
+
+/// Compute a tensor shape from a combination of static values and the dynamic
+/// shapes of inputs.
+///
+/// This is a custom internal operator produced by fusions.
+#[derive(Debug)]
+pub struct ComputeShape {
+    /// Specifies the length of the output vector and how to compute each element.
+    pub shape: Vec<DimSpec>,
+}
+
+impl Operator for ComputeShape {
+    fn name(&self) -> &str {
+        "ComputeShape"
+    }
+
+    fn max_inputs(&self) -> Option<usize> {
+        None
+    }
+
+    fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+        let inputs = ctx.inputs();
+
+        let output = self
+            .shape
+            .iter()
+            .map(|dim| match dim {
+                DimSpec::Static(size) => Ok(*size as i32),
+                DimSpec::Dynamic {
+                    input: input_idx,
+                    dim,
+                } => {
+                    let dim = *dim as usize;
+                    let input = inputs.require(*input_idx as usize)?;
+                    if input.ndim() > dim {
+                        Ok(input.size(dim).min(i32::MAX as usize) as i32)
+                    } else {
+                        Err(OpError::InvalidValue(
+                            "Dim index invalid for input tensor shape",
+                        ))
+                    }
+                }
+            })
+            .collect::<Result<Vec<i32>, _>>()?;
+
+        Tensor::from(output).into_op_result()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::error::Error;
@@ -677,7 +734,7 @@ mod tests {
     use rten_tensor::{NdTensor, Tensor};
     use rten_testing::TestCases;
 
-    use super::{DepthToSpaceMode, depth_to_space};
+    use super::{ComputeShape, DepthToSpaceMode, DimSpec, depth_to_space};
     use crate::buffer_pool::BufferPool;
     use crate::operator::{OpError, OperatorExt};
     use crate::ops::layout::{
@@ -685,6 +742,43 @@ mod tests {
         squeeze_in_place, transpose, unsqueeze,
     };
     use crate::value::Value;
+
+    #[test]
+    fn test_compute_shape() {
+        // Valid input with a mix of static and dynamic output values.
+        let input_a = NdTensor::<f32, _>::zeros([2, 4, 8]);
+        let input_b = NdTensor::<f32, _>::zeros([24]);
+
+        let op = ComputeShape {
+            shape: [
+                DimSpec::Static(3),
+                DimSpec::Dynamic { input: 0, dim: 1 },
+                DimSpec::Static(5),
+                DimSpec::Dynamic { input: 1, dim: 0 },
+            ]
+            .into(),
+        };
+        let result: NdTensor<i32, 1> = op.run_simple((input_a.view(), input_b.view())).unwrap();
+
+        assert_eq!(result, NdTensorView::from(&[3, 4, 5, 24]));
+
+        // Dynamic input with invalid input index.
+        let op = ComputeShape {
+            shape: [DimSpec::Dynamic { input: 1, dim: 0 }].into(),
+        };
+        let result: Result<NdTensor<i32, 1>, _> = op.run_simple(input_a.view());
+        assert_eq!(result.err().unwrap(), OpError::MissingInputs);
+
+        // Dynamic input with invalid dim index.
+        let op = ComputeShape {
+            shape: [DimSpec::Dynamic { input: 0, dim: 3 }].into(),
+        };
+        let result: Result<NdTensor<i32, 1>, _> = op.run_simple(input_a.view());
+        assert_eq!(
+            result.err().unwrap(),
+            OpError::InvalidValue("Dim index invalid for input tensor shape")
+        );
+    }
 
     #[test]
     fn test_depth_to_space() {

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -80,7 +80,10 @@ pub(crate) use {
     generate::{ConstantOfShape, EyeLike, OneHot, Range},
     grid_sample::GridSample,
     identity::Identity,
-    layout::{DepthToSpace, Expand, Flatten, Reshape, Shape, Size, Squeeze, Transpose, Unsqueeze},
+    layout::{
+        ComputeShape, DepthToSpace, DimSpec, Expand, Flatten, Reshape, Shape, Size, Squeeze,
+        Transpose, Unsqueeze,
+    },
     matmul::{
         AccuracyLevel, FusedMatMul, Gemm, MatMul, MatMulInteger, MatMulIntegerToFloat, MatMulNBits,
     },

--- a/src/optimize/fusions.rs
+++ b/src/optimize/fusions.rs
@@ -1,6 +1,7 @@
 //! Traits for defining operator fusions and implementations of fusions.
 
 use std::borrow::Cow;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use rten_tensor::{ArcTensor, NdTensorView, SliceRange};
@@ -12,9 +13,9 @@ use crate::graph::{
 use crate::operator::Operator;
 use crate::ops::transform_inputs::TransformInputsBuilder;
 use crate::ops::{
-    AddSoftmax, Cast, DynamicQuantizeLinear, FusedMatMul, Gelu, LayerNormalization,
-    MatMulIntegerToFloat, Mul, Reciprocal, ReduceMean, RepeatInterleave, RmsNormalization, Silu,
-    Softmax, Swish, Transpose,
+    AddSoftmax, Cast, ComputeShape, DimSpec, DynamicQuantizeLinear, FusedMatMul, Gelu,
+    LayerNormalization, MatMulIntegerToFloat, Mul, Reciprocal, ReduceMean, RepeatInterleave,
+    RmsNormalization, Shape, Silu, Softmax, Swish, Transpose,
 };
 use crate::optimize::pattern_matcher::{Match, Pattern};
 
@@ -1232,6 +1233,121 @@ impl PatternFusion for SafeSoftmaxFusion {
             flush_nans_to_zero: true,
             ..*softmax_op
         })
+    }
+}
+
+/// Replace `Shape` operators with `ComputeShape` operators which generate the
+/// same output using dimension sizes that are either precomputed or extracted
+/// from graph inputs.
+///
+/// The benefit of this fusion is to remove a consumer of the value which feeds
+/// into the Shape operator. This potentially frees up the source operator to be
+/// included in fusions. For example, given:
+///
+/// ```text
+/// T = Sigmoid(X)
+/// S = Shape(T)
+/// Y = Mul(X, T)
+/// ```
+///
+/// The `Shape` operator prevents fusing this subgraph into `Silu(X)`, because
+/// it relies on the intermediate value `S`. If however we determine that `S`
+/// can be computed from another node closer to the graph inputs, we remove the
+/// `Shape(T)` and free up the remaining `Mul(X, Sigmoid(X))` to be fused.
+pub struct ComputeShapeFusion {}
+
+impl FusionVisitor for ComputeShapeFusion {
+    // Map of symbolic_dimension => (input_id, dimension_index)
+    type State = HashMap<String, (NodeId, u32)>;
+
+    fn prepare(&self, graph: &Graph) -> Self::State {
+        let mut map = HashMap::new();
+
+        for id in graph.input_ids() {
+            let Some(node) = graph.get_node(*id) else {
+                continue;
+            };
+            let Some(shape) = node.shape() else {
+                continue;
+            };
+
+            for (dim_idx, dim) in shape.iter().enumerate() {
+                match dim {
+                    Dimension::Symbolic(name) => {
+                        if !map.contains_key(name) {
+                            map.insert(name.to_string(), (*id, dim_idx as u32));
+                        }
+                    }
+                    Dimension::Fixed(_) => {}
+                }
+            }
+        }
+
+        map
+    }
+
+    fn maybe_fuse(
+        &self,
+        state: &Self::State,
+        graph: &Graph,
+        _op_node_id: NodeId,
+        op_node: &OperatorNode,
+    ) -> Option<Fusion> {
+        let shape_op = op_node.operator().downcast_ref::<Shape>()?;
+
+        // Shape operators which slice their inputs are not supported yet.
+        if shape_op.start.is_some() || shape_op.end.is_some() {
+            return None;
+        }
+
+        let &[Some(shape_source)] = op_node.input_ids() else {
+            return None;
+        };
+        let dims = graph.get_node(shape_source)?.shape()?;
+
+        if dims.iter().any(|dim| match dim {
+            Dimension::Symbolic(name) => !state.contains_key(name),
+            Dimension::Fixed(_) => false,
+        }) {
+            return None;
+        }
+
+        let mut input_ids = Vec::new();
+        let shape: Vec<DimSpec> = dims
+            .into_iter()
+            .map(|dim| match dim {
+                Dimension::Fixed(size) => DimSpec::Static(size as u32),
+                Dimension::Symbolic(name) => {
+                    let (input_id, dim) = state
+                        .get(&name)
+                        .copied()
+                        .expect("should have symbolic name");
+                    let idx =
+                        if let Some(used_idx) = input_ids.iter().position(|id| *id == input_id) {
+                            used_idx
+                        } else {
+                            input_ids.push(input_id);
+                            input_ids.len() - 1
+                        };
+                    DimSpec::Dynamic {
+                        input: idx as u32,
+                        dim,
+                    }
+                }
+            })
+            .collect();
+
+        let input_ids: Vec<_> = input_ids.into_iter().map(Some).collect();
+
+        let compute_shape = ComputeShape { shape };
+
+        Some(Fusion::from_op(
+            op_node.name(),
+            Arc::new(compute_shape),
+            &input_ids,
+            op_node.output_ids(),
+            op_node.input_ids(),
+        ))
     }
 }
 


### PR DESCRIPTION
Add a fusion which replaces `Shape` operators with a `ComputeShape` operator that produces the same output using information from shape inference. This information includes a mix of static values and dynamic values extracted from graph inputs.

The main benefit of this fusion is to remove a consumer of the operator output which feeds into the Shape op. This frees up that operator to be included in fusions. In the context of Llama 3, this will enable fusing the RepeatInterleave operator that broadcasts keys with the query-key matmul.

A hazard with this change is that it relies on metadata baked into the model from shape inference to be correct. This could eventually be avoided by implementing shape inference analysis within RTen.

Part of https://github.com/robertknight/rten/issues/1091.