### PR TITLE
Enable addition and subtraction to cancel

### DIFF
--- a/rten-shape-inference/src/ops.rs
+++ b/rten-shape-inference/src/ops.rs
@@ -103,6 +103,7 @@ impl InferShapes for ConstantOfShape {
                             }
                         }
                         SymElem::Var(_)
+                        | SymElem::Neg(_)
                         | SymElem::Add(_)
                         | SymElem::Sub(_)
                         | SymElem::Mul(_)
@@ -303,6 +304,7 @@ impl InferShapes for Where {
                     let cond_bool = match cond {
                         SymElem::Value(v) => Some(*v == 1),
                         SymElem::Var(_)
+                        | SymElem::Neg(_)
                         | SymElem::Add(_)
                         | SymElem::Sub(_)
                         | SymElem::Mul(_)

--- a/rten-shape-inference/src/ops/layout.rs
+++ b/rten-shape-inference/src/ops/layout.rs
@@ -23,7 +23,8 @@ impl InferShapes for Expand {
         } else if let Some(data_dims) = data.shape()
             && let Some(shape_len) = shape.size(0).and_then(|d| match d {
                 SymElem::Value(size) => Some(size),
-                SymElem::Add(_)
+                SymElem::Neg(_)
+                | SymElem::Add(_)
                 | SymElem::Mul(_)
                 | SymElem::Div(_)
                 | SymElem::Max(_)
@@ -497,7 +498,7 @@ mod tests {
         assert_eq!(
             result[0],
             sym_shape!(
-                SymElem::from("batch") * SymElem::from("rows") * SymElem::from("cols"),
+                SymElem::from("batch") * SymElem::from("cols") * SymElem::from("rows"),
                 1
             )
         );


### PR DESCRIPTION
Enable addition and subtraction of the same symbol to cancel. This enables simplifying `x + y - x` to `y` for example. Eliminating the subtraction makes it possible to reason that the expression evaluates to a positive value, if all the symbols are positive. This is useful for a common ONNX subgraph of the form `Where(Equal(shape, -1), x, y)`. If we can reason that all elements of `shape` are positive, then the output is equal to `y`.

The implementation works by:

 1. Changing canonicalization to rewrite subtraction as addition of negation (`x - y` => `x + (-x)`).
 2. Sorting terms by symbol name during re-association (`x + y - x` => `x + (-x) + y`)
 3. Adding a step after re-association that removes adjacent terms which are negations of each other (`x + (-x) + y` => `y`).

---

This is the last change needed after https://github.com/robertknight/rten/pull/1146 to make shape inference work fully for the GPT-2 model.