### PR TITLE
Add Acosh, Asinh, Atanh, Cosh and Sinh operators

### DIFF
--- a/rten-convert/rten_convert/schema_generated.py
+++ b/rten-convert/rten_convert/schema_generated.py
@@ -137,6 +137,11 @@ class OperatorType(object):
     STFT = 127
     GlobalMaxPool = 128
     ReduceL1 = 129
+    Acosh = 130
+    Asinh = 131
+    Atanh = 132
+    Cosh = 133
+    Sinh = 134
 
 
 class RNNDirection(object):

--- a/rten-model-file/src/schema.fbs
+++ b/rten-model-file/src/schema.fbs
@@ -143,6 +143,11 @@ enum OperatorType: ubyte {
   STFT,
   GlobalMaxPool,
   ReduceL1,
+  Acosh,
+  Asinh,
+  Atanh,
+  Cosh,
+  Sinh,
 }
 
 enum RNNDirection: ubyte {

--- a/rten-model-file/src/schema_generated.rs
+++ b/rten-model-file/src/schema_generated.rs
@@ -11,13 +11,13 @@ pub const ENUM_MIN_OPERATOR_TYPE: u8 = 0;
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
-pub const ENUM_MAX_OPERATOR_TYPE: u8 = 129;
+pub const ENUM_MAX_OPERATOR_TYPE: u8 = 134;
 #[deprecated(
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 130] = [
+pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 135] = [
     OperatorType::Add,
     OperatorType::ArgMin,
     OperatorType::ArgMax,
@@ -148,6 +148,11 @@ pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 130] = [
     OperatorType::STFT,
     OperatorType::GlobalMaxPool,
     OperatorType::ReduceL1,
+    OperatorType::Acosh,
+    OperatorType::Asinh,
+    OperatorType::Atanh,
+    OperatorType::Cosh,
+    OperatorType::Sinh,
 ];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -285,9 +290,14 @@ impl OperatorType {
     pub const STFT: Self = Self(127);
     pub const GlobalMaxPool: Self = Self(128);
     pub const ReduceL1: Self = Self(129);
+    pub const Acosh: Self = Self(130);
+    pub const Asinh: Self = Self(131);
+    pub const Atanh: Self = Self(132);
+    pub const Cosh: Self = Self(133);
+    pub const Sinh: Self = Self(134);
 
     pub const ENUM_MIN: u8 = 0;
-    pub const ENUM_MAX: u8 = 129;
+    pub const ENUM_MAX: u8 = 134;
     pub const ENUM_VALUES: &'static [Self] = &[
         Self::Add,
         Self::ArgMin,
@@ -419,6 +429,11 @@ impl OperatorType {
         Self::STFT,
         Self::GlobalMaxPool,
         Self::ReduceL1,
+        Self::Acosh,
+        Self::Asinh,
+        Self::Atanh,
+        Self::Cosh,
+        Self::Sinh,
     ];
     /// Returns the variant's name or "" if unknown.
     pub fn variant_name(self) -> Option<&'static str> {
@@ -553,6 +568,11 @@ impl OperatorType {
             Self::STFT => Some("STFT"),
             Self::GlobalMaxPool => Some("GlobalMaxPool"),
             Self::ReduceL1 => Some("ReduceL1"),
+            Self::Acosh => Some("Acosh"),
+            Self::Asinh => Some("Asinh"),
+            Self::Atanh => Some("Atanh"),
+            Self::Cosh => Some("Cosh"),
+            Self::Sinh => Some("Sinh"),
             _ => None,
         }
     }

