### PR TITLE
Support creating value nodes with sequence types in the graph builder

### DIFF
--- a/src/graph/builder.rs
+++ b/src/graph/builder.rs
@@ -66,7 +66,7 @@ impl Expr {
 
     /// Create an expression representing a runtime-computed value (eg. model
     /// inputs), with shape and dtype information.
-    pub fn value_with_info(name: &str, dtype: DataType, shape: &[Dimension]) -> Expr {
+    pub fn value_with_info(name: &str, dtype: ValueType, shape: &[Dimension]) -> Expr {
         Expr::from(ExprKind::Value(ValueExpr {
             name: name.to_string(),
             dtype: Some(dtype),
@@ -206,7 +206,7 @@ impl Expr {
             ExprKind::Value(value_info) => [graph.add_value(
                 Some(value_info.name.as_str()),
                 value_info.shape.clone(),
-                value_info.dtype.map(ValueType::Tensor),
+                value_info.dtype,
             )]
             .into(),
             ExprKind::Constant(value) => {
@@ -311,7 +311,7 @@ struct OperatorExpr {
 
 struct ValueExpr {
     name: String,
-    dtype: Option<DataType>,
+    dtype: Option<ValueType>,
     shape: Option<Vec<Dimension>>,
 }
 

--- a/src/infer_shapes.rs
+++ b/src/infer_shapes.rs
@@ -261,7 +261,11 @@ mod tests {
     #[test]
     fn test_infer_shapes() {
         let graph = {
-            let x = Expr::value_with_info("data", DataType::Float, &dims!("batch", 64));
+            let x = Expr::value_with_info(
+                "data",
+                ValueType::Tensor(DataType::Float),
+                &dims!("batch", 64),
+            );
             let w = Expr::constant(NdTensor::<f32, _>::zeros([64, 12]));
             let out = x.apply(MatMul {}, &[w], &[OutputMeta::NoMeta]);
             out.build_graph(&["data"])
@@ -283,7 +287,11 @@ mod tests {
     #[test]
     fn test_infer_split_op_types() {
         let graph = {
-            let x = Expr::value_with_info("data", DataType::Float, &dims!("batch", 64));
+            let x = Expr::value_with_info(
+                "data",
+                ValueType::Tensor(DataType::Float),
+                &dims!("batch", 64),
+            );
             let split = x.apply(
                 Split {
                     axis: -1,


### PR DESCRIPTION
This makes it possible to write type inference tests involving sequence values. There is no way to express the _shapes_ of sequences yet, so shape inference tests are not possible.