### PR TITLE
Enable type inference for many operators

### DIFF
--- a/src/operator.rs
+++ b/src/operator.rs
@@ -313,6 +313,7 @@ impl<'a, 'i> OpRunContext<'a, 'i> {
 }
 
 /// Rule for determining the type of an operator output.
+#[derive(Copy, Clone)]
 pub enum OutputType {
     /// This output has a fixed type, given the operator's attributes.
     Fixed(DataType),

--- a/src/ops/attention.rs
+++ b/src/ops/attention.rs
@@ -8,7 +8,9 @@ use rten_tensor::{NdTensorView, Tensor, TensorView};
 use rten_vecmath::Softmax;
 
 use crate::buffer_pool::{AutoReturn, BufferPool};
-use crate::operator::{IntoOpResult, OpError, OpRunContext, Operator, OutputList};
+use crate::operator::{
+    IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType, OutputTypeList,
+};
 use crate::ops::{
     binary_elementwise::broadcast_shapes, layout::expand_to, norm::NanHandling, resolve_axis,
 };
@@ -140,6 +142,10 @@ impl Operator for AddSoftmax {
 
         add_softmax_in_place(ctx.pool(), qk, m, self.nan_handling()).map(|qk| qk.into())
     }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        Some([OutputType::CopyFromInput(0)].into())
+    }
 }
 
 fn repeat_interleave<T: Copy>(
@@ -196,6 +202,10 @@ impl Operator for RepeatInterleave {
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let input: TensorView<f32> = ctx.inputs().require_as(0)?;
         repeat_interleave(ctx.pool(), input, self.axis, self.repeats).into_op_result()
+    }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        Some([OutputType::CopyFromInput(0)].into())
     }
 }
 
@@ -279,6 +289,10 @@ impl Operator for GroupedQueryAttentionMatMul {
         unsafe { out_data.set_len(out_size) };
 
         Tensor::from_data(&[batch, heads, seq, rhs_n], out_data).into_op_result()
+    }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        Some([OutputType::CopyFromInput(0)].into())
     }
 }
 

--- a/src/ops/conv.rs
+++ b/src/ops/conv.rs
@@ -12,12 +12,15 @@ use rten_tensor::prelude::*;
 use rten_tensor::{CowTensor, NdTensor, NdTensorView, Tensor, TensorView};
 
 use crate::buffer_pool::{AutoReturn, BufferPool, PoolRef};
-use crate::operator::{IntoOpResult, OpError, OpRunContext, Operator, OutputList, static_dims};
+use crate::operator::{
+    IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType, OutputTypeList,
+    static_dims,
+};
 use crate::ops::Padding;
 use crate::ops::matmul::zero_point_to_vec;
 use crate::ops::pooling::{RoundMode, calc_output_size_and_padding};
 use crate::shift_cast::ShiftCast;
-use crate::value::ValueView;
+use crate::value::{DataType, ValueView};
 
 mod depthwise;
 mod im2col;
@@ -389,6 +392,10 @@ impl Operator for Conv {
         )
         .into_op_result()
     }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        Some([OutputType::CopyFromInput(0)].into())
+    }
 }
 
 pub fn conv_integer<X, W>(
@@ -541,6 +548,10 @@ impl Operator for ConvInteger {
             (ValueView::UInt8Tensor(x), ValueView::UInt8Tensor(w)) => conv_integer!(x, w),
             _ => Err(OpError::UnsupportedType),
         }
+    }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        Some([OutputType::Fixed(DataType::Int32)].into())
     }
 }
 

--- a/src/ops/conv_transpose.rs
+++ b/src/ops/conv_transpose.rs
@@ -8,7 +8,10 @@ use rten_tensor::prelude::*;
 use rten_tensor::{NdTensor, NdTensorView, NdTensorViewMut, Tensor, TensorView};
 
 use crate::buffer_pool::{AutoReturn, BufferPool};
