### PR TITLE
Add type inference rules for most remaining operators

### DIFF
--- a/src/graph/tests.rs
+++ b/src/graph/tests.rs
@@ -13,7 +13,8 @@ use crate::graph::{
     Dimension, Graph, Node, NodeId, RunError, RunErrorKind, RunOptions, TypedConstant,
 };
 use crate::operator::{
-    IntoOpResult, OpError, OpRunContext, Operator, OutputList, PrepackedInput, SubgraphOperator,
+    IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputTypeList, PrepackedInput,
+    SubgraphOperator,
 };
 use crate::ops::{Add, Concat, Conv, Identity, If, MatMul, Mul, Relu, Shape};
 use crate::timing::Profiler;
@@ -66,6 +67,10 @@ impl<Op: Operator> Operator for TrackUsage<Op> {
         self.inner.max_inputs()
     }
 
+    fn output_types(&self) -> Option<OutputTypeList> {
+        self.inner.output_types()
+    }
+
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         {
             let mut m = self.metrics.lock().unwrap();
@@ -110,6 +115,10 @@ impl<V: Into<Value> + 'static, F: Fn(&OpRunContext) -> Result<V, OpError>> Opera
     }
 
     fn max_inputs(&self) -> Option<usize> {
+        None
+    }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
         None
     }
 
@@ -279,6 +288,10 @@ impl Operator for AddOne {
 
     fn max_inputs(&self) -> Option<usize> {
         Some(1)
+    }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        None
     }
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
@@ -702,6 +715,10 @@ impl Operator for AddOneInPlace {
         Some(1)
     }
 
+    fn output_types(&self) -> Option<OutputTypeList> {
+        None
+    }
+
     fn can_run_in_place(&self) -> bool {
         true
     }
@@ -853,6 +870,10 @@ impl Operator for Split {
 
     fn max_inputs(&self) -> Option<usize> {
         Some(1)
+    }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        None
     }
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
@@ -1043,6 +1064,10 @@ impl Operator for Counter {
         Some(0)
     }
 
+    fn output_types(&self) -> Option<OutputTypeList> {
+        None
+    }
+
     fn is_deterministic(&self) -> bool {
         false
     }
@@ -1126,6 +1151,10 @@ impl Operator for Subgraph {
     }
 
     fn max_inputs(&self) -> Option<usize> {
+        None
+    }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
         None
     }
 
@@ -1486,6 +1515,10 @@ impl Operator for MatMulExpectPacked {
 
     fn max_inputs(&self) -> Option<usize> {
         self.inner.max_inputs()
+    }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        None
     }
 
     fn prepack_inputs(&self) -> SmallVec<[usize; 1]> {

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -356,6 +356,9 @@ pub trait Operator: Any + Debug {
     /// This can return `None` for variadic inputs with no limit.
     fn max_inputs(&self) -> Option<usize>;
 
+    /// Return the rules for determining the types of this operator's outputs.
+    fn output_types(&self) -> Option<OutputTypeList>;
+
     /// Return true if this operator supports in-place execution via
     /// `run_in_place`.
     ///
@@ -433,11 +436,6 @@ pub trait Operator: Any + Debug {
 
     /// Return the shape inference implementation for this operator.
     fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
-        None
-    }
-
-    /// Return the rules for determining the types of this operator's outputs.
-    fn output_types(&self) -> Option<OutputTypeList> {
         None
     }
 }

--- a/src/ops/binary_elementwise.rs
+++ b/src/ops/binary_elementwise.rs
@@ -793,6 +793,10 @@ impl Operator for Mod {
             mod_op(ctx.pool(), a, b, mode).into_op_result()
         })
     }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        Some([OutputType::CopyFromInput(0)].into())
+    }
 }
 
 /// Multiply two tensors elementwise.

--- a/src/ops/concat.rs
+++ b/src/ops/concat.rs
@@ -302,6 +302,10 @@ impl Operator for Tile {
             tile(ctx.pool(), input.view(), repeats).map(|t| t.into())
         })
     }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        Some([OutputType::CopyFromInput(0)].into())
