### PR TITLE
Add shape inference traits and common implementations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -562,6 +562,10 @@ version = "0.23.0"
 [[package]]
 name = "rten-shape-inference"
 version = "0.23.0"
+dependencies = [
+ "rten-testing",
+ "smallvec",
+]
 
 [[package]]
 name = "rten-simd"

--- a/rten-shape-inference/Cargo.toml
+++ b/rten-shape-inference/Cargo.toml
@@ -10,3 +10,9 @@ repository = "https://github.com/robertknight/rten"
 
 [lib]
 crate-type = ["lib"]
+
+[dependencies]
+smallvec = { workspace = true }
+
+[dev-dependencies]
+rten-testing = { path = "../rten-testing" }

--- a/rten-shape-inference/src/infer_shapes.rs
+++ b/rten-shape-inference/src/infer_shapes.rs
@@ -1,0 +1,422 @@
+//! Traits for shape inference and common implementations.
+
+use smallvec::SmallVec;
+
+pub use crate::{
+    sym_gen::SymbolGen,
+    sym_tensor::{Constant, SymElem, SymTensor, Symbol},
+};
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum InferShapesError {
+    /// Too many or too few inputs were provided for this operator.
+    IncorrectInputCount,
+
+    /// The input shapes are incompatible.
+    ///
+    /// Operator execution will fail if given inputs with these shapes.
+    IncompatibleShapes,
+
+    /// An input's rank does not match that expected by the operator.
+    IncorrectRank,
+
+    /// An operator input or attribute has an invalid value.
+    InvalidValue,
+}
+
+/// Infer the shapes of an operator's outputs given its inputs.
+pub trait InferShapes {
+    /// Infer the shapes and optionally values of an operator's outputs given
+    /// its inputs.
+    ///
+    /// The operator may need to generate new symbolic dimensions to represent
+    /// dimensions that are unknown or combinations of inputs. These should be
+    /// generated using `sym_gen`.
+    fn infer_shapes(
+        &self,
+        inputs: &[SymTensor],
+        sym_gen: &mut SymbolGen,
+    ) -> Result<Vec<SymTensor>, InferShapesError>;
+}
+
+/// Shape inference for unary operators.
+///
+/// These operators take at least one input and return a single output with
+/// the same shape as the first input. Unary operators may take additional
+/// inputs (eg. min/max parameters for the Clip operator) that don't affect
+/// the output shape.
+pub struct UnaryOp;
+
+impl InferShapes for UnaryOp {
+    fn infer_shapes(
+        &self,
+        inputs: &[SymTensor],
+        _sym_gen: &mut SymbolGen,
+    ) -> Result<Vec<SymTensor>, InferShapesError> {
+        let Some(data) = inputs.first() else {
+            return Err(InferShapesError::IncorrectInputCount);
+        };
+
+        let shape = if let Some(shape) = data.shape() {
+            SymTensor::from_shape(shape.collect())
+        } else {
+            SymTensor::unknown("unknown input shape")
+        };
+
+        Ok([shape].into())
+    }
+}
+
+/// Shape inference for binary operators.
+///
+/// These operators take two inputs and return an output whose shape is the
+/// result of broadcasting the two input shapes together following ONNX's
+/// [broadcasting rules](https://onnx.ai/onnx/repo-docs/Broadcasting.html).
+pub struct BinaryOp;
+
+impl InferShapes for BinaryOp {
+    fn infer_shapes(
+        &self,
+        inputs: &[SymTensor],
+        _sym_gen: &mut SymbolGen,
+    ) -> Result<Vec<SymTensor>, InferShapesError> {
+        let [a, b] = inputs else {
+            return Err(InferShapesError::IncorrectInputCount);
+        };
+
+        let (Some(a_dims), Some(b_dims)) = (a.shape(), b.shape()) else {
+            return Ok([SymTensor::unknown("unknown input shape")].into());
+        };
+
+        let a_pad = b_dims.len().saturating_sub(a_dims.len());
+        let b_pad = a_dims.len().saturating_sub(b_dims.len());
+        let mut out_shape: Vec<SymElem> = Vec::with_capacity(a_pad + a_dims.len());
+
+        let a_iter = std::iter::repeat_n(SymElem::Value(1), a_pad).chain(a_dims);
+        let b_iter = std::iter::repeat_n(SymElem::Value(1), b_pad).chain(b_dims);
+
+        for (a, b) in a_iter.zip(b_iter) {
+            let dim: SymElem = match (a, b) {
+                (a, b) if a == b => a.clone(),
+
+                // If either size is 1, it will be broadcast against the other
+                // size.
+                (SymElem::Value(1), b) => b.clone(),
+                (a, SymElem::Value(1)) => a.clone(),
+
+                // If both sizes are fixed and different, we know execution
+                // will fail.
+                (SymElem::Value(_), SymElem::Value(_)) => {
+                    return Err(InferShapesError::IncompatibleShapes);
+                }
+
+                // If one dim is a fixed value other than 1 and the other
+                // dim is symbolic, execution can only succeed if the symbolic
+                // dim has the same size as the fixed dim.
+                (SymElem::Var(_a), SymElem::Value(b)) => SymElem::Value(b),
+                (SymElem::Value(a), SymElem::Var(_b)) => SymElem::Value(a),
+
+                // In cases where both values are unknown, the result can be
+                // either of the dimensions.
+                //
+                // 1. If both sizes are equal, the result can be seen as either
+                //    the first or second dim.
+                // 2. If only one of the sizes is 1, the result will be the other
+                //    dim.
+                // 3. If the sizes are different, the op will fail.
+                //
+                // Where the op succeeds, the result is the maximum of the LHS
+                // and RHS sizes.
+                (a, b) => SymElem::Max((a.into(), b.into())),
+            };
+            out_shape.push(dim);
+        }
+
+        Ok([SymTensor::from_shape(out_shape)].into())
+    }
+}
+
+/// Shape inference for reduction operators.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ReductionOp<'a> {
+    /// Axes over which the reduction is applied.
+    ///
+    /// Reduction ops take the axes as an attribute in ONNX opset <= 13 and an
+    /// input in opset 18+.
+    pub axes: Option<&'a [i32]>,
+
+    /// True if the reduced dimension is retained as a 1-sized dimension in the
+    /// output.
+    pub keep_dims: bool,
+}
+
+impl InferShapes for ReductionOp<'_> {
+    fn infer_shapes(
+        &self,
+        inputs: &[SymTensor],
+        _sym_gen: &mut SymbolGen,
+    ) -> Result<Vec<SymTensor>, InferShapesError> {
+        match inputs.len() {
+            1 | 2 => {}
+            _ => {
+                return Err(InferShapesError::IncorrectInputCount);
+            }
+        }
+
+        let data = &inputs[0];
+
+        let Some(data_dims) = data.shape() else {
+            return Ok([SymTensor::unknown("unknown input shape")].into());
+        };
+
+        let ndim = data_dims.len();
+        let mut axes: SmallVec<[usize; 4]> =
+            if let Some(Constant::Vector(axes)) = inputs.get(1).and_then(|x| x.to_constant()) {
+                resolve_axes(ndim, axes.iter()).map_err(|_| InferShapesError::IncorrectRank)?
+            } else if let Some(axes) = self.axes {
+                resolve_axes(ndim, axes.iter()).map_err(|_| InferShapesError::IncorrectRank)?
+            } else {
+                (0..ndim).collect()
+            };
+        axes.sort();
+        axes.dedup();
+
+        let out_ndim = if self.keep_dims {
+            ndim
+        } else {
+            ndim - axes.len()
+        };
+        let mut out_shape = Vec::with_capacity(out_ndim);
+
+        for (i, dim) in data_dims.enumerate() {
+            if !axes.contains(&i) {
+                out_shape.push(dim.clone());
+                continue;
+            } else if self.keep_dims {
+                out_shape.push(SymElem::Value(1));
+            }
+        }
+
+        Ok([SymTensor::from_shape(out_shape)].into())
+    }
+}
+
+/// Resolve an index given as a value in `[-len, len-1]` to a positive index in
+/// `[0, len)`, or return None if the index is out of bounds.
+fn resolve_index(len: usize, index: i32) -> Option<usize> {
+    let len = len.min(i32::MAX as usize) as i32;
+    if index < -len || index >= len {
+        return None;
+    }
+
+    if index >= 0 {
+        Some(index as usize)
+    } else {
+        Some((len + index) as usize)
+    }
+}
+
+/// Resolve an axis given as a value in `[-ndim, ndim-1]` to the zero-based
+/// dimension of a tensor with `ndim` dimensions.
+///
+/// Negative axis values count backwards from the last dimension.
+fn resolve_axis(ndim: usize, axis: i32) -> Result<usize, InferShapesError> {
+    resolve_index(ndim, axis).ok_or(InferShapesError::IncorrectRank)
+}
+
+/// Resolve a sequence of axes values in `[-ndim, ndim-1]` to zero-based dimension
+/// indexes in a tensor with `ndim` dimensions.
+///
+/// Negative axis values count backwards from the last dimension.
+fn resolve_axes<'a, I: ExactSizeIterator<Item = &'a i32>>(
+    ndim: usize,
+    axes: I,
+) -> Result<SmallVec<[usize; 4]>, InferShapesError> {
+    let mut resolved_axes = SmallVec::with_capacity(axes.len());
+    for axis in axes {
+        let resolved = resolve_axis(ndim, *axis)?;
+        resolved_axes.push(resolved);
+    }
+    Ok(resolved_axes)
+}
+
+#[cfg(test)]
+mod tests {
+    use rten_testing::TestCases;
+
+    use super::{
+        BinaryOp, InferShapes, InferShapesError, ReductionOp, SymElem, SymTensor, SymbolGen,
+        UnaryOp,
+    };
+
+    macro_rules! dims {
+        ($($x:expr),* $(,)?) => {
+            vec![$(SymElem::from($x)),*]
+        };
+    }
+
+    fn inputs(dims: impl IntoIterator<Item = Vec<SymElem>>) -> Vec<SymTensor> {
+        dims.into_iter().map(SymTensor::from_shape).collect()
+    }
+
+    #[test]
+    fn test_unary_op_infer() {
+        let input = dims!("batch", 16, "seq", 24);
+        let mut sym_gen = SymbolGen::new();
+        let shape = UnaryOp
+            .infer_shapes(&inputs([input.clone()]), &mut sym_gen)
+            .unwrap();
+        assert_eq!(shape.len(), 1);
+        assert_eq!(shape[0], SymTensor::from_shape(input.clone()));
+
+        let err = UnaryOp.infer_shapes(&[], &mut sym_gen).err().unwrap();
+        assert_eq!(err, InferShapesError::IncorrectInputCount);
+    }
+
+    #[test]
+    fn test_binary_op() {
+        #[derive(Debug)]
+        struct Case {
+            lhs: Vec<SymElem>,
+            rhs: Vec<SymElem>,
+            expected: Vec<SymElem>,
+        }
+
+        let cases = [
+            Case {
+                lhs: dims!("batch"),
+                rhs: dims!("batch"),
+                expected: dims!("batch"),
+            },
+            Case {
+                lhs: dims!(2, 3),
+                rhs: dims!(2, 3),
+                expected: dims!(2, 3),
+            },
+            Case {
+                lhs: dims!(1, 5),
+                rhs: dims!(4, 1),
+                expected: dims!(4, 5),
+            },
+            Case {
+                lhs: dims!(1, 1),
+                rhs: dims!(1, 1),
+                expected: dims!(1, 1),
+            },
+            Case {
+                lhs: dims!(1, "bar"),
+                rhs: dims!("foo", 1),
+                expected: dims!("foo", "bar"),
+            },
+            Case {
+                lhs: dims!("foo"),
+                rhs: dims!("bar"),
+                expected: dims!(SymElem::Max((
+                    SymElem::from("foo").into(),
+                    SymElem::from("bar").into()
+                ))),
+            },
+        ];
+
+        cases.test_each(|case| {
+            let mut sym_gen = SymbolGen::new();
+            let shape = BinaryOp
+                .infer_shapes(&inputs([case.lhs.clone(), case.rhs.clone()]), &mut sym_gen)
+                .unwrap();
+            assert_eq!(shape.len(), 1);
+            assert_eq!(shape[0], SymTensor::from_shape(case.expected.clone()));
+        });
+    }
+
+    #[test]
+    fn test_binary_op_invalid() {
+        #[derive(Clone, Debug)]
+        struct Case {
+            inputs: Vec<Vec<SymElem>>,
+            expected: InferShapesError,
+        }
+
+        let cases = [
+            Case {
+                inputs: [dims!(5)].into(),
+                expected: InferShapesError::IncorrectInputCount,
+            },
+            Case {
+                inputs: [dims!(5), dims!(3)].into(),
+                expected: InferShapesError::IncompatibleShapes,
+            },
+        ];
+
+        cases.test_each_clone(|case| {
+            let mut sym_gen = SymbolGen::new();
+            let inputs: Vec<_> = case.inputs.into_iter().map(SymTensor::from_shape).collect();
+            let err = BinaryOp.infer_shapes(&inputs, &mut sym_gen).err().unwrap();
+            assert_eq!(err, case.expected);
+        });
+    }
+
+    #[test]
+    fn test_reduction_op() {
+        #[derive(Clone, Debug)]
+        struct Case<'a> {
+            inputs: Vec<SymTensor>,
+            op: ReductionOp<'a>,
+            expected: Vec<SymElem>,
+        }
+
+        let axes = vec![SymElem::Value(1i32)];
+
+        let default_op = ReductionOp {
+            axes: None,
+            keep_dims: false,
+        };
+
+        let cases = [
+            // Reduce single axis
+            Case {
+                inputs: [
+                    SymTensor::from_shape(dims!("batch", 4, 5)),
+                    SymTensor::from_vec(axes.clone()),
+                ]
+                .into(),
+                op: default_op.clone(),
+                expected: dims!("batch", 5),
+            },
+            // Reduce single axis specified as an attribute
+            Case {
+                inputs: [SymTensor::from_shape(dims!("batch", 4, 5))].into(),
+                op: ReductionOp {
+                    axes: Some(&[1i32]),
+                    ..default_op
+                },
+                expected: dims!("batch", 5),
+            },
+            // Reduce single axis with `keep_dims=true`
+            Case {
+                inputs: [
+                    SymTensor::from_shape(dims!("batch", 4, 5)),
+                    SymTensor::from_vec(axes.clone()),
+                ]
+                .into(),
+                op: ReductionOp {
+                    keep_dims: true,
+                    ..default_op
+                },
+                expected: dims!("batch", 1, 5),
+            },
+            // Reduce all axes
+            Case {
+                inputs: [SymTensor::from_shape(dims!(3, 4, 5))].into(),
+                op: default_op.clone(),
+                expected: dims!(),
+            },
+        ];
+
+        cases.test_each(|case| {
+            let mut sym_gen = SymbolGen::new();
+            let shapes = case.op.infer_shapes(&case.inputs, &mut sym_gen).unwrap();
+            assert_eq!(shapes.len(), 1);
+            assert_eq!(shapes[0], SymTensor::from_shape(case.expected.clone()));
+        });
+    }
+}

