### PR TITLE
Make optimizer pattern matching agnostic about ordering of associative ops

### DIFF
--- a/src/graph/tests.rs
+++ b/src/graph/tests.rs
@@ -63,6 +63,10 @@ impl<Op: Operator> Operator for TrackUsage<Op> {
         self.inner.is_commutative()
     }
 
+    fn is_associative(&self) -> bool {
+        self.inner.is_associative()
+    }
+
     fn max_inputs(&self) -> Option<usize> {
         self.inner.max_inputs()
     }

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -388,6 +388,17 @@ pub trait Operator: Any + Debug {
         false
     }
 
+    /// Return true if this operator is associative, meaning that the operands
+    /// of nested chains of this operator can be regrouped without affecting the
+    /// result. Formally, `Op(Op(a, b), c) == Op(a, Op(b, c))`.
+    ///
+    /// The term _associative_ here refers to the ideal mathematical behavior of
+    /// the operation, ignoring the non-associativity of corresponding
+    /// floating-point operations.
+    fn is_associative(&self) -> bool {
+        false
+    }
+
     /// Return true if this operator's outputs depend only on its inputs.
     ///
     /// The default implementation returns true, since most operators are

--- a/src/ops/binary_elementwise.rs
+++ b/src/ops/binary_elementwise.rs
@@ -490,6 +490,10 @@ impl Operator for Add {
         true
     }
 
+    fn is_associative(&self) -> bool {
+        true
+    }
+
     fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<Value, OpError> {
         run_typed_op_in_place!(ctx.pool(), input, ctx.inputs(), add_in_place, add)
     }
@@ -842,6 +846,10 @@ impl Operator for Mul {
     }
 
     fn is_commutative(&self) -> bool {
+        true
+    }
+
+    fn is_associative(&self) -> bool {
         true
     }
 

--- a/src/optimize/fusions.rs
+++ b/src/optimize/fusions.rs
@@ -404,11 +404,6 @@ impl PatternFusion for GeluFusion {
     }
 
     fn pattern(&self) -> Pattern {
-        // The expression for GELU is usually written as `x * 0.5 * (...)`
-        // instead of `x * (...) * 0.5`. Ideally our graph pattern matcher
-        // would be smart enough to let us write one pattern and have it match
-        // either structure. However it isn't. The pattern used matches PyTorch's
-        // `nn.GELU`.
         let x = Pattern::symbol("x");
         x.clone() * (Pattern::unary_op("Erf", x.clone() / (2.0f32).sqrt()) + 1.0) * 0.5
     }

--- a/src/optimize/pattern_matcher.rs
+++ b/src/optimize/pattern_matcher.rs
@@ -1,8 +1,16 @@
 use std::ops::{Add, Div, Mul, Neg, Sub};
 use std::rc::Rc;
 
+use smallvec::SmallVec;
+
 use crate::graph::{Constant, Graph, Node, NodeId, OperatorNode};
 use crate::value::ValueView;
+
+/// Inline capacity for chains of associative+commutative operands.
+const SMALL_VEC_CAP: usize = 4;
+
+type PatternVec<'a> = SmallVec<[&'a Pattern; SMALL_VEC_CAP]>;
+type NodeIdVec = SmallVec<[NodeId; SMALL_VEC_CAP]>;
 
 /// Tells [`SymbolMap::transaction`] what to do with the symbol bindings added
 /// during the transaction body.
@@ -136,9 +144,33 @@ impl OpPattern {
             return false;
         }
 
+        let op = node.operator();
+
+        // For binary operators that are both associative and commutative
+        // (eg. `Add`, `Mul`), match against the flattened chain of operands.
+        // This makes patterns insensitive to the bracketing of nested chains:
+        // a pattern of the form `Op(Op(a, b), c)` will match a graph of the
+        // form `Op(a, Op(b, c))` and vice versa.
+        //
+        // The multiset match only adds value when at least one side has a
+        // nested chain (so its flattened length is >= 3). If both sides
+        // flatten to two inputs, the strict commutative matcher below handles
+        // the case identically.
+        if op.is_associative() && op.is_commutative() && self.inputs.len() == 2 {
+            let patterns = self.flatten_associative_chain();
+            if patterns.len() >= 3 {
+                let nodes = flatten_graph_associative_chain(node, graph, self.name);
+                if patterns.len() == nodes.len()
+                    && match_pattern_set(&patterns, &nodes, graph, symbols)
+                {
+                    return true;
+                }
+            }
+        }
+
         // For commutative binary operators, we allow the pattern to match
         // either way around.
