### PR TITLE
Add GroupedQueryAttentionMatMul fusion

### DIFF
--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -65,7 +65,7 @@ pub(crate) use random::{
     Dropout, RandomNormal, RandomNormalLike, RandomUniform, RandomUniformLike,
 };
 pub(crate) use {
-    attention::{AddSoftmax, RepeatInterleave},
+    attention::{AddSoftmax, GroupedQueryAttentionMatMul, RepeatInterleave},
     binary_elementwise::{
         Add, And, Div, Equal, Greater, GreaterOrEqual, Less, LessOrEqual, Mod, Mul, Or, Pow, Sub,
         Where, Xor,

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -19,10 +19,10 @@ mod pattern_matcher;
 
 use fusions::{
     AddSoftmaxFusion, ApproxGeluFusion, CastElimination, ComputeShapeFusion, Fusion, FusionVisitor,
-    GeluFusion, IdentityFusion, LayerNormalizationFusion, MatMulAddFusion,
-    MatMulIntegerToFloatFusion, MatMulScaleFusion, PatternFusion, ReciprocalFusion,
-    ReduceMeanAxesFusion, RepeatInterleaveFusion, RmsNormalizationFusion, SafeSoftmaxFusion,
-    ShapeSliceToConstant, SiluFusion, SwishFusion, TransposeFusion,
+    GeluFusion, GroupedQueryAttentionMatMulFusion, IdentityFusion, LayerNormalizationFusion,
+    MatMulAddFusion, MatMulIntegerToFloatFusion, MatMulScaleFusion, PatternFusion,
+    ReciprocalFusion, ReduceMeanAxesFusion, RepeatInterleaveFusion, RmsNormalizationFusion,
+    SafeSoftmaxFusion, ShapeSliceToConstant, SiluFusion, SwishFusion, TransposeFusion,
 };
 
 /// Errors that occur while applying graph optimizations.
@@ -418,6 +418,7 @@ impl GraphOptimizer {
         fusions.push(SafeSoftmaxFusion {}.into_visitor());
         fusions.push(AddSoftmaxFusion {}.into_visitor());
         fusions.push(RepeatInterleaveFusion {}.into_visitor());
+        fusions.push(GroupedQueryAttentionMatMulFusion {}.into_visitor());
 
         // Layout fusions
         fusions.push(TransposeFusion {});


### PR DESCRIPTION
Add a GroupedQueryAttentionMatMul operator that fuses RepeatInterleave + MatMul
in the case where the LHS and RHS inputs are 4D, and the RHS is optionally
transposed and scaled. This fusion avoids materializing the broadcasted
key/value tensors.

Tests for fusions co-authored by Claude.

Part of https://github.com/robertknight/rten/issues/1091.

