### PR TITLE
Use shape inference results to replace more values with constants

### DIFF
--- a/rten-shape-inference/src/sym_tensor.rs
+++ b/rten-shape-inference/src/sym_tensor.rs
@@ -6,7 +6,7 @@ use std::ops::{Add, AddAssign, Div, Mul, Sub};
 use std::rc::Rc;
 
 /// Vector or scalar with integer values.
-#[derive(Clone, PartialEq)]
+#[derive(Clone, Eq, Hash, PartialEq)]
 pub enum Constant {
     Scalar(i32),
     Vector(Vec<i32>),

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -3,6 +3,8 @@ use std::error::Error;
 use std::fmt::{Display, Formatter};
 use std::sync::Arc;
 
+use rten_shape_inference::sym_tensor;
+use rten_tensor::Tensor;
 use rustc_hash::FxHashSet;
 use smallvec::SmallVec;
 
@@ -11,7 +13,7 @@ use crate::graph::{
     CaptureEnv, Constant, ConstantNode, ConstantNodeData, Graph, Node, NodeId, OperatorNode,
     PlanOptions, RunError,
 };
-use crate::infer_shapes::infer_shapes;
+use crate::infer_shapes::{Shape, infer_shapes};
 use crate::operator::Operator;
 use crate::ops::Identity;
 
@@ -361,8 +363,28 @@ impl GraphOptimizer {
         if opts.infer_shapes
             && let Ok(infer_result) = infer_shapes(&graph_mut.graph)
         {
+            let const_ids: Vec<NodeId> = infer_result
+                .constants
+                .into_iter()
+                .map(|constant| {
+                    let tensor = match constant {
+                        sym_tensor::Constant::Scalar(x) => Tensor::from(x),
+                        sym_tensor::Constant::Vector(vec) => Tensor::from(vec),
+                    };
+                    graph_mut.add_constant(None, tensor.into_arc())
+                })
+                .collect();
+
             for (value_id, shape) in infer_result.shapes {
-                graph_mut.graph.update_value_shape(value_id, shape);
+                match shape {
+                    Shape::Constant { index } => {
+                        let const_id = const_ids[index];
+                        graph_mut.replace_value(value_id, const_id);
+                    }
+                    Shape::Shape(shape) => {
+                        graph_mut.graph.update_value_shape(value_id, shape);
+                    }
+                }
             }
             for (value_id, value_type) in infer_result.types {
                 graph_mut.graph.update_value_type(value_id, value_type);


### PR DESCRIPTION
Shape inference may determine that a node has a fixed constant output which doesn't depend on model inputs. In that case the value node in the graph can be replaced by a constant, avoiding the need to compute it on each inference. Since ML models typically consist of many identical or at least similar layers, many of these inferred constants will have the same value.

For the Llama 3 3B model, shape inference infers that 960 value nodes have constant values, of which there are only 21 unique values. Replacing these 960 values with constants reduces the number of operators run on each generation step from 2022 to 1740 (-14%). The reduction in op count is smaller than the number of value-to-constant substitutions because some of these substitutions were previously performed later in the optimization process by constant propagation.

The impact on runtime is small, since the removed operations are cheap ops that operate on small tensors. This nevertheless saves interpreter overhead over the course of generation and replacing more values with constants can enable additional optimizations elsewhere.