### PR TITLE
Support shape inference for .rten model format

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -833,6 +833,18 @@ impl ModelOptions {
             FileType::Onnx => Err(LoadErrorImpl::FormatNotEnabled.into()),
         }
     }
+
+    /// Convert optimization settings into the internal representation passed
+    /// to the graph optimizer.
+    fn optimize_mode(&self) -> OptimizeMode {
+        if self.optimize {
+            OptimizeMode::On(OptimizeOptions {
+                infer_shapes: self.infer_shapes,
+            })
+        } else {
+            OptimizeMode::Off
+        }
+    }
 }
 
 impl std::fmt::Debug for ModelOptions {

--- a/src/model/onnx_loader.rs
+++ b/src/model/onnx_loader.rs
@@ -17,7 +17,7 @@ use crate::graph::{
 };
 use crate::op_registry::onnx_registry::{ConstInput, DynParsedOp, OpLoadContext};
 use crate::op_registry::{OpRegistry, ReadOpError};
-use crate::optimize::{GraphOptimizer, OptimizeOptions};
+use crate::optimize::GraphOptimizer;
 use crate::value::{DataType, ValueType};
 use crate::weight_cache::WeightCache;
 
@@ -49,16 +49,14 @@ pub fn load(
     }
     .map_err(|err| LoadErrorImpl::ParseFailed(Box::new(err)))?;
 
-    let optimize_opts = if options.optimize {
-        OptimizeMode::On(OptimizeOptions {
-            infer_shapes: options.infer_shapes,
-        })
-    } else {
-        OptimizeMode::Off
-    };
-
     let graph = if let Some(onnx_graph) = &model.graph {
-        load_graph(onnx_graph, &options.registry, optimize_opts, None, loader)?
+        load_graph(
+            onnx_graph,
+            &options.registry,
+            options.optimize_mode(),
+            None,
+            loader,
+        )?
     } else {
         Graph::new()
     };

--- a/src/model/rten_loader.rs
+++ b/src/model/rten_loader.rs
@@ -12,7 +12,7 @@ use rten_tensor::ArcTensor;
 
 use super::load_error::{LoadError, LoadErrorImpl, load_error};
 use super::metadata::{MetadataField, ModelMetadata};
-use super::{Model, ModelOptions, OptimizeMode, OptimizeOptions};
+use super::{Model, ModelOptions, OptimizeMode};
 use crate::constant_storage::{ArcSlice, ArcTensorView, ConstantStorage};
 use crate::graph::{CaptureEnv, ConstantNodeData, Dimension, Graph, NodeId};
 use crate::op_registry::rten_registry::{OpLoadContext, convert_dtype};
@@ -52,19 +52,13 @@ pub fn load(storage: Arc<ConstantStorage>, options: &ModelOptions) -> Result<Mod
         return Err(LoadErrorImpl::ParseFailed(err.into()).into());
     }
 
-    let optimize_opts = if options.optimize {
-        OptimizeMode::On(OptimizeOptions::default())
-    } else {
-        OptimizeMode::Off
-    };
-
     let tensor_data_offset = header.as_ref().map(|h| h.tensor_data_offset);
     let graph = load_graph(
         model.graph(),
         registry,
         storage.clone(),
         tensor_data_offset,
-        optimize_opts,
+        options.optimize_mode(),
         None, /* capture_env */
     )?;
 


### PR DESCRIPTION
Refactor processing of optimization settings in `ModelOptions` so that it can be shared by both ONNX and rten model format loaders.