-        if node.operator().is_commutative()
+        if op.is_commutative()
             && let [pat_a, pat_b] = &self.inputs[..]
             && let [Some(input_a), Some(input_b)] = node.input_ids()
         {
@@ -163,6 +195,123 @@ impl OpPattern {
                 })
         }
     }
+
+    /// Flatten operands of a nested associative pattern.
+    ///
+    /// eg. `Add(A, Add(B, C))` is flattened to `[A, B, C]`.
+    fn flatten_associative_chain(&self) -> PatternVec<'_> {
+        let mut patterns = PatternVec::new();
+        for input in &self.inputs {
+            flatten_associative_pattern_impl(input, self.name, &mut patterns);
+        }
+        patterns
+    }
+}
+
+fn flatten_associative_pattern_impl<'a>(
+    pat: &'a Pattern,
+    op_name: &'static str,
+    patterns: &mut PatternVec<'a>,
+) {
+    if let PatternKind::Operator(op_pat) = &*pat.kind
+        && op_pat.name == op_name
+        && op_pat.inputs.len() == 2
+        // Don't flatten through patterns that have a key, since we need to
+        // preserve them as a single unit so the matching node ID can be
+        // recorded.
+        && op_pat.key.is_none()
+    {
+        for input in &op_pat.inputs {
+            flatten_associative_pattern_impl(input, op_name, patterns);
+        }
+    } else {
+        patterns.push(pat);
+    }
+}
+
+/// Flatten the graph subtree rooted at `node`, descending recursively through
+/// any operator with the same name as `op_name` that has two inputs. Returns
+/// the list of sub-graph nodes that form the chain.
+fn flatten_graph_associative_chain(node: &OperatorNode, graph: &Graph, op_name: &str) -> NodeIdVec {
+    let mut nodes = NodeIdVec::new();
+    for input in node.input_ids() {
+        match input {
+            Some(input_id) => flatten_associative_graph_impl(*input_id, graph, op_name, &mut nodes),
+            None => {
+                // Bail out: a missing input means we can't represent the chain
+                // faithfully. Return an empty list so the multiset matcher
+                // falls back to the strict matcher.
+                return NodeIdVec::new();
+            }
+        }
+    }
+    nodes
+}
+
+fn flatten_associative_graph_impl(
+    node_id: NodeId,
+    graph: &Graph,
+    op_name: &str,
+    nodes: &mut NodeIdVec,
+) {
+    if let Some((_, op_node)) = graph.get_source_node(node_id)
+        && op_node.operator().name() == op_name
+        && let [Some(lhs), Some(rhs)] = op_node.input_ids()
+    {
+        flatten_associative_graph_impl(*lhs, graph, op_name, nodes);
+        flatten_associative_graph_impl(*rhs, graph, op_name, nodes);
+    } else {
+        nodes.push(node_id);
+    }
+}
+
+/// Try to match each pattern against a distinct graph node, allowing any
+/// permutation. Returns true if a successful assignment is found, in which case
+/// symbol bindings are added to `symbols`.
+fn match_pattern_set(
+    patterns: &[&Pattern],
+    nodes: &[NodeId],
+    graph: &Graph,
+    symbols: &mut SymbolMap,
+) -> bool {
+    debug_assert_eq!(patterns.len(), nodes.len());
+    let mut used = SmallVec::<[bool; SMALL_VEC_CAP]>::from_elem(false, nodes.len());
+    match_pattern_set_recursive(patterns, nodes, &mut used, graph, symbols)
+}
+
+fn match_pattern_set_recursive(
+    patterns: &[&Pattern],
+    nodes: &[NodeId],
+    used: &mut [bool],
+    graph: &Graph,
+    symbols: &mut SymbolMap,
+) -> bool {
+    let Some((pat, rest)) = patterns.split_first() else {
+        return true;
+    };
+
+    for (i, &graph_input) in nodes.iter().enumerate() {
+        if used[i] {
+            continue;
+        }
+        let action = symbols.transaction(|s| {
+            if !pat.test_impl(graph_input, graph, s) {
+                return SymbolsAction::Discard;
+            }
+            used[i] = true;
+            if match_pattern_set_recursive(rest, nodes, used, graph, s) {
+                SymbolsAction::Keep
+            } else {
+                used[i] = false;
+                SymbolsAction::Discard
+            }
+        });
+        if action.is_keep() {
+            return true;
+        }
+    }
+
+    false
 }
 
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -433,7 +582,7 @@ mod tests {
     use super::Pattern;
     use crate::graph::builder::Expr;
     use crate::graph::{Graph, Node};
-    use crate::ops::{Abs, Reciprocal, Sqrt};
+    use crate::ops::{Abs, Pow, Reciprocal, Sqrt};
 
     /// Create a graph that implements the softsign function `x / 1 + |x|`.
     fn softsign_graph() -> Graph {
@@ -577,5 +726,128 @@ mod tests {
             rcp_match.node_id("x").unwrap(),
             rsqrt_rcp_graph.input_ids()[0]
         );
+    }
+
+    /// A pattern of the form `(a op b) op c` for an associative+commutative
+    /// `op` should match any bracketing of an equivalent chain in the graph.
+    #[test]
+    fn test_pattern_match_associative_chain() {
+        let make_graph = |build: fn(Expr, Expr, Expr) -> Expr| -> Graph {
+            let a = Expr::value("a");
+            let b = Expr::value("b");
+            let c = Expr::value("c");
+            let pow_ab = a.clone().binary(Pow {}, b);
+            build(a, pow_ab, c).build_graph(["a", "b", "c"])
+        };
+
+        // Pattern is `(x * pow(x, y)) * z` (left-associated). Each input is
+        // distinct: `x` and `z` are symbols, the middle input is a `Pow`.
+        let x = Pattern::symbol("x");
+        let y = Pattern::symbol("y");
+        let z = Pattern::symbol("z");
+        let pat = x.clone() * Pattern::binary_op("Pow", x.clone(), y.clone()) * z.clone();
+
+        let matching = [
+            // `(a * pow(a,b)) * c` — same shape as the pattern.
+            (|a, p, c| a * p * c) as fn(Expr, Expr, Expr) -> Expr,
+            // `a * (pow(a,b) * c)` — right-associated.
+            |a, p, c| a * (p * c),
+            // `(c * a) * pow(a,b)` — operands re-ordered.
+            |a, p, c| c * a * p,
+            // `pow(a,b) * (a * c)` — re-ordered and re-associated.
+            |a, p, c| p * (a * c),
+        ];
+
+        for (i, build) in matching.iter().enumerate() {
+            let graph = make_graph(*build);
+            let m = pat.test(graph.output_ids()[0], &graph);
+            assert!(m.is_some(), "expected match for case {}", i);
+        }
+
+        // The chain in the graph only has two `Mul` operands (the pattern
+        // expects three), so the pattern must not match.
+        let graph = {
+            let a = Expr::value("a");
+            let b = Expr::value("b");
+            let pow_ab = a.clone().binary(Pow {}, b);
+            (a * pow_ab).build_graph(["a", "b"])
+        };
+        assert!(pat.test(graph.output_ids()[0], &graph).is_none());
+    }
+
+    /// `Equal` is commutative (`a == b` iff `b == a`) but not associative
+    /// (`(a == b) == c` differs from `a == (b == c)` in general). A pattern
+    /// with a chain of `Equal` ops should NOT match a re-associated graph:
+    /// the associative-chain path is gated on `is_associative()` being true.
+    #[test]
+    fn test_pattern_match_skips_non_associative_ops() {
+        use crate::ops::Equal;
+
+        let w = Pattern::symbol("w");
+        let x = Pattern::symbol("x");
+        let y = Pattern::symbol("y");
+        let z = Pattern::symbol("z");
+        let eq = |a, b| Pattern::binary_op("Equal", a, b);
+        let pat = eq(eq(w, x), eq(y, z));
+
+        let graph = {
+            let a = Expr::value("a");
+            let b = Expr::value("b");
+            let c = Expr::value("c");
+            let d = Expr::value("d");
+            let eq_ab = a.binary(Equal {}, b);
+            let eq_abc = eq_ab.binary(Equal {}, c);
+            let eq_abcd = eq_abc.binary(Equal {}, d);
+            eq_abcd.build_graph(["a", "b", "c", "d"])
+        };
+
+        assert!(pat.test(graph.output_ids()[0], &graph).is_none());
+    }
+
+    /// Flattening an associative chain must not descend through a keyed
+    /// pattern: doing so would prevent the key from being recorded.
+    #[test]
+    fn test_pattern_match_associative_preserves_keyed_pattern() {
+        let x = Pattern::symbol("x");
+        let y = Pattern::symbol("y");
+        let z = Pattern::symbol("z");
+        let inner = Pattern::binary_op("Mul", x, y).with_name("inner");
+        let pat = inner * z;
+
+        let graph = {
+            let a = Expr::value("a");
+            let b = Expr::value("b");
+            let c = Expr::value("c");
+            ((a * b) * c).build_graph(["a", "b", "c"])
+        };
+
+        let m = pat.test(graph.output_ids()[0], &graph).unwrap();
+        let inner_id = m
+            .node_id("inner")
+            .expect("expected key 'inner' to be recorded");
+        let inner_node = graph.get_node(inner_id).unwrap();
+        assert!(matches!(inner_node, Node::Operator(op) if op.operator().name() == "Mul"));
+    }
+
+    /// An associative pattern with more inputs than the graph chain should not
+    /// match. An associative pattern with fewer inputs than the graph chain
+    /// should still match by binding a single symbol to a `Mul` sub-chain.
+    #[test]
+    fn test_pattern_match_associative_partial() {
+        let x = Pattern::symbol("x");
+        let y = Pattern::symbol("y");
+        let pat = x.clone() * y.clone();
+
+        let graph = {
+            let a = Expr::value("a");
+            let b = Expr::value("b");
+            let c = Expr::value("c");
+            (a * b * c).build_graph(["a", "b", "c"])
+        };
+
+        let m = pat.test(graph.output_ids()[0], &graph).unwrap();
+        let x_id = m.node_id("x").unwrap();
+        let y_id = m.node_id("y").unwrap();
+        assert_ne!(x_id, y_id);
     }
 }

