### PR TITLE
Enable manual_repeat_n clippy lint and replace repeat().take() calls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,7 +121,6 @@ assertions_on_constants = "allow"
 # potentially less efficient.
 needless_range_loop = "allow"
 too_many_arguments = "allow"
-manual_repeat_n = "allow"  # TODO - Address existing failures
 uninlined_format_args = "allow"
 
 [package.metadata.docs.rs]

--- a/rten-examples/Cargo.toml
+++ b/rten-examples/Cargo.toml
@@ -30,7 +30,6 @@ smallvec = { workspace = true }
 # Allows use of `..Default::default()` for future compatibility even when not
 # currently needed.
 needless_update = "allow"
-manual_repeat_n = "allow"  # TODO - Address existing failures
 uninlined_format_args = "allow"
 
 [package.metadata.release]

--- a/rten-examples/src/whisper.rs
+++ b/rten-examples/src/whisper.rs
@@ -156,7 +156,7 @@ fn log_mel_spectrogram(
             audio
                 .iter()
                 .copied()
-                .chain(std::iter::repeat(0.).take(n_pad))
+                .chain(std::iter::repeat_n(0., n_pad))
                 .collect(),
         ),
     };

--- a/rten-tensor/Cargo.toml
+++ b/rten-tensor/Cargo.toml
@@ -29,7 +29,6 @@ crate-type = ["lib"]
 # See comments about `needless_range_loop` in root Cargo.toml.
 needless_range_loop = "allow"
 manual_memcpy = "allow"
-manual_repeat_n = "allow"  # TODO - Address existing failures
 uninlined_format_args = "allow"
 
 [features]

--- a/rten-tensor/src/layout.rs
+++ b/rten-tensor/src/layout.rs
@@ -1,6 +1,6 @@
 //! Layouts which describe the shape and strides of a tensor.
 
-use std::iter::repeat;
+use std::iter::repeat_n;
 use std::ops::Range;
 
 use smallvec::{SmallVec, smallvec};
@@ -199,8 +199,8 @@ pub trait Layout {
         let a_pad = b.len().saturating_sub(a.len());
         let b_pad = a.len().saturating_sub(b.len());
 
-        let a_iter = a.iter().copied().rev().chain(repeat(1).take(a_pad));
-        let b_iter = b.iter().copied().rev().chain(repeat(1).take(b_pad));
+        let a_iter = a.iter().copied().rev().chain(repeat_n(1, a_pad));
+        let b_iter = b.iter().copied().rev().chain(repeat_n(1, b_pad));
 
         a_iter.zip(b_iter).all(|(a, b)| a == b || a == 1 || b == 1)
     }
@@ -468,17 +468,15 @@ fn broadcast_strides<'a>(
     to_shape: &'a [usize],
 ) -> impl Iterator<Item = usize> + 'a {
     let pad = to_shape.len() - from_shape.len();
