### PR TITLE
Enable shape inference for MatMulInteger, DynamicQuantizeLinear

### DIFF
--- a/src/ops/matmul.rs
+++ b/src/ops/matmul.rs
@@ -605,6 +605,10 @@ impl Operator for MatMulInteger {
     fn output_types(&self) -> Option<OutputTypeList> {
         Some([OutputType::Fixed(DataType::Int32)].into())
     }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        Some(&shape_ops::MatMul)
+    }
 }
 
 /// Cast elements in `data` to f32 and scale by the per-column scales in `scale`.

--- a/src/ops/quantize.rs
+++ b/src/ops/quantize.rs
@@ -1,6 +1,7 @@
 use std::mem::MaybeUninit;
 
 use rayon::prelude::*;
+use rten_shape_inference::ops as shape_ops;
 use rten_simd::SimdOp;
 use rten_tensor::prelude::*;
 use rten_tensor::{AssumeInit, NdTensor, NdTensorView, Scalar, Tensor, TensorView};
@@ -458,6 +459,10 @@ impl Operator for DynamicQuantizeLinear {
             OutputType::Fixed(DataType::Float),
             OutputType::Fixed(DataType::UInt8),
         ]))
+    }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        Some(&shape_ops::DynamicQuantizeLinear)
     }
 }
 


### PR DESCRIPTION
MatMulInteger is the same as MatMul but with extra inputs that don't affect the output shape. DynamicQuantizeLinear is a unary op with two extra scalar outputs.