### PR TITLE
Add shape inference for additional unary operators

### DIFF
--- a/src/ops/embedding.rs
+++ b/src/ops/embedding.rs
@@ -2,6 +2,7 @@ use rten_tensor::{AsView, Layout, NdTensorView, SliceRange, Tensor, TensorView};
 
 use crate::{
     buffer_pool::{AutoReturn, BufferPool},
+    infer_shapes::{InferShapes, UnaryOp},
     operator::{
         IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType, OutputTypeList,
         OutputTypesContext,
@@ -168,6 +169,10 @@ impl Operator for RotaryEmbedding {
     fn output_types(&self, _ctx: &OutputTypesContext) -> Option<OutputTypeList> {
         Some([OutputType::CopyFromInput(0)].into())
     }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        Some(&UnaryOp)
+    }
 }
 
 #[derive(Debug)]
@@ -217,6 +222,10 @@ impl Operator for RotaryEmbeddingMicrosoft {
 
     fn output_types(&self, _ctx: &OutputTypesContext) -> Option<OutputTypeList> {
         Some([OutputType::CopyFromInput(0)].into())
+    }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        Some(&UnaryOp)
     }
 }
 

--- a/src/ops/gather.rs
+++ b/src/ops/gather.rs
@@ -569,6 +569,10 @@ impl Operator for ScatterElements {
     fn output_types(&self, _ctx: &OutputTypesContext) -> Option<OutputTypeList> {
         Some([OutputType::CopyFromInput(0)].into())
     }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        Some(&UnaryOp)
+    }
 }
 
 pub fn scatter_nd<

--- a/src/ops/generate.rs
+++ b/src/ops/generate.rs
@@ -7,7 +7,7 @@ use rten_tensor::prelude::*;
 use rten_tensor::{NdTensor, NdTensorView, Tensor, TensorView};
 
 use crate::buffer_pool::BufferPool;
-use crate::infer_shapes::{InferShapes, impl_infer_shapes};
+use crate::infer_shapes::{InferShapes, UnaryOp, impl_infer_shapes};
 use crate::operator::{
     IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType, OutputTypeList,
     OutputTypesContext, static_dims,
@@ -275,6 +275,10 @@ impl Operator for EyeLike {
             }]
             .into(),
         )
+    }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        Some(&UnaryOp)
     }
 }
 

--- a/src/ops/norm.rs
+++ b/src/ops/norm.rs
@@ -622,6 +622,10 @@ impl Operator for SkipSimplifiedLayerNormalization {
     fn output_types(&self, _ctx: &OutputTypesContext) -> Option<OutputTypeList> {
         Some([OutputType::CopyFromInput(0)].into())
     }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        Some(&UnaryOp)
+    }
 }
 
 /// Root Mean Square normalization.

--- a/src/ops/random.rs
+++ b/src/ops/random.rs
@@ -3,6 +3,7 @@ use fastrand_contrib::RngExt;
 use rten_tensor::prelude::*;
 use rten_tensor::{Tensor, TensorView};
 
+use crate::infer_shapes::{InferShapes, UnaryOp};
 use crate::operator::{
     IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType, OutputTypeList,
     OutputTypesContext,
@@ -87,6 +88,10 @@ impl Operator for RandomUniformLike {
 
     fn output_types(&self, _ctx: &OutputTypesContext) -> Option<OutputTypeList> {
         Some([OutputType::Fixed(ValueType::Tensor(DataType::Float))].into())
+    }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        Some(&UnaryOp)
     }
 }
 
@@ -178,6 +183,10 @@ impl Operator for RandomNormalLike {
 
     fn output_types(&self, _ctx: &OutputTypesContext) -> Option<OutputTypeList> {
         Some([OutputType::Fixed(ValueType::Tensor(DataType::Float))].into())
+    }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        Some(&UnaryOp)
     }
 }
 

--- a/src/ops/reduce.rs
+++ b/src/ops/reduce.rs
@@ -258,6 +258,10 @@ impl Operator for CumSum {
     fn output_types(&self, _ctx: &OutputTypesContext) -> Option<OutputTypeList> {
         Some([OutputType::CopyFromInput(0)].into())
     }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        Some(&rten_shape_inference::UnaryOp)
+    }
 }
 
 /// Return the indices of nonzero elements in `input` as a `(dim, index)` tensor.


### PR DESCRIPTION
Implement shape inference for several unary operators that were previously missing it:

- CumSum
- EyeLike
- RandomNormalLike
- RandomUniformLike
- RotaryEmbedding (standard + Microsoft variants)
- ScatterElements
- SkipSimplifiedLayerNormalization