### PR TITLE
Replace `DataType` with `ValueType` in value metadata

### DIFF
--- a/rten-cli/src/input_info.rs
+++ b/rten-cli/src/input_info.rs
@@ -5,7 +5,7 @@ use std::fmt::{Display, Formatter};
 use std::ops::Range;
 use std::str::FromStr;
 
-use rten::{DataType, Dimension, Model, NodeId, Value, ValueOrView};
+use rten::{Dimension, Model, NodeId, Value, ValueOrView, ValueType};
 use rten_tensor::Layout;
 
 /// Format an input or output shape as a `[dim0, dim1, ...]` string, where each
@@ -125,7 +125,7 @@ impl Display for GroupName {
 pub fn print_input_output_list(model: &Model, node_ids: &[NodeId]) {
     struct Group {
         name: GroupName,
-        dtype: Option<DataType>,
+        dtype: Option<ValueType>,
         shape: Option<Vec<Dimension>>,
     }
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -18,7 +18,7 @@ use crate::env::env_flag;
 use crate::operator::{InputList, OpRunContext, Operator, OutputList, PrepackedInput};
 use crate::threading;
 use crate::timing::{Instant, ProfileFormat, Profiler, TimingFilter, TimingRecord, TimingSort};
-use crate::value::{DataType, Value, ValueMeta, ValueOrView, ValueView};
+use crate::value::{Value, ValueMeta, ValueOrView, ValueType, ValueView};
 use crate::weight_cache::WeightCache;
 
 #[cfg(test)]
@@ -560,7 +560,7 @@ impl Graph {
         &mut self,
         name: Option<&str>,
         shape: Option<Vec<Dimension>>,
-        dtype: Option<DataType>,
+        dtype: Option<ValueType>,
     ) -> NodeId {
         let value_node = Node::Value(ValueNode::new(name, shape, dtype));
         self.add_node(value_node)
@@ -637,7 +637,7 @@ impl Graph {
     }
 
     /// Update the type metadata for a value node.
-    pub fn update_value_type(&mut self, value_id: NodeId, dtype: DataType) {
+    pub fn update_value_type(&mut self, value_id: NodeId, dtype: ValueType) {
         let Some(Node::Value(value_node)) = self.get_node_mut(value_id) else {
             panic!("value node not found");
         };

--- a/src/graph/builder.rs
+++ b/src/graph/builder.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 
 use crate::graph::{Graph, NodeId};
 use crate::operator::Operator;
-use crate::{DataType, Dimension, Value};
+use crate::{DataType, Dimension, Value, ValueType};
 
 enum ExprKind {
     /// Expression representing a value node.
@@ -206,7 +206,7 @@ impl Expr {
             ExprKind::Value(value_info) => [graph.add_value(
                 Some(value_info.name.as_str()),
                 value_info.shape.clone(),
-                value_info.dtype,
+                value_info.dtype.map(ValueType::Tensor),
             )]
             .into(),
             ExprKind::Constant(value) => {
@@ -244,7 +244,11 @@ impl Expr {
                             OutputMeta::NoMeta => (None, None),
                             OutputMeta::Meta((dtype, shape)) => (Some(*dtype), Some(shape.clone())),
                         };
-                        graph.add_value(Some(output_name.as_str()), output_shape, output_dtype)
+                        graph.add_value(
+                            Some(output_name.as_str()),
+                            output_shape,
+                            output_dtype.map(ValueType::Tensor),
+                        )
                     })
                     .collect();
 

--- a/src/graph/tests.rs
+++ b/src/graph/tests.rs
@@ -18,7 +18,7 @@ use crate::operator::{
 };
 use crate::ops::{Add, Concat, Conv, Identity, If, MatMul, Mul, Relu, Shape};
 use crate::timing::Profiler;
-use crate::value::{DataType, Value, ValueView};
+use crate::value::{DataType, Value, ValueType, ValueView};
 use crate::weight_cache::WeightCache;
 
 #[derive(Clone, Debug, Default)]
@@ -273,9 +273,9 @@ fn test_graph_value_dtype() {
         DataType::UInt8,
         DataType::Int8,
     ] {
-        let input_id = g.add_value(None, None, Some(dtype));
+        let input_id = g.add_value(None, None, Some(ValueType::Tensor(dtype)));
         let input_dtype = g.get_node(input_id).and_then(|n| n.dtype());
-        assert_eq!(input_dtype, Some(dtype));
+        assert_eq!(input_dtype, Some(ValueType::Tensor(dtype)));
     }
 }
 

--- a/src/infer_shapes.rs
+++ b/src/infer_shapes.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use crate::env::env_flag;
 use crate::graph::{Dimension, Graph, Node, NodeId, RunError, TypedConstant};
 use crate::operator::OutputType;
-use crate::value::DataType;
+use crate::value::ValueType;
 
 pub use rten_shape_inference::{
     infer_shapes::{BinaryOp, InferShapes, InferShapesError, ReductionOp, UnaryOp},
@@ -54,7 +54,7 @@ pub struct InferResult {
     pub shapes: HashMap<NodeId, Vec<Dimension>>,
 
     /// Map of value node ID to inferred type.
-    pub types: HashMap<NodeId, DataType>,
+    pub types: HashMap<NodeId, ValueType>,
 }
 
 /// Infer the shapes and types of operator outputs in a graph.
@@ -81,7 +81,7 @@ pub fn infer_shapes(graph: &Graph) -> Result<InferResult, InferError> {
     // Reserve initial capacity assuming each operator produces one output,
     // which is the case for most operators.
     let mut values: HashMap<NodeId, SymTensor> = HashMap::with_capacity(ops.len());
-    let mut types: HashMap<NodeId, DataType> = HashMap::with_capacity(ops.len());
+    let mut types: HashMap<NodeId, ValueType> = HashMap::with_capacity(ops.len());
 
     let debug = env_flag("RTEN_INFER_SHAPES_DEBUG", false);
 
@@ -241,7 +241,7 @@ mod tests {
     use crate::Dimension;
     use crate::graph::builder::{Expr, OutputMeta, dims};
     use crate::ops::MatMul;
-    use crate::value::DataType;
+    use crate::value::{DataType, ValueType};
 
     use super::infer_shapes;
 
@@ -261,6 +261,9 @@ mod tests {
             shapes.shapes.get(&output_id).map(|s| s.as_slice()),
             Some(dims!("batch", 12).as_slice())
         );
-        assert_eq!(shapes.types.get(&output_id).copied(), Some(DataType::Float));
+        assert_eq!(
+            shapes.types.get(&output_id).copied(),
+            Some(ValueType::Tensor(DataType::Float))
+        );
     }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -15,7 +15,7 @@ use crate::graph::{Dimension, Graph, Node, NodeId, RunError, RunErrorImpl, RunOp
 use crate::op_registry::OpRegistry;
 use crate::optimize::OptimizeOptions;
 use crate::timing::{TimingFilter, TimingSort};
-use crate::value::{DataType, Value, ValueOrView};
+use crate::value::{Value, ValueOrView, ValueType};
 use crate::weight_cache::WeightCache;
 
 #[cfg(feature = "onnx_format")]
@@ -593,7 +593,7 @@ impl<'a> NodeInfo<'a> {
     ///
     /// For constants the data type is always known. For values the data type
     /// may be specified. For operators this always returns `None`.
-    pub fn dtype(&self) -> Option<DataType> {
+    pub fn dtype(&self) -> Option<ValueType> {
         self.node.dtype()
     }
 }
@@ -875,7 +875,7 @@ mod tests {
     use crate::ops::{
         BoxOrder, CoordTransformMode, DepthToSpaceMode, NearestMode, ResizeMode, Shape,
     };
-    use crate::value::{DataType, Scalar, Value};
+    use crate::value::{DataType, Scalar, Value, ValueType};
 
     fn generate_model_buffer(format: ModelFormat) -> Vec<u8> {
         let mut builder = ModelBuilder::new(format);
@@ -1001,7 +1001,7 @@ mod tests {
             .node_info(input_id)
             .and_then(|ni| ni.dtype())
             .expect("input dtype missing");
-        assert_eq!(dtype, DataType::Float);
+        assert_eq!(dtype, ValueType::Tensor(DataType::Float));
     }
 
     #[test]

--- a/src/model/onnx_loader.rs
+++ b/src/model/onnx_loader.rs
@@ -17,7 +17,7 @@ use crate::graph::{
 use crate::op_registry::onnx_registry::{ConstInput, DynParsedOp, OpLoadContext};
 use crate::op_registry::{OpRegistry, ReadOpError};
 use crate::optimize::{GraphOptimizer, OptimizeOptions};
-use crate::value::DataType;
+use crate::value::{DataType, ValueType};
 use crate::weight_cache::WeightCache;
 
 /// Specifies where to load an ONNX model from.
@@ -106,7 +106,7 @@ fn load_graph(
 
     let add_value = |graph: &mut Graph, name, value| {
         let (dtype, shape) = load_value_info(value);
-        graph.add_value(Some(name), shape, dtype)
+        graph.add_value(Some(name), shape, dtype.map(ValueType::Tensor))
     };
 
     // Create value nodes corresponding to graph inputs and outputs.

--- a/src/model/rten_loader.rs
+++ b/src/model/rten_loader.rs
@@ -18,6 +18,7 @@ use crate::graph::{CaptureEnv, ConstantNodeData, Dimension, Graph, NodeId};
 use crate::op_registry::rten_registry::{OpLoadContext, convert_dtype};
 use crate::op_registry::{OpRegistry, ReadOpError};
 use crate::optimize::GraphOptimizer;
+use crate::value::ValueType;
 use crate::weight_cache::WeightCache;
 
 /// Load a model from a .rten model file.
@@ -310,7 +311,7 @@ fn add_graph_value(
         .map(|dtype| convert_dtype("", dtype))
         .transpose()
         .map_err(|err| load_error!(OperatorInvalid, name, err))?;
-    let graph_node = graph.add_value(name, shape, dtype);
+    let graph_node = graph.add_value(name, shape, dtype.map(ValueType::Tensor));
     Ok(graph_node)
 }
 

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -316,7 +316,7 @@ impl<'a, 'i> OpRunContext<'a, 'i> {
 #[derive(Copy, Clone)]
 pub enum OutputType {
     /// This output has a fixed type, given the operator's attributes.
-    Fixed(DataType),
+    Fixed(ValueType),
     /// This output has the same type as the input at a given index.
     CopyFromInput(u32),
 }

--- a/src/ops/binary_elementwise.rs
+++ b/src/ops/binary_elementwise.rs
@@ -15,7 +15,7 @@ use crate::operator::{
     IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType, OutputTypeList,
 };
 use crate::ops::{map_value, map_value_view};
-use crate::value::{DataType, Value, ValueView};
+use crate::value::{DataType, Value, ValueType, ValueView};
 
 /// Given the shapes of two inputs to a binary operation, return the shape
 /// that will result from broadcasting them following NumPy rules or `None`
@@ -545,7 +545,7 @@ macro_rules! logical_boolean_op {
             }
 
             fn output_types(&self) -> Option<OutputTypeList> {
-                Some([OutputType::Fixed(DataType::Int32)].into())
+                Some([OutputType::Fixed(ValueType::Tensor(DataType::Int32))].into())
             }
 
             fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
@@ -689,7 +689,7 @@ macro_rules! boolean_cmp_op {
             }
 
             fn output_types(&self) -> Option<OutputTypeList> {
-                Some([OutputType::Fixed(DataType::Int32)].into())
+                Some([OutputType::Fixed(ValueType::Tensor(DataType::Int32))].into())
             }
 
             fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {

--- a/src/ops/conv.rs
+++ b/src/ops/conv.rs
@@ -20,7 +20,7 @@ use crate::ops::Padding;
 use crate::ops::matmul::zero_point_to_vec;
 use crate::ops::pooling::{RoundMode, calc_output_size_and_padding};
 use crate::shift_cast::ShiftCast;
-use crate::value::{DataType, ValueView};
+use crate::value::{DataType, ValueType, ValueView};
 
 mod depthwise;
 mod im2col;
@@ -551,7 +551,7 @@ impl Operator for ConvInteger {
     }
 
     fn output_types(&self) -> Option<OutputTypeList> {
-        Some([OutputType::Fixed(DataType::Int32)].into())
+        Some([OutputType::Fixed(ValueType::Tensor(DataType::Int32))].into())
     }
 }
 

--- a/src/ops/convert.rs
+++ b/src/ops/convert.rs
@@ -142,7 +142,7 @@ impl Operator for Cast {
     }
 
     fn output_types(&self) -> Option<OutputTypeList> {
-        Some([OutputType::Fixed(self.to)].into())
+        Some([OutputType::Fixed(ValueType::Tensor(self.to))].into())
     }
 }
 

--- a/src/ops/generate.rs
+++ b/src/ops/generate.rs
@@ -57,7 +57,7 @@ impl Operator for ConstantOfShape {
     }
 
     fn output_types(&self) -> Option<OutputTypeList> {
-        Some([OutputType::Fixed(self.value.dtype())].into())
+        Some([OutputType::Fixed(ValueType::Tensor(self.value.dtype()))].into())
     }
 }
 
@@ -269,7 +269,7 @@ impl Operator for EyeLike {
     fn output_types(&self) -> Option<OutputTypeList> {
         Some(
             [if let Some(dtype) = self.dtype {
-                OutputType::Fixed(dtype)
+                OutputType::Fixed(ValueType::Tensor(dtype))
             } else {
                 OutputType::CopyFromInput(0)
             }]

--- a/src/ops/layout.rs
+++ b/src/ops/layout.rs
@@ -15,7 +15,7 @@ use crate::operator::{
 };
 use crate::ops::binary_elementwise::{broadcast_shapes, fast_broadcast_cycles_repeats};
 use crate::ops::{map_value, map_value_view, resolve_axes, resolve_axis};
-use crate::value::{DataType, Value, ValueView};
+use crate::value::{DataType, Value, ValueType, ValueView};
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum DepthToSpaceMode {
@@ -474,7 +474,7 @@ impl Operator for Shape {
     }
 
     fn output_types(&self) -> Option<OutputTypeList> {
-        Some([OutputType::Fixed(DataType::Int32)].into())
+        Some([OutputType::Fixed(ValueType::Tensor(DataType::Int32))].into())
     }
 }
 
@@ -512,7 +512,7 @@ impl Operator for Size {
     }
 
     fn output_types(&self) -> Option<OutputTypeList> {
-        Some([OutputType::Fixed(DataType::Int32)].into())
+        Some([OutputType::Fixed(ValueType::Tensor(DataType::Int32))].into())
     }
 }
 
@@ -800,7 +800,7 @@ impl Operator for ComputeShape {
     }
 
     fn output_types(&self) -> Option<OutputTypeList> {
-        Some([OutputType::Fixed(DataType::Int32)].into())
+        Some([OutputType::Fixed(ValueType::Tensor(DataType::Int32))].into())
     }
 }
 

--- a/src/ops/matmul.rs
+++ b/src/ops/matmul.rs
@@ -19,7 +19,7 @@ use crate::operator::{
 };
 use crate::ops::binary_elementwise::broadcast_shapes;
 use crate::ops::layout::expand_to;
-use crate::value::{DataType, ValueView};
+use crate::value::{DataType, ValueType, ValueView};
 
 /// Compute the General Matrix Multiplication (GEMM) `c = alpha * (ab) + beta * c`.
 ///
@@ -396,7 +396,7 @@ impl Operator for MatMul {
     }
 
     fn output_types(&self) -> Option<OutputTypeList> {
-        Some([OutputType::Fixed(DataType::Float)].into())
+        Some([OutputType::Fixed(ValueType::Tensor(DataType::Float))].into())
     }
 
     fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
@@ -603,7 +603,7 @@ impl Operator for MatMulInteger {
     }
 
     fn output_types(&self) -> Option<OutputTypeList> {
-        Some([OutputType::Fixed(DataType::Int32)].into())
+        Some([OutputType::Fixed(ValueType::Tensor(DataType::Int32))].into())
     }
 
     fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
@@ -670,7 +670,7 @@ impl Operator for MatMulIntegerToFloat {
     }
 
     fn output_types(&self) -> Option<OutputTypeList> {
-        Some([OutputType::Fixed(DataType::Float)].into())
+        Some([OutputType::Fixed(ValueType::Tensor(DataType::Float))].into())
     }
 }
 
@@ -842,7 +842,7 @@ impl Operator for MatMulNBits {
     }
 
     fn output_types(&self) -> Option<OutputTypeList> {
-        Some([OutputType::Fixed(DataType::Float)].into())
+        Some([OutputType::Fixed(ValueType::Tensor(DataType::Float))].into())
     }
 
     fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {

--- a/src/ops/non_max_suppression.rs
+++ b/src/ops/non_max_suppression.rs
@@ -5,7 +5,7 @@ use crate::buffer_pool::BufferPool;
 use crate::operator::{
     IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType, OutputTypeList,
 };
-use crate::value::DataType;
+use crate::value::{DataType, ValueType};
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum BoxOrder {
@@ -221,7 +221,7 @@ impl Operator for NonMaxSuppression {
     }
 
     fn output_types(&self) -> Option<OutputTypeList> {
-        Some([OutputType::Fixed(DataType::Int32)].into())
+        Some([OutputType::Fixed(ValueType::Tensor(DataType::Int32))].into())
     }
 }
 

--- a/src/ops/quantize.rs
+++ b/src/ops/quantize.rs
@@ -13,7 +13,7 @@ use crate::operator::{
     IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType, OutputTypeList,
 };
 use crate::ops::{map_value_view, resolve_axis};
-use crate::value::{DataType, Value, ValueView};
+use crate::value::{DataType, Value, ValueType, ValueView};
 
 /// Convert a quantized tensor element to a higher precision value.
 pub trait Dequantize<To> {
@@ -117,7 +117,7 @@ impl Operator for DequantizeLinear {
     }
 
     fn output_types(&self) -> Option<OutputTypeList> {
-        Some([OutputType::Fixed(DataType::Float)].into())
+        Some([OutputType::Fixed(ValueType::Tensor(DataType::Float))].into())
     }
 
     fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
@@ -315,7 +315,7 @@ impl Operator for QuantizeLinear {
 
     fn output_types(&self) -> Option<OutputTypeList> {
         let dtype = self.output_dtype.unwrap_or(DataType::Int8);
-        Some([OutputType::Fixed(dtype)].into())
+        Some([OutputType::Fixed(ValueType::Tensor(dtype))].into())
     }
 
     fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
@@ -455,9 +455,9 @@ impl Operator for DynamicQuantizeLinear {
 
     fn output_types(&self) -> Option<OutputTypeList> {
         Some(OutputTypeList::from_slice(&[
-            OutputType::Fixed(DataType::UInt8),
-            OutputType::Fixed(DataType::Float),
-            OutputType::Fixed(DataType::UInt8),
+            OutputType::Fixed(ValueType::Tensor(DataType::UInt8)),
+            OutputType::Fixed(ValueType::Tensor(DataType::Float)),
+            OutputType::Fixed(ValueType::Tensor(DataType::UInt8)),
         ]))
     }
 

--- a/src/ops/random.rs
+++ b/src/ops/random.rs
@@ -6,7 +6,7 @@ use rten_tensor::{Tensor, TensorView};
 use crate::operator::{
     IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType, OutputTypeList,
 };
-use crate::value::{DataType, Value};
+use crate::value::{DataType, Value, ValueType};
 
 #[derive(Debug)]
 pub struct RandomUniform {
@@ -47,7 +47,7 @@ impl Operator for RandomUniform {
     }
 
     fn output_types(&self) -> Option<OutputTypeList> {
-        Some([OutputType::Fixed(DataType::Float)].into())
+        Some([OutputType::Fixed(ValueType::Tensor(DataType::Float))].into())
     }
 }
 
@@ -85,7 +85,7 @@ impl Operator for RandomUniformLike {
     }
 
     fn output_types(&self) -> Option<OutputTypeList> {
-        Some([OutputType::Fixed(DataType::Float)].into())
+        Some([OutputType::Fixed(ValueType::Tensor(DataType::Float))].into())
     }
 }
 
@@ -138,7 +138,7 @@ impl Operator for RandomNormal {
     }
 
     fn output_types(&self) -> Option<OutputTypeList> {
-        Some([OutputType::Fixed(DataType::Float)].into())
+        Some([OutputType::Fixed(ValueType::Tensor(DataType::Float))].into())
     }
 }
 
@@ -176,7 +176,7 @@ impl Operator for RandomNormalLike {
     }
 
     fn output_types(&self) -> Option<OutputTypeList> {
-        Some([OutputType::Fixed(DataType::Float)].into())
+        Some([OutputType::Fixed(ValueType::Tensor(DataType::Float))].into())
     }
 }
 
@@ -261,7 +261,7 @@ impl Operator for Dropout {
     fn output_types(&self) -> Option<OutputTypeList> {
         Some(OutputTypeList::from_slice(&[
             OutputType::CopyFromInput(0),
-            OutputType::Fixed(DataType::Int32),
+            OutputType::Fixed(ValueType::Tensor(DataType::Int32)),
         ]))
     }
 }

--- a/src/ops/reduce.rs
+++ b/src/ops/reduce.rs
@@ -17,7 +17,7 @@ use crate::operator::{
 use crate::ops::layout::squeeze_in_place;
 use crate::ops::{map_value_view, resolve_axes, resolve_axis};
 use crate::slice_reductions::{slice_fold_assoc, slice_sum};
-use crate::value::{DataType, ValueView};
+use crate::value::{DataType, ValueType, ValueView};
 
 macro_rules! impl_infer_shapes {
     ($op:ident) => {
@@ -127,7 +127,7 @@ impl Operator for ArgMax {
     }
 
     fn output_types(&self) -> Option<OutputTypeList> {
-        Some([OutputType::Fixed(DataType::Int32)].into())
+        Some([OutputType::Fixed(ValueType::Tensor(DataType::Int32))].into())
     }
 }
 
@@ -171,7 +171,7 @@ impl Operator for ArgMin {
     }
 
     fn output_types(&self) -> Option<OutputTypeList> {
-        Some([OutputType::Fixed(DataType::Int32)].into())
+        Some([OutputType::Fixed(ValueType::Tensor(DataType::Int32))].into())
     }
 }
 
@@ -278,7 +278,7 @@ impl Operator for NonZero {
     }
 
     fn output_types(&self) -> Option<OutputTypeList> {
-        Some([OutputType::Fixed(DataType::Int32)].into())
+        Some([OutputType::Fixed(ValueType::Tensor(DataType::Int32))].into())
     }
 }
 
@@ -1076,7 +1076,7 @@ impl Operator for TopK {
     fn output_types(&self) -> Option<OutputTypeList> {
         Some(OutputTypeList::from_slice(&[
             OutputType::CopyFromInput(0),
-            OutputType::Fixed(DataType::Int32),
+            OutputType::Fixed(ValueType::Tensor(DataType::Int32)),
         ]))
     }
 }

--- a/src/ops/rnn.rs
+++ b/src/ops/rnn.rs
@@ -12,7 +12,7 @@ use crate::operator::{
 };
 use crate::ops::binary_elementwise::{add_in_place, mul_in_place};
 use crate::ops::unary_elementwise::{sigmoid, tanh};
-use crate::value::DataType;
+use crate::value::{DataType, ValueType};
 
 /// Direction that an RNN operator will traverse the input sequence in.
 #[derive(Copy, Clone, Debug)]
@@ -349,8 +349,8 @@ impl Operator for GRU {
 
     fn output_types(&self) -> Option<OutputTypeList> {
         Some(OutputTypeList::from_slice(&[
-            OutputType::Fixed(DataType::Float),
-            OutputType::Fixed(DataType::Float),
+            OutputType::Fixed(ValueType::Tensor(DataType::Float)),
+            OutputType::Fixed(ValueType::Tensor(DataType::Float)),
         ]))
     }
 }
@@ -603,9 +603,9 @@ impl Operator for LSTM {
 
     fn output_types(&self) -> Option<OutputTypeList> {
         Some(OutputTypeList::from_slice(&[
-            OutputType::Fixed(DataType::Float),
-            OutputType::Fixed(DataType::Float),
-            OutputType::Fixed(DataType::Float),
+            OutputType::Fixed(ValueType::Tensor(DataType::Float)),
+            OutputType::Fixed(ValueType::Tensor(DataType::Float)),
+            OutputType::Fixed(ValueType::Tensor(DataType::Float)),
         ]))
     }
 }

--- a/src/ops/sequence.rs
+++ b/src/ops/sequence.rs
@@ -243,7 +243,7 @@ impl Operator for SequenceLength {
     }
 
     fn output_types(&self) -> Option<OutputTypeList> {
-        Some([OutputType::Fixed(DataType::Int32)].into())
+        Some([OutputType::Fixed(ValueType::Tensor(DataType::Int32))].into())
     }
 }
 

--- a/src/ops/unary_elementwise.rs
+++ b/src/ops/unary_elementwise.rs
@@ -17,7 +17,7 @@ use crate::operator::{
 };
 use crate::ops::binary_elementwise::binary_op;
 use crate::ops::{map_value, map_value_view};
-use crate::value::{DataType, Value, ValueView};
+use crate::value::{DataType, Value, ValueType, ValueView};
 
 trait UnaryKernel<T> {
     /// Apply the unary operation to elements of `src`, writing to `dst`.
@@ -456,7 +456,7 @@ impl Operator for IsInf {
     }
 
     fn output_types(&self) -> Option<OutputTypeList> {
-        Some([OutputType::Fixed(DataType::Int32)].into())
+        Some([OutputType::Fixed(ValueType::Tensor(DataType::Int32))].into())
     }
 
     fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
@@ -483,7 +483,7 @@ impl Operator for IsNaN {
     }
 
     fn output_types(&self) -> Option<OutputTypeList> {
-        Some([OutputType::Fixed(DataType::Int32)].into())
+        Some([OutputType::Fixed(ValueType::Tensor(DataType::Int32))].into())
     }
 
     fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
@@ -559,7 +559,7 @@ impl Operator for Not {
     }
 
     fn output_types(&self) -> Option<OutputTypeList> {
-        Some([OutputType::Fixed(DataType::Int32)].into())
+        Some([OutputType::Fixed(ValueType::Tensor(DataType::Int32))].into())
     }
 
     fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -364,8 +364,8 @@ impl GraphOptimizer {
             for (value_id, shape) in infer_result.shapes {
                 graph_mut.graph.update_value_shape(value_id, shape);
             }
-            for (value_id, dtype) in infer_result.types {
-                graph_mut.graph.update_value_type(value_id, dtype);
+            for (value_id, value_type) in infer_result.types {
+                graph_mut.graph.update_value_type(value_id, value_type);
             }
         }
 

--- a/src/optimize/fusions.rs
+++ b/src/optimize/fusions.rs
@@ -18,6 +18,7 @@ use crate::ops::{
     ReduceMean, RepeatInterleave, RmsNormalization, Shape, Silu, Softmax, Swish, Transpose,
 };
 use crate::optimize::pattern_matcher::{Match, Pattern};
+use crate::value::ValueType;
 
 #[derive(Debug)]
 pub struct FusedOp {
@@ -435,7 +436,7 @@ impl FusionVisitor for CastElimination {
         };
 
         let input_dtype = graph.get_node(input_id).and_then(|n| n.dtype())?;
-        if input_dtype != to_dtype {
+        if input_dtype != ValueType::Tensor(to_dtype) {
             // This Cast op is not a no-op.
             return None;
         }

--- a/src/optimize/tests.rs
+++ b/src/optimize/tests.rs
@@ -6,6 +6,7 @@ use rten_tensor::{NdTensor, Tensor};
 use rten_testing::TestCases;
 
 use super::{GraphOptimizer, OptimizeError, OptimizeOptions};
+use crate::Dimension;
 use crate::constant_storage::{ArcSlice, ArcTensorView, ConstantStorage};
 use crate::graph::builder::{Expr, OutputMeta, dims};
 use crate::graph::{
@@ -17,8 +18,7 @@ use crate::ops::{
     Pow, ReduceMean, RepeatInterleave, Reshape, RmsNormalization, Shape, Sigmoid, Slice, Softmax,
     Sqrt, Swish, Tanh, Transpose, Unsqueeze, Where,
 };
-use crate::value::Value;
-use crate::{DataType, Dimension};
+use crate::value::{DataType, Value, ValueType};
 
 fn optimize_graph(graph: Graph) -> Result<Graph, OptimizeError> {
     let optimizer = GraphOptimizer::new();
@@ -1242,5 +1242,5 @@ fn test_infer_shapes() {
         output.shape().as_deref(),
         Some(dims!("batch", 12).as_slice())
     );
-    assert_eq!(output.dtype(), Some(DataType::Float));
+    assert_eq!(output.dtype(), Some(ValueType::Tensor(DataType::Float)));
 }


### PR DESCRIPTION
Replace DataType with ValueType in various graph node fields and operator output type inference. This allows this metadata to represent sequence values, and any other non-tensor value types added in future.