-use crate::operator::{IntoOpResult, OpError, OpRunContext, Operator, OutputList, static_dims};
+use crate::operator::{
+    IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType, OutputTypeList,
+    static_dims,
+};
 use crate::ops::Padding;
 
 /// Compute the range of input positions along a spatial axis that result in
@@ -387,6 +390,10 @@ impl Operator for ConvTranspose {
             self.output_padding.as_deref(),
         )
         .into_op_result()
+    }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        Some([OutputType::CopyFromInput(0)].into())
     }
 }
 

--- a/src/ops/fft.rs
+++ b/src/ops/fft.rs
@@ -4,7 +4,10 @@ use rustfft::FftPlanner;
 use rustfft::num_complex::Complex32;
 
 use crate::buffer_pool::BufferPool;
-use crate::operator::{IntoOpResult, OpError, OpRunContext, Operator, OutputList};
+use crate::operator::{
+    IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType, OutputTypeList,
+};
+use crate::value::DataType;
 
 enum FftType {
     /// FFT with real input signal.
@@ -150,6 +153,10 @@ impl Operator for STFT {
             self.onesided,
         )
         .into_op_result()
+    }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        Some([OutputType::CopyFromInput(0)].into())
     }
 }
 

--- a/src/ops/grid_sample.rs
+++ b/src/ops/grid_sample.rs
@@ -2,7 +2,9 @@ use rten_tensor::prelude::*;
 use rten_tensor::{NdTensor, NdTensorView};
 
 use crate::buffer_pool::BufferPool;
-use crate::operator::{IntoOpResult, OpError, OpRunContext, Operator, OutputList};
+use crate::operator::{
+    IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType, OutputTypeList,
+};
 
 /// Interpolate between `x0` and `x1` according to the `factor` in range [0, 1].
 fn lerp(x0: f32, x1: f32, factor: f32) -> f32 {
@@ -137,6 +139,10 @@ impl Operator for GridSample {
         let input = ctx.inputs().require_as(0)?;
         let grid = ctx.inputs().require_as(1)?;
         grid_sample(ctx.pool(), input, grid, self.align_corners).into_op_result()
+    }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        Some([OutputType::CopyFromInput(0)].into())
     }
 }
 

--- a/src/ops/identity.rs
+++ b/src/ops/identity.rs
@@ -2,7 +2,9 @@ use rten_tensor::prelude::*;
 use rten_tensor::{Tensor, TensorView};
 
 use crate::buffer_pool::BufferPool;
-use crate::operator::{IntoOpResult, OpError, OpRunContext, Operator, OutputList};
+use crate::operator::{
+    IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType, OutputTypeList,
+};
 use crate::ops::map_value_view;
 use crate::value::{Value, ValueView};
 
@@ -33,6 +35,10 @@ impl Operator for Identity {
 
     fn run_in_place(&self, input: Value, _ctx: &OpRunContext) -> Result<Value, OpError> {
         Ok(input)
+    }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        Some([OutputType::CopyFromInput(0)].into())
     }
 }
 

--- a/src/ops/non_max_suppression.rs
+++ b/src/ops/non_max_suppression.rs
@@ -2,7 +2,10 @@ use rten_tensor::prelude::*;
 use rten_tensor::{NdTensor, NdTensorView};
 
 use crate::buffer_pool::BufferPool;
-use crate::operator::{IntoOpResult, OpError, OpRunContext, Operator, OutputList};
+use crate::operator::{
+    IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType, OutputTypeList,
+};
+use crate::value::DataType;
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum BoxOrder {
@@ -215,6 +218,10 @@ impl Operator for NonMaxSuppression {
         )?;
 
         selected_box_indices.into_op_result()
+    }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        Some([OutputType::Fixed(DataType::Int32)].into())
     }
 }
 