--- a/rten-shape-inference/src/lib.rs
+++ b/rten-shape-inference/src/lib.rs
@@ -1,3 +1,39 @@
 //! Shape inference for ONNX graphs.
-
+//!
+//! # About shape inference
+//!
+//! Some ONNX model optimizations depend upon knowledge about the shapes and
+//! types of various values in the graph. These values may have dynamic sizes
+//! that depend on model inputs. In a typical language model for example, the
+//! input has dynamic dimensions for the batch size and sequence length.
+//!
+//! The goal of shape inference is to take information embedded in the model
+//! about the shapes of model inputs and trace how graph operators transform,
+//! extract and otherwise process tensor shapes, and produce metadata about the
+//! shape of each value in the graph.
+//!
+//! As an example, suppose a model has an image input of shape (batch, 3,
+//! height, width) and computes a mask with shape (batch, height, width). This
+//! could be done with a sequence of operators such as:
+//!
+//! ```text
+//! S = Shape(Image) // ["batch", 3, "height", "width"]
+//! B = Gather(S, axis=0, indices=0) // "batch"
+//! BV = Unsqueeze(B, axis=0) // ["batch"]
+//! H = Gather(S, axis=0, indices=2) // "height"
+//! HV = Unsqueeze(H, axis=0) // ["height"]
+//! W = Gather(S, axis=0, indices=3) // "width"
+//! WV = Unsqueeze(H, axis=0) // ["width"]
+//! S2 = Concat<axis=0>(BV, HV, WV) // ["batch", "height", "width"]
+//! Mask = ConstantOfShape<value=1>(S2) // shape("batch", "height", "width")
+//! ```
+//!
+//! Shape inference of this graph involves following the extraction of the of
+//! the input shape, its transformation and uses in order to determine the shape
+//! of the output. If there was an optimization to combine all these nodes into
+//! one, which depended on knowing that the output shape was the same as the
+//! input minus the second dimension, the results of shape inference could be
+//! used to verify this.
+pub mod infer_shapes;
+pub mod sym_gen;
 pub mod sym_tensor;

