### PR TITLE
Add basic optimizer diagnostics infrastructure

### DIFF
--- a/src/optimize/diagnostics.rs
+++ b/src/optimize/diagnostics.rs
@@ -1,0 +1,46 @@
+use std::cell::RefCell;
+
+use rustc_hash::FxHashSet;
+
+use crate::NodeId;
+
+#[derive(PartialEq, Eq, PartialOrd, Ord)]
+pub enum DiagnosticLevel {
+    Off,
+    Warn,
+}
+
+/// Diagnostic reporter for graph optimizations.
+pub struct Diagnostics {
+    /// Nodes against which issues have been reported.
+    nodes: RefCell<FxHashSet<NodeId>>,
+    level: DiagnosticLevel,
+}
+
+impl Diagnostics {
+    pub fn new() -> Self {
+        Self {
+            nodes: RefCell::new(FxHashSet::default()),
+            level: DiagnosticLevel::Off,
+        }
+    }
+
+    /// Enable reporting of all messages at or above a given level.
+    pub fn set_level(&mut self, level: DiagnosticLevel) {
+        self.level = level;
+    }
+
+    /// Return true if diagnostic messages are enabled at a given level.
+    pub fn enabled(&self, level: DiagnosticLevel) -> bool {
+        self.level >= level
+    }
+
+    /// Log a diagnostic message for a given node at the [`Warn`](DiagnosticLevel::Warn) level.
+    pub fn warn(&self, node: NodeId, message: std::fmt::Arguments<'_>) {
+        if self.level < DiagnosticLevel::Warn || self.nodes.borrow().contains(&node) {
+            return;
+        }
+        self.nodes.borrow_mut().insert(node);
+        println!("{}", message);
+    }
+}

--- a/src/optimize/fusions.rs
+++ b/src/optimize/fusions.rs
@@ -112,6 +112,15 @@ impl Fusion {
             Fusion::Constant { output_id, .. } => [*output_id].into(),
         }
     }
+
+    /// Return a short identifier for the kind of fusion this is.
+    pub fn name(&self) -> &str {
+        match self {
+            Fusion::Op(op) => op.fused_op.name(),
+            Fusion::Identity { .. } => "identity",
+            Fusion::Constant { .. } => "constant",
+        }
+    }
 }
 
 /// Interface for graph visitors which match graph patterns and return fused


### PR DESCRIPTION
Add a minimal diagnostic reporter for the graph optimizer, which is enabled by setting the `RTEN_OPTIMIZER_DEBUG` env var to a truthy value.  Initially this reports a single diagnostic, which is for fusions that are skipped because an intermediate value in the fused subgraph is used outside the subgraph.

Part of https://github.com/robertknight/rten/issues/1110.