### PR TITLE
Add basic shape inference for Split operator

### DIFF
--- a/rten-shape-inference/src/infer_shapes.rs
+++ b/rten-shape-inference/src/infer_shapes.rs
@@ -22,6 +22,9 @@ pub enum InferShapesError {
 
     /// An operator input or attribute has an invalid value.
     InvalidValue,
+
+    /// The number of outputs could not be determined.
+    UnknownOutputCount,
 }
 
 /// Infer the shapes of an operator's outputs given its inputs.

--- a/rten-shape-inference/src/ops.rs
+++ b/rten-shape-inference/src/ops.rs
@@ -11,11 +11,13 @@ mod binary;
 mod layout;
 mod matmul;
 mod slice;
+mod split;
 
 pub use binary::{Add, Div, Equal, Mul, Sub};
 pub use layout::{Expand, Flatten, Reshape, Shape, Squeeze, Transpose, Unsqueeze};
 pub use matmul::{Gemm, MatMul, MatMulNBits};
 pub use slice::Slice;
+pub use split::Split;
 
 /// Concat operator.
 ///

--- a/rten-shape-inference/src/ops/split.rs
+++ b/rten-shape-inference/src/ops/split.rs
@@ -1,0 +1,87 @@
+use crate::infer_shapes::{InferShapes, InferShapesError};
+use crate::ops::resolve_axis;
+use crate::sym_gen::SymbolGen;
+use crate::sym_tensor::SymTensor;
+
+/// Split operator.
+///
+/// See <https://onnx.ai/onnx/operators/onnx__Split.html>.
+pub struct Split {
+    /// Axis to split the tensor along.
+    pub axis: i32,
+
+    /// Number of pieces to split the tensor into, if split sizes are not
+    /// explicitly provided as an input.
+    pub num_outputs: Option<u32>,
+}
+
+impl InferShapes for Split {
+    fn infer_shapes(
+        &self,
+        inputs: &[SymTensor],
+        _sym_gen: &mut SymbolGen,
+    ) -> Result<Vec<SymTensor>, InferShapesError> {
+        let [data, rest @ ..] = inputs else {
+            return Err(InferShapesError::IncorrectInputCount);
+        };
+
+        let Some(splits) = rest.first() else {
+            return Err(InferShapesError::UnknownOutputCount);
+        };
+
+        // This currently supports only the case where split sizes are
+        // explicitly specified. Otherwise the splits should be determined using
+        // the `num_outputs` attribute. If that is not set, this needs to be
+        // determined from the number of output values this operator has. That
+        // information is not currently exposed to the `infer_shapes` method.
+        let Some(split_sizes) = splits.as_vector() else {
+            return Err(InferShapesError::UnknownOutputCount);
+        };
+
+        let outputs: Result<Vec<SymTensor>, _> = split_sizes
+            .iter()
+            .map(|size| {
+                if let Some(shape) = data.shape() {
+                    let axis = resolve_axis(shape.len(), self.axis)?;
+                    let mut shape: Vec<_> = shape.collect();
+                    shape[axis] = size.clone();
+                    Ok(SymTensor::from_shape(shape))
+                } else {
+                    Ok(SymTensor::unknown("unknown input shape"))
+                }
+            })
+            .collect();
+
+        outputs
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::infer_shapes::InferShapes;
+    use crate::sym_gen::SymbolGen;
+    use crate::sym_tensor::{SymElem, SymTensor, sym_shape, sym_vec};
+
+    use super::Split;
+
+    #[test]
+    fn test_split() {
+        // Split with explicitly specified split sizes.
+        let mut sym_gen = SymbolGen::new();
+        let data = sym_shape!("batch", "seq", 2304);
+        let splits = sym_vec!(768, 768, 768);
+        let op = Split {
+            axis: 2,
+            num_outputs: None,
+        };
+        let result = op.infer_shapes(&[data, splits], &mut sym_gen).unwrap();
+        assert_eq!(
+            result,
+            [
+                sym_shape!("batch", "seq", 768),
+                sym_shape!("batch", "seq", 768),
+                sym_shape!("batch", "seq", 768),
+            ]
+        );
+    }
+}

--- a/src/ops/split.rs
+++ b/src/ops/split.rs
@@ -1,8 +1,10 @@
 use rten_base::iter::range_chunks;
+use rten_shape_inference::ops as shape_ops;
 use rten_tensor::prelude::*;
 use rten_tensor::{NdTensorView, Tensor, TensorView};
 
 use crate::buffer_pool::BufferPool;
+use crate::infer_shapes::{InferShapes, impl_infer_shapes};
 use crate::operator::{
     OpError, OpRunContext, Operator, OutputList, OutputType, OutputTypeList, OutputTypesContext,
 };
@@ -137,7 +139,20 @@ impl Operator for Split {
             ctx.num_outputs,
         ))
     }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        Some(self)
+    }
 }
+
+impl_infer_shapes!(
+    Split,
+    op,
+    shape_ops::Split {
+        axis: op.axis as i32,
+        num_outputs: op.num_outputs
+    }
+);
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
This supports the most common case where split sizes are explicitly specified.

After https://github.com/robertknight/rten/pull/1145 this is step 4 in making shape inference work for GPT-2. There is one more change needed after this which is to enable symbolic expression simplification to understand that `x + x + y - x` simplifies to `x + y`.