### PR TITLE
Support `auto_pad` attribute for pool ops in ONNX loader

### DIFF
--- a/src/ops/conv.rs
+++ b/src/ops/conv.rs
@@ -411,7 +411,7 @@ impl_infer_shapes!(
         strides: &op.strides,
         dilations: &op.dilations,
         padding: match &op.padding {
-            Padding::Fixed(pads) => Some(&pads),
+            Padding::Fixed(pads) => Some(pads),
             Padding::Same => None,
         }
     }

--- a/src/ops/pooling.rs
+++ b/src/ops/pooling.rs
@@ -475,7 +475,7 @@ impl_infer_shapes!(
         dilations: &[1, 1],
         kernel_size: &op.kernel_size,
         padding: match &op.padding {
-            Padding::Fixed(pads) => Some(&pads),
+            Padding::Fixed(pads) => Some(pads),
             Padding::Same => None,
         }
     }
@@ -657,7 +657,7 @@ impl_infer_shapes!(
         dilations: &[1, 1],
         kernel_size: &op.kernel_size,
         padding: match &op.padding {
-            Padding::Fixed(pads) => Some(&pads),
+            Padding::Fixed(pads) => Some(pads),
             Padding::Same => None,
         }
     }


### PR DESCRIPTION
Support `auto_pad="SAME_UPPER"` attribute in pooling ops (AveragePool, MaxPool) in the ONNX loader. This is already supported in the .rten loader.

In the process an issue was uncovered where padding was set incorrectly in pooling ops if the `pads` field was not set explicitly. The issue had been previously fixed for convolution operators. Now pooling and convolution ops use a common function to read the `pads`/`auto_pad` attributes.

The issue was encountered using a [Tiny YOLO v3](https://github.com/onnx/models/blob/main/validated/vision/object_detection_segmentation/tiny-yolov3/model/tiny-yolov3-11.onnx) model originally authored in Keras.