+    }
 }
 
 #[cfg(test)]

--- a/src/ops/control_flow.rs
+++ b/src/ops/control_flow.rs
@@ -3,7 +3,9 @@ use rten_tensor::{Tensor, TensorView};
 use smallvec::SmallVec;
 
 use crate::graph::{CaptureEnv, Graph, NodeId, RunError, RunOptions};
-use crate::operator::{OpError, OpRunContext, Operator, OutputList, SubgraphOperator};
+use crate::operator::{
+    OpError, OpRunContext, Operator, OutputList, OutputTypeList, SubgraphOperator,
+};
 use crate::ops::map_value;
 use crate::timing::Profiler;
 use crate::value::Value;
@@ -42,6 +44,11 @@ impl Operator for If {
 
     fn as_subgraph_op(&self) -> Option<&dyn SubgraphOperator> {
         Some(self as &dyn SubgraphOperator)
+    }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        // Type inference is not implemented for ops with subgraphs yet.
+        None
     }
 }
 
@@ -126,6 +133,11 @@ impl Operator for Loop {
 
     fn as_subgraph_op(&self) -> Option<&dyn SubgraphOperator> {
         Some(self as &dyn SubgraphOperator)
+    }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        // Type inference is not implemented for ops with subgraphs yet.
+        None
     }
 }
 

--- a/src/ops/convert.rs
+++ b/src/ops/convert.rs
@@ -201,6 +201,10 @@ impl Operator for CastLike {
         };
         Cast { to }.run_in_place(input, ctx)
     }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        Some([OutputType::CopyFromInput(1)].into())
+    }
 }
 
 #[cfg(test)]

--- a/src/ops/einsum.rs
+++ b/src/ops/einsum.rs
@@ -7,7 +7,9 @@ use rten_tensor::{Contiguous, DynLayout, Tensor, TensorView};
 use smallvec::SmallVec;
 
 use crate::buffer_pool::{AutoReturn, BufferPool, PoolRef};
-use crate::operator::{IntoOpResult, OpError, OpRunContext, Operator, OutputList};
+use crate::operator::{
+    IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType, OutputTypeList,
+};
 use crate::ops::layout::expand_to;
 use crate::ops::{matmul, mul, reduce_sum};
 
@@ -146,6 +148,10 @@ impl Operator for Einsum {
             typed_inputs.push(inputs.require_as(i)?);
         }
         einsum(ctx.pool(), &typed_inputs, &self.equation).into_op_result()
+    }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        Some([OutputType::CopyFromInput(0)].into())
     }
 }
 

--- a/src/ops/gather.rs
+++ b/src/ops/gather.rs
@@ -320,6 +320,10 @@ impl Operator for GatherElements {
             gather_elements(ctx.pool(), x, indices, self.axis).into_op_result()
         })
     }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        Some([OutputType::CopyFromInput(0)].into())
+    }
 }
 
 pub fn gather_nd<T: Clone + Default>(
@@ -442,6 +446,10 @@ impl Operator for GatherND {
             gather_nd(ctx.pool(), x, indices, self.batch_dims).into_op_result()
         })
     }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        Some([OutputType::CopyFromInput(0)].into())
+    }
 }
 
 // Specifies how to combine an existing element value with an update in a
@@ -555,6 +563,10 @@ impl Operator for ScatterElements {
                 .into_op_result()
         })
     }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        Some([OutputType::CopyFromInput(0)].into())
+    }
 }
 
 pub fn scatter_nd<
@@ -646,6 +658,10 @@ impl Operator for ScatterND {
             let updates = inputs.require_as(2)?;
             scatter_nd(ctx.pool(), x, indices, updates, self.reduction).into_op_result()
         })
+    }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        Some([OutputType::CopyFromInput(0)].into())
     }
 }
 

--- a/src/ops/generate.rs
+++ b/src/ops/generate.rs
@@ -145,6 +145,10 @@ impl Operator for OneHot {
             onehot(ctx.pool(), indices, self.axis, depth, on_value, off_value).into_op_result()
         })
     }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        Some([OutputType::CopyFromInput(2)].into())