--- a/src/optimize/pattern_matcher.rs
+++ b/src/optimize/pattern_matcher.rs
@@ -4,38 +4,51 @@ use std::rc::Rc;
 use crate::graph::{Constant, Graph, Node, NodeId, OperatorNode};
 use crate::value::ValueView;
 
+/// Tells [`SymbolMap::transaction`] what to do with the symbol bindings added
+/// during the transaction body.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+enum SymbolsAction {
+    /// Keep the bindings added during the transaction.
+    Keep,
+    /// Roll back the bindings added during the transaction.
+    Discard,
+}
+
+impl SymbolsAction {
+    fn is_keep(self) -> bool {
+        matches!(self, SymbolsAction::Keep)
+    }
+}
+
 /// Tracks an association between named symbols (variables) in a pattern and
 /// the node IDs they have been resolved to.
 struct SymbolMap {
     // Map of `(name, node_id)` for resolved symbols. This is modified only
     // by extending and truncating it.
     symbols: Vec<(&'static str, NodeId)>,
-
-    // Stack of checkpoints. Each is the length of `symbols` at the time of
-    // the checkpoint.
-    checkpoints: Vec<usize>,
 }
 
 impl SymbolMap {
     fn new() -> SymbolMap {
         SymbolMap {
             symbols: Vec::new(),
-            checkpoints: Vec::new(),
         }
     }
 
-    /// Save the current state of the map.
+    /// Run `f`, which may extend the symbol map, then either keep or discard
+    /// any bindings it added based on the [`SymbolsAction`] it returns.
     ///
-    /// This is useful if we need to backtrack during pattern matching.
-    fn checkpoint(&mut self) {
-        self.checkpoints.push(self.symbols.len());
-    }
-
-    /// Discard any new symbols recorded since the last call to `checkpoint`.
-    fn revert(&mut self) {
-        if let Some(checkpoint) = self.checkpoints.pop() {
-            self.symbols.truncate(checkpoint);
+    /// Returns the result of `f`.
+    fn transaction<F>(&mut self, f: F) -> SymbolsAction
+    where
+        F: FnOnce(&mut Self) -> SymbolsAction,
+    {
+        let saved_len = self.symbols.len();
+        let action = f(self);
+        if action == SymbolsAction::Discard {
+            self.symbols.truncate(saved_len);
         }
+        action
     }
 
     /// Add a new symbol-node association.
@@ -129,16 +142,16 @@ impl OpPattern {
             && let [pat_a, pat_b] = &self.inputs[..]
             && let [Some(input_a), Some(input_b)] = node.input_ids()
         {
-            symbols.checkpoint();
-
-            if pat_a.test_impl(*input_a, graph, symbols)
-                && pat_b.test_impl(*input_b, graph, symbols)
-            {
+            let action = symbols.transaction(|s| {
+                if pat_a.test_impl(*input_a, graph, s) && pat_b.test_impl(*input_b, graph, s) {
+                    SymbolsAction::Keep
+                } else {
+                    SymbolsAction::Discard
+                }
+            });
+            if action.is_keep() {
                 return true;
             }
-
-            symbols.revert();
-
             pat_b.test_impl(*input_a, graph, symbols) && pat_a.test_impl(*input_b, graph, symbols)
         } else {
             self.inputs
@@ -341,16 +354,17 @@ impl Pattern {
                     true
                 }
             }
-            (PatternKind::AnyOf(patterns), _) => {
-                for pattern in patterns {
-                    symbols.checkpoint();
-                    if pattern.test_impl(node_id, graph, symbols) {
-                        return true;
-                    }
-                    symbols.revert();
-                }
-                false
-            }
+            (PatternKind::AnyOf(patterns), _) => patterns.iter().any(|pattern| {
+                symbols
+                    .transaction(|s| {
+                        if pattern.test_impl(node_id, graph, s) {
+                            SymbolsAction::Keep
+                        } else {
+                            SymbolsAction::Discard
+                        }
+                    })
+                    .is_keep()
+            }),
             _ => false,
         }
     }

--- a/src/optimize/tests.rs
+++ b/src/optimize/tests.rs
@@ -428,18 +428,54 @@ fn test_chained_fused_ops() {
 
 #[test]
 fn test_fuse_gelu() {
-    let graph = {
-        let x = Expr::value("x");
-        let sqrt_2 = (2.0f32).sqrt();
-        let expr = x.clone() * ((x / sqrt_2).erf() + 1.0) * 0.5;
-        expr.build_graph(["x"])
-    };
+    #[derive(Debug)]
+    struct Case {
+        build: fn(Expr) -> Expr,
+    }
 
-    let graph = optimize_graph(graph).unwrap();
+    // Test all bracketings of the GELU expression. The optimizer should fuse
+    // each form, regardless of how the chain of `Mul` ops is associated.
+    let cases = [
+        // PyTorch's `nn.GELU` form.
+        Case {
+            build: |x| x.clone() * ((x / (2.0f32).sqrt()).erf() + 1.0) * 0.5,
+        },
+        // Scale-first form: `(x * 0.5) * (1 + erf(x / sqrt(2)))`
+        Case {
+            build: |x| x.clone() * 0.5 * ((x / (2.0f32).sqrt()).erf() + 1.0),
+        },
+        // Right-associated form: `x * ((1 + erf(x / sqrt(2))) * 0.5)`
+        Case {
+            build: |x| {
+                let half = Expr::constant(0.5);
+                x.clone() * (((x / (2.0f32).sqrt()).erf() + 1.0) * half)
+            },
+        },
+        // Right-associated, scale-first form: `x * (0.5 * (1 + erf(...)))`
+        Case {
+            build: |x| {
+                let half = Expr::constant(0.5);
+                x.clone() * (half * ((x / (2.0f32).sqrt()).erf() + 1.0))
+            },
+        },
+    ];
 
-    let (_, op) = graph.get_source_node(graph.output_ids()[0]).unwrap();
-    let gelu = op.operator().downcast_ref::<Gelu>().unwrap();
-    assert_eq!(gelu.approximate, false);
+    cases.test_each(|case| {
+        let graph = {
+            let x = Expr::value("x");
+            let expr = (case.build)(x);
+            expr.build_graph(["x"])
+        };
+
+        let graph = optimize_graph(graph).unwrap();
+
+        let (_, op) = graph.get_source_node(graph.output_ids()[0]).unwrap();
+        let gelu = op
+            .operator()
+            .downcast_ref::<Gelu>()
+            .expect("expected fused Gelu op");
+        assert_eq!(gelu.approximate, false);
+    });
 }
 
 #[test]


### PR DESCRIPTION
Teach the graph pattern matcher used by the optimizer to be agnostic about the ordering of nested associative operations. This means that a pattern `Add(A, Add(B, C))` will match a graph `Add(Add(A, B), C)`. For the moment, the only two operations marked as associative are `Add` and `Mul`.

The implementation here is by Claude Opus 4.7 with light initial guidance and several rounds of review afterwards. I tried Claude Opus (v4.5 I think?) back on this same task late last year and it got stuck. By contrast Opus 4.7 produced a working implementation after about 12 minutes of thinking.

Fixes https://github.com/robertknight/rten/issues/675