### PR TITLE
Avoid unnecessary copies in `Node::shape`

### DIFF
--- a/src/graph/node.rs
+++ b/src/graph/node.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::sync::Arc;
 
 use rten_tensor::prelude::*;
@@ -29,14 +30,14 @@ impl Node {
     ///
     /// For constants this is the shape of the tensor. Operator nodes have no
     /// shape. For values (eg. inputs/outputs) this is the expected shape.
-    pub fn shape(&self) -> Option<Vec<Dimension>> {
+    pub fn shape(&self) -> Option<Cow<'_, [Dimension]>> {
         let dims_from_fixed_shape =
             |shape: &[usize]| shape.iter().copied().map(Dimension::Fixed).collect();
 
         match self {
             Node::Operator(_) => None,
-            Node::Constant(node) => Some(dims_from_fixed_shape(node.layout().shape())),
-            Node::Value(node) => node.shape.clone(),
+            Node::Constant(node) => Some(Cow::Owned(dims_from_fixed_shape(node.layout().shape()))),
+            Node::Value(node) => node.shape.as_deref().map(Cow::Borrowed),
         }
     }
 

--- a/src/graph/tests.rs
+++ b/src/graph/tests.rs
@@ -237,7 +237,7 @@ fn test_graph_node_shapes() {
 
     assert_eq!(
         g.get_node(weights_id).and_then(|n| n.shape()),
-        Some([1, 1, 2].map(Dimension::Fixed).to_vec())
+        Some([1, 1, 2].map(Dimension::Fixed).as_slice().into())
     );
     assert_eq!(
         g.get_node(input_id).and_then(|n| n.shape()),
@@ -248,7 +248,8 @@ fn test_graph_node_shapes() {
                 Dimension::Fixed(5),
                 Dimension::Fixed(5),
             ]
-            .to_vec()
+            .as_slice()
+            .into()
         )
     );
     assert_eq!(g.get_node(relu_op_id).and_then(|n| n.shape()), None);

--- a/src/model.rs
+++ b/src/model.rs
@@ -586,7 +586,7 @@ impl<'a> NodeInfo<'a> {
     ///
     /// The shape can be a combination of fixed values and symbolic names.
     pub fn shape(&self) -> Option<Vec<Dimension>> {
-        self.node.shape()
+        self.node.shape().map(|n| n.into_owned())
     }
 
     /// Return the expected data type for this node at runtime.


### PR DESCRIPTION
Avoid cloning the `Vec<Dimension>` when `Node::shape` is called on a value node.

This is worthwhile if we have a large graph and a lot of value node shape queries are performed by the optimizer.