-    repeat(0)
-        .take(pad)
-        .chain(from_shape.iter().zip(from_strides.iter()).enumerate().map(
-            move |(i, (size, stride))| {
-                if *size == 1 && to_shape[i + pad] > 1 {
-                    0
-                } else {
-                    *stride
-                }
-            },
-        ))
+    repeat_n(0, pad).chain(from_shape.iter().zip(from_strides.iter()).enumerate().map(
+        move |(i, (size, stride))| {
+            if *size == 1 && to_shape[i + pad] > 1 {
+                0
+            } else {
+                *stride
+            }
+        },
+    ))
 }
 
 impl<const N: usize> NdLayout<N> {

--- a/rten-text/Cargo.toml
+++ b/rten-text/Cargo.toml
@@ -26,5 +26,4 @@ unicode-normalization = "0.1.22"
 rten-testing = { path = "../rten-testing" }
 
 [lints.clippy]
-manual_repeat_n = "allow"  # TODO - Address existing failures
 uninlined_format_args = "allow"

--- a/rten-text/src/normalizers.rs
+++ b/rten-text/src/normalizers.rs
@@ -210,7 +210,10 @@ impl Normalizer for Replace {
             offsets.extend(last_match_end..match_.range().start);
 
             normalized.push_str(&self.content);
-            offsets.extend(std::iter::repeat(match_.range().start).take(self.content.len()));
+            offsets.extend(std::iter::repeat_n(
+                match_.range().start,
+                self.content.len(),
+            ));
 
             last_match_end = match_.range().end;
         }

--- a/rten-text/src/tokenizer.rs
+++ b/rten-text/src/tokenizer.rs
@@ -13,7 +13,7 @@
 use std::borrow::Cow;
 use std::error::Error;
 use std::fmt;
-use std::iter::repeat;
+use std::iter::repeat_n;
 use std::ops::Range;
 use std::path::Path;
 
@@ -123,9 +123,7 @@ impl<'a> Encoded<'a> {
     /// in the model, if it has one.
     pub fn token_type_ids(&self) -> impl Iterator<Item = usize> {
         let second_seq_tokens = self.token_ids.len() - self.first_seq_tokens;
-        repeat(0)
-            .take(self.first_seq_tokens)
-            .chain(repeat(1).take(second_seq_tokens))
+        repeat_n(0, self.first_seq_tokens).chain(repeat_n(1, second_seq_tokens))
     }
 
     /// Return the text from the input sequence(s) that corresponds to a range

--- a/src/model/file_type.rs
+++ b/src/model/file_type.rs
@@ -131,7 +131,7 @@ mod tests {
                     (128u32)
                         .to_le_bytes()
                         .into_iter()
-                        .chain(std::iter::repeat(0).take(128))
+                        .chain(std::iter::repeat_n(0, 128))
                         .collect()
                 },
                 expected: Some(FileType::Rten),

--- a/src/model/rten_builder.rs
+++ b/src/model/rten_builder.rs
@@ -1138,7 +1138,7 @@ impl TensorDataBuilder {
         // of matrices start on a cache line boundary.
         let align = std::mem::align_of::<T>();
         let padding = offset.next_multiple_of(align) - offset;
-        self.data.extend(std::iter::repeat(0).take(padding));
+        self.data.extend(std::iter::repeat_n(0, padding));
 
         let start_offset = self.data.len();
 

--- a/src/op_registry/rten_registry.rs
+++ b/src/op_registry/rten_registry.rs
@@ -415,7 +415,7 @@ impl_read_op!(
         let strides = attrs
             .strides()
             .map(|stride| stride.iter().map(|x| x.as_usize()).collect())
-            .unwrap_or(std::iter::repeat(1).take(kernel_size.len()).collect());
+            .unwrap_or(std::iter::repeat_n(1, kernel_size.len()).collect());
 
         Ok(ops::AveragePool {
             kernel_size,
@@ -748,7 +748,7 @@ impl_read_op!(
         let strides = attrs
             .strides()
             .map(|stride| stride.iter().map(|x| x.as_usize()).collect())
-            .unwrap_or(std::iter::repeat(1).take(kernel_size.len()).collect());
+            .unwrap_or(std::iter::repeat_n(1, kernel_size.len()).collect());
 
         Ok(ops::MaxPool {
             kernel_size,

--- a/src/ops/binary_elementwise.rs
+++ b/src/ops/binary_elementwise.rs
@@ -1,6 +1,6 @@
 use smallvec::SmallVec;
 use std::fmt::Debug;
-use std::iter::repeat;
+use std::iter::repeat_n;
 use std::mem::MaybeUninit;
 
 use rten_base::num::{AsBool, Identities, IsInt};
@@ -33,8 +33,8 @@ pub fn broadcast_shapes(a: &[usize], b: &[usize]) -> Option<SmallVec<[usize; 4]>
     let a_pad = b.len().saturating_sub(a.len());
     let b_pad = a.len().saturating_sub(b.len());
 
-    let a_iter = a.iter().copied().rev().chain(repeat(1).take(a_pad));
-    let b_iter = b.iter().copied().rev().chain(repeat(1).take(b_pad));
+    let a_iter = a.iter().copied().rev().chain(repeat_n(1, a_pad));
+    let b_iter = b.iter().copied().rev().chain(repeat_n(1, b_pad));
 
     let mut result = SmallVec::with_capacity(a.len().max(b.len()));
     for (a, b) in a_iter.zip(b_iter) {

--- a/src/ops/conv/im2col.rs
+++ b/src/ops/conv/im2col.rs
@@ -48,12 +48,14 @@ pub fn build_im2col<T>(
     let mut row_x_offsets = Vec::<i32>::with_capacity(n_rows_padded);
     for chan in 0..chans {
         // Offset to image channel
-        row_chan_offsets.extend(std::iter::repeat(chan as i32 * im_stride_c).take(k_h * k_w));
+        row_chan_offsets.extend(std::iter::repeat_n(chan as i32 * im_stride_c, k_h * k_w));
 
         for k_y in 0..k_h {
             // Offset from top-left corner of patch
-            row_y_offsets
-                .extend(std::iter::repeat(im_stride_h * k_y as i32 * dilation_y as i32).take(k_w));
+            row_y_offsets.extend(std::iter::repeat_n(
+                im_stride_h * k_y as i32 * dilation_y as i32,
+                k_w,
+            ));
             row_x_offsets.extend(
                 (0..k_w as i32)
                     .map(|k_x| im_stride_w * k_x * dilation_x as i32)
@@ -87,7 +89,7 @@ pub fn build_im2col<T>(
     let mut col_x_offsets = Vec::with_capacity(n_cols_padded);
     for patch_y in 0..y_patches {
         let img_y = (patch_y as i32 * stride_h as i32) - pad_top as i32;
-        col_y_offsets.extend(std::iter::repeat(img_y * im_stride_h).take(x_patches));
+        col_y_offsets.extend(std::iter::repeat_n(img_y * im_stride_h, x_patches));
         col_x_offsets.extend((0..x_patches).map(|patch_x| {
             let img_x = (patch_x as i32 * stride_w as i32) - pad_left as i32;
             img_x * im_stride_w


### PR DESCRIPTION
Address TODO in Cargo.toml files by removing the `manual_repeat_n = "allow"` exemption and converting `repeat(x).take(n)` to `std::iter::repeat_n(x, n)`.