### PR TITLE
Fix wasm32 build with relaxed-simd target feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,12 @@ jobs:
         make wasm-test PACKAGE=rten-simd
         make wasm-test PACKAGE=rten-gemm
       if: ${{ matrix.os == 'ubuntu-latest' }}
+    - name: Test (WASM relaxed-simd)
+      run: |
+        make wasm-test RELAXED=y
+        make wasm-test RELAXED=y PACKAGE=rten-simd
+        make wasm-test RELAXED=y PACKAGE=rten-gemm
+      if: ${{ matrix.os == 'ubuntu-latest' }}
     - name: Build (Intel macOS)
       run: cargo check --workspace --target x86_64-apple-darwin
       if: ${{ matrix.os == 'macos-14' }}

--- a/rten-simd/src/arch/wasm32.rs
+++ b/rten-simd/src/arch/wasm32.rs
@@ -17,7 +17,7 @@ use std::arch::wasm32::{
 use std::mem::transmute;
 
 #[cfg(target_feature = "relaxed-simd")]
-use std::arch::wasm32::f32x4_relaxed_madd;
+use std::arch::wasm32::{f32x4_relaxed_madd, f32x4_relaxed_nmadd};
 
 use super::{lanes, simd_type};
 use crate::ops::{


### PR DESCRIPTION
`f32x4_relaxed_nmadd` was used in `mul_sub_from` but never imported, breaking the build whenever the `relaxed-simd` target feature was enabled. Add it to the gated import alongside `f32x4_relaxed_madd`.

Also extend CI to run the wasm test suite a second time with `RELAXED=y` so this code path is exercised on every PR.

Fixes #1200