### PR TITLE
Add in SimplifiedLayerNormalization

### DIFF
--- a/src/op_registry/onnx_registry.rs
+++ b/src/op_registry/onnx_registry.rs
@@ -1186,14 +1186,6 @@ impl_read_op!(LSTM, |attrs: &Attrs| {
 impl_read_op!(MatMul);
 impl_read_op!(MatMulInteger);
 
-impl_read_op!("ai.onnx", SimplifiedLayerNormalization, |attrs: &Attrs| {
-    let axis = attrs.get_as_int("axis")?.unwrap_or(-1);
-    let epsilon = attrs.get_as("epsilon");
-    attrs.check_eq("stash_type", 1)?;
-
-    Ok(ops::SimplifiedLayerNormalization { axis, epsilon })
-});
-
 impl_read_op!("com.microsoft", MatMulNBits, |attrs: &Attrs| {
     // Spec allows any value between 2 and 8.
     attrs.check_eq("bits", 4)?;
@@ -1534,6 +1526,15 @@ impl_read_op!(Shape, |attrs: &Attrs| {
 
 impl_read_op!(Sigmoid);
 impl_read_op!(Sign);
+
+impl_read_op!("ai.onnx", SimplifiedLayerNormalization, |attrs: &Attrs| {
+    let axis = attrs.get_as_int("axis")?.unwrap_or(-1);
+    let epsilon = attrs.get_as("epsilon");
+    attrs.check_eq("stash_type", 1)?;
+
+    Ok(ops::SimplifiedLayerNormalization { axis, epsilon })
+});
+
 impl_read_op!(Sin);
 impl_read_op!(Size);
 impl_read_op!(Slice);

--- a/src/op_registry/onnx_registry.rs
+++ b/src/op_registry/onnx_registry.rs
@@ -229,6 +229,9 @@ impl OnnxOpRegistry {
         register_op!(Where);
         register_op!(Xor);
 
+        // ai.onnx experimental
+        register_op!(SimplifiedLayerNormalization);
+
         // com.microsoft ops.
         register_op!(MatMulNBits);
 
@@ -1182,6 +1185,14 @@ impl_read_op!(LSTM, |attrs: &Attrs| {
 
 impl_read_op!(MatMul);
 impl_read_op!(MatMulInteger);
+
+impl_read_op!("ai.onnx", SimplifiedLayerNormalization, |attrs: &Attrs| {
+    let axis = attrs.get_as_int("axis")?.unwrap_or(-1);
+    let epsilon = attrs.get_as("epsilon");
+    attrs.check_eq("stash_type", 1)?;
+
+    Ok(ops::SimplifiedLayerNormalization { axis, epsilon })
+});
 
 impl_read_op!("com.microsoft", MatMulNBits, |attrs: &Attrs| {
     // Spec allows any value between 2 and 8.

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -90,7 +90,7 @@ pub(crate) use {
     non_max_suppression::NonMaxSuppression,
     norm::{
         BatchNormalization, InstanceNormalization, LayerNormalization, LogSoftmax,
-        RMSNormalization, Softmax,
+        RMSNormalization, SimplifiedLayerNormalization, Softmax,
     },
     pad::Pad,
     pooling::{AveragePool, GlobalAveragePool, GlobalMaxPool, MaxPool},

--- a/src/ops/norm.rs
+++ b/src/ops/norm.rs
@@ -531,7 +531,8 @@ impl Operator for LayerNormalization {
 /// Simplified Layer Normalization
 ///
 /// This is a experimental ONNX operator for layer normalization which is equivalent to the later
-/// stabilised RMSNormalization.
+/// stabilised RMSNormalization. See [onnx/onnx#6582](https://github.com/onnx/onnx/issues/6582) for
+/// more details.
 #[derive(Debug)]
 pub struct SimplifiedLayerNormalization {
     pub axis: isize,

--- a/src/ops/norm.rs
+++ b/src/ops/norm.rs
@@ -528,6 +528,42 @@ impl Operator for LayerNormalization {
     }
 }
 
+/// Simplified Layer Normalization
+///
+/// This is a experimental ONNX operator for layer normalization which is equivalent to the later
+/// stabilised RMSNormalization.
+#[derive(Debug)]
+pub struct SimplifiedLayerNormalization {
+    pub axis: isize,
+    pub epsilon: Option<f32>,
+}
+
+impl Operator for SimplifiedLayerNormalization {
+    fn name(&self) -> &str {
+        "SimplifiedLayerNormalization"
+    }
+
+    fn max_inputs(&self) -> Option<usize> {
+        Some(2)
+    }
+
+    fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+        let inputs = ctx.inputs();
+        let input = inputs.require_as(0)?;
+        let scale = inputs.require_as(1)?;
+
+        rms_normalization(ctx.pool(), input, scale, self.axis, self.epsilon).into_op_result()
+    }
+
+    fn output_types(&self, _ctx: &OutputTypesContext) -> Option<OutputTypeList> {
+        Some([OutputType::CopyFromInput(0)].into())
+    }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        Some(&UnaryOp)
+    }
+}
+
 /// Root Mean Square normalization.
 ///
 /// This is a simplified version of [`LayerNormalization`] which does not center


### PR DESCRIPTION
Fixes #1205. I was looking for a way to essentially add an alias for the operator but it seems given the reliance on the `Operator` trait it seemed easier to just copy and paste the implementation and rename.

Can confirm it gets past this node but now there's a new one I have to implement for the model to work (com.microsoft.RotaryEmbedding, later stabilised as
https://onnx.ai/onnx/operators/onnx__RotaryEmbedding.html) so I haven't fully tested it.

I'll make an issue for the RotaryEmbedding node and start looking at that. Hopefully I can get this running and check with an actual inference