+    }
 }
 
 pub fn range<T: Copy + Default + ops::Add<Output = T> + PartialOrd>(
@@ -260,6 +264,17 @@ impl Operator for EyeLike {
             })?;
             eye_like::<T>(ctx.pool(), shape, self.k).into_op_result()
         })
+    }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        Some(
+            [if let Some(dtype) = self.dtype {
+                OutputType::Fixed(dtype)
+            } else {
+                OutputType::CopyFromInput(0)
+            }]
+            .into(),
+        )
     }
 }
 

--- a/src/ops/layout.rs
+++ b/src/ops/layout.rs
@@ -82,6 +82,10 @@ impl Operator for DepthToSpace {
         let input = ctx.inputs().require_as(0)?;
         depth_to_space::<f32>(ctx.pool(), input, self.block_size, self.mode).into_op_result()
     }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        Some([OutputType::CopyFromInput(0)].into())
+    }
 }
 
 /// Return the tensor shape resulting from broadcasting `input_shape` with `shape`.
@@ -506,6 +510,10 @@ impl Operator for Size {
 
         output.into_op_result()
     }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        Some([OutputType::Fixed(DataType::Int32)].into())
+    }
 }
 
 pub fn squeeze_in_place<T: Clone>(
@@ -585,6 +593,10 @@ impl Operator for Squeeze {
             squeeze_in_place(&mut output, axes)?;
             Ok(output.into())
         })
+    }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        Some([OutputType::CopyFromInput(0)].into())
     }
 }
 
@@ -785,6 +797,10 @@ impl Operator for ComputeShape {
             .collect::<Result<Vec<i32>, _>>()?;
 
         Tensor::from(output).into_op_result()
+    }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        Some([OutputType::Fixed(DataType::Int32)].into())
     }
 }
 

--- a/src/ops/matmul.rs
+++ b/src/ops/matmul.rs
@@ -126,6 +126,10 @@ impl Operator for Gemm {
         )
         .into_op_result()
     }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        Some([OutputType::CopyFromInput(0)].into())
+    }
 }
 
 /// Hints for how a batched MatMul should be performed. This exists to enable
@@ -468,6 +472,10 @@ impl Operator for FusedMatMul {
             None
         }
     }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        Some([OutputType::CopyFromInput(0)].into())
+    }
 }
 
 /// Normalize a zero point input by converting it to a vector.
@@ -593,6 +601,10 @@ impl Operator for MatMulInteger {
             None
         }
     }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        Some([OutputType::Fixed(DataType::Int32)].into())
+    }
 }
 
 /// Cast elements in `data` to f32 and scale by the per-column scales in `scale`.
@@ -651,6 +663,10 @@ impl Operator for MatMulIntegerToFloat {
 
     fn prepack(&self, index: usize, input: ValueView) -> Option<PrepackedInput> {
         self.matmul.prepack(index, input)
+    }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        Some([OutputType::Fixed(DataType::Float)].into())
     }
 }
 

--- a/src/ops/norm.rs
+++ b/src/ops/norm.rs
@@ -275,6 +275,10 @@ impl Operator for BatchNormalization {
 
         Ok(output.into())
     }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        Some([OutputType::CopyFromInput(0)].into())
+    }
 }
 
 pub fn instance_normalization(
@@ -361,6 +365,10 @@ impl Operator for InstanceNormalization {
         instance_normalization_in_place(&mut output, scale, bias, self.epsilon)?;
 
         Ok(output.into())
+    }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        Some([OutputType::CopyFromInput(0)].into())
     }
 }
 
@@ -501,6 +509,10 @@ impl Operator for LayerNormalization {
         layer_normalization(ctx.pool(), input, scale, bias, self.axis, self.epsilon)
             .into_op_result()
     }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        Some([OutputType::CopyFromInput(0)].into())
+    }
 }
 
 /// Root Mean Square normalization.
@@ -531,6 +543,10 @@ impl Operator for RmsNormalization {
         let scale = inputs.require_as(1)?;
 
         rms_normalization(ctx.pool(), input, scale, self.axis, self.epsilon).into_op_result()
+    }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        Some([OutputType::CopyFromInput(0)].into())
     }
 }
 
