### PR TITLE
Add strict shape inference mode

### DIFF
--- a/rten-shape-inference/src/infer_shapes.rs
+++ b/rten-shape-inference/src/infer_shapes.rs
@@ -1,5 +1,8 @@
 //! Traits for shape inference and common implementations.
 
+use std::error::Error;
+use std::fmt;
+
 use smallvec::SmallVec;
 
 pub use crate::{
@@ -28,6 +31,20 @@ pub enum InferShapesError {
     /// The number of outputs could not be determined.
     UnknownOutputCount,
 }
+
+impl fmt::Display for InferShapesError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::IncorrectInputCount => write!(f, "operator has incorrect input count"),
+            Self::IncompatibleShapes => write!(f, "input shapes are incompatible"),
+            Self::IncorrectRank => write!(f, "incorrect input rank"),
+            Self::InvalidValue => write!(f, "input or attribute has invalid value"),
+            Self::UnknownOutputCount => write!(f, "unknown output count"),
+        }
+    }
+}
+
+impl Error for InferShapesError {}
 
 /// Infer the shapes of an operator's outputs given its inputs.
 pub trait InferShapes {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,7 +188,9 @@ pub mod ops;
 
 pub use buffer_pool::{BufferPool, ExtractBuffer, PoolRef};
 pub use graph::{Dimension, NodeId, RunError, RunErrorKind, RunOptions};
-pub use model::{LoadError, LoadErrorKind, Model, ModelMetadata, ModelOptions, NodeInfo};
+pub use model::{
+    LoadError, LoadErrorKind, Model, ModelMetadata, ModelOptions, NodeInfo, ShapeInferenceMode,
+};
 pub use op_registry::{OpRegistry, RegisterOp, op_types};
 pub use ops::{FloatOperators, Operators};
 pub use threading::{ThreadPool, thread_pool};

--- a/src/optimize/tests.rs
+++ b/src/optimize/tests.rs
@@ -12,6 +12,7 @@ use crate::graph::builder::{Expr, OutputMeta, dims};
 use crate::graph::{
     CaptureEnv, Constant, Graph, Node, NodeId, OperatorNode, PlanOptions, TypedConstant,
 };
+use crate::infer_shapes::InferShapeOptions;
 use crate::ops::{
     Add, Cast, ComputeShape, DimSpec, DynamicQuantizeLinear, Erf, Expand, FusedMatMul, Gather,
     Gelu, GroupedQueryAttentionMatMul, Identity, IsNaN, LayerNormalization, MatMul, MatMulInteger,
@@ -1249,7 +1250,13 @@ fn test_infer_shapes() {
     // Run optimization with shape inference enabled.
     let optimizer = GraphOptimizer::new();
     let graph = optimizer
-        .optimize(graph, None, OptimizeOptions { infer_shapes: true })
+        .optimize(
+            graph,
+            None,
+            OptimizeOptions {
+                infer_shapes: Some(InferShapeOptions::default()),
+            },
+        )
         .unwrap();
 
     // Verify that values were updated with inferred shapes and types.
@@ -1280,7 +1287,13 @@ fn test_shape_inference_replaces_values_with_constants() {
 
     let optimizer = GraphOptimizer::new();
     let graph = optimizer
-        .optimize(graph, None, OptimizeOptions { infer_shapes: true })
+        .optimize(
+            graph,
+            None,
+            OptimizeOptions {
+                infer_shapes: Some(InferShapeOptions::default()),
+            },
+        )
         .unwrap();
 
     // The output should be replaced with a constant as it doesn't depend on


### PR DESCRIPTION
Add a strict mode for shape inference. When enabled, models will fail to load if shape inference is unsupported or is incomplete for any operators. This makes it easier to check if shape inference encounters any problems that might limit optimization.

In the CLI, the `--infer-shapes` switch has been changed to an option which accepts "off", "on" or "strict" values.

**TODO:**

- [x] Add a test