--- a/src/model.rs
+++ b/src/model.rs
@@ -1416,12 +1416,15 @@ mod tests {
 
         add_operator!(Abs, [input_node]);
         add_operator!(Acos, [input_node]);
+        add_operator!(Acosh, [input_node]);
         add_operator!(Add, [input_node, input_node]);
         add_operator!(And, [input_bool, input_bool]);
         add_operator!(ArgMax, [input_node], { axis: 3, keep_dims: false });
         add_operator!(ArgMin, [input_node], { axis: 3, keep_dims: false });
         add_operator!(Asin, [input_node]);
+        add_operator!(Asinh, [input_node]);
         add_operator!(Atan, [input_node]);
+        add_operator!(Atanh, [input_node]);
         add_operator!(AveragePool, [input_node], {
             kernel_size: [2, 2].into(),
             strides: [2, 2].into(),
@@ -1477,6 +1480,7 @@ mod tests {
             output_padding: None,
         });
         add_operator!(Cos, [input_node]);
+        add_operator!(Cosh, [input_node]);
 
         let const_u8_val = Tensor::from([0u8, 1, 2, 3, 4]);
         let const_u8 = graph_builder.add_constant(const_u8_val.view());
@@ -1755,6 +1759,7 @@ mod tests {
         add_operator!(Sigmoid, [input_node]);
         add_operator!(Sign, [input_node]);
         add_operator!(Sin, [input_node]);
+        add_operator!(Sinh, [input_node]);
         add_operator!(Size, [input_node]);
 
         let scatter_elem_indices_val = Tensor::<i32>::zeros(&input_shape);

--- a/src/model/rten_builder.rs
+++ b/src/model/rten_builder.rs
@@ -32,12 +32,15 @@ pub struct IfArgs<'a> {
 pub enum OpType<'a> {
     Abs,
     Acos,
+    Acosh,
     Add,
     And,
     ArgMax(ArgMax),
     ArgMin(ArgMin),
     Asin,
+    Asinh,
     Atan,
+    Atanh,
     AveragePool(AveragePool),
     BatchNormalization(BatchNormalization),
     Cast(Cast),
@@ -50,6 +53,7 @@ pub enum OpType<'a> {
     ConvInteger(ConvInteger),
     ConvTranspose(ConvTranspose),
     Cos,
+    Cosh,
     DequantizeLinear(DequantizeLinear),
     DepthToSpace(DepthToSpace),
     Div,
@@ -142,6 +146,7 @@ pub enum OpType<'a> {
     Sigmoid,
     Sign,
     Sin,
+    Sinh,
     Size,
     Slice,
     Softmax(Softmax),
@@ -427,6 +432,7 @@ impl<'mb, 'a> GraphBuilder<'mb, 'a> {
         let (op_type, attrs_type, attrs) = match op_info {
             OpType::Abs => op!(Abs),
             OpType::Acos => op!(Acos),
+            OpType::Acosh => op!(Acosh),
             OpType::Add => op!(Add),
             OpType::And => op!(And),
             OpType::ArgMax(args) => op_with_attrs!(ArgMax, ArgMaxAttrs, {
@@ -442,7 +448,9 @@ impl<'mb, 'a> GraphBuilder<'mb, 'a> {
                 }
             }),
             OpType::Asin => op!(Asin),
+            OpType::Asinh => op!(Asinh),
             OpType::Atan => op!(Atan),
+            OpType::Atanh => op!(Atanh),
             OpType::AveragePool(args) => op_with_attrs!(AveragePool, AveragePoolAttrs, {
                 let pad_args = pad_args_from_padding(args.padding);
                 let pads = self.create_vec(pad_args.pads, |pad| pad as u32);
@@ -551,6 +559,7 @@ impl<'mb, 'a> GraphBuilder<'mb, 'a> {
                 }
             }),
             OpType::Cos => op!(Cos),
+            OpType::Cosh => op!(Cosh),
             OpType::DequantizeLinear(args) => op_with_attrs!(
                 DequantizeLinear,
                 DequantizeLinearAttrs,
@@ -906,6 +915,7 @@ impl<'mb, 'a> GraphBuilder<'mb, 'a> {
             OpType::Sigmoid => op!(Sigmoid),
             OpType::Slice => op!(Slice),
             OpType::Sin => op!(Sin),
+            OpType::Sinh => op!(Sinh),
             OpType::Sign => op!(Sign),
             OpType::Size => op!(Size),
             OpType::Softmax(args) => op_with_attrs!(

--- a/src/op_registry/onnx_registry.rs
+++ b/src/op_registry/onnx_registry.rs
@@ -99,12 +99,15 @@ impl OnnxOpRegistry {
         // ai.onnx ops.
         register_op!(Abs);
         register_op!(Acos);
+        register_op!(Acosh);
         register_op!(Add);
         register_op!(And);
         register_op!(ArgMax);
         register_op!(ArgMin);
         register_op!(Asin);
+        register_op!(Asinh);
         register_op!(Atan);
+        register_op!(Atanh);
         register_op!(AveragePool);
         register_op!(BatchNormalization);
         register_op!(Cast);
@@ -118,6 +121,7 @@ impl OnnxOpRegistry {
         register_op!(ConstantOfShape);
         register_op!(ConvTranspose);
         register_op!(Cos);
+        register_op!(Cosh);
         register_op!(CumSum);
         register_op!(DequantizeLinear);
         register_op!(DepthToSpace);
@@ -209,6 +213,7 @@ impl OnnxOpRegistry {
         register_op!(Sigmoid);
         register_op!(Sign);
         register_op!(Sin);
+        register_op!(Sinh);
         register_op!(Size);
         register_op!(Slice);
         register_op!(Softmax);
@@ -653,6 +658,7 @@ macro_rules! impl_read_op {
 
 impl_read_op!(Abs);
 impl_read_op!(Acos);
+impl_read_op!(Acosh);
 impl_read_op!(Add);
 impl_read_op!(And);
 
@@ -680,7 +686,9 @@ impl_read_op!(ArgMin, |attrs: &Attrs| {
 });
 
 impl_read_op!(Asin);
+impl_read_op!(Asinh);
 impl_read_op!(Atan);
+impl_read_op!(Atanh);
 
 impl_read_op!(AveragePool, |attrs: &Attrs| {
     let PoolAttrs {
@@ -932,6 +940,7 @@ impl_read_op!(ConvTranspose, |attrs: &Attrs| {
 });
 
 impl_read_op!(Cos);
+impl_read_op!(Cosh);
 impl_read_op!(CumSum, |attrs: &Attrs| {
     attrs.check_eq("exclusive", 0)?;
     attrs.check_eq("reverse", 0)?;
@@ -1572,6 +1581,7 @@ impl_read_op!("ai.onnx", SimplifiedLayerNormalization, |attrs: &Attrs| {
 });
 
 impl_read_op!(Sin);
+impl_read_op!(Sinh);
 impl_read_op!(Size);
 
 impl_read_op!(

--- a/src/op_registry/rten_registry.rs
+++ b/src/op_registry/rten_registry.rs
@@ -95,12 +95,15 @@ impl RtenOpRegistry {
 
         register_op!(Abs);
         register_op!(Acos);
+        register_op!(Acosh);
         register_op!(Add);
         register_op!(And);
         register_op!(ArgMax);
         register_op!(ArgMin);
         register_op!(Asin);
+        register_op!(Asinh);
         register_op!(Atan);
+        register_op!(Atanh);
         register_op!(AveragePool);
         register_op!(BatchNormalization);
         register_op!(Cast);
@@ -114,6 +117,7 @@ impl RtenOpRegistry {
         register_op!(ConstantOfShape);
         register_op!(ConvTranspose);
         register_op!(Cos);
+        register_op!(Cosh);
         register_op!(CumSum);
         register_op!(DequantizeLinear);
         register_op!(DepthToSpace);
@@ -203,6 +207,7 @@ impl RtenOpRegistry {
         register_op!(Sigmoid);
         register_op!(Sign);
         register_op!(Sin);
+        register_op!(Sinh);
         register_op!(Size);
         register_op!(Slice);
         register_op!(Softmax);
@@ -400,12 +405,15 @@ macro_rules! impl_read_op {
 
 impl_read_op!(Abs);
 impl_read_op!(Acos);
+impl_read_op!(Acosh);
 impl_read_op!(Add);
 impl_read_op!(And);
 impl_read_op!(ArgMax, attrs_as_arg_max_attrs, reduce_axis);
 impl_read_op!(ArgMin, attrs_as_arg_max_attrs, reduce_axis);
 impl_read_op!(Asin);
+impl_read_op!(Asinh);
 impl_read_op!(Atan);
+impl_read_op!(Atanh);
 impl_read_op!(
     AveragePool,
     attrs_as_average_pool_attrs,
@@ -511,6 +519,7 @@ impl_read_op!(
     }
 );
 impl_read_op!(Cos);
+impl_read_op!(Cosh);
 impl_read_op!(CumSum);
 impl_read_op!(DequantizeLinear, attrs_as_dequantize_linear_attrs, axis);
 impl_read_op!(
@@ -985,6 +994,7 @@ impl ReadOp for ops::Shape {
 impl_read_op!(Sigmoid);
 impl_read_op!(Sign);
 impl_read_op!(Sin);
+impl_read_op!(Sinh);
 impl_read_op!(Size);
 impl_read_op!(Slice);
 impl_read_op!(

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -111,9 +111,9 @@ pub(crate) use {
     split::Split,
     trilu::Trilu,
     unary_elementwise::{
-        Abs, Acos, Asin, Atan, Ceil, Clip, Cos, Elu, Erf, Exp, Floor, Gelu, HardSigmoid, HardSwish,
-        IsInf, IsNaN, LeakyRelu, Log, Neg, Not, PRelu, Reciprocal, Relu, Round, Sigmoid, Sign,
-        Silu, Sin, Softplus, Sqrt, Swish, Tan, Tanh,
+        Abs, Acos, Acosh, Asin, Asinh, Atan, Atanh, Ceil, Clip, Cos, Cosh, Elu, Erf, Exp, Floor,
+        Gelu, HardSigmoid, HardSwish, IsInf, IsNaN, LeakyRelu, Log, Neg, Not, PRelu, Reciprocal,
+        Relu, Round, Sigmoid, Sign, Silu, Sin, Sinh, Softplus, Sqrt, Swish, Tan, Tanh,
     },
     variadic_elementwise::{Max, Mean, Min, Sum},
 };

--- a/src/ops/unary_elementwise.rs
+++ b/src/ops/unary_elementwise.rs
@@ -223,6 +223,18 @@ declare_operator!(Atan);
 impl_operator!(Atan, [FloatTensor]);
 impl_get_kernel!(Atan, f32, |val: f32| val.atan());
 
+declare_operator!(Acosh);
+impl_operator!(Acosh, [FloatTensor]);
+impl_get_kernel!(Acosh, f32, |val: f32| val.acosh());
+
+declare_operator!(Asinh);
+impl_operator!(Asinh, [FloatTensor]);
+impl_get_kernel!(Asinh, f32, |val: f32| val.asinh());
+
+declare_operator!(Atanh);
+impl_operator!(Atanh, [FloatTensor]);
+impl_get_kernel!(Atanh, f32, |val: f32| val.atanh());
+
 declare_operator!(Ceil);
 impl_operator!(Ceil, [FloatTensor]);
 impl_operator_fn!(Ceil, ceil, cfg_test);
@@ -340,6 +352,10 @@ impl Operator for Clip {
 declare_operator!(Cos);
 impl_operator!(Cos, [FloatTensor]);
 impl_get_kernel!(Cos, f32, SimdKernel(vecmath::Cos::new()));
+
+declare_operator!(Cosh);
+impl_operator!(Cosh, [FloatTensor]);
+impl_get_kernel!(Cosh, f32, |val: f32| val.cosh());
 
 #[derive(Debug)]
 pub struct Elu {
@@ -676,6 +692,10 @@ declare_operator!(Sin);
 impl_operator!(Sin, [FloatTensor]);
 impl_get_kernel!(Sin, f32, SimdKernel(vecmath::Sin::new()));
 
+declare_operator!(Sinh);
+impl_operator!(Sinh, [FloatTensor]);
+impl_get_kernel!(Sinh, f32, |val: f32| val.sinh());
+
 /// Trait for obtaining the sign of a number (-1, 0 or 1) as a value of the
 /// same type.
 pub trait Signum: Copy {
@@ -733,9 +753,10 @@ mod tests {
     use rten_testing::TestCases;
 
     use super::{
-        Abs, Acos, Asin, Atan, Cos, Elu, Exp, Gelu, IsInf, IsNaN, Log, Neg, Not, PRelu, Reciprocal,
-        Relu, Sigmoid, Sign, Silu, Sin, Softplus, Sqrt, Swish, Tan, Tanh, ceil, clip,
-        clip_in_place, erf, floor, hard_sigmoid, hard_swish, leaky_relu, round,
+        Abs, Acos, Acosh, Asin, Asinh, Atan, Atanh, Cos, Cosh, Elu, Exp, Gelu, IsInf, IsNaN, Log,
+        Neg, Not, PRelu, Reciprocal, Relu, Sigmoid, Sign, Silu, Sin, Sinh, Softplus, Sqrt, Swish,
+        Tan, Tanh, ceil, clip, clip_in_place, erf, floor, hard_sigmoid, hard_swish, leaky_relu,
+        round,
     };
     use crate::buffer_pool::BufferPool;
     use crate::operator::{OpError, Operator, OperatorExt};
@@ -844,6 +865,14 @@ mod tests {
     test_unary_op!(test_acos, Acos {}, |x: &f32| x.acos());
     test_unary_op!(test_asin, Asin {}, |x: &f32| x.asin());
     test_unary_op!(test_atan, Atan {}, |x: &f32| x.atan());
+    test_unary_op!(
+        test_acosh,
+        Acosh {},
+        |x: &f32| x.acosh(),
+        Tensor::from([1.0, 1.5, 2.0, 5.0, 100.0])
+    );
+    test_unary_op!(test_asinh, Asinh {}, |x: &f32| x.asinh());
+    test_unary_op!(test_atanh, Atanh {}, |x: &f32| x.atanh());
 
     #[test]
     fn test_ceil() {
@@ -915,6 +944,7 @@ mod tests {
     }
 
     test_unary_op!(test_cos, Cos {}, |x: &f32| x.cos());
+    test_unary_op!(test_cosh, Cosh {}, |x: &f32| x.cosh());
 
     #[test]
     fn test_elu() {
@@ -1149,6 +1179,7 @@ mod tests {
     );
     test_unary_op!(test_silu, Silu {}, |x: &f32| x * reference_sigmoid(*x));
     test_unary_op!(test_sin, Sin {}, |x: &f32| x.sin());
+    test_unary_op!(test_sinh, Sinh {}, |x: &f32| x.sinh());
     test_unary_op!(test_softplus, Softplus {}, |x: &f32| { x.exp().ln_1p() });
     test_unary_op!(
         test_sqrt,


### PR DESCRIPTION
These are the hyperbolic trig operators that were the only trig ops still listed as unsupported in #14. Each uses the scalar f32 method from std, following the same pattern as Acos/Asin/Atan.

These operators are rarely used in practice, so this is mainly for completeness. I did [find one](https://huggingface.co/mnm-matin/hyperbolic-clip/tree/main/hycoclip-vit-s) which uses `Sinh`.