### PR TITLE
Align Reduce* operators with ONNX spec for empty inputs

### DIFF
--- a/rten-vecmath/src/min_max.rs
+++ b/rten-vecmath/src/min_max.rs
@@ -2,6 +2,9 @@ use rten_simd::ops::NumOps;
 use rten_simd::{Isa, Simd, SimdIterable, SimdOp};
 
 /// Compute the minimum and maximum values in a slice of floats.
+///
+/// For an empty slice, returns `(+infinity, -infinity)` — the identity values
+/// for min and max on the extended reals.
 pub struct MinMax<'a> {
     input: &'a [f32],
 }
@@ -19,7 +22,7 @@ impl SimdOp for MinMax<'_> {
     fn eval<I: Isa>(self, isa: I) -> Self::Output {
         let ops = isa.f32();
         let [vec_min, vec_max] = self.input.simd_iter(ops).fold_n_unroll::<2, 4>(
-            [ops.splat(f32::MAX), ops.splat(f32::MIN)],
+            [ops.splat(f32::INFINITY), ops.splat(f32::NEG_INFINITY)],
             #[inline(always)]
             |[min, max], x| [ops.min(x, min), ops.max(x, max)],
             #[inline(always)]
@@ -29,17 +32,20 @@ impl SimdOp for MinMax<'_> {
             .to_array()
             .as_ref()
             .iter()
-            .fold(f32::MAX, |min, x| x.min(min));
+            .fold(f32::INFINITY, |min, x| x.min(min));
         let max = vec_max
             .to_array()
             .as_ref()
             .iter()
-            .fold(f32::MIN, |max, x| x.max(max));
+            .fold(f32::NEG_INFINITY, |max, x| x.max(max));
         (min, max)
     }
 }
 
 /// Compute the maximum value in a slice, propagating NaNs.
+///
+/// For an empty slice, returns `-infinity` — the identity value for max on
+/// the extended reals.
 pub struct MaxNum<'a, T> {
     input: &'a [T],
 }
@@ -63,17 +69,18 @@ impl<'a> SimdOp for MaxNum<'a, f32> {
             ops.select(new_max, x, not_nan)
         };
 
-        let vec_max =
-            self.input
-                .simd_iter(ops)
-                .fold_unroll::<2>(ops.splat(f32::MIN), max_num, max_num);
+        let vec_max = self.input.simd_iter(ops).fold_unroll::<2>(
+            ops.splat(f32::NEG_INFINITY),
+            max_num,
+            max_num,
+        );
 
         vec_max
             .to_array()
             .as_ref()
             .iter()
             .copied()