--- a/src/ops/pad.rs
+++ b/src/ops/pad.rs
@@ -4,7 +4,9 @@ use rten_tensor::prelude::*;
 use rten_tensor::{NdTensorView, NdTensorViewMut, SliceItem, Tensor, TensorView};
 
 use crate::buffer_pool::BufferPool;
-use crate::operator::{IntoOpResult, OpError, OpRunContext, Operator, OutputList};
+use crate::operator::{
+    IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType, OutputTypeList,
+};
 use crate::ops::map_value_view;
 use crate::value::ValueView;
 
@@ -282,6 +284,10 @@ impl Operator for Pad {
             let const_val = inputs.get_as(2)?.unwrap_or_default();
             pad(ctx.pool(), x, &pads, self.mode, const_val).into_op_result()
         })
+    }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        Some([OutputType::CopyFromInput(0)].into())
     }
 }
 

--- a/src/ops/pooling.rs
+++ b/src/ops/pooling.rs
@@ -8,7 +8,10 @@ use rten_tensor::{NdTensor, NdTensorView, NdTensorViewMut, Tensor, TensorView, T
 use smallvec::SmallVec;
 
 use crate::buffer_pool::BufferPool;
-use crate::operator::{IntoOpResult, OpError, OpRunContext, Operator, OutputList, static_dims};
+use crate::operator::{
+    IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType, OutputTypeList,
+    static_dims,
+};
 use crate::ops::{Padding, check_value};
 
 /// Rounding method to use when computing the output shape for a pooling
@@ -452,6 +455,10 @@ impl Operator for AveragePool {
         )
         .into_op_result()
     }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        Some([OutputType::CopyFromInput(0)].into())
+    }
 }
 
 fn global_pool<T: Clone + Send + Sync>(
@@ -516,6 +523,10 @@ impl Operator for GlobalAveragePool {
         let input = ctx.inputs().require_as(0)?;
         global_average_pool(ctx.pool(), input).into_op_result()
     }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        Some([OutputType::CopyFromInput(0)].into())
+    }
 }
 
 pub fn global_max_pool(pool: &BufferPool, input: TensorView) -> Result<Tensor, OpError> {
@@ -539,6 +550,10 @@ impl Operator for GlobalMaxPool {
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let input = ctx.inputs().require_as(0)?;
         global_max_pool(ctx.pool(), input).into_op_result()
+    }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        Some([OutputType::CopyFromInput(0)].into())
     }
 }
 
@@ -595,6 +610,10 @@ impl Operator for MaxPool {
             },
         )
         .into_op_result()
+    }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        Some([OutputType::CopyFromInput(0)].into())
     }
 }
 

--- a/src/ops/random.rs
+++ b/src/ops/random.rs
@@ -3,8 +3,10 @@ use fastrand_contrib::RngExt;
 use rten_tensor::prelude::*;
 use rten_tensor::{Tensor, TensorView};
 
-use crate::operator::{IntoOpResult, OpError, OpRunContext, Operator, OutputList};
-use crate::value::Value;
+use crate::operator::{
+    IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType, OutputTypeList,
+};
+use crate::value::{DataType, Value};
 
 #[derive(Debug)]
 pub struct RandomUniform {
@@ -43,6 +45,10 @@ impl Operator for RandomUniform {
         };
         Tensor::from_simple_fn_in(ctx.pool(), shape, || scale_value(rng.f32())).into_op_result()
     }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        Some([OutputType::Fixed(DataType::Float)].into())
+    }
 }
 
 #[derive(Debug)]
@@ -76,6 +82,10 @@ impl Operator for RandomUniformLike {
             shape: input.shape().to_vec(),
         };
         op.run(ctx)
+    }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        Some([OutputType::Fixed(DataType::Float)].into())
     }
 }
 
@@ -126,6 +136,10 @@ impl Operator for RandomNormal {
         })
         .into_op_result()
     }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        Some([OutputType::Fixed(DataType::Float)].into())
