### PR TITLE
Add `broadcast` and `min` symbolic expressions

### DIFF
--- a/rten-shape-inference/src/infer_shapes.rs
+++ b/rten-shape-inference/src/infer_shapes.rs
@@ -130,7 +130,7 @@ impl InferShapes for BinaryOp {
                 //
                 // Where the op succeeds, the result is the maximum of the LHS
                 // and RHS sizes.
-                (a, b) => SymElem::Max((a.into(), b.into())),
+                (a, b) => a.broadcast(&b),
             };
             out_shape.push(dim);
         }
@@ -341,10 +341,7 @@ mod tests {
             Case {
                 lhs: sym_shape!("foo"),
                 rhs: sym_shape!("bar"),
-                expected: sym_shape!(SymElem::Max((
-                    SymElem::from("foo").into(),
-                    SymElem::from("bar").into()
-                ))),
+                expected: sym_shape!(SymElem::from("foo").broadcast(&SymElem::from("bar"))),
             },
         ];
 

--- a/rten-shape-inference/src/ops.rs
+++ b/rten-shape-inference/src/ops.rs
@@ -110,7 +110,9 @@ impl InferShapes for ConstantOfShape {
                         | SymElem::Sub(_)
                         | SymElem::Mul(_)
                         | SymElem::Div(_)
-                        | SymElem::Max(_) => SymTensor::from_shape(vec![vec_len.clone()]),
+                        | SymElem::Max(_)
+                        | SymElem::Min(_)
+                        | SymElem::Broadcast(_) => SymTensor::from_shape(vec![vec_len.clone()]),
                     }
                 } else {
                     SymTensor::from_scalar(SymElem::Value(val))
@@ -311,7 +313,9 @@ impl InferShapes for Where {
                         | SymElem::Sub(_)
                         | SymElem::Mul(_)
                         | SymElem::Div(_)
-                        | SymElem::Max(_) => None,
+                        | SymElem::Max(_)
+                        | SymElem::Min(_)
+                        | SymElem::Broadcast(_) => None,
                     }?;
                     if cond_bool {
                         Some(x.clone())

--- a/rten-shape-inference/src/ops/layout.rs
+++ b/rten-shape-inference/src/ops/layout.rs
@@ -28,8 +28,10 @@ impl InferShapes for Expand {
                 | SymElem::Mul(_)
                 | SymElem::Div(_)
                 | SymElem::Max(_)
+                | SymElem::Min(_)
                 | SymElem::Sub(_)
-                | SymElem::Var(_) => None,
+                | SymElem::Var(_)
+                | SymElem::Broadcast(_) => None,
             })
         {
             // If we know the length of the shape but not the values, then we


### PR DESCRIPTION
Add symbolic expressions for the broadcast and min operations and use them to improve shape inference for binary and Slice ops.

`broadcast(x, y)` is the function used to broadcast two dimension sizes in various ONNX ops. It functions like `max` but implies more constraints on the arguments: they must be positive and either equal or one of them must be 1. `min` is useful to represent the output size in a Slice op if both input dimension sizes are symbolic.

Shape inference for the BERT-base model now infers the output shape as `[batch_size, broadcast(sequence_length, min(sequence_length, 512)), 30522]`. This implies an inconsistency if `sequence_length` exceeds 512, and indeed inference fails if that is the case. I haven't decided how to handle these constraints on symbolic dimensions uncovered through shape inference yet, but it would be useful to expose to the user.