### PR TITLE
Fix warning about unused macro import

### DIFF
--- a/rten-base/src/unroll.rs
+++ b/rten-base/src/unroll.rs
@@ -69,8 +69,6 @@ pub use {unroll_loop, unroll_loop_x4};
 
 #[cfg(test)]
 mod tests {
-    use super::unroll_loop;
-
     #[test]
     fn test_unroll_loop() {
         let mut items: Vec<i32> = Vec::new();


### PR DESCRIPTION
This import is unnecessary due to the textual scoping that macros use. See https://doc.rust-lang.org/reference/macros-by-example.html#r-macro.decl.scope.textual.