--- a/rten-shape-inference/src/sym_gen.rs
+++ b/rten-shape-inference/src/sym_gen.rs
@@ -1,0 +1,69 @@
+//! Symbol name generator.
+
+use std::borrow::Cow;
+
+use crate::sym_tensor::{SymElem, Symbol};
+
+/// Generates named symbols.
+///
+/// Sometimes during shape inference it may be necessary to generate a new
+/// symbol to represent a value that cannot be represented as an expression.
+///
+/// Note that generally it is preferred to represent values computed from other
+/// values as symbolic expressions. This allows the expressions to be compared,
+/// simplified and otherwise manipulated.
+pub struct SymbolGen {
+    prefix: Cow<'static, str>,
+    next_symbol_id: u32,
+}
+
+impl Default for SymbolGen {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SymbolGen {
+    pub fn new() -> Self {
+        Self::with_prefix("unknown".into())
+    }
+
+    pub fn with_prefix(prefix: Cow<'static, str>) -> Self {
+        Self {
+            prefix,
+            next_symbol_id: 0,
+        }
+    }
+
+    fn gen_name(&mut self) -> String {
+        self.next_symbol_id += 1;
+        format!("{}_{}", self.prefix, self.next_symbol_id)
+    }
+
+    /// Generate a new symbolic value which is assumed to be positive.
+    pub fn gen_positive(&mut self) -> SymElem {
+        SymElem::Var(
+            Symbol {
+                name: self.gen_name(),
+                positive: true,
+            }
+            .into(),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SymElem, SymbolGen};
+
+    #[test]
+    fn test_symbol_gen() {
+        let mut sym_gen = SymbolGen::new();
+        assert_eq!(sym_gen.gen_positive(), SymElem::pos_var("unknown_1"));
+        assert_eq!(sym_gen.gen_positive(), SymElem::pos_var("unknown_2"));
+
+        let mut sym_gen = SymbolGen::with_prefix("foo".into());
+        assert_eq!(sym_gen.gen_positive(), SymElem::pos_var("foo_1"));
+        assert_eq!(sym_gen.gen_positive(), SymElem::pos_var("foo_2"));
+    }
+}


### PR DESCRIPTION
Add traits for shape inference and common implementations for unary, binary and reduction ops.

The common implementations handle shape inference but ignore any symbolic values in the tensor. This means that the symbolic output always contains just a shape and any information about the values is lost.

Part of https://github.com/robertknight/rten/issues/1091.