-            .fold(f32::MIN, |max, x| {
+            .fold(f32::NEG_INFINITY, |max, x| {
                 if x.is_nan() {
                     x
                 } else if max.is_nan() {
@@ -86,6 +93,9 @@ impl<'a> SimdOp for MaxNum<'a, f32> {
 }
 
 /// Compute the minimum value in a slice, propagating NaNs.
+///
+/// For an empty slice, returns `+infinity` — the identity value for min on
+/// the extended reals.
 pub struct MinNum<'a, T> {
     input: &'a [T],
 }
@@ -109,14 +119,17 @@ impl<'a> SimdOp for MinNum<'a, f32> {
             ops.select(new_min, x, not_nan)
         };
 
-        let vec_min = self.input.simd_iter(ops).fold(ops.splat(f32::MAX), min_num);
+        let vec_min = self
+            .input
+            .simd_iter(ops)
+            .fold(ops.splat(f32::INFINITY), min_num);
 
         vec_min
             .to_array()
             .as_ref()
             .iter()
             .copied()
-            .fold(f32::MAX, |min, x| {
+            .fold(f32::INFINITY, |min, x| {
                 if x.is_nan() {
                     x
                 } else if min.is_nan() {
@@ -173,5 +186,19 @@ mod tests {
         let xs = [0.1, 1.0, 0.2, f32::NAN, 0.4, 0.5, 0.6];
         let min = MinNum::new(&xs).dispatch();
         assert!(min.is_nan());
+    }
+
+    // For an empty slice, min and max return their identity values on the
+    // extended reals (+/-infinity). This matches the ONNX spec for ReduceMin
+    // and ReduceMax.
+    #[test]
+    fn test_empty() {
+        let xs: [f32; 0] = [];
+        assert_eq!(MinNum::new(&xs).dispatch(), f32::INFINITY);
+        assert_eq!(MaxNum::new(&xs).dispatch(), f32::NEG_INFINITY);
+        assert_eq!(
+            MinMax::new(&xs).dispatch(),
+            (f32::INFINITY, f32::NEG_INFINITY)
+        );
     }
 }

--- a/src/ops/reduce.rs
+++ b/src/ops/reduce.rs
@@ -391,20 +391,6 @@ fn reduce<T: Copy>(
         return Ok(Tensor::from_scalar(kernel.reduce_slice(&[*item])));
     }
 
-    // nb. Some reduce operations cannot produce a meaningful result with
-    // an empty tensor, but others can, if there is a suitable identity.
-    if input.is_empty() {
-        return Err(OpError::InvalidValue("Cannot reduce empty tensor"));
-    }
-
-    // Number of innermost dims being iterated over, or None if we're not
-    // iterating over innermost dims.
-    let reduced_inner_dims: Option<usize> = resolved_axes
-        .iter()
-        .enumerate()
-        .all(|(i, &axis)| axis == input.ndim() - 1 - i)
-        .then_some(resolved_axes.len());
-
     let reduced_shape: Vec<usize> = input
         .shape()
         .iter()
@@ -417,55 +403,72 @@ fn reduce<T: Copy>(
             }
         })
         .collect();
-    let mut reduced_data = pool.alloc(reduced_shape.iter().product());
+    let output_size: usize = reduced_shape.iter().product();
+    let mut reduced_data = pool.alloc(output_size);
 
-    match (reduced_inner_dims, input.data()) {
-        (Some(ndims), Some(input_data)) => {
-            // Fast path for reducing over contiguous chunks of the input.
-            let slice_len = if ndims == input.ndim() {
-                input.len()
-            } else {
-                input.stride(input.ndim() - 1 - ndims)
-            };
-
-            reduced_data.extend(
-                input_data
-                    .chunks(slice_len)
-                    .map(|chunk| kernel.reduce_slice(chunk)),
-            );
+    if input.is_empty() {
+        // Per the ONNX spec, reduction over an empty set yields the kernel's
+        // identity. Output may itself be empty if a non-reduced dim is zero.
+        if output_size > 0 {
+            reduced_data.resize(output_size, kernel.reduce_slice(&[]));
         }
-        _ => {
-            if resolved_axes.len() == 1 {
-                // Fast path for reducing a single axis.
-                let resolved_axis = resolved_axes[0];
-                reduced_data.extend(input.lanes(resolved_axis).map(|lane| {
-                    if let Some(lane_slice) = lane.as_slice() {
-                        kernel.reduce_slice(lane_slice)
-                    } else {
-                        let buf = tmp_buf.reserve(lane.len());
-                        buf.extend(lane.copied());
-                        kernel.reduce_slice(buf)
-                    }
-                }));
-            } else {
-                // Permute input so the N reduced dims are last, then iterate
-                // over slices of the inner N dims.
-                let mut perm: Vec<usize> = (0..input.ndim()).collect();
-                perm.sort_by_key(|&dim| (resolved_axes.contains(&dim), dim));
-                let permuted = input.permuted(&perm);
+    } else {
+        // Number of innermost dims being iterated over, or None if we're not
+        // iterating over innermost dims.
+        let reduced_inner_dims: Option<usize> = resolved_axes
+            .iter()
+            .enumerate()
+            .all(|(i, &axis)| axis == input.ndim() - 1 - i)
+            .then_some(resolved_axes.len());
 
-                for slice in permuted.inner_iter_dyn(resolved_axes.len()) {
-                    // The reduced dimensions may be contiguous even if the
-                    // tensor is not.
-                    let reduced = if let Some(data) = slice.data() {
-                        kernel.reduce_slice(data)
-                    } else {
-                        let buf = tmp_buf.reserve(slice.len());
-                        let tmp_uninit = &mut buf.spare_capacity_mut()[..slice.len()];
-                        let tmp = slice.copy_into_slice(tmp_uninit);
-                        kernel.reduce_slice(tmp)
-                    };
-                    reduced_data.push(reduced);
+        match (reduced_inner_dims, input.data()) {
+            (Some(ndims), Some(input_data)) => {
+                // Fast path for reducing over contiguous chunks of the input.
+                let slice_len = if ndims == input.ndim() {
+                    input.len()
+                } else {
+                    input.stride(input.ndim() - 1 - ndims)
+                };
+
+                reduced_data.extend(
+                    input_data
+                        .chunks(slice_len)
+                        .map(|chunk| kernel.reduce_slice(chunk)),
+                );
+            }
+            _ => {
+                if resolved_axes.len() == 1 {
+                    // Fast path for reducing a single axis.
+                    let resolved_axis = resolved_axes[0];
+                    reduced_data.extend(input.lanes(resolved_axis).map(|lane| {
+                        if let Some(lane_slice) = lane.as_slice() {
+                            kernel.reduce_slice(lane_slice)
+                        } else {
+                            let buf = tmp_buf.reserve(lane.len());
+                            buf.extend(lane.copied());
+                            kernel.reduce_slice(buf)
+                        }
+                    }));
+                } else {
+                    // Permute input so the N reduced dims are last, then iterate
+                    // over slices of the inner N dims.
+                    let mut perm: Vec<usize> = (0..input.ndim()).collect();
+                    perm.sort_by_key(|&dim| (resolved_axes.contains(&dim), dim));
+                    let permuted = input.permuted(&perm);
+
+                    for slice in permuted.inner_iter_dyn(resolved_axes.len()) {
+                        // The reduced dimensions may be contiguous even if the
+                        // tensor is not.
+                        let reduced = if let Some(data) = slice.data() {
+                            kernel.reduce_slice(data)
+                        } else {
+                            let buf = tmp_buf.reserve(slice.len());
+                            let tmp_uninit = &mut buf.spare_capacity_mut()[..slice.len()];
+                            let tmp = slice.copy_into_slice(tmp_uninit);
+                            kernel.reduce_slice(tmp)
+                        };
+                        reduced_data.push(reduced);
+                    }
                 }
             }
         }
@@ -491,6 +494,9 @@ pub fn reduce_mean(
     struct MeanKernel {}
     impl ReduceKernel<f32> for MeanKernel {
         fn reduce_slice(&self, slice: &[f32]) -> f32 {
+            // ONNX leaves reduction over an empty set undefined for
+            // ReduceMean. We yield NaN here, matching numpy and the ONNX
+            // reference implementation. ONNX Runtime returns 0 instead.
             vecmath::Sum::new(slice).dispatch() / slice.len() as f32
         }
     }
@@ -755,6 +761,11 @@ impl<T: Copy + IsNaN + MinMax> ReduceKernel<T> for GenericMinKernel {
 struct OptimizedMinKernel;
 impl ReduceKernel<f32> for OptimizedMinKernel {
     fn reduce_slice(&self, slice: &[f32]) -> f32 {
+        // Override the vecmath kernel's `f32::MAX` seed: ONNX ReduceMin
+        // requires `+infinity` as the identity.
+        if slice.is_empty() {
+            return f32::INFINITY;
+        }
         vecmath::MinNum::new(slice).dispatch()
     }
 }
@@ -824,6 +835,11 @@ impl<T: Copy + IsNaN + MinMax> ReduceKernel<T> for GenericMaxKernel {
 struct OptimizedMaxKernel;
 impl ReduceKernel<f32> for OptimizedMaxKernel {
     fn reduce_slice(&self, slice: &[f32]) -> f32 {
+        // Override the vecmath kernel's `f32::MIN` seed: ONNX ReduceMax
+        // requires `-infinity` as the identity.
+        if slice.is_empty() {
+            return f32::NEG_INFINITY;
+        }
         vecmath::MaxNum::new(slice).dispatch()
     }
 }
@@ -1686,18 +1702,82 @@ mod tests {
 
         let result = reduce_mean(&pool, input.view(), Some(&[-3]), false /* keep_dims */);
         assert_eq!(result.err(), Some(OpError::InvalidValue("Axis is invalid")));
+    }
 
-        // Empty tensor
-        let result = reduce_mean(
-            &pool,
-            Tensor::from([0.; 0]).view(),
-            Some(&[0]),
-            false, /* keep_dims */
-        );
-        assert_eq!(
-            result.err(),
-            Some(OpError::InvalidValue("Cannot reduce empty tensor"))
-        );
+    // ONNX leaves `ReduceMean` over an empty set undefined. We follow numpy
+    // and yield NaN, rather than erroring.
+    #[test]
+    fn test_reduce_mean_empty() {
+        let pool = BufferPool::new();
+        let input = Tensor::<f32>::from_data(&[0], vec![]);
+        let result = reduce_mean(&pool, input.view(), Some(&[0]), false /* keep_dims */).unwrap();
+        assert!(result.item().unwrap().is_nan());
+    }
+
+    // Verify the identity values returned for reduction over an empty set.
+    #[test]
+    fn test_reduce_empty() {
+        let pool = BufferPool::new();
+
+        // ReduceMin: spec says +infinity (or max of dtype if no inf).
+        let input = Tensor::<f32>::from_data(&[0], vec![]);
+        let result = reduce_min(&pool, input.view(), Some(&[0]), false).unwrap();
+        assert_eq!(result.item(), Some(&f32::INFINITY));
+
+        let input = Tensor::<i32>::from_data(&[0], vec![]);
+        let result = reduce_min(&pool, input.view(), Some(&[0]), false).unwrap();
+        assert_eq!(result.item(), Some(&i32::MAX));
+
+        // ReduceMax: spec says -infinity (or min of dtype if no inf).
+        let input = Tensor::<f32>::from_data(&[0], vec![]);
+        let result = reduce_max(&pool, input.view(), Some(&[0]), false).unwrap();
+        assert_eq!(result.item(), Some(&f32::NEG_INFINITY));
+
+        let input = Tensor::<i32>::from_data(&[0], vec![]);
+        let result = reduce_max(&pool, input.view(), Some(&[0]), false).unwrap();
+        assert_eq!(result.item(), Some(&i32::MIN));
+
+        // ReduceSum: spec says 0.
+        let input = Tensor::<f32>::from_data(&[0], vec![]);
+        let result = reduce_sum(&pool, input.view(), Some(&[0]), false).unwrap();
+        assert_eq!(result.item(), Some(&0.0));
+
+        // ReduceProd: spec says 1.
+        let input = Tensor::<f32>::from_data(&[0], vec![]);
+        let result = reduce_prod(&pool, input.view(), Some(&[0]), false).unwrap();
+        assert_eq!(result.item(), Some(&1.0));
+
+        let input = Tensor::<i32>::from_data(&[0], vec![]);
+        let result = reduce_prod(&pool, input.view(), Some(&[0]), false).unwrap();
+        assert_eq!(result.item(), Some(&1));
+
+        // ReduceL1, ReduceL2, ReduceSumSquare: spec says 0.
+        let input = Tensor::<f32>::from_data(&[0], vec![]);
+        let result = reduce_l1(&pool, input.view(), Some(&[0]), false).unwrap();
+        assert_eq!(result.item(), Some(&0.0));
+        let result = reduce_l2(&pool, input.view(), Some(&[0]), false).unwrap();
+        assert_eq!(result.item(), Some(&0.0));
+        let result = reduce_sum_square(&pool, input.view(), Some(&[0]), false).unwrap();
+        assert_eq!(result.item(), Some(&0.0));
+
+        // Reduce a tensor where only a non-reduced dim is 0. Output should
+        // be empty.
+        let input = Tensor::<f32>::from_data(&[3, 0, 5], vec![]);
+        let result = reduce_max(&pool, input.view(), Some(&[0]), false).unwrap();
+        assert_eq!(result.shape(), &[0, 5]);
+
+        // Reduce a tensor where only the reduced dim is 0. Output should
+        // be filled with the identity value.
+        let input = Tensor::<f32>::from_data(&[3, 0, 5], vec![]);
+        let result = reduce_max(&pool, input.view(), Some(&[1]), false).unwrap();
+        assert_eq!(result.shape(), &[3, 5]);
+        assert!(result.iter().all(|&x| x == f32::NEG_INFINITY));
+
+        // Same, with keep_dims.
+        let input = Tensor::<f32>::from_data(&[3, 0, 5], vec![]);
+        let result = reduce_min(&pool, input.view(), Some(&[1]), true).unwrap();
+        assert_eq!(result.shape(), &[3, 1, 5]);
+        assert!(result.iter().all(|&x| x == f32::INFINITY));
     }
 
     fn result_item<T: Copy>(result: Result<Tensor<T>, OpError>) -> T {

--- a/src/ops/reduce.rs
+++ b/src/ops/reduce.rs
@@ -761,11 +761,6 @@ impl<T: Copy + IsNaN + MinMax> ReduceKernel<T> for GenericMinKernel {
 struct OptimizedMinKernel;
 impl ReduceKernel<f32> for OptimizedMinKernel {
     fn reduce_slice(&self, slice: &[f32]) -> f32 {
-        // Override the vecmath kernel's `f32::MAX` seed: ONNX ReduceMin
-        // requires `+infinity` as the identity.
-        if slice.is_empty() {
-            return f32::INFINITY;
-        }
         vecmath::MinNum::new(slice).dispatch()
     }
 }
@@ -835,11 +830,6 @@ impl<T: Copy + IsNaN + MinMax> ReduceKernel<T> for GenericMaxKernel {
 struct OptimizedMaxKernel;
 impl ReduceKernel<f32> for OptimizedMaxKernel {
     fn reduce_slice(&self, slice: &[f32]) -> f32 {
-        // Override the vecmath kernel's `f32::MIN` seed: ONNX ReduceMax
-        // requires `-infinity` as the identity.
-        if slice.is_empty() {
-            return f32::NEG_INFINITY;
-        }
         vecmath::MaxNum::new(slice).dispatch()
     }
 }


### PR DESCRIPTION
Per the ONNX spec, reductions over an empty set of values yield the operator's identity (e.g. 0 for sum, 1 for prod, +/-inf for min/max), rather than an error.

Note for min/max this behavior diverges from numpy. `np.min` yields `ValueError: zero-size array to reduction operation minimum which has no identity` for an empty input.

For `ReduceMean`, the spec says behavior is undefined. There is currently a difference in behavior between the reference implementation / numpy (yields NaN) and ONNX Runtime (yields zero).

Closes #341