### PR TITLE
Replace shape-manipulating subgraphs with `ComputeShape` operator

### DIFF
--- a/src/infer_shapes.rs
+++ b/src/infer_shapes.rs
@@ -13,8 +13,8 @@ use crate::operator::{OutputType, OutputTypesContext};
 use crate::value::ValueType;
 
 pub use rten_shape_inference::{
-    BinaryOp, Constant, InferShapes, InferShapesContext, InferShapesError, ReductionOp, SymExpr,
-    SymTensor, Symbol, SymbolGen, UnaryOp,
+    BinaryOp, InferShapes, InferShapesContext, InferShapesError, ReductionOp, SymExpr, SymTensor,
+    Symbol, SymbolGen, UnaryOp,
 };
 
 /// Impl [`InferShapes`] for a type by delegating to another type which
@@ -113,24 +113,32 @@ impl fmt::Display for InferError {
 
 impl Error for InferError {}
 
-/// Info about a value node determined by shape inference.
-#[derive(Debug, PartialEq)]
-pub enum Shape {
-    Constant { index: usize },
-    Shape(Vec<Dimension>),
-}
-
 /// Results of shape and type inference.
 #[derive(Debug)]
 pub struct InferResult {
-    /// Unique constants.
-    pub constants: Vec<Constant>,
+    /// Unique shapes or symbolic values.
+    pub values: Vec<SymTensor>,
 
-    /// Map of value node ID to inferred shape or constant index.
-    pub shapes: HashMap<NodeId, Shape>,
+    /// Map of value node ID to index in `values`.
+    pub shapes: HashMap<NodeId, usize>,
 
     /// Map of value node ID to inferred type.
     pub types: HashMap<NodeId, ValueType>,
+}
+
+impl InferResult {
+    /// Return the inferred shape for a value node as a [`Dimension`] vec.
+    pub fn dims(&self, id: NodeId) -> Option<Vec<Dimension>> {
+        let shape_id = self.shapes.get(&id)?;
+        let shape = self.values[*shape_id].shape()?;
+        let dims = shape
+            .map(|dim| match dim {
+                SymExpr::Value(size) => Dimension::Fixed(size as usize),
+                expr => Dimension::Symbolic(expr.to_string()),
+            })
+            .collect();
+        Some(dims)
+    }
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -327,54 +335,40 @@ pub fn infer_shapes(graph: &Graph, opts: InferShapeOptions) -> Result<InferResul
         }
     }
 