+    }
 }
 
 #[derive(Debug)]
@@ -159,6 +173,10 @@ impl Operator for RandomNormalLike {
             shape: input.shape().to_vec(),
         };
         op.run(ctx)
+    }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        Some([OutputType::Fixed(DataType::Float)].into())
     }
 }
 
@@ -239,6 +257,13 @@ impl Operator for Dropout {
     //
     // Operators currently do not have a way to check if an output is unused, so
     // we can't check condition (1).
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        Some(OutputTypeList::from_slice(&[
+            OutputType::CopyFromInput(0),
+            OutputType::Fixed(DataType::Int32),
+        ]))
+    }
 }
 
 #[cfg(test)]

--- a/src/ops/resize.rs
+++ b/src/ops/resize.rs
@@ -8,7 +8,8 @@ use rten_tensor::{NdTensor, NdTensorView, NdTensorViewMut, Tensor, TensorView};
 
 use crate::buffer_pool::{AutoReturn, BufferPool};
 use crate::operator::{
-    InputList, IntoOpResult, OpError, OpRunContext, Operator, OutputList, static_dims,
+    InputList, IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType,
+    OutputTypeList, static_dims,
 };
 use crate::value::{TryFromValueError, Value, ValueView};
 
@@ -502,6 +503,10 @@ impl Operator for Resize {
             self.nearest_mode,
         )
         .into_op_result()
+    }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        Some([OutputType::CopyFromInput(0)].into())
     }
 
     fn can_run_in_place(&self) -> bool {

--- a/src/ops/rnn.rs
+++ b/src/ops/rnn.rs
@@ -6,9 +6,13 @@ use rten_tensor::prelude::*;
 use rten_tensor::{NdTensor, Tensor, TensorView};
 
 use crate::buffer_pool::{AutoReturn, BufferPool};
-use crate::operator::{IntoOpResult, OpError, OpRunContext, Operator, OutputList, static_dims};
+use crate::operator::{
+    IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType, OutputTypeList,
+    static_dims,
+};
 use crate::ops::binary_elementwise::{add_in_place, mul_in_place};
 use crate::ops::unary_elementwise::{sigmoid, tanh};
+use crate::value::DataType;
 
 /// Direction that an RNN operator will traverse the input sequence in.
 #[derive(Copy, Clone, Debug)]
@@ -342,6 +346,13 @@ impl Operator for GRU {
         )
         .into_op_result()
     }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        Some(OutputTypeList::from_slice(&[
+            OutputType::Fixed(DataType::Float),
+            OutputType::Fixed(DataType::Float),
+        ]))
+    }
 }
 
 /// Long Short-Term Memory operator.
@@ -588,6 +599,14 @@ impl Operator for LSTM {
             initial_cell,
         )
         .into_op_result()
+    }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        Some(OutputTypeList::from_slice(&[
+            OutputType::Fixed(DataType::Float),
+            OutputType::Fixed(DataType::Float),
+            OutputType::Fixed(DataType::Float),
+        ]))
     }
 }
 

--- a/src/ops/sequence.rs
+++ b/src/ops/sequence.rs
@@ -2,7 +2,10 @@ use rten_tensor::prelude::*;
 use rten_tensor::{Tensor, TensorView};
 
 use crate::buffer_pool::BufferPool;
-use crate::operator::{InputList, IntoOpResult, OpError, OpRunContext, Operator, OutputList};
+use crate::operator::{
+    InputList, IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType,
+    OutputTypeList,
+};
 use crate::ops::split::SplitSizes;
 use crate::ops::split::split;
 use crate::ops::{Concat, map_value_view, resolve_axis, resolve_index};
@@ -212,6 +215,10 @@ impl Operator for SequenceLength {
         let seq: &Sequence = ctx.inputs().require_as(0)?;
         let len = seq.len() as i32;
         Tensor::from(len).into_op_result()
+    }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        Some([OutputType::Fixed(DataType::Int32)].into())
     }
 }
 

