### PR TITLE
Support type inference for sequence operators

### DIFF
--- a/src/operator.rs
+++ b/src/operator.rs
@@ -319,6 +319,10 @@ pub enum OutputType {
     Fixed(ValueType),
     /// This output has the same type as the input at a given index.
     CopyFromInput(u32),
+    /// The output is the element type of an input sequence.
+    ElementTypeOfInputSequence(u32),
+    /// The output is a sequence whose element type matches an input.
+    SequenceWithElementTypeOfInput(u32),
 }
 
 /// List of type rules for each operator output.

--- a/src/ops/sequence.rs
+++ b/src/ops/sequence.rs
@@ -31,8 +31,8 @@ impl Operator for SequenceEmpty {
     }
 
     fn output_types(&self) -> Option<OutputTypeList> {
-        // Type inference does not support sequence types yet.
-        None
+        let dtype = self.dtype.unwrap_or(DataType::Float);
+        Some([OutputType::Fixed(ValueType::Sequence(dtype))].into())
     }
 }
 
@@ -60,8 +60,7 @@ impl Operator for SequenceAt {
     }
 
     fn output_types(&self) -> Option<OutputTypeList> {
-        // Type inference does not support sequence types yet.
-        None
+        Some([OutputType::ElementTypeOfInputSequence(0)].into())
     }
 }
 
@@ -97,8 +96,7 @@ impl Operator for SequenceConstruct {
     }
 
     fn output_types(&self) -> Option<OutputTypeList> {
-        // Type inference does not support sequence types yet.
-        None
+        Some([OutputType::SequenceWithElementTypeOfInput(0)].into())
     }
 }
 
@@ -153,8 +151,7 @@ impl Operator for SequenceErase {
     }
 
     fn output_types(&self) -> Option<OutputTypeList> {
-        // Type inference does not support sequence types yet.
-        None
+        Some([OutputType::CopyFromInput(0)].into())
     }
 }
 
@@ -219,8 +216,7 @@ impl Operator for SequenceInsert {
     }
 
     fn output_types(&self) -> Option<OutputTypeList> {
-        // Type inference does not support sequence types yet.
-        None
+        Some([OutputType::CopyFromInput(0)].into())
     }
 }
 
@@ -299,8 +295,7 @@ impl Operator for ConcatFromSequence {
     }
 
     fn output_types(&self) -> Option<OutputTypeList> {
-        // Type inference does not support sequence types yet.
-        None
+        Some([OutputType::ElementTypeOfInputSequence(0)].into())
     }
 }
 
@@ -367,8 +362,7 @@ impl Operator for SplitToSequence {
     }
 
     fn output_types(&self) -> Option<OutputTypeList> {
-        // Type inference does not support sequence types yet.
-        None
+        Some([OutputType::SequenceWithElementTypeOfInput(0)].into())
     }
 }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -44,6 +44,24 @@ pub enum ValueType {
     Sequence(DataType),
 }
 
+impl ValueType {
+    /// Convert to a tensor type.
+    pub(crate) fn to_tensor_type(&self) -> Self {
+        match self {
+            ttype @ Self::Tensor(_) => *ttype,
+            Self::Sequence(dtype) => Self::Tensor(*dtype),
+        }
+    }
+
+    /// Convert to a sequence type.
+    pub(crate) fn to_sequence_type(&self) -> Self {
+        match self {
+            Self::Tensor(dtype) => Self::Sequence(*dtype),
+            stype @ Self::Sequence(_) => *stype,
+        }
+    }
+}
+
 impl std::fmt::Display for ValueType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {


### PR DESCRIPTION
Extend the type inference rules in `OutputType` to support converting between sequence and tensor types and use this to enable type inference for sequence operators.