### PR TITLE
Enable shape inference for more unary, binary and reduction ops

### DIFF
--- a/src/ops/binary_elementwise.rs
+++ b/src/ops/binary_elementwise.rs
@@ -797,6 +797,10 @@ impl Operator for Mod {
     fn output_types(&self) -> Option<OutputTypeList> {
         Some([OutputType::CopyFromInput(0)].into())
     }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        Some(&BinaryOp)
+    }
 }
 
 /// Multiply two tensors elementwise.

--- a/src/ops/convert.rs
+++ b/src/ops/convert.rs
@@ -5,7 +5,7 @@ use rten_tensor::Tensor;
 use rten_tensor::prelude::*;
 
 use crate::buffer_pool::BufferPool;
-use crate::infer_shapes::{InferShapes, InferShapesError, SymTensor, SymbolGen};
+use crate::infer_shapes::{InferShapes, InferShapesError, SymTensor, SymbolGen, UnaryOp};
 use crate::operator::{
     IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType, OutputTypeList,
 };
@@ -204,6 +204,10 @@ impl Operator for CastLike {
 
     fn output_types(&self) -> Option<OutputTypeList> {
         Some([OutputType::CopyFromInput(1)].into())
+    }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        Some(&UnaryOp)
     }
 }
 

--- a/src/ops/identity.rs
+++ b/src/ops/identity.rs
@@ -2,6 +2,7 @@ use rten_tensor::prelude::*;
 use rten_tensor::{Tensor, TensorView};
 
 use crate::buffer_pool::BufferPool;
+use crate::infer_shapes::{InferShapes, UnaryOp};
 use crate::operator::{
     IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType, OutputTypeList,
 };
@@ -35,6 +36,10 @@ impl Operator for Identity {
 
     fn run_in_place(&self, input: Value, _ctx: &OpRunContext) -> Result<Value, OpError> {
         Ok(input)
+    }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        Some(&UnaryOp)
     }
 
     fn output_types(&self) -> Option<OutputTypeList> {

--- a/src/ops/norm.rs
+++ b/src/ops/norm.rs
@@ -276,6 +276,10 @@ impl Operator for BatchNormalization {
         Ok(output.into())
     }
 
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        Some(&UnaryOp)
+    }
+
     fn output_types(&self) -> Option<OutputTypeList> {
         Some([OutputType::CopyFromInput(0)].into())
     }
@@ -365,6 +369,10 @@ impl Operator for InstanceNormalization {
         instance_normalization_in_place(&mut output, scale, bias, self.epsilon)?;
 
         Ok(output.into())
+    }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        Some(&UnaryOp)
     }
 
     fn output_types(&self) -> Option<OutputTypeList> {
@@ -510,6 +518,10 @@ impl Operator for LayerNormalization {
             .into_op_result()
     }
 
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        Some(&UnaryOp)
+    }
+
     fn output_types(&self) -> Option<OutputTypeList> {
         Some([OutputType::CopyFromInput(0)].into())
     }
@@ -547,6 +559,10 @@ impl Operator for RmsNormalization {
 
     fn output_types(&self) -> Option<OutputTypeList> {
         Some([OutputType::CopyFromInput(0)].into())
+    }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        Some(&UnaryOp)
     }
 }
 
@@ -666,6 +682,10 @@ impl Operator for LogSoftmax {
         let mut output: Tensor = input.try_into()?;
         log_softmax_in_place(&mut output, self.axis)?;
         Ok(output.into())
+    }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        Some(&UnaryOp)
     }
 
     fn output_types(&self) -> Option<OutputTypeList> {

--- a/src/ops/quantize.rs
+++ b/src/ops/quantize.rs
@@ -7,6 +7,7 @@ use rten_tensor::{AssumeInit, NdTensor, NdTensorView, Scalar, Tensor, TensorView
 use rten_vecmath as vecmath;
 
 use crate::buffer_pool::BufferPool;
+use crate::infer_shapes::{InferShapes, UnaryOp};
 use crate::operator::{
     IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType, OutputTypeList,
 };
@@ -116,6 +117,10 @@ impl Operator for DequantizeLinear {
 
     fn output_types(&self) -> Option<OutputTypeList> {
         Some([OutputType::Fixed(DataType::Float)].into())
+    }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        Some(&UnaryOp)
     }
 }
 
@@ -310,6 +315,10 @@ impl Operator for QuantizeLinear {
     fn output_types(&self) -> Option<OutputTypeList> {
         let dtype = self.output_dtype.unwrap_or(DataType::Int8);
         Some([OutputType::Fixed(dtype)].into())
+    }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        Some(&UnaryOp)
     }
 }
 

--- a/src/ops/reduce.rs
+++ b/src/ops/reduce.rs
@@ -701,10 +701,16 @@ impl Operator for ReduceMin {
         })
     }
 
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        Some(self)
+    }
+
     fn output_types(&self) -> Option<OutputTypeList> {
         Some([OutputType::CopyFromInput(0)].into())
     }
 }
+
+impl_infer_shapes!(ReduceMin);
 
 struct GenericMaxKernel;
 impl<T: Copy + IsNaN + MinMax> ReduceKernel<T> for GenericMaxKernel {
@@ -760,10 +766,16 @@ impl Operator for ReduceMax {
         })
     }
 
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        Some(self)
+    }
+
     fn output_types(&self) -> Option<OutputTypeList> {
         Some([OutputType::CopyFromInput(0)].into())
     }
 }
+
+impl_infer_shapes!(ReduceMax);
 
 pub fn reduce_prod<T: Copy + std::iter::Product>(
     pool: &BufferPool,
@@ -810,10 +822,16 @@ impl Operator for ReduceProd {
         })
     }
 
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        Some(self)
+    }
+
     fn output_types(&self) -> Option<OutputTypeList> {
         Some([OutputType::CopyFromInput(0)].into())
     }
 }
+
+impl_infer_shapes!(ReduceProd);
 
 struct OptimizedSumKernel;
 impl ReduceKernel<f32> for OptimizedSumKernel {
@@ -938,10 +956,16 @@ impl Operator for ReduceSumSquare {
         })
     }
 
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        Some(self)
+    }
+
     fn output_types(&self) -> Option<OutputTypeList> {
         Some([OutputType::CopyFromInput(0)].into())
     }
 }
+
+impl_infer_shapes!(ReduceSumSquare);
 
 pub fn topk<T: Copy + Default + PartialOrd + IsNaN>(
     pool: &BufferPool,

--- a/src/ops/unary_elementwise.rs
+++ b/src/ops/unary_elementwise.rs
@@ -458,6 +458,10 @@ impl Operator for IsInf {
     fn output_types(&self) -> Option<OutputTypeList> {
         Some([OutputType::Fixed(DataType::Int32)].into())
     }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        Some(&UnaryOp)
+    }
 }
 
 #[derive(Debug)]
@@ -557,6 +561,10 @@ impl Operator for Not {
     fn output_types(&self) -> Option<OutputTypeList> {
         Some([OutputType::Fixed(DataType::Int32)].into())
     }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        Some(&UnaryOp)
+    }
 }
 
 declare_operator!(Reciprocal);
@@ -618,6 +626,10 @@ impl Operator for PRelu {
 
     fn output_types(&self) -> Option<OutputTypeList> {
         Some([OutputType::CopyFromInput(0)].into())
+    }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        Some(&UnaryOp)
     }
 }
 


### PR DESCRIPTION
Enable shape inference for remaining unary, binary and reduction ops that can use the common implementations.