### PR TITLE
Support symbolic (flooring) division expressions

### DIFF
--- a/rten-shape-inference/src/ops.rs
+++ b/rten-shape-inference/src/ops.rs
@@ -104,6 +104,7 @@ impl InferShapes for ConstantOfShape {
                         | SymElem::Add(_)
                         | SymElem::Sub(_)
                         | SymElem::Mul(_)
+                        | SymElem::Div(_)
                         | SymElem::Max(_) => SymTensor::from_shape(vec![vec_len.clone()]),
                     }
                 } else {
@@ -303,6 +304,7 @@ impl InferShapes for Where {
                         | SymElem::Add(_)
                         | SymElem::Sub(_)
                         | SymElem::Mul(_)
+                        | SymElem::Div(_)
                         | SymElem::Max(_) => None,
                     }?;
                     if cond_bool {

--- a/rten-shape-inference/src/ops/layout.rs
+++ b/rten-shape-inference/src/ops/layout.rs
@@ -25,6 +25,7 @@ impl InferShapes for Expand {
                 SymElem::Value(size) => Some(size),
                 SymElem::Add(_)
                 | SymElem::Mul(_)
+                | SymElem::Div(_)
                 | SymElem::Max(_)
                 | SymElem::Sub(_)
                 | SymElem::Var(_) => None,


### PR DESCRIPTION
This will be needed to represent output shapes for pooling and convolution operators.

The `PartialEq<SymElem>` impl was rewritten to remove the blanket case for the `self` match, as I keep forgetting to update this after adding new expressions.