### PR TITLE
Make SymExpr and SymTensor hashable

### DIFF
--- a/rten-shape-inference/src/sym_tensor.rs
+++ b/rten-shape-inference/src/sym_tensor.rs
@@ -43,7 +43,7 @@ impl fmt::Debug for Constant {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 enum SymTensorKind {
     Scalar(SymExpr),
     Vector(Vec<SymExpr>),
@@ -87,7 +87,7 @@ enum SymTensorKind {
 /// ).simplify());
 /// assert_eq!(len, Some(SymExpr::Mul(nr.into(), nc.into())));
 /// ```
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct SymTensor(SymTensorKind);
 
 impl SymTensor {


### PR DESCRIPTION
SymExpr requires a custom hash to match the PartialEq implementation, which considers only the name of symbols and uses order-independent comparison for commutative operations.

This will be used for computing unique expressions in shape inference results.