--- a/src/ops/transform_inputs.rs
+++ b/src/ops/transform_inputs.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use rten_tensor::prelude::*;
 
-use crate::operator::{OpError, OpRunContext, Operator, OutputList};
+use crate::operator::{OpError, OpRunContext, Operator, OutputList, OutputTypeList};
 use crate::ops::map_value_view;
 use crate::value::{Value, ValueView};
 
@@ -138,6 +138,10 @@ impl Operator for TransformInputs {
         }
         let inner_ctx = OpRunContext::new(ctx.pool(), &inputs);
         self.inner.run_in_place(input, &inner_ctx)
+    }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        self.inner.output_types()
     }
 }
 

--- a/src/ops/trilu.rs
+++ b/src/ops/trilu.rs
@@ -4,7 +4,9 @@ use rten_tensor::prelude::*;
 use rten_tensor::{NdTensorView, NdTensorViewMut, Tensor, TensorView};
 
 use crate::buffer_pool::BufferPool;
-use crate::operator::{IntoOpResult, OpError, OpRunContext, Operator, OutputList};
+use crate::operator::{
+    IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType, OutputTypeList,
+};
 use crate::ops::map_value_view;
 use crate::value::ValueView;
 
@@ -81,6 +83,10 @@ impl Operator for Trilu {
         map_value_view!(input, input, [FloatTensor, Int32Tensor], {
             trilu(ctx.pool(), input, k, self.upper).into_op_result()
         })
+    }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        Some([OutputType::CopyFromInput(0)].into())
     }
 }
 

--- a/src/ops/variadic_elementwise.rs
+++ b/src/ops/variadic_elementwise.rs
@@ -5,7 +5,10 @@ use rten_tensor::prelude::*;
 use rten_tensor::{Tensor, TensorView};
 
 use crate::buffer_pool::{AutoReturn, BufferPool};
-use crate::operator::{InputList, IntoOpResult, OpError, OpRunContext, Operator, OutputList};
+use crate::operator::{
+    InputList, IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType,
+    OutputTypeList,
+};
 use crate::ops::binary_elementwise::binary_op;
 use crate::ops::map_value_view;
 use crate::ops::reduce::{cmp_nan_greater, cmp_nan_less};
@@ -81,6 +84,10 @@ impl Operator for Max {
             max(ctx.pool(), &inputs).into_op_result()
         })
     }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        Some([OutputType::CopyFromInput(0)].into())
+    }
 }
 
 pub fn mean(pool: &BufferPool, inputs: &[TensorView]) -> Result<Tensor, OpError> {
@@ -106,6 +113,10 @@ impl Operator for Mean {
         let first = inputs.require_as(0)?;
         let inputs = typed_views(inputs, first)?;
         mean(ctx.pool(), &inputs).into_op_result()
+    }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        Some([OutputType::CopyFromInput(0)].into())
     }
 }
 
@@ -139,6 +150,10 @@ impl Operator for Min {
             min(ctx.pool(), &inputs).into_op_result()
         })
     }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        Some([OutputType::CopyFromInput(0)].into())
+    }
 }
 
 pub fn sum<T: Copy + std::ops::Add<Output = T>>(
@@ -167,6 +182,10 @@ impl Operator for Sum {
             let inputs = typed_views(inputs, first)?;
             sum(ctx.pool(), &inputs).into_op_result()
         })
+    }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        Some([OutputType::CopyFromInput(0)].into())
     }
 }
 


### PR DESCRIPTION
Add an implementation of `Operator::output_types` to many operators that were missing it. A few operators have been skipped because they require additional work:

 - Sequence operators return sequence types, which the interface can't represent.
 - The Split operator returns a variable number of outputs
 - Operators which run subgraphs (eg. If, Loop)

Generated by Claude with a few manual tweaks and optimizations.