### PR TITLE
SimplifiedSkipLayerNormalization

### DIFF
--- a/src/op_registry/onnx_registry.rs
+++ b/src/op_registry/onnx_registry.rs
@@ -234,7 +234,7 @@ impl OnnxOpRegistry {
 
         // com.microsoft ops.
         register_op!(MatMulNBits);
-        register_op!(SimplifiedLayerNormalization);
+        register_op!(SkipSimplifiedLayerNormalization);
 
         reg
     }
@@ -1538,6 +1538,17 @@ impl_read_op!("ai.onnx", SimplifiedLayerNormalization, |attrs: &Attrs| {
 
 impl_read_op!(Sin);
 impl_read_op!(Size);
+
+impl_read_op!(
+    "com.microsoft",
+    SkipSimplifiedLayerNormalization,
+    |attrs: &Attrs| {
+        let epsilon = attrs.require("epsilon")?.as_f32();
+
+        Ok(ops::SkipSimplifiedLayerNormalization { epsilon })
+    }
+);
+
 impl_read_op!(Slice);
 
 impl_read_op!(Softmax, |attrs: &Attrs| {

--- a/src/op_registry/onnx_registry.rs
+++ b/src/op_registry/onnx_registry.rs
@@ -234,6 +234,7 @@ impl OnnxOpRegistry {
 
         // com.microsoft ops.
         register_op!(MatMulNBits);
+        register_op!(SimplifiedLayerNormalization);
 
         reg
     }

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -90,7 +90,7 @@ pub(crate) use {
     non_max_suppression::NonMaxSuppression,
     norm::{
         BatchNormalization, InstanceNormalization, LayerNormalization, LogSoftmax,
-        RMSNormalization, SkipSimplifiedLayerNormalisation, SimplifiedLayerNormalization, Softmax,
+        RMSNormalization, SimplifiedLayerNormalization, SkipSimplifiedLayerNormalization, Softmax,
     },
     pad::Pad,
     pooling::{AveragePool, GlobalAveragePool, GlobalMaxPool, MaxPool},

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -90,7 +90,7 @@ pub(crate) use {
     non_max_suppression::NonMaxSuppression,
     norm::{
         BatchNormalization, InstanceNormalization, LayerNormalization, LogSoftmax,
-        RMSNormalization, SimplifiedLayerNormalization, Softmax,
+        RMSNormalization, SkipSimplifiedLayerNormalisation, SimplifiedLayerNormalization, Softmax,
     },
     pad::Pad,
     pooling::{AveragePool, GlobalAveragePool, GlobalMaxPool, MaxPool},

--- a/src/ops/norm.rs
+++ b/src/ops/norm.rs
@@ -8,7 +8,7 @@ use rten_tensor::{NdTensorView, Tensor, TensorView};
 use rten_tensor::{TensorBase, prelude::*};
 use rten_vecmath as vecmath;
 
-use crate::buffer_pool::BufferPool;
+use crate::buffer_pool::{AutoReturn, BufferPool};
 use crate::infer_shapes::{InferShapes, UnaryOp};
 use crate::operator::{
     IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType, OutputTypeList,
@@ -568,7 +568,7 @@ impl Operator for SimplifiedLayerNormalization {
 
 /// Skip Simplified Layer Normalization
 ///
-/// See https://github.com/microsoft/onnxruntime/blob/main/docs/ContribOperators.md#commicrosoftskiplayernormalization
+/// See https://github.com/microsoft/onnxruntime/blob/main/docs/ContribOperators.md#com.microsoft.SkipSimplifiedLayerNormalization
 #[derive(Debug)]
 pub struct SkipSimplifiedLayerNormalization {
     pub epsilon: f32,
@@ -585,10 +585,10 @@ impl Operator for SkipSimplifiedLayerNormalization {
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let inputs = ctx.inputs();
-        let input: TensorBase<ViewData<'_, f32>, _> = inputs.require_as(0)?;
-        let skip: TensorBase<ViewData<'_, f32>, _> = inputs.require_as(1)?;
-        let gamma: TensorBase<ViewData<'_, f32>, _> = inputs.require_as(2)?;
-        let bias: Option<TensorBase<ViewData<'_, f32>, _>> = inputs.get_as(3)?;
+        let input: TensorView<_> = inputs.require_as(0)?;
+        let skip: TensorView<_> = inputs.require_as(1)?;
+        let gamma: TensorView<_> = inputs.require_as(2)?;
+        let bias: Option<TensorView<_>> = inputs.get_as(3)?;
 
         if input.shape() != skip.shape() {
             return Err(OpError::IncompatibleInputShapes(
@@ -600,12 +600,12 @@ impl Operator for SkipSimplifiedLayerNormalization {
             return Err(OpError::InvalidValue("input must be 2 or 3 dimensioned"));
         }
 
-        let x_plus_skip = add(ctx.pool(), input, skip)?;
+        let x_plus_skip = add(ctx.pool(), input, skip)?.auto_return(ctx.pool());
 
         layer_normalization_impl(
             ctx.pool(),
             x_plus_skip.view(),
-            gamma.view(),
+            gamma,
             bias,
             -1,
             Some(self.epsilon),

--- a/src/ops/norm.rs
+++ b/src/ops/norm.rs
@@ -3,8 +3,9 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use rayon::prelude::*;
 use rten_simd::SimdOp;
-use rten_tensor::prelude::*;
+use rten_tensor::storage::ViewData;
 use rten_tensor::{NdTensorView, Tensor, TensorView};
+use rten_tensor::{TensorBase, prelude::*};
 use rten_vecmath as vecmath;
 
 use crate::buffer_pool::BufferPool;
@@ -13,7 +14,8 @@ use crate::operator::{
     IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType, OutputTypeList,
     OutputTypesContext,
 };
-use crate::ops::resolve_axis;
+use crate::ops::binary_elementwise::add_in_place;
+use crate::ops::{add, resolve_axis};
 use crate::slice_reductions::slice_max;
 use crate::value::Value;
 
@@ -562,6 +564,55 @@ impl Operator for SimplifiedLayerNormalization {
 
     fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
         Some(&UnaryOp)
+    }
+}
+
+/// Skip Simplified Layer Normalization
+///
+/// See https://github.com/microsoft/onnxruntime/blob/main/docs/ContribOperators.md#commicrosoftskiplayernormalization 
+#[derive(Debug)]
+pub struct SkipSimplifiedLayerNormalisation {
+    epsilon: f32,
+}
+
+impl Operator for SkipSimplifiedLayerNormalisation {
+    fn name(&self) -> &str {
+        "SkipSimplifiedLayerNormalisation"
+    }
+
+    fn max_inputs(&self) -> Option<usize> {
+        Some(4)
+    }
+
+    fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+        let inputs = ctx.inputs();
+        let input: TensorBase<ViewData<'_, f32>, _> = inputs.require_as(0)?;
+        let skip: TensorBase<ViewData<'_, f32>, _> = inputs.require_as(1)?;
+        let gamma: TensorBase<ViewData<'_, f32>, _> = inputs.require_as(2)?;
+        let bias: Option<TensorBase<ViewData<'_, f32>, _>> = inputs.get_as(3)?;
+
+        if input.shape() != skip.shape() {
+            return Err(OpError::IncompatibleInputShapes(
+                "input and skip tensor shapes must match",
+            ));
+        }
+
+        let x_plus_skip = add(ctx.pool(), input, skip)?;
+
+        layer_normalization_impl(
+            ctx.pool(),
+            x_plus_skip.view(),
+            gamma.view(),
+            bias,
+            -1,
+            Some(self.epsilon),
+            MeanNormalize::DynamicRootMeanSquare,
+        )
+        .into_op_result()
+    }
+
+    fn output_types(&self, ctx: &OutputTypesContext) -> Option<OutputTypeList> {
+        Some([OutputType::CopyFromInput(0)].into())
     }
 }
 

--- a/src/ops/norm.rs
+++ b/src/ops/norm.rs
@@ -14,7 +14,6 @@ use crate::operator::{
     IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType, OutputTypeList,
     OutputTypesContext,
 };
-use crate::ops::binary_elementwise::add_in_place;
 use crate::ops::{add, resolve_axis};
 use crate::slice_reductions::slice_max;
 use crate::value::Value;
@@ -569,13 +568,13 @@ impl Operator for SimplifiedLayerNormalization {
 
 /// Skip Simplified Layer Normalization
 ///
-/// See https://github.com/microsoft/onnxruntime/blob/main/docs/ContribOperators.md#commicrosoftskiplayernormalization 
+/// See https://github.com/microsoft/onnxruntime/blob/main/docs/ContribOperators.md#commicrosoftskiplayernormalization
 #[derive(Debug)]
-pub struct SkipSimplifiedLayerNormalisation {
-    epsilon: f32,
+pub struct SkipSimplifiedLayerNormalization {
+    pub epsilon: f32,
 }
 
-impl Operator for SkipSimplifiedLayerNormalisation {
+impl Operator for SkipSimplifiedLayerNormalization {
     fn name(&self) -> &str {
         "SkipSimplifiedLayerNormalisation"
     }
@@ -597,6 +596,10 @@ impl Operator for SkipSimplifiedLayerNormalisation {
             ));
         }
 
+        if !matches!(input.ndim(), 2 | 3) {
+            return Err(OpError::InvalidValue("input must be 2 or 3 dimensioned"));
+        }
+
         let x_plus_skip = add(ctx.pool(), input, skip)?;
 
         layer_normalization_impl(
@@ -611,7 +614,7 @@ impl Operator for SkipSimplifiedLayerNormalisation {
         .into_op_result()
     }
 
-    fn output_types(&self, ctx: &OutputTypesContext) -> Option<OutputTypeList> {
+    fn output_types(&self, _ctx: &OutputTypesContext) -> Option<OutputTypeList> {
         Some([OutputType::CopyFromInput(0)].into())
     }
 }

--- a/src/ops/norm.rs
+++ b/src/ops/norm.rs
@@ -567,6 +567,9 @@ impl Operator for SimplifiedLayerNormalization {
 
 /// Skip Simplified Layer Normalization
 ///
+/// This is a fusion of `Add` and `RMSNormalization` (also known as
+/// SimplifiedLayerNormalization in Microsoft's contrib ops).
+///
 /// See https://github.com/microsoft/onnxruntime/blob/main/docs/ContribOperators.md#com.microsoft.SkipSimplifiedLayerNormalization
 #[derive(Debug)]
 pub struct SkipSimplifiedLayerNormalization {
@@ -586,7 +589,10 @@ impl Operator for SkipSimplifiedLayerNormalization {
         let inputs = ctx.inputs();
         let input: TensorView<_> = inputs.require_as(0)?;
         let skip: TensorView<_> = inputs.require_as(1)?;
+
+        // Scale factor, called gamma (γ) in the RMS normalization paper.
         let gamma: TensorView<_> = inputs.require_as(2)?;
+
         let bias: Option<TensorView<_>> = inputs.get_as(3)?;
 
         if input.shape() != skip.shape() {

--- a/src/ops/norm.rs
+++ b/src/ops/norm.rs
@@ -3,9 +3,8 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use rayon::prelude::*;
 use rten_simd::SimdOp;
-use rten_tensor::storage::ViewData;
+use rten_tensor::prelude::*;
 use rten_tensor::{NdTensorView, Tensor, TensorView};
-use rten_tensor::{TensorBase, prelude::*};
 use rten_vecmath as vecmath;
 
 use crate::buffer_pool::{AutoReturn, BufferPool};


### PR DESCRIPTION
Another microsoft contrib op:  https://github.com/microsoft/onnxruntime/blob/main/docs/ContribOperators.md#commicrosoftskipsimplifiedlayernormalization 

Seemed fairly straightforward compared to the RotaryEncoder - let me know if I've missed anything!