### PR TITLE
Add shape inference for TopK operator

### DIFF
--- a/rten-shape-inference/src/ops.rs
+++ b/rten-shape-inference/src/ops.rs
@@ -308,6 +308,49 @@ impl InferShapes for Range {
     }
 }
 
+/// TopK operator.
+///
+/// See <https://onnx.ai/onnx/operators/onnx__TopK.html>.
+pub struct TopK {
+    pub axis: Option<i32>,
+}
+
+impl InferShapes for TopK {
+    fn infer_shapes(
+        &self,
+        inputs: &[SymTensor],
+        sym_gen: &mut SymbolGen,
+    ) -> Result<Vec<SymTensor>, InferShapesError> {
+        let [data, k] = inputs else {
+            return Err(InferShapesError::IncorrectInputCount);
+        };
+
+        let Some(data_dims) = data.shape() else {
+            return Ok([
+                SymTensor::unknown("unknown input shape"),
+                SymTensor::unknown("unknown input shape"),
+            ]
+            .into());
+        };
+
+        let ndim = data_dims.len();
+        let axis = resolve_axis(ndim, self.axis.unwrap_or(-1))
+            .map_err(|_| InferShapesError::IncorrectRank)?;
+
+        // `k` is a 1D tensor with one element.
+        let k_val = k
+            .as_vector()
+            .and_then(|v| v.first().cloned())
+            .unwrap_or_else(|| sym_gen.gen_positive());
+
+        let mut out_shape: Vec<SymExpr> = data_dims.collect();
+        out_shape[axis] = k_val;
+
+        let shape = SymTensor::from_shape(out_shape);
+        Ok([shape.clone(), shape].into())
+    }
+}
+
 /// Where operator.
 ///
 /// See <https://onnx.ai/onnx/operators/onnx__Where.html>.
@@ -378,7 +421,7 @@ mod tests {
     use crate::sym_tensor::{SymTensor, sym_elems, sym_shape, sym_vec};
 
     use super::{
-        Concat, ConstantOfShape, DynamicQuantizeLinear, Gather, GatherElements, Range, Where,
+        Concat, ConstantOfShape, DynamicQuantizeLinear, Gather, GatherElements, Range, TopK, Where,
     };
 
     fn extract_shape(mut result: Vec<SymTensor>) -> Vec<SymExpr> {
@@ -567,6 +610,34 @@ mod tests {
             .infer_shapes(&[start, limit, delta], &mut sym_gen)
             .unwrap();
         assert_eq!(result[0], sym_shape!("unknown_1"));
+    }
+
+    #[test]
+    fn test_top_k() {
+        let mut sym_gen = SymbolGen::new();
+
+        // Default axis (-1) with known K.
+        let data = sym_shape!("batch", 16, 32);
+        let k = sym_vec!(5);
+        let op = TopK { axis: None };
+        let result = op.infer_shapes(&[data, k], &mut sym_gen).unwrap();
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0], sym_shape!("batch", 16, 5));
+        assert_eq!(result[1], sym_shape!("batch", 16, 5));
+
+        // Explicit axis.
+        let data = sym_shape!("batch", 16, 32);
+        let k = sym_vec!(5);
+        let op = TopK { axis: Some(0) };
+        let result = op.infer_shapes(&[data, k], &mut sym_gen).unwrap();
+        assert_eq!(result[0], sym_shape!(5, 16, 32));
+
+        // Symbolic K value.
+        let data = sym_shape!("batch", 32);
+        let k = sym_vec!(SymExpr::from("k"));
+        let op = TopK { axis: Some(-1) };
+        let result = op.infer_shapes(&[data, k], &mut sym_gen).unwrap();
+        assert_eq!(result[0], sym_shape!("batch", "k"));
     }
 
     #[test]

--- a/src/ops/reduce.rs
+++ b/src/ops/reduce.rs
@@ -2,6 +2,7 @@ use std::borrow::Cow;
 use std::cmp::Ordering;
 
 use rten_base::num::{Identities, IsNaN, MinMax};
+use rten_shape_inference::ops as shape_ops;
 use rten_simd::SimdOp;
 use rten_tensor;
 use rten_tensor::prelude::*;
@@ -9,7 +10,9 @@ use rten_tensor::{NdTensor, NdTensorView, Tensor, TensorView};
 use rten_vecmath as vecmath;
 
 use crate::buffer_pool::BufferPool;
-use crate::infer_shapes::{InferShapes, InferShapesError, ReductionOp, SymTensor, SymbolGen};
+use crate::infer_shapes::{
+    InferShapes, InferShapesError, ReductionOp, SymTensor, SymbolGen, impl_infer_shapes,
+};
 use crate::operator::{
     InputList, IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType,
     OutputTypeList, OutputTypesContext,
@@ -1191,7 +1194,19 @@ impl Operator for TopK {
             OutputType::Fixed(ValueType::Tensor(DataType::Int32)),
         ]))
     }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        Some(self)
+    }
 }
+
+impl_infer_shapes!(
+    TopK,
+    op,
+    shape_ops::TopK {
+        axis: op.axis.map(|a| a as i32),
+    }
+);
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
TopK produces two outputs (values and indices) both with the same shape as the input but with the `axis` dimension replaced by `K`.