### PR TITLE
Add and use trait for safer conversion of uN to usize

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -475,6 +475,7 @@ dependencies = [
  "argh",
  "fastrand",
  "rten",
+ "rten-base",
  "rten-tensor",
  "rten-testing",
  "safetensors",
@@ -521,6 +522,7 @@ version = "0.24.0"
 dependencies = [
  "fastrand",
  "rten",
+ "rten-base",
  "rten-simd",
  "rten-tensor",
  "rten-testing",
@@ -534,6 +536,7 @@ version = "0.24.0"
 dependencies = [
  "image",
  "png",
+ "rten-base",
  "rten-tensor",
 ]
 
@@ -606,6 +609,7 @@ name = "rten-text"
 version = "0.24.0"
 dependencies = [
  "fancy-regex",
+ "rten-base",
  "rten-testing",
  "rustc-hash",
  "serde",

--- a/rten-base/src/num.rs
+++ b/rten-base/src/num.rs
@@ -20,6 +20,36 @@ impl AsBool for i32 {
     }
 }
 
+/// Trait for value-preserving, non-fallible conversion to usize.
+///
+/// This is like `x as usize` but only implemented for types where conversion
+/// will preserve the value, under the assumption that the pointer width is
+/// 32 or 64 bits. This differs from Rust's `Into<usize>` impls which do not
+/// support u32 -> usize conversion because pointers are 16-bits on some
+/// platforms. We assume that such platforms are not relevant for consumers
+/// of this crate.
+///
+/// This trait should be used instead of `as usize` where possible, as it
+/// ensures the conversion is value-preserving.
+pub trait AsUsize {
+    fn as_usize(self) -> usize;
+}
+
+macro_rules! impl_as_usize {
+    ($type:ty) => {
+        impl AsUsize for $type {
+            fn as_usize(self) -> usize {
+                self as usize
+            }
+        }
+    };
+}
+
+impl_as_usize!(u8);
+impl_as_usize!(u16);
+impl_as_usize!(u32);
+impl_as_usize!(usize);
+
 /// Trait indicating whether type is an integer or float.
 pub trait IsInt {
     fn is_int() -> bool;

--- a/rten-cli/Cargo.toml
+++ b/rten-cli/Cargo.toml
@@ -13,6 +13,7 @@ include = ["/src", "/README.md"]
 argh = { workspace = true }
 fastrand = { workspace = true }
 rten = { path = "../", version = "0.24.0", features=["all-ops", "mmap"] }
+rten-base = { path = "../rten-base", version = "0.24.0" }
 safetensors = "0.6.2"
 
 [dependencies.rten-tensor]

--- a/rten-cli/src/main.rs
+++ b/rten-cli/src/main.rs
@@ -9,6 +9,7 @@ use rten::{
     DataType, Dimension, Model, ModelMetadata, ModelOptions, NodeId, RunOptions, ThreadPool, Value,
     ValueOrView, ValueType,
 };
+use rten_base::num::AsUsize;
 use rten_tensor::prelude::*;
 use rten_tensor::{Tensor, TensorView};
 use safetensors::SafeTensors;
@@ -639,7 +640,7 @@ fn main() {
 
     let thread_pool = args
         .num_threads
-        .map(|nt| ThreadPool::with_num_threads(nt as usize).into());
+        .map(|nt| ThreadPool::with_num_threads(nt.as_usize()).into());
     let run_opts = RunOptions::default()
         .with_timing(profile_mode != ProfileMode::None)
         .with_timing_by_shape(profile_mode == ProfileMode::Detailed)

--- a/rten-gemm/src/block_quant.rs
+++ b/rten-gemm/src/block_quant.rs
@@ -5,6 +5,7 @@ use std::ops::Range;
 
 use rayon::prelude::*;
 use rten_base::iter::range_chunks;
+use rten_base::num::AsUsize;
 use rten_parallel::par_iter::ParIter;
 use rten_simd::ops::{Extend, IntOps, Interleave, NumOps, ToFloat};
 use rten_simd::{Isa, Simd, SimdOp};
@@ -691,7 +692,7 @@ impl<'a, T: Copy> BlockQuantizedMatrix<'a, T> {
 
         let [_batch, _k_blocks, block_bytes] = quant.shape();
 
-        let block_size = block_bytes * n_elem as usize;
+        let block_size = block_bytes * n_elem.as_usize();
         if !block_size.is_power_of_two() || block_size < Self::MIN_BLOCK_SIZE {
             return Err(BlockQuantizedError::UnsupportedBlockSize);
         }
@@ -733,7 +734,7 @@ impl<'a, T: Copy> BlockQuantizedMatrix<'a, T> {
     }
 
     pub(crate) fn elements_per_block(&self) -> usize {
-        (self.bytes_per_block() * 8) / self.bits as usize
+        (self.bytes_per_block() * 8) / self.bits.as_usize()
     }
 
     pub(crate) fn bytes_per_block(&self) -> usize {

--- a/rten-gemm/src/tests.rs
+++ b/rten-gemm/src/tests.rs
@@ -1,6 +1,7 @@
 use std::error::Error;
 use std::time::Instant;
 
+use rten_base::num::AsUsize;
 use rten_bench::run_bench;
 use rten_tensor::prelude::*;
 use rten_tensor::rng::XorShiftRng;
@@ -1036,7 +1037,7 @@ fn test_gemm_f32_with_block_quantized_rhs() {
         } = case;
 
         let n_bits = 4 as u8;
-        let elements_per_byte = 8 / n_bits as usize;
+        let elements_per_byte = 8 / n_bits.as_usize();
         let block_bytes = block_size / elements_per_byte;
 
         let mut rng = XorShiftRng::new(1234);

--- a/rten-generate/Cargo.toml
+++ b/rten-generate/Cargo.toml
@@ -12,6 +12,7 @@ include = ["/src", "/README.md"]
 [dependencies]
 fastrand = { workspace = true }
 rten = { path = "../", version = "0.24.0" }
+rten-base = { path = "../rten-base", version = "0.24.0" }
 rten-simd = { path = "../rten-simd", version = "0.24.0" }
 rten-text = { path = "../rten-text", version = "0.24.0", optional = true }
 rten-tensor = { path = "../rten-tensor", version = "0.24.0" }

--- a/rten-generate/src/generator.rs
+++ b/rten-generate/src/generator.rs
@@ -1066,6 +1066,7 @@ mod tests {
     use std::rc::Rc;
 
     use rten::{Dimension, NodeId, RunOptions, Value, ValueOrView};
+    use rten_base::num::AsUsize;
     use rten_tensor::NdTensor;
     use rten_tensor::prelude::*;
 
@@ -1208,7 +1209,7 @@ mod tests {
     fn generate_logits(n_vocab: usize, token_ids: &[u32]) -> NdTensor<f32, 3> {
         let mut logits = NdTensor::zeros([1, token_ids.len(), n_vocab]);
         for (idx, id) in token_ids.iter().copied().enumerate() {
-            logits[[0, idx, id as usize]] = 1.0;
+            logits[[0, idx, id.as_usize()]] = 1.0;
         }
         logits
     }

--- a/rten-generate/src/sampler.rs
+++ b/rten-generate/src/sampler.rs
@@ -127,6 +127,7 @@ fn multinomial(rng: &mut fastrand::Rng, probs: &[f32]) -> Option<usize> {
 
 #[cfg(test)]
 mod tests {
+    use rten_base::num::AsUsize;
     use rten_simd::SimdOp;
     use rten_testing::TestCases;
     use rten_vecmath::Softmax;
@@ -155,7 +156,7 @@ mod tests {
         let mut counts = vec![0u32; logits.len()];
         for _ in 0..n_iters {
             let tok_id = sampler.sample(&logits);
-            counts[tok_id as usize] += 1;
+            counts[tok_id.as_usize()] += 1;
         }
 
         let mut normalized_logits = logits.logits().to_vec();

--- a/rten-imageio/Cargo.toml
+++ b/rten-imageio/Cargo.toml
@@ -11,6 +11,7 @@ include = ["/src", "/README.md"]
 
 [dependencies]
 png = "0.18"
+rten-base = { path = "../rten-base", version = "0.24.0" }
 rten-tensor = { path = "../rten-tensor", version = "0.24.0" }
 image = { workspace = true }
 

--- a/rten-imageio/src/lib.rs
+++ b/rten-imageio/src/lib.rs
@@ -8,6 +8,7 @@
 use std::error::Error;
 use std::path::Path;
 
+use rten_base::num::AsUsize;
 use rten_tensor::errors::FromDataError;
 use rten_tensor::prelude::*;
 use rten_tensor::{NdTensor, NdTensorView};
@@ -40,7 +41,7 @@ pub fn image_to_tensor(image: image::DynamicImage) -> Result<NdTensor<f32, 3>, R
     let layout = image.sample_layout();
 
     let chw_tensor = NdTensorView::from_data_with_strides(
-        [height as usize, width as usize, 3],
+        [height.as_usize(), width.as_usize(), 3],
         image.as_raw().as_slice(),
         [
             layout.height_stride,

--- a/rten-text/Cargo.toml
+++ b/rten-text/Cargo.toml
@@ -14,6 +14,7 @@ crate-type = ["lib"]
 
 [dependencies]
 fancy-regex = { version = "0.14.0", default-features = false, features = ["std", "unicode"] }
+rten-base = { path = "../rten-base", version = "0.24.0" }
 rustc-hash = { workspace = true }
 serde = { workspace = true }
 serde_derive = { workspace = true }

--- a/rten-text/src/models/bpe.rs
+++ b/rten-text/src/models/bpe.rs
@@ -4,6 +4,8 @@ use std::error::Error;
 use std::fmt;
 use std::fmt::{Debug, Display};
 
+use rten_base::num::AsUsize;
+
 use super::{DecodeError, EncodeError, Model};
 use crate::tokenizer::TokenId;
 use rustc_hash::{FxBuildHasher, FxHashMap};
@@ -77,14 +79,14 @@ fn byte_to_char() -> [char; 256] {
     for b in 0..=255u8 {
         let ch = char::from(b);
         if is_printable(ch) {
-            chars[b as usize] = ch;
+            chars[b.as_usize()] = ch;
         }
     }
 
     let mut non_printable_count = 0;
     for b in 0..=255u8 {
         if !is_printable(char::from(b)) {
-            chars[b as usize] = char::from_u32(256 + non_printable_count).unwrap();
+            chars[b.as_usize()] = char::from_u32(256 + non_printable_count).unwrap();
             non_printable_count += 1;
         }
     }
@@ -216,14 +218,14 @@ fn build_vocab(
         let mut rank = 0;
         for byte in 0..=255u8 {
             if is_printable(char::from(byte)) {
-                ranks[byte as usize] = Rank(rank);
+                ranks[byte.as_usize()] = Rank(rank);
                 rank += 1;
             }
         }
 
         for byte in 0..=255u8 {
             if !is_printable(char::from(byte)) {
-                ranks[byte as usize] = Rank(rank);
+                ranks[byte.as_usize()] = Rank(rank);
                 rank += 1;
             }
         }
@@ -404,7 +406,7 @@ impl Bpe {
             let encoded: EncodedBytes = piece
                 .as_bytes()
                 .iter()
-                .map(|&b| self.byte_to_char[b as usize])
+                .map(|&b| self.byte_to_char[b.as_usize()])
                 .collect();
             if let Some(&id) = vocab.get(&encoded) {
                 return [id].into();
@@ -415,7 +417,7 @@ impl Bpe {
         let mut tokens: Vec<TokenId> = piece
             .as_bytes()
             .iter()
-            .map(|&b| self.byte_to_token_id[b as usize])
+            .map(|&b| self.byte_to_token_id[b.as_usize()])
             .collect();
 
         // If the end-of-word suffix is enabled, replace the last byte's token

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -4,6 +4,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use rayon::prelude::*;
+use rten_base::num::AsUsize;
 use rten_tensor::prelude::*;
 
 // The std HashMap/HashSet provide DOS resistance. In this module hash keys are
@@ -77,17 +78,17 @@ impl NodeRefCount {
 
         // If the refcount reaches the max value, it becomes sticky.
         if *rc == u8::MAX {
-            return Some(*rc as usize);
+            return Some((*rc).as_usize());
         } else if *rc == 0 {
             return None;
         }
 
         *rc = rc.saturating_sub(1);
-        Some(*rc as usize)
+        Some((*rc).as_usize())
     }
 
     fn count(&self, id: NodeId) -> usize {
-        self.rc[id.as_usize()] as usize
+        self.rc[id.as_usize()].as_usize()
     }
 }
 
@@ -841,7 +842,7 @@ impl Graph {
 
         // Count how often each temporary output is used, so we can free them
         // when no longer needed.
-        let mut temp_value_refcount = NodeRefCount::with_capacity(self.next_node_id as usize);
+        let mut temp_value_refcount = NodeRefCount::with_capacity(self.next_node_id.as_usize());
         for &op_node_id in plan.iter() {
             let Some(Node::Operator(op_node)) = self.nodes.get(&op_node_id) else {
                 return Err(

--- a/src/infer_shapes.rs
+++ b/src/infer_shapes.rs
@@ -4,6 +4,8 @@ use std::collections::HashMap;
 use std::error::Error;
 use std::fmt;
 
+use rten_base::num::AsUsize;
+
 use crate::env::env_flag;
 use crate::graph::{Dimension, Graph, Node, NodeId, RunError, TypedConstant};
 use crate::operator::{OutputType, OutputTypesContext};
@@ -179,7 +181,7 @@ pub fn infer_shapes(graph: &Graph, opts: InferShapeOptions) -> Result<InferResul
 
                 let get_input_type = |index: u32| {
                     op.input_ids()
-                        .get(index as usize)
+                        .get(index.as_usize())
                         .copied()
                         .flatten()
                         .and_then(|id| {

--- a/src/model/file_type.rs
+++ b/src/model/file_type.rs
@@ -1,6 +1,8 @@
 use std::ffi::OsStr;
 use std::path::Path;
 
+use rten_base::num::AsUsize;
+
 /// File type of a machine learning model.
 #[derive(Debug, PartialEq)]
 pub enum FileType {
@@ -55,7 +57,7 @@ impl FileType {
         // to the root table, as described at
         // https://flatbuffers.dev/internals/#encoding-example.
         if let Some(root_offset) = magic.map(u32::from_le_bytes)
-            && data.len() >= root_offset as usize
+            && data.len() >= root_offset.as_usize()
         {
             return Some(FileType::Rten);
         }

--- a/src/model/rten_loader.rs
+++ b/src/model/rten_loader.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use rten_base::byte_cast::{Pod, cast_pod_slice};
-use rten_base::num::LeBytes;
+use rten_base::num::{AsUsize, LeBytes};
 use rten_model_file::header::{Header, HeaderError};
 use rten_model_file::schema as sg;
 use rten_model_file::schema::root_as_model;
@@ -316,7 +316,7 @@ fn add_graph_constant(
     storage: &Arc<ConstantStorage>,
     tensor_data_offset: Option<u64>,
 ) -> Result<NodeId, LoadError> {
-    let shape: Vec<usize> = constant.shape().iter().map(|x| x as usize).collect();
+    let shape: Vec<usize> = constant.shape().iter().map(|x| x.as_usize()).collect();
 
     if let Some(data_offset) = constant.data_offset() {
         // Constant data is stored outside the model buffer, in the same file.

--- a/src/ops/compute_shape.rs
+++ b/src/ops/compute_shape.rs
@@ -1,5 +1,6 @@
 //! Operator which computes a tensor shape by evaluating symbolic expressions.
 
+use rten_base::num::AsUsize;
 use rten_shape_inference::{SymExpr, SymbolMap};
 use rten_tensor::Tensor;
 use rten_tensor::prelude::*;
@@ -52,11 +53,11 @@ impl Operator for ComputeShape {
             .symbols
             .iter()
             .map(|sym| {
-                let input = inputs.require(sym.input as usize)?;
-                if input.ndim() <= sym.axis as usize {
+                let input = inputs.require(sym.input.as_usize())?;
+                if input.ndim() <= sym.axis.as_usize() {
                     return Err(OpError::InvalidValue("Axis invalid for input shape"));
                 }
-                let size = input.size(sym.axis as usize) as i32;
+                let size = input.size(sym.axis.as_usize()) as i32;
                 Ok((sym.name.as_str(), size))
             })
             .collect::<Result<Vec<_>, _>>()?;

--- a/src/ops/einsum.rs
+++ b/src/ops/einsum.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use rten_base::num::AsUsize;
 use rten_tensor::layout::{MutLayout, OverlapPolicy};
 use rten_tensor::prelude::*;
 use rten_tensor::{Contiguous, DynLayout, Tensor, TensorView};
@@ -62,7 +63,7 @@ impl EinsumExpr {
                     .flat_map(|term| term.chars().filter(|c| c.is_ascii_lowercase()))
                 {
                     let ascii_idx = ch as u8 - b'a';
-                    char_count[ascii_idx as usize] += 1;
+                    char_count[ascii_idx.as_usize()] += 1;
                 }
 
                 // Generate output as sequence of alphabetically ordered
@@ -74,7 +75,7 @@ impl EinsumExpr {
                 }
 
                 for i in 0..N_LETTERS as u8 {
-                    if char_count[i as usize] == 1 {
+                    if char_count[i.as_usize()] == 1 {
                         let ascii_ch = b'a' + i;
                         output.push(ascii_ch as char);
                     }
@@ -214,11 +215,11 @@ pub fn einsum(
     for step in &path {
         let output_view = output.as_ref().map(|o| o.view());
         let x = match step.lhs.input {
-            EinsumInput::Index(idx) => &inputs[idx as usize],
+            EinsumInput::Index(idx) => &inputs[idx.as_usize()],
             EinsumInput::PrevOutput => output_view.as_ref().expect("invalid einsum path"),
         };
         let y = step.rhs.as_ref().map(|rhs| match rhs.input {
-            EinsumInput::Index(idx) => &inputs[idx as usize],
+            EinsumInput::Index(idx) => &inputs[idx.as_usize()],
             EinsumInput::PrevOutput => output_view.as_ref().expect("invalid einsum path"),
         });
         let new_output = einsum_step(pool, step, x, y)?.auto_return(pool);

--- a/src/ops/layout.rs
+++ b/src/ops/layout.rs
@@ -1,6 +1,7 @@
 //! Operators which query or change the shape of a tensor, or copy/move/reorder
 //! elements.
 
+use rten_base::num::AsUsize;
 use rten_shape_inference::ops as shape_ops;
 use rten_tensor::layout::is_valid_permutation;
 use rten_tensor::prelude::*;
@@ -35,7 +36,7 @@ pub fn depth_to_space<T: Clone>(
 
     let input = static_dims!(input, 4, "NCHW")?;
     let [n, c, h, w] = input.shape();
-    let block_size = block_size as usize;
+    let block_size = block_size.as_usize();
 
     if c % (block_size * block_size) != 0 {
         return Err(OpError::InvalidValue(

--- a/src/ops/split.rs
+++ b/src/ops/split.rs
@@ -1,4 +1,5 @@
 use rten_base::iter::range_chunks;
+use rten_base::num::AsUsize;
 use rten_shape_inference::ops as shape_ops;
 use rten_tensor::prelude::*;
 use rten_tensor::{NdTensorView, Tensor, TensorView};
@@ -75,7 +76,7 @@ pub fn split<T: Copy>(
                 .collect()
         }
         SplitSizes::NumSplits(n_splits) => {
-            let n_splits = n_splits as usize;
+            let n_splits = n_splits.as_usize();
             if n_splits == 0 {
                 return Err(OpError::InvalidValue("num_outputs must be > 0"));
             }

--- a/src/threading.rs
+++ b/src/threading.rs
@@ -1,6 +1,8 @@
 use std::env;
 use std::sync::OnceLock;
 
+use rten_base::num::AsUsize;
+
 /// A wrapper around the Rayon thread pool used to run models.
 ///
 /// On platforms where threads are not supported (eg. WebAssembly) this runs
@@ -86,7 +88,7 @@ pub fn thread_pool() -> &'static ThreadPool {
             physical_cpus
         };
 
-        ThreadPool::with_num_threads(num_threads as usize)
+        ThreadPool::with_num_threads(num_threads.as_usize())
     })
 }
 


### PR DESCRIPTION
Replace `x as usize` with `x.as_usize()` where possible. `AsUsize::as_usize` is a method for safe (value-preserving) conversion of uN types to usize, under the assumption that the pointer width is at least 32-bits. This differs from Rust's `Into<usize>` impls which is not implemented for u32 because some platforms have a pointer width of 16.  Such platforms are not relevant for rten.

`AsUsize` trait implemented by me, search and replacement of existing casts by Claude.