### PR TITLE
Add shape inference for ConvInteger operator

### DIFF
--- a/src/ops/conv.rs
+++ b/src/ops/conv.rs
@@ -525,7 +525,21 @@ impl Operator for ConvInteger {
     fn output_types(&self, _ctx: &OutputTypesContext) -> Option<OutputTypeList> {
         Some([OutputType::Fixed(ValueType::Tensor(DataType::Int32))].into())
     }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        Some(self)
+    }
 }
+
+impl_infer_shapes!(
+    ConvInteger,
+    op,
+    shape_ops::Conv {
+        strides: &op.strides,
+        dilations: &op.dilations,
+        padding: op.padding.as_shape_inference_padding(),
+    }
+);
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
ConvInteger has the same shape inference rules as Conv: it shares the input/weights layout and uses the same padding/stride/dilation arithmetic. It just differs in the element types and in not taking a bias input.