### PR TITLE
Add ONNX deserialization for Swish and rename beta to alpha

### DIFF
--- a/rten-vecmath/src/exp.rs
+++ b/rten-vecmath/src/exp.rs
@@ -229,9 +229,9 @@ impl SimdUnaryOp<f32> for Silu {
 
 /// Vectorized Swish function.
 ///
-/// This computes `x * sigmoid(beta * x)` for each element.
+/// This computes `x * sigmoid(alpha * x)` for each element.
 pub struct Swish {
-    pub beta: f32,
+    pub alpha: f32,
 }
 
 impl SimdUnaryOp<f32> for Swish {
@@ -239,8 +239,8 @@ impl SimdUnaryOp<f32> for Swish {
     fn eval<I: Isa>(&self, isa: I, x: I::F32) -> I::F32 {
         let ops = isa.f32();
 
-        let beta = ops.splat(self.beta);
-        ops.mul(x, Sigmoid::apply(isa, ops.mul(x, beta)))
+        let alpha = ops.splat(self.alpha);
+        ops.mul(x, Sigmoid::apply(isa, ops.mul(x, alpha)))
     }
 }
 
@@ -298,8 +298,8 @@ mod tests {
         x * reference_sigmoid(x)
     }
 
-    fn reference_swish(x: f32, beta: f32) -> f32 {
-        x * reference_sigmoid(beta * x)
+    fn reference_swish(x: f32, alpha: f32) -> f32 {
+        x * reference_sigmoid(alpha * x)
     }
 
     #[test]
@@ -406,10 +406,10 @@ mod tests {
 
     #[test]
     fn test_swish() {
-        let beta = 1.7;
+        let alpha = 1.7;
         let test = UnaryOpTester {
-            reference: |x| reference_swish(x, beta),
-            simd: Swish { beta },
+            reference: |x| reference_swish(x, alpha),
+            simd: Swish { alpha },
             range: arange(-6., 6., 0.001),
             tolerance: Tolerance::Ulp(MAX_SIGMOID_ERROR_ULPS),
         };

--- a/src/op_registry/onnx_registry.rs
+++ b/src/op_registry/onnx_registry.rs
@@ -220,6 +220,7 @@ impl OnnxOpRegistry {
         register_op!(STFT, feature = "fft");
         register_op!(Sub);
         register_op!(Sum);
+        register_op!(Swish);
         register_op!(Tan);
         register_op!(Tanh);
         register_op!(Tile);
@@ -1631,6 +1632,12 @@ impl_read_op!(STFT, |attrs: &Attrs| {
 
 impl_read_op!(Sub);
 impl_read_op!(Sum);
+
+impl_read_op!(Swish, |attrs: &Attrs| {
+    let alpha = attrs.get_as("alpha").unwrap_or(1.0);
+    Ok(ops::Swish { alpha })
+});
+
 impl_read_op!(Tan);
 impl_read_op!(Tanh);
 impl_read_op!(Tile);

--- a/src/ops/unary_elementwise.rs
+++ b/src/ops/unary_elementwise.rs
@@ -657,18 +657,18 @@ impl_get_kernel!(Silu, f32, SimdKernel(vecmath::Silu {}));
 
 /// Swish function (<https://en.wikipedia.org/wiki/Swish_function>).
 ///
-/// This computes `x * sigmoid(beta * x)`. The special case where beta = 1 is
+/// This computes `x * sigmoid(alpha * x)`. The special case where alpha = 1 is
 /// known as [`Silu`].
 #[derive(Debug)]
 pub struct Swish {
-    pub beta: f32,
+    pub alpha: f32,
 }
 
 impl_operator!(Swish, [FloatTensor]);
 
 impl GetKernel<f32> for Swish {
     fn get_kernel(&self) -> impl UnaryKernel<f32> + Send + Sync {
-        SimdKernel(vecmath::Swish { beta: self.beta })
+        SimdKernel(vecmath::Swish { alpha: self.alpha })
     }
 }
 
@@ -1156,7 +1156,7 @@ mod tests {
         |x: &f32| x.sqrt(),
         Tensor::from([4., 9., 16.])
     );
-    test_unary_op!(test_swish, Swish { beta: 0.5 }, |x: &f32| x
+    test_unary_op!(test_swish, Swish { alpha: 0.5 }, |x: &f32| x
         * reference_sigmoid(0.5 * *x));
     test_unary_op!(test_tan, Tan {}, |x: &f32| x.tan());
     test_unary_op!(test_tanh, Tanh {}, |x: &f32| x.tanh());

--- a/src/optimize/fusions.rs
+++ b/src/optimize/fusions.rs
@@ -586,8 +586,8 @@ impl PatternFusion for SwishFusion {
 
     fn pattern(&self) -> Pattern {
         let x = Pattern::symbol("x");
-        let beta = Pattern::const_symbol("beta");
-        x.clone() * Pattern::unary_op("Sigmoid", beta * x.clone())
+        let alpha = Pattern::const_symbol("alpha");
+        x.clone() * Pattern::unary_op("Sigmoid", alpha * x.clone())
     }
 
     fn inputs(&self) -> &[&str] {
@@ -595,11 +595,11 @@ impl PatternFusion for SwishFusion {
     }
 
     fn maybe_fuse(&self, pat_match: &Match, g: &Graph) -> Result<Swish, FusionError> {
-        let beta_input = pat_match.node_id("beta").expect("missing symbol");
-        let beta = g
-            .get_scalar(beta_input)
-            .ok_or(FusionError::CheckFailed("beta not a scalar"))?;
-        Ok(Swish { beta })
+        let alpha_input = pat_match.node_id("alpha").expect("missing symbol");
+        let alpha = g
+            .get_scalar(alpha_input)
+            .ok_or(FusionError::CheckFailed("alpha not a scalar"))?;
+        Ok(Swish { alpha })
     }
 }
 

--- a/src/optimize/tests.rs
+++ b/src/optimize/tests.rs
@@ -341,8 +341,8 @@ fn test_fuse_silu() {
 fn test_fuse_swish() {
     let graph = {
         let x = Expr::value("x");
-        let beta = 1.7;
-        let expr = x.clone() * (x.clone() * beta).sigmoid();
+        let alpha = 1.7;
+        let expr = x.clone() * (x.clone() * alpha).sigmoid();
         expr.build_graph(["x"])
     };
 
@@ -350,7 +350,7 @@ fn test_fuse_swish() {
 
     let (_, op) = graph.get_source_node(graph.output_ids()[0]).unwrap();
     let swish_op = op.operator().downcast_ref::<Swish>().unwrap();
-    assert_eq!(swish_op.beta, 1.7);
+    assert_eq!(swish_op.alpha, 1.7);
 }
 
 #[test]


### PR DESCRIPTION
Register the Swish operator in the ONNX op registry so it can be parsed from .onnx model files, in addition to being produced by operator fusion.

Rename the `beta` field of the Swish struct (and the corresponding `vecmath::Swish` field) to `alpha` to match the name used in the ONNX operator spec. The original paper that introduced the function uses `beta` (see https://en.wikipedia.org/wiki/Swish_function), but ONNX uses `alpha`.