@@ -650,6 +666,10 @@ impl Operator for LogSoftmax {
         let mut output: Tensor = input.try_into()?;
         log_softmax_in_place(&mut output, self.axis)?;
         Ok(output.into())
+    }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        Some([OutputType::CopyFromInput(0)].into())
     }
 }
 

--- a/src/ops/reduce.rs
+++ b/src/ops/reduce.rs
@@ -17,7 +17,7 @@ use crate::operator::{
 use crate::ops::layout::squeeze_in_place;
 use crate::ops::{map_value_view, resolve_axes, resolve_axis};
 use crate::slice_reductions::{slice_fold_assoc, slice_sum};
-use crate::value::ValueView;
+use crate::value::{DataType, ValueView};
 
 macro_rules! impl_infer_shapes {
     ($op:ident) => {
@@ -125,6 +125,10 @@ impl Operator for ArgMax {
             arg_max(ctx.pool(), input, self.axis, self.keep_dims).into_op_result()
         })
     }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        Some([OutputType::Fixed(DataType::Int32)].into())
+    }
 }
 
 /// Return the index of the minimum value along a given axis.
@@ -164,6 +168,10 @@ impl Operator for ArgMin {
         map_value_view!(input, input, [FloatTensor, Int32Tensor], {
             arg_min(ctx.pool(), input, self.axis, self.keep_dims).into_op_result()
         })
+    }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        Some([OutputType::Fixed(DataType::Int32)].into())
     }
 }
 
@@ -216,6 +224,10 @@ impl Operator for CumSum {
             cum_sum(ctx.pool(), input, axis as isize).into_op_result()
         })
     }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        Some([OutputType::CopyFromInput(0)].into())
+    }
 }
 
 /// Return the indices of nonzero elements in `input` as a `(dim, index)` tensor.
@@ -263,6 +275,10 @@ impl Operator for NonZero {
         map_value_view!(input, input, [FloatTensor, Int32Tensor], {
             nonzero(ctx.pool(), input).into_op_result()
         })
+    }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        Some([OutputType::Fixed(DataType::Int32)].into())
     }
 }
 
@@ -684,6 +700,10 @@ impl Operator for ReduceMin {
             reduce_min(ctx.pool(), input, axes.as_deref(), self.keep_dims).into_op_result()
         })
     }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        Some([OutputType::CopyFromInput(0)].into())
+    }
 }
 
 struct GenericMaxKernel;
@@ -739,6 +759,10 @@ impl Operator for ReduceMax {
             reduce_max(ctx.pool(), input, axes.as_deref(), self.keep_dims).into_op_result()
         })
     }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        Some([OutputType::CopyFromInput(0)].into())
+    }
 }
 
 pub fn reduce_prod<T: Copy + std::iter::Product>(
@@ -784,6 +808,10 @@ impl Operator for ReduceProd {
         map_value_view!(input, input, [FloatTensor, Int32Tensor], {
             reduce_prod(ctx.pool(), input, axes.as_deref(), self.keep_dims).into_op_result()
         })
+    }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        Some([OutputType::CopyFromInput(0)].into())
     }
 }
 
@@ -909,6 +937,10 @@ impl Operator for ReduceSumSquare {
             }
         })
     }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        Some([OutputType::CopyFromInput(0)].into())
+    }
 }
 
 pub fn topk<T: Copy + Default + PartialOrd + IsNaN>(
@@ -1015,6 +1047,13 @@ impl Operator for TopK {
                 topk(ctx.pool(), values, k, self.axis, self.largest, self.sorted)?;
             Ok([values.into(), indices.into()].into_iter().collect())
         })
+    }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        Some(OutputTypeList::from_slice(&[
+            OutputType::CopyFromInput(0),
+            OutputType::Fixed(DataType::Int32),
+        ]))
     }
 }
 

--- a/src/ops/sequence.rs
+++ b/src/ops/sequence.rs
@@ -29,6 +29,11 @@ impl Operator for SequenceEmpty {
         let dtype = self.dtype.unwrap_or(DataType::Float);
         Value::from(Sequence::new(dtype)).into_op_result()
     }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        // Type inference does not support sequence types yet.
