### PR TITLE
Update JS / WASM usage guide and example

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,18 +109,11 @@ the WebAssembly library"](#building-the-webassembly-library) below.
 The general steps for using RTen's built-in WebAssembly API to run models in
 a JavaScript project are:
 
-1.  Develop a model or find a pre-trained one that you want to run. Pre-trained
-    models in ONNX format can be obtained from the [ONNX Model Zoo](https://github.com/onnx/models)
-    or [Hugging Face](https://huggingface.co/docs/transformers/serialization).
-2.  If the model is not already in ONNX format, convert it to ONNX. PyTorch
-    users can use [torch.onnx](https://pytorch.org/docs/stable/onnx.html) for this.
-3.  Use the `rten-convert` package in this repository to convert the model
-    to the optimized format RTen uses. See the section above on converting models.
-4.  In your JavaScript code, fetch the WebAssembly binary and initialize RTen
+1.  In your JavaScript code, fetch the WebAssembly binary and initialize RTen
     using the `init` function.
-5.  Fetch the prepared `.rten` model and use it to an instantiate the `Model`
+2.  Fetch the prepared `.onnx` model and use it to an instantiate the `Model`
     class from this library.
-6.  Each time you want to run the model, prepare one or more `Float32Array`s
+3.  Each time you want to run the model, prepare one or more `Float32Array`s
     containing input data in the format expected by the model, and call
     `Model.run`. This will return a `TensorList` that provides access to the
     shapes and data of the outputs.

--- a/js-examples/image-classification/Makefile
+++ b/js-examples/image-classification/Makefile
@@ -1,0 +1,8 @@
+.PHONY: fetch-model
+fetch-model:
+	curl -L https://github.com/onnx/models/raw/main/Computer_Vision/mobilenetv2_110d_Opset18_timm/mobilenetv2_110d_Opset18.onnx -o mobilenet.onnx
+
+.PHONY: test-node
+test-node:
+	npm ci > /dev/null
+	node classify-node.js ../../tools/test-images/sofa-cats.jpg

--- a/js-examples/image-classification/README.md
+++ b/js-examples/image-classification/README.md
@@ -10,13 +10,10 @@ kind of object.
 1. Build the main RTen project for WebAssembly. See the README.md file at the
    root of the repository.
 2. In this directory, run `npm install`
-3. Download the ONNX MobileNet model from the ONNX Model Zoo and convert it
-   to `.rten` format:
+3. Download the ONNX MobileNet model from the ONNX Model Zoo:
 
    ```sh
    curl -L https://github.com/onnx/models/raw/main/Computer_Vision/mobilenetv2_110d_Opset18_timm/mobilenetv2_110d_Opset18.onnx -o mobilenet.onnx
-
-   rten-convert mobilenet.onnx mobilenet.rten
    ```
 4. Follow either of the subsections below to run the example in Node or the
    browser
@@ -24,15 +21,16 @@ kind of object.
 ## Running in Node
 
 ```sh
-$ node classify-node.js espresso.png
+$ node classify-node.js ../../tools/test-images/sofa-cats.jpg
 
 # Example output
+
 Most likely categories:
-  - espresso
-  - chocolate sauce, chocolate syrup
-  - cup
-  - ice cream, icecream
-  - plate
+  - Egyptian cat
+  - tabby, tabby cat
+  - tiger cat
+  - lynx, catamount
+  - marmoset
 ```
 
 ## Running in a browser

--- a/js-examples/image-classification/classify-node.js
+++ b/js-examples/image-classification/classify-node.js
@@ -22,7 +22,7 @@ async function loadImage(path, width, height) {
 }
 
 const path = process.argv[2];
-const modelPath = process.argv[3] ?? "./mobilenet.rten";
+const modelPath = process.argv[3] ?? "./mobilenet.onnx";
 
 // Initialize RTen.
 const rtenBinary = readFileSync("node_modules/rten/dist/" + binaryName());

--- a/js-examples/image-classification/classify-web.js
+++ b/js-examples/image-classification/classify-web.js
@@ -50,7 +50,7 @@ async function createClassifier() {
   // Fetch the RTen engine and MobileNet model in parallel.
   const [, modelData] = await Promise.all([
     fetch("./node_modules/rten/dist/" + binaryName()).then(initRTen),
-    fetchBinary("./mobilenet.rten"),
+    fetchBinary("./mobilenet.onnx"),
   ]);
 
   // Initialize the classifier. This must be done after RTen is initialized.


### PR DESCRIPTION
 - Remove reference to the deprecated ONNX Model Zoo. For the JS instructions, we assume that the user has already found an ONNX model they want to run. Information on where to find ONNX models is covered in the rten crate docs.
 - Simplify instructions by loading the model in ONNX format instead of converting to the .rten format first
 - Change the instructions for running the example to use an image that is in the repository.
 - Add a `Makefile` to simplify fetching the model and running the Node example for testing.