-    // Unique constant values.
-    let mut constants = Vec::new();
-    let mut constant_to_index = HashMap::new();
-    let mut total_const_values = 0;
+    // Unique values
+    let mut unique_values = Vec::new();
+    let mut value_to_index = HashMap::new();
+    let mut total_values = 0;
 
     // Map of value ID to shape.
     let mut shapes = HashMap::with_capacity(values.len());
 
     for (value_id, sym_value) in values {
-        let shape = if let Some(val) = sym_value.to_constant() {
-            total_const_values += 1;
-            if let Some(&index) = constant_to_index.get(&val) {
-                Some(Shape::Constant { index })
-            } else {
-                let index = constants.len();
-                constant_to_index.insert(val.clone(), index);
-                constants.push(val);
-                Some(Shape::Constant { index })
-            }
-        } else if let Some(dims) = sym_value.shape() {
-            let dims = dims
-                .map(|dim| match dim {
-                    // If a dimension size is unexpectedly inferred as a negative
-                    // value, just ignore it.
-                    SymExpr::Value(size) if size >= 0 => Some(Dimension::Fixed(size as usize)),
-                    dim => Some(Dimension::Symbolic(dim.to_string())),
-                })
-                .collect::<Option<Vec<_>>>();
-            dims.map(Shape::Shape)
-        } else {
-            None
-        };
-
-        if let Some(shape) = shape {
-            shapes.insert(value_id, shape);
+        if sym_value.ndim().is_none() {
+            continue;
         }
+        total_values += 1;
+        let value_index = if let Some(idx) = value_to_index.get(&sym_value) {
+            *idx
+        } else {
+            let idx = unique_values.len();
+            value_to_index.insert(sym_value.clone(), idx);
+            unique_values.push(sym_value);
+            idx
+        };
+        shapes.insert(value_id, value_index);
     }
 
     if debug {
         println!(
-            "Shape inference: {} constant values, {} unique",
-            total_const_values,
-            constants.len()
+            "Shape inference: {} values, {} unique",
+            total_values,
+            unique_values.len()
         );
     }
 
     Ok(InferResult {
-        constants,
+        values: unique_values,
         shapes,
         types,
     })
@@ -487,6 +481,7 @@ fn sym_tensor_from_input(
 
 #[cfg(test)]
 mod tests {
+    use rten_shape_inference::Constant;
     use rten_tensor::NdTensor;
 
     use crate::Dimension;
@@ -494,7 +489,7 @@ mod tests {
     use crate::ops::{Concat, Gather, Gemm, MatMul, Shape as ShapeOp, Split, Unsqueeze};
     use crate::value::{DataType, ValueType};
 
-    use super::{Constant, InferError, InferShapeOptions, Shape, infer_shapes};
+    use super::{InferError, InferShapeOptions, infer_shapes};
 
     #[test]
     fn test_infer_shapes() {
@@ -512,9 +507,7 @@ mod tests {
         let shapes = infer_shapes(&graph, Default::default()).unwrap();
 
         let output_id = graph.output_ids()[0];
-        let Some(Shape::Shape(shape)) = shapes.shapes.get(&output_id) else {
-            panic!("output is not a shape");
-        };
+        let shape = shapes.dims(output_id).unwrap();
         assert_eq!(shape.as_slice(), dims!("batch", 12).as_slice());
         assert_eq!(
             shapes.types.get(&output_id).copied(),
@@ -668,11 +661,8 @@ mod tests {
 
         let output_id = graph.output_ids()[0];
         let result = infer_shapes(&graph, Default::default()).unwrap();
-
-        let shape = result.shapes.get(&output_id).unwrap();
-        let Shape::Constant { index } = shape else {
-            panic!("{:?} is not a constant", shape);
-        };
-        assert_eq!(result.constants[*index], Constant::Vector(vec![64, 32]));
+        let shape_index = result.shapes.get(&output_id).unwrap();
+        let const_value = result.values[*shape_index].to_constant().unwrap();
+        assert_eq!(const_value, Constant::Vector(vec![64, 32]));
     }
 }

--- a/src/ops/compute_shape.rs
+++ b/src/ops/compute_shape.rs
@@ -25,17 +25,28 @@ pub struct SymbolInfo {
     pub axis: u32,
 }
 
-/// Compute a tensor shape from a combination of static values and the dynamic
-/// shapes of inputs.
+#[derive(Debug)]
+pub enum SymExprKind {
+    Scalar(SymExpr),
+    Vector(Vec<SymExpr>),
+}
+
+/// Produce a tensor by evaluating symbolic expressions.
+///
+/// The symbolic expressions can include named symbols whose values are obtained
+/// from the dimension sizes of input tensors.
+///
+/// This operator can replace subgraphs in ONNX models which extract and
+/// manipulate tensor shapes.
 #[derive(Debug)]
 pub struct ComputeShape {
     /// Specifies how to map dimension sizes of inputs to symbols used by the
     /// `shape` field.
     pub symbols: Vec<SymbolInfo>,
 
-    /// Specifies the symbolic expression to evaluate for each position in the
-    /// output vector.
-    pub shape: Vec<SymExpr>,
+    /// Specifies the rank of the output tensor and the symbolic expression to
+    /// evaluate for each element.
+    pub elements: SymExprKind,
 }
 
 impl Operator for ComputeShape {
@@ -64,16 +75,26 @@ impl Operator for ComputeShape {
             .collect::<Result<Vec<_>, _>>()?;
         let symbols = SymbolMap::new(&symbols);
 
-        let output = self
-            .shape
-            .iter()
-            .map(|expr| {
-                expr.eval(&symbols)
-                    .map_err(|_| OpError::InvalidValue("Failed to evaluate symbolic shape"))
-            })
-            .collect::<Result<Vec<i32>, _>>()?;
+        let output = match &self.elements {
+            SymExprKind::Scalar(expr) => {
+                let item = expr
+                    .eval(&symbols)
+                    .map_err(|_| OpError::InvalidValue("Failed to evaluate symbolic shape"))?;
+                Tensor::from(item)
+            }
+            SymExprKind::Vector(shape) => {
+                let output = shape
+                    .iter()
+                    .map(|expr| {
+                        expr.eval(&symbols)
+                            .map_err(|_| OpError::InvalidValue("Failed to evaluate symbolic shape"))
+                    })
+                    .collect::<Result<Vec<i32>, _>>()?;
+                Tensor::from(output)
+            }
+        };
 
-        Tensor::from(output).into_op_result()
+        output.into_op_result()
     }
 
     fn output_types(&self, _ctx: &OutputTypesContext) -> Option<OutputTypeList> {
@@ -114,7 +135,7 @@ mod tests {
                 },
             ]
             .to_vec(),
-            shape: [
+            elements: super::SymExprKind::Vector(vec![
                 SymExpr::Value(3),
                 SymExpr::Var(
                     Symbol {
@@ -133,8 +154,7 @@ mod tests {
                     }
                     .into(),
                 ),
-            ]
-            .into(),
+            ]),
         };
         let result: NdTensor<i32, 1> = op.run_simple((input_a.view(), input_b.view())).unwrap();
 
@@ -148,7 +168,7 @@ mod tests {
                 axis: 0,
             }]
             .into(),
-            shape: Vec::new(),
+            elements: super::SymExprKind::Vector(Vec::new()),
         };
         let result: Result<NdTensor<i32, 1>, _> = op.run_simple(input_a.view());
         assert_eq!(result.err().unwrap(), OpError::MissingInputs);
@@ -161,7 +181,7 @@ mod tests {
                 axis: 3,
             }]
             .into(),
-            shape: Vec::new(),
+            elements: super::SymExprKind::Vector(Vec::new()),
         };
         let result: Result<NdTensor<i32, 1>, _> = op.run_simple(input_a.view());
         assert_eq!(

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -73,7 +73,7 @@ pub(crate) use {
         Add, And, Div, Equal, Greater, GreaterOrEqual, Less, LessOrEqual, Mod, Mul, Or, Pow, Sub,
         Where, Xor,
     },
-    compute_shape::{ComputeShape, SymbolInfo},
+    compute_shape::{ComputeShape, SymExprKind, SymbolInfo},
     concat::{Concat, Tile},
     control_flow::{If, Loop},
     conv::{Conv, ConvInteger},

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -1,13 +1,14 @@
 use std::any::Any;
+use std::collections::HashMap;
 use std::error::Error;
 use std::fmt::{Display, Formatter};
 use std::sync::Arc;
 
+use rten_shape_inference::SymExpr;
 use rten_tensor::Tensor;
 use rustc_hash::FxHashSet;
 use smallvec::SmallVec;
 
-use crate::Value;
 use crate::env::str_as_bool;
 use crate::graph::{
     CaptureEnv, Constant, ConstantNode, ConstantNodeData, Graph, Node, NodeId, OperatorNode,
@@ -15,7 +16,8 @@ use crate::graph::{
 };
 use crate::infer_shapes::{InferError, InferShapeOptions, infer_shapes};
 use crate::operator::Operator;
-use crate::ops::Identity;
+use crate::ops::{ComputeShape, Identity, SymExprKind, SymbolInfo};
+use crate::{Dimension, Value};
 
 mod diagnostics;
 mod fusions;
@@ -24,8 +26,8 @@ mod pattern_matcher;
 use diagnostics::{DiagnosticLevel, Diagnostics};
 
 use fusions::{
-    AddSoftmaxFusion, ApproxGeluFusion, CastElimination, ComputeShapeFusion, ConvAddFusion, Fusion,
-    FusionError, FusionVisitor, GeluFusion, GroupedQueryAttentionMatMulFusion, IdentityFusion,
+    AddSoftmaxFusion, ApproxGeluFusion, CastElimination, ConvAddFusion, Fusion, FusionError,
+    FusionVisitor, GeluFusion, GroupedQueryAttentionMatMulFusion, IdentityFusion,
     LayerNormalizationFusion, MatMulAddFusion, MatMulIntegerToFloatFusion, MatMulScaleFusion,
     PatternFusion, RMSNormalizationFusion, ReciprocalFusion, ReduceMeanAxesFusion,
     RepeatInterleaveFusion, SafeSoftmaxFusion, ShapeSliceToConstant, SiluFusion, SwishFusion,
@@ -431,23 +433,55 @@ impl GraphOptimizer {
         if let Some(infer_opts) = opts.infer_shapes {
             let infer_result = infer_shapes(&graph_mut.graph, infer_opts)
                 .map_err(OptimizeError::InferShapesError)?;
-            let const_ids: Vec<Option<NodeId>> = infer_result
+
+            let sym_map = symbol_map(&graph_mut.graph);
+
+            // IDs of constants and value nodes that replace value IDs in the
+            // input.
+            //
+            // Where shape inference infers that a value node has a fixed value,
+            // it can be replaced with a constant. Where it infers the value
+            // can be produced by evaluating a symbolic expression, replace the
+            // value with the output of a `ComputeShape` node.
+            let replacement_ids: Vec<Option<NodeId>> = infer_result
                 .values
                 .iter()
                 .map(|expr| {
-                    let constant = expr.to_constant()?;
-                    let tensor = match constant {
-                        rten_shape_inference::Constant::Scalar(x) => Tensor::from(x),
-                        rten_shape_inference::Constant::Vector(vec) => Tensor::from(vec),
-                    };
-                    let const_id = graph_mut.add_constant(None, tensor.into_arc());
-                    Some(const_id)
+                    if let Some(constant) = expr.to_constant() {
+                        let tensor = match constant {
+                            rten_shape_inference::Constant::Scalar(x) => Tensor::from(x),
+                            rten_shape_inference::Constant::Vector(vec) => Tensor::from(vec),
+                        };
+                        let const_id = graph_mut.add_constant(None, tensor.into_arc());
+                        Some(const_id)
+                    } else if let Some(values) = expr.values() {
+                        let (symbols, input_ids) = compute_shape_inputs(values, &sym_map);
+                        let op = ComputeShape {
+                            symbols,
+                            elements: if let Some(expr) = expr.as_vector() {
+                                SymExprKind::Vector(expr.to_vec())
+                            } else {
+                                SymExprKind::Scalar(values[0].clone())
+                            },
+                        };
+                        let input_ids: Vec<_> = input_ids.into_iter().map(Some).collect();
+                        let output_id = graph_mut.graph.add_value(None, None, None);
+                        graph_mut.add_operator(None, Arc::new(op), &input_ids, &[Some(output_id)]);
+                        Some(output_id)
+                    } else {
+                        None
+                    }
                 })
                 .collect();
 
+            let mut removed_nodes = Vec::new();
             for (value_id, shape_index) in &infer_result.shapes {
-                if let Some(const_id) = const_ids[*shape_index] {
-                    graph_mut.replace_value(*value_id, const_id);
+                if let Some(new_value_id) = replacement_ids[*shape_index] {
+                    graph_mut.replace_value(*value_id, new_value_id);
+                    removed_nodes.push(*value_id);
+                    if let Some((src_op_id, _src_op)) = graph_mut.graph.get_source_node(*value_id) {
+                        removed_nodes.push(src_op_id);
+                    }
                 } else if let Some(dims) = infer_result.dims(*value_id) {
                     graph_mut.graph.update_value_shape(*value_id, dims);
                 }
@@ -455,6 +489,8 @@ impl GraphOptimizer {
             for (value_id, value_type) in infer_result.types {
                 graph_mut.graph.update_value_type(value_id, value_type);
             }
+
+            graph_mut.graph.remove_nodes(&removed_nodes);
         }
 
         // "Early" fusions. These are fusions which can benefit constant
@@ -470,13 +506,6 @@ impl GraphOptimizer {
         // and inference.
         early_fusions.push(CastElimination {});
         early_fusions.push(IdentityFusion {});
-
-        // Fusion which replaces Shape nodes using shape inference metadata.
-        //
-        // This can free up the source of the Shape's input to be included in
-        // other fusions. If all dimensions have static sizes, constant prop
-        // will remove the ComputeShape node and downstream nodes.
-        early_fusions.push(ComputeShapeFusion {});
 
         self.apply_fusions(&mut graph_mut, early_fusions.visitors(), &diag)?;
 
@@ -744,6 +773,74 @@ impl FusionList {
     fn visitors(&self) -> &[Box<dyn DynFusionVisitor>] {
         &self.fusions
     }
+}
+
+/// Create a map of dimension name to (value_id, dim), for use with
+/// [`compute_shape_inputs`].
+fn symbol_map(graph: &Graph) -> HashMap<String, (NodeId, u32)> {
+    let mut map = HashMap::new();
+
+    for id in graph.input_ids() {
+        let Some(node) = graph.get_node(*id) else {
+            continue;
+        };
+        let Some(shape) = node.shape() else {
+            continue;
+        };
+
+        for (dim_idx, dim) in shape.iter().enumerate() {
+            match dim {
+                Dimension::Symbolic(name) => {
+                    if !map.contains_key(name) {
+                        map.insert(name.to_string(), (*id, dim_idx as u32));
+                    }
+                }
+                Dimension::Fixed(_) => {}
+            }
+        }
+    }
+
+    map
+}
+
+/// Generate the input ID list and symbol_name => (input_id, axis) mappings for
+/// a [`ComputeShape`] operator.
+fn compute_shape_inputs(
+    elements: &[SymExpr],
+    syms: &HashMap<String, (NodeId, u32)>,
+) -> (Vec<SymbolInfo>, Vec<NodeId>) {
+    let vars = elements
+        .iter()
+        .flat_map(|expr| expr.iter())
+        .filter_map(|node| match node {
+            SymExpr::Var(sym) => Some(sym.name.as_ref()),
+            _ => None,
+        });
+
+    let mut input_ids = Vec::new();
+    let mut symbols = Vec::<SymbolInfo>::new();
+    for var in vars {
+        if symbols.iter().any(|s| s.name == var) {
+            continue;
+        }
+        let Some((input_id, axis)) = syms.get(var) else {
+            continue;
+        };
+        let input_id = if let Some(idx) = input_ids.iter().position(|id| id == input_id) {
+            idx
+        } else {
+            let idx = input_ids.len();
+            input_ids.push(*input_id);
+            idx
+        };
+        symbols.push(SymbolInfo {
+            name: var.to_string(),
+            input: input_id as u32,
+            axis: *axis,
+        });
+    }
+
+    (symbols, input_ids)
 }
 
 #[cfg(test)]

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -13,7 +13,7 @@ use crate::graph::{
     CaptureEnv, Constant, ConstantNode, ConstantNodeData, Graph, Node, NodeId, OperatorNode,
     PlanOptions, RunError,
 };
-use crate::infer_shapes::{InferError, InferShapeOptions, Shape, infer_shapes};
+use crate::infer_shapes::{InferError, InferShapeOptions, infer_shapes};
 use crate::operator::Operator;
 use crate::ops::Identity;
 
@@ -431,27 +431,25 @@ impl GraphOptimizer {
         if let Some(infer_opts) = opts.infer_shapes {
             let infer_result = infer_shapes(&graph_mut.graph, infer_opts)
                 .map_err(OptimizeError::InferShapesError)?;
-            let const_ids: Vec<NodeId> = infer_result
-                .constants
-                .into_iter()
-                .map(|constant| {
+            let const_ids: Vec<Option<NodeId>> = infer_result
+                .values
+                .iter()
+                .map(|expr| {
+                    let constant = expr.to_constant()?;
                     let tensor = match constant {
                         rten_shape_inference::Constant::Scalar(x) => Tensor::from(x),
                         rten_shape_inference::Constant::Vector(vec) => Tensor::from(vec),
                     };
-                    graph_mut.add_constant(None, tensor.into_arc())
+                    let const_id = graph_mut.add_constant(None, tensor.into_arc());
+                    Some(const_id)
                 })
                 .collect();
 
-            for (value_id, shape) in infer_result.shapes {
-                match shape {
-                    Shape::Constant { index } => {
-                        let const_id = const_ids[index];
-                        graph_mut.replace_value(value_id, const_id);
-                    }
-                    Shape::Shape(shape) => {
-                        graph_mut.graph.update_value_shape(value_id, shape);
-                    }
+            for (value_id, shape_index) in &infer_result.shapes {
+                if let Some(const_id) = const_ids[*shape_index] {
+                    graph_mut.replace_value(*value_id, const_id);
+                } else if let Some(dims) = infer_result.dims(*value_id) {
+                    graph_mut.graph.update_value_shape(*value_id, dims);
                 }
             }
             for (value_id, value_type) in infer_result.types {

--- a/src/optimize/fusions.rs
+++ b/src/optimize/fusions.rs
@@ -1,10 +1,8 @@
 //! Traits for defining operator fusions and implementations of fusions.
 
 use std::borrow::Cow;
-use std::collections::HashMap;
 use std::sync::Arc;
 
-use rten_shape_inference::{SymExpr, Symbol};
 use rten_tensor::{ArcTensor, NdTensorView, SliceRange};
 
 use crate::graph::{
@@ -14,9 +12,9 @@ use crate::graph::{
 use crate::operator::Operator;
 use crate::ops::transform_inputs::TransformInputsBuilder;
 use crate::ops::{
-    AddSoftmax, Cast, ComputeShape, Conv, FusedMatMul, Gelu, GroupedQueryAttentionMatMul,
-    LayerNormalization, MatMulIntegerToFloat, RMSNormalization, Reciprocal, ReduceMean,
-    RepeatInterleave, Shape, Silu, Softmax, Swish, SymbolInfo, Transpose,
+    AddSoftmax, Cast, Conv, FusedMatMul, Gelu, GroupedQueryAttentionMatMul, LayerNormalization,
+    MatMulIntegerToFloat, RMSNormalization, Reciprocal, ReduceMean, RepeatInterleave, Silu,
+    Softmax, Swish, Transpose,
 };
 use crate::optimize::pattern_matcher::{Match, Pattern};
 use crate::value::ValueType;
@@ -1377,150 +1375,6 @@ impl PatternFusion for SafeSoftmaxFusion {
             flush_nans_to_zero: true,
             ..*softmax_op
         })
-    }
-}
-
-/// Replace `Shape` operators with `ComputeShape` operators which generate the
-/// same output using dimension sizes that are either precomputed or extracted
-/// from graph inputs.
-///
-/// The benefit of this fusion is to remove a consumer of the value which feeds
-/// into the Shape operator. This potentially frees up the source operator to be
-/// included in fusions. For example, given:
-///
-/// ```text
-/// T = Sigmoid(X)
-/// S = Shape(T)
-/// Y = Mul(X, T)
-/// ```
-///
-/// The `Shape` operator prevents fusing this subgraph into `Silu(X)`, because
-/// it relies on the intermediate value `S`. If however we determine that `S`
-/// can be computed from another node closer to the graph inputs, we remove the
-/// `Shape(T)` and free up the remaining `Mul(X, Sigmoid(X))` to be fused.
-pub struct ComputeShapeFusion {}
-
-impl FusionVisitor for ComputeShapeFusion {
-    // Map of symbolic_dimension => (input_id, dimension_index)
-    type State = HashMap<String, (NodeId, u32)>;
-
-    fn name(&self) -> &str {
-        "ComputeShapeFusion"
-    }
-
-    fn prepare(&self, graph: &Graph) -> Self::State {
-        let mut map = HashMap::new();
-
-        for id in graph.input_ids() {
-            let Some(node) = graph.get_node(*id) else {
-                continue;
-            };
-            let Some(shape) = node.shape() else {
-                continue;
-            };
-
-            for (dim_idx, dim) in shape.iter().enumerate() {
-                match dim {
-                    Dimension::Symbolic(name) => {
-                        if !map.contains_key(name) {
-                            map.insert(name.to_string(), (*id, dim_idx as u32));
-                        }
-                    }
-                    Dimension::Fixed(_) => {}
-                }
-            }
-        }
-
-        map
-    }
-
-    fn maybe_fuse(
-        &self,
-        state: &Self::State,
-        graph: &Graph,
-        _op_node_id: NodeId,
-        op_node: &OperatorNode,
-    ) -> Result<Fusion, FusionError> {
-        let shape_op = op_node
-            .operator()
-            .downcast_ref::<Shape>()
-            .ok_or(FusionError::NoMatch)?;
-
-        // Shape operators which slice their inputs are not supported yet.
-        if shape_op.start.is_some() || shape_op.end.is_some() {
-            return Err(FusionError::CheckFailed(
-                "slice has start or end attributes",
-            ));
-        }
-
-        let &[Some(shape_source)] = op_node.input_ids() else {
-            return Err(FusionError::CheckFailed("wrong input count"));
-        };
-        let dims = graph
-            .get_node(shape_source)
-            .ok_or(FusionError::NoMatch)?
-            .shape()
-            .ok_or(FusionError::CheckFailed("unknown input shape"))?;
-
-        if dims.iter().any(|dim| match dim {
-            Dimension::Symbolic(name) => !state.contains_key(name),
-            Dimension::Fixed(_) => false,
-        }) {
-            return Err(FusionError::CheckFailed("unknown symbolic dim"));
-        }
-
-        let mut input_ids = Vec::new();
-        let symbols: Vec<SymbolInfo> = dims
-            .iter()
-            .filter_map(|dim| match dim {
-                Dimension::Fixed(_) => None,
-                Dimension::Symbolic(name) => {
-                    let (input_id, dim) = state
-                        .get(name.as_str())
-                        .copied()
-                        .expect("should have symbolic name");
-                    let idx =
-                        if let Some(used_idx) = input_ids.iter().position(|id| *id == input_id) {
-                            used_idx
-                        } else {
-                            input_ids.push(input_id);
-                            input_ids.len() - 1
-                        };
-                    Some(SymbolInfo {
-                        name: name.clone(),
-                        input: idx as u32,
-                        axis: dim,
-                    })
-                }
-            })
-            .collect();
-
-        let shape: Vec<SymExpr> = dims
-            .iter()
-            .map(|dim| match dim {
-                Dimension::Fixed(size) => SymExpr::Value(*size as i32),
-                Dimension::Symbolic(name) => SymExpr::Var(
-                    Symbol {
-                        name: name.to_string(),
-                        positive: true,
-                        synthetic: false,
-                    }
-                    .into(),
-                ),
-            })
-            .collect();
-
-        let input_ids: Vec<_> = input_ids.into_iter().map(Some).collect();
-
-        let compute_shape = ComputeShape { shape, symbols };
-
-        Ok(Fusion::from_op(
-            op_node.name(),
-            Arc::new(compute_shape),
-            &input_ids,
-            op_node.output_ids(),
-            op_node.input_ids(),
-        ))
     }
 }
 

--- a/src/optimize/tests.rs
+++ b/src/optimize/tests.rs
@@ -2,7 +2,6 @@ use std::error::Error;
 use std::sync::Arc;
 
 use rten_base::byte_cast::cast_slice;
-use rten_shape_inference::{SymExpr, Symbol};
 use rten_tensor::{NdTensor, Tensor};
 use rten_testing::TestCases;
 
@@ -15,7 +14,7 @@ use crate::graph::{
 };
 use crate::infer_shapes::InferShapeOptions;
 use crate::ops::{
-    Add, Cast, ComputeShape, Conv, DynamicQuantizeLinear, Erf, Expand, FusedMatMul, Gather, Gelu,
+    Add, Cast, Conv, DynamicQuantizeLinear, Erf, Expand, FusedMatMul, Gather, Gelu,
     GroupedQueryAttentionMatMul, Identity, IsNaN, LayerNormalization, MatMul, MatMulInteger, Neg,
     Padding, Pow, RMSNormalization, ReduceMean, RepeatInterleave, Reshape, Shape, Sigmoid, Slice,
     Softmax, Sqrt, Swish, Tanh, Transpose, Unsqueeze, Where,
@@ -1182,31 +1181,9 @@ fn test_fuse_compute_shape() {
     });
 
     let graph = Expr::make_graph([x], [y, shape]);
-    let optimized = optimize_graph(graph).unwrap();
+    let _optimized = optimize_graph(graph).unwrap();
 
-    let op = optimized
-        .get_node_id("Shape")
-        .and_then(|id| optimized.get_node(id))
-        .and_then(|n| n.as_operator())
-        .unwrap();
-    let op = op.operator().downcast_ref::<ComputeShape>().unwrap();
-
-    assert_eq!(
-        op.shape,
-        [
-            SymExpr::Var(
-                Symbol {
-                    name: "batch".into(),
-                    positive: true,
-                    synthetic: false,
-                }
-                .into()
-            ),
-            SymExpr::Value(3),
-            SymExpr::Value(224),
-            SymExpr::Value(224),
-        ]
-    );
+    // TODO - Check that outputs were replaced.
 }
 
 #[test]


### PR DESCRIPTION
Use symbolic tensor values produced by shape inference to replace subgraphs in models with a `ComputeShape` operator.

In the Llama 3 3B model, this reduces the total number of operators run on each inference pass from 1740 to 1192 (-31%). This reduces interpreter overhead, although the impact is usually small because shape-manipulating subgraphs are
operating on small values. More importantly, it removes more potentially fusion-blocking value consumers from the graph. This generalizes the idea of `ComputeShapeFusion`.

Fixes https://github.com/robertknight/rten/issues/270

**TODO:**

- [ ] Tests
- [ ] Rename `ComputeShape` to something more general?