+        None
+    }
 }
 
 #[derive(Debug)]
@@ -52,6 +57,11 @@ impl Operator for SequenceAt {
             .unwrap()
             .to_owned_in(ctx.pool())
             .into_op_result()
+    }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        // Type inference does not support sequence types yet.
+        None
     }
 }
 
@@ -84,6 +94,11 @@ impl Operator for SequenceConstruct {
         })?;
 
         Value::from(sequence).into_op_result()
+    }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        // Type inference does not support sequence types yet.
+        None
     }
 }
 
@@ -135,6 +150,11 @@ impl Operator for SequenceErase {
         let seq: Sequence = input.try_into()?;
         let pos: Option<i32> = ctx.inputs().get_as(0)?;
         sequence_erase(seq, pos).map(Value::from)
+    }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        // Type inference does not support sequence types yet.
+        None
     }
 }
 
@@ -196,6 +216,11 @@ impl Operator for SequenceInsert {
         let value = ctx.inputs().require(0)?;
         let pos: Option<i32> = ctx.inputs().get_as(1)?;
         sequence_insert(ctx.pool(), seq, pos, value).map(Value::from)
+    }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        // Type inference does not support sequence types yet.
+        None
     }
 }
 
@@ -272,6 +297,11 @@ impl Operator for ConcatFromSequence {
         let concat_ctx = ctx.with_new_inputs(&concat_inputs);
         concat_op.run(&concat_ctx)
     }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        // Type inference does not support sequence types yet.
+        None
+    }
 }
 
 #[derive(Debug)]
@@ -334,6 +364,11 @@ impl Operator for SplitToSequence {
         })?;
 
         Value::from(sequence).into_op_result()
+    }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        // Type inference does not support sequence types yet.
+        None
     }
 }
 

--- a/src/ops/split.rs
+++ b/src/ops/split.rs
@@ -3,7 +3,7 @@ use rten_tensor::prelude::*;
 use rten_tensor::{NdTensorView, Tensor, TensorView};
 
 use crate::buffer_pool::BufferPool;
-use crate::operator::{OpError, OpRunContext, Operator, OutputList};
+use crate::operator::{OpError, OpRunContext, Operator, OutputList, OutputTypeList};
 use crate::ops::{map_value_view, resolve_axis};
 use crate::value::ValueView;
 
@@ -127,6 +127,13 @@ impl Operator for Split {
             split(ctx.pool(), x, self.axis, split_sizes)
                 .map(|tensors| tensors.into_iter().map(|t| t.into()).collect())
         })
+    }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        // The number of outputs here is variable, though always of the same
+        // type as the first input. `OutputTypeList` doesn't have a way to
+        // represent this yet.
+        None
     }
 }
 

--- a/src/ops/unary_elementwise.rs
+++ b/src/ops/unary_elementwise.rs
@@ -454,6 +454,10 @@ impl Operator for IsInf {
         let output = input.map_in(ctx.pool(), |x| i32::from(x.is_infinite()));
         output.into_op_result()
     }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        Some([OutputType::Fixed(DataType::Int32)].into())
+    }
 }
 
 #[derive(Debug)]
@@ -549,6 +553,10 @@ impl Operator for Not {
         not_in_place(output.view_mut());
         Ok(output.into())
     }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        Some([OutputType::Fixed(DataType::Int32)].into())
+    }
 }
 
 declare_operator!(Reciprocal);
@@ -606,6 +614,10 @@ impl Operator for PRelu {
             let slope = ctx.inputs().require_as(1)?;
             prelu(ctx.pool(), input, slope).into_op_result()
         })
+    }
+
+    fn output_types(&self) -> Option<OutputTypeList> {
+        Some([OutputType::CopyFromInput(0)].into())
     }
 }
 


### PR DESCRIPTION
Add output type inference rules for remaining operators except for control flow ops, Split and sequence ops.

 - Add `output_types` methods to remaining Operator trait impls

 - Remove the default impl for `output_types`