### PR TITLE
Add shape inference for Gemm operator

### DIFF
--- a/rten-shape-inference/src/ops.rs
+++ b/rten-shape-inference/src/ops.rs
@@ -14,7 +14,7 @@ mod slice;
 
 pub use binary::{Add, Div, Equal, Mul, Sub};
 pub use layout::{Expand, Flatten, Reshape, Shape, Squeeze, Transpose, Unsqueeze};
-pub use matmul::{MatMul, MatMulNBits};
+pub use matmul::{Gemm, MatMul, MatMulNBits};
 pub use slice::Slice;
 
 /// Concat operator.

--- a/src/ops/matmul.rs
+++ b/src/ops/matmul.rs
@@ -12,7 +12,7 @@ use rten_vecmath::ExtendInit;
 use smallvec::SmallVec;
 
 use crate::buffer_pool::{AutoReturn, BufferPool};
-use crate::infer_shapes::InferShapes;
+use crate::infer_shapes::{InferShapes, impl_infer_shapes};
 use crate::operator::{
     IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType, OutputTypeList,
     OutputTypesContext, PrepackedInput, static_dims,
@@ -130,7 +130,20 @@ impl Operator for Gemm {
     fn output_types(&self, _ctx: &OutputTypesContext) -> Option<OutputTypeList> {
         Some([OutputType::CopyFromInput(0)].into())
     }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        Some(self)
+    }
 }
+
+impl_infer_shapes!(
+    Gemm,
+    op,
+    shape_ops::Gemm {
+        transpose_a: op.transpose_a,
+        transpose_b: op.transpose_b,
+    }
+);
 
 /// Hints for how a batched MatMul should be performed. This exists to enable
 /// comparisons in tests and benchmarks.


### PR DESCRIPTION
After https://github.com/robertknight/rten/pull/1143 and https://github.com/robertknight/rten/pull/1144 this is step 3 in making shape inference work for a GPT-2 model exported from HF via Optimum.