### PR TITLE
Improve shape inference for Slice op when input is a symbolic vector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -563,6 +563,7 @@ version = "0.23.0"
 name = "rten-shape-inference"
 version = "0.23.0"
 dependencies = [
+ "rten-tensor",
  "rten-testing",
  "smallvec",
 ]

--- a/rten-shape-inference/Cargo.toml
+++ b/rten-shape-inference/Cargo.toml
@@ -12,6 +12,7 @@ repository = "https://github.com/robertknight/rten"
 crate-type = ["lib"]
 
 [dependencies]
+rten-tensor = { version = "0.23.0", path = "../rten-tensor" }
 smallvec = { workspace = true }
 
 [dev-dependencies]


### PR DESCRIPTION
When the input is a symbolic vector, make the result also a (sliced) symbolic vector instead of just a shape. Implementing this would have involved copying additional parts of `SliceRange` from rten-tensor into the rten-shape-inference crate, so I bit the bullet and added rten-tensor as a dependency instead. This could be avoided by splitting out the `SliceRange` type into its own mini-crate in future.