### PR TITLE
Add support for ONNX RMSNormalization operator

### DIFF
--- a/src/op_registry/onnx_registry.rs
+++ b/src/op_registry/onnx_registry.rs
@@ -177,6 +177,7 @@ impl OnnxOpRegistry {
         register_op!(Pow);
         register_op!(PRelu);
         register_op!(QuantizeLinear);
+        register_op!(RMSNormalization);
         register_op!(RandomNormal, feature = "random");
         register_op!(RandomNormalLike, feature = "random");
         register_op!(RandomUniform, feature = "random");
@@ -1318,6 +1319,14 @@ impl_read_op!(QuantizeLinear, |attrs: &Attrs| {
         .transpose()?;
     let axis = attrs.get_as_int("axis")?.unwrap_or(-1);
     Ok(ops::QuantizeLinear { axis, output_dtype })
+});
+
+impl_read_op!(RMSNormalization, |attrs: &Attrs| {
+    let axis = attrs.get_as_int("axis")?.unwrap_or(-1);
+    let epsilon = attrs.get_as("epsilon");
+    attrs.check_eq("stash_type", 1)?;
+
+    Ok(ops::RMSNormalization { axis, epsilon })
 });
 
 #[cfg(feature = "random")]

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -90,7 +90,7 @@ pub(crate) use {
     non_max_suppression::NonMaxSuppression,
     norm::{
         BatchNormalization, InstanceNormalization, LayerNormalization, LogSoftmax,
-        RmsNormalization, Softmax,
+        RMSNormalization, Softmax,
     },
     pad::Pad,
     pooling::{AveragePool, GlobalAveragePool, GlobalMaxPool, MaxPool},

--- a/src/ops/norm.rs
+++ b/src/ops/norm.rs
@@ -536,14 +536,14 @@ impl Operator for LayerNormalization {
 ///
 /// See <https://pytorch.org/docs/stable/generated/torch.nn.modules.normalization.RMSNorm.html>.
 #[derive(Debug)]
-pub struct RmsNormalization {
+pub struct RMSNormalization {
     pub axis: isize,
     pub epsilon: Option<f32>,
 }
 
-impl Operator for RmsNormalization {
+impl Operator for RMSNormalization {
     fn name(&self) -> &str {
-        "RmsNormalization"
+        "RMSNormalization"
     }
 
     fn max_inputs(&self) -> Option<usize> {

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -27,8 +27,8 @@ use fusions::{
     AddSoftmaxFusion, ApproxGeluFusion, CastElimination, ComputeShapeFusion, Fusion, FusionError,
     FusionVisitor, GeluFusion, GroupedQueryAttentionMatMulFusion, IdentityFusion,
     LayerNormalizationFusion, MatMulAddFusion, MatMulIntegerToFloatFusion, MatMulScaleFusion,
-    PatternFusion, ReciprocalFusion, ReduceMeanAxesFusion, RepeatInterleaveFusion,
-    RmsNormalizationFusion, SafeSoftmaxFusion, ShapeSliceToConstant, SiluFusion, SwishFusion,
+    PatternFusion, RMSNormalizationFusion, ReciprocalFusion, ReduceMeanAxesFusion,
+    RepeatInterleaveFusion, SafeSoftmaxFusion, ShapeSliceToConstant, SiluFusion, SwishFusion,
     TransposeFusion,
 };
 
@@ -507,7 +507,7 @@ impl GraphOptimizer {
 
         // Normalization fusions
         fusions.push(LayerNormalizationFusion {}.into_visitor());
-        fusions.push(RmsNormalizationFusion {}.into_visitor());
+        fusions.push(RMSNormalizationFusion {}.into_visitor());
 
         // Matmul fusions
         fusions.push(MatMulAddFusion {}.into_visitor());

--- a/src/optimize/fusions.rs
+++ b/src/optimize/fusions.rs
@@ -15,9 +15,8 @@ use crate::operator::Operator;
 use crate::ops::transform_inputs::TransformInputsBuilder;
 use crate::ops::{
     AddSoftmax, Cast, ComputeShape, DynamicQuantizeLinear, FusedMatMul, Gelu,
-    GroupedQueryAttentionMatMul, LayerNormalization, MatMulIntegerToFloat, Mul, Reciprocal,
-    ReduceMean, RepeatInterleave, RmsNormalization, Shape, Silu, Softmax, Swish, SymbolInfo,
-    Transpose,
+    GroupedQueryAttentionMatMul, LayerNormalization, MatMulIntegerToFloat, Mul, RMSNormalization,
+    Reciprocal, ReduceMean, RepeatInterleave, Shape, Silu, Softmax, Swish, SymbolInfo, Transpose,
 };
 use crate::optimize::pattern_matcher::{Match, Pattern};
 use crate::value::ValueType;
@@ -740,13 +739,13 @@ impl PatternFusion for LayerNormalizationFusion {
 /// Fuse `RMSNormalization(x)`.
 ///
 /// See https://pytorch.org/docs/stable/generated/torch.nn.modules.normalization.RMSNorm.html.
-pub struct RmsNormalizationFusion {}
+pub struct RMSNormalizationFusion {}
 
-impl PatternFusion for RmsNormalizationFusion {
-    type Operator = RmsNormalization;
+impl PatternFusion for RMSNormalizationFusion {
+    type Operator = RMSNormalization;
 
     fn name(&self) -> &str {
-        "RmsNormalizationFusion"
+        "RMSNormalizationFusion"
     }
 
     fn pattern(&self) -> Pattern {
@@ -789,7 +788,7 @@ impl PatternFusion for RmsNormalizationFusion {
             return Err(FusionError::CheckFailed("not applied to last axis"));
         }
 
-        Ok(RmsNormalization {
+        Ok(RMSNormalization {
             axis: -1,
             epsilon: Some(epsilon),
         })

--- a/src/optimize/tests.rs
+++ b/src/optimize/tests.rs
@@ -17,7 +17,7 @@ use crate::infer_shapes::InferShapeOptions;
 use crate::ops::{
     Add, Cast, ComputeShape, DynamicQuantizeLinear, Erf, Expand, FusedMatMul, Gather, Gelu,
     GroupedQueryAttentionMatMul, Identity, IsNaN, LayerNormalization, MatMul, MatMulInteger, Neg,
-    Pow, ReduceMean, RepeatInterleave, Reshape, RmsNormalization, Shape, Sigmoid, Slice, Softmax,
+    Pow, RMSNormalization, ReduceMean, RepeatInterleave, Reshape, Shape, Sigmoid, Slice, Softmax,
     Sqrt, Swish, Tanh, Transpose, Unsqueeze, Where,
 };
 use crate::value::{DataType, Value, ValueType};
@@ -519,7 +519,7 @@ fn test_fuse_rms_norm() {
     let graph = optimize_graph(graph).unwrap();
 
     let (_, op) = graph.get_source_node(graph.output_ids()[0]).unwrap();
-    let rms_norm = op.operator().downcast_ref::<RmsNormalization>().unwrap();
+    let rms_norm = op.operator().downcast_ref::<RMSNormalization>().unwrap();
     assert_eq!(rms_norm.epsilon, Some(1e-6));
 }
 
@@ -554,7 +554,7 @@ fn test_fuse_rms_norm_with_positive_axes() {
     let graph = optimize_graph(graph).unwrap();
 
     let (_, op) = graph.get_source_node(graph.output_ids()[0]).unwrap();
-    let rms_norm = op.operator().downcast_ref::<RmsNormalization>().unwrap();
+    let rms_norm = op.operator().downcast_ref::<RMSNormalization>().unwrap();
     assert_eq!(rms_norm.epsilon, Some(1e-6));
 }
 


### PR DESCRIPTION
RMSNormalization was added as a native ONNX operator in opset 23. The operator was already implemented in RTen under a slightly different name (`RmsNormalization`) and could be produced by the graph optimizer.