### PR TITLE
Make conversion of `to` attribute for Cast op match initializer loader

### DIFF
--- a/src/op_registry/onnx_registry.rs
+++ b/src/op_registry/onnx_registry.rs
@@ -530,11 +530,18 @@ impl<'a> Attr<'a> {
     /// This can fail if the ONNX data type is unsupported in RTen.
     fn as_dtype(&self) -> Result<DataType, ReadOpError> {
         let onnx_dtype = onnx::DataType(self.cast_int()?);
+
+        // The conversions here should match those used when converting
+        // initializers and value types in the ONNX model loader.
         match onnx_dtype {
-            onnx::DataType::FLOAT | onnx::DataType::FLOAT16 => Ok(DataType::Float),
+            onnx::DataType::FLOAT | onnx::DataType::FLOAT16 | onnx::DataType::DOUBLE => {
+                Ok(DataType::Float)
+            }
             onnx::DataType::INT32 | onnx::DataType::INT64 | onnx::DataType::BOOL => {
                 Ok(DataType::Int32)
             }
+            onnx::DataType::INT8 => Ok(DataType::Int8),
+            onnx::DataType::UINT8 => Ok(DataType::UInt8),
             _ => Err(ReadOpError::attr_error(
                 self.name,
                 format!("unsupported data type {onnx_dtype}"),


### PR DESCRIPTION
Make the conversion of ONNX dtypes to RTen's internally supported dtypes in `onnx_registry.rs` match those used when converting initializers and value info in `onnx_loader.rs`.

This enables loading models with `Cast` nodes where the target type is f64. As with f64 -> f32 conversion of initializers, this may potentially affect accuracy, but this has not been a problem with real models so far. See also https://github.com/robertknight/rten/issues/1176.