### PR TITLE
Add shape inference for RandomUniform and RandomNormal operators

### DIFF
--- a/rten-shape-inference/src/ops.rs
+++ b/rten-shape-inference/src/ops.rs
@@ -254,6 +254,21 @@ impl InferShapes for GatherElements {
     }
 }
 
+/// Operator which produces a tensor of a fixed shape.
+pub struct FixedShape<'a> {
+    pub shape: &'a [usize],
+}
+
+impl InferShapes for FixedShape<'_> {
+    fn infer_shapes(
+        &self,
+        _inputs: &[SymTensor],
+        _sym_gen: &mut SymbolGen,
+    ) -> Result<Vec<SymTensor>, InferShapesError> {
+        Ok([SymTensor::from_fixed_shape(self.shape)].into())
+    }
+}
+
 /// Range operator.
 ///
 /// See <https://onnx.ai/onnx/operators/onnx__Range.html>.
@@ -421,7 +436,8 @@ mod tests {
     use crate::sym_tensor::{SymTensor, sym_elems, sym_shape, sym_vec};
 
     use super::{
-        Concat, ConstantOfShape, DynamicQuantizeLinear, Gather, GatherElements, Range, TopK, Where,
+        Concat, ConstantOfShape, DynamicQuantizeLinear, FixedShape, Gather, GatherElements, Range,
+        TopK, Where,
     };
 
     fn extract_shape(mut result: Vec<SymTensor>) -> Vec<SymExpr> {
@@ -557,6 +573,19 @@ mod tests {
             .infer_shapes(&[data, indices], &mut sym_gen)
             .unwrap();
         assert_eq!(result[0].ndim(), None);
+    }
+
+    #[test]
+    fn test_fixed_shape() {
+        let mut sym_gen = SymbolGen::new();
+        let op = FixedShape { shape: &[2, 3, 4] };
+        let result = op.infer_shapes(&[], &mut sym_gen).unwrap();
+        assert_eq!(result[0], sym_shape!(2, 3, 4));
+
+        // Zero-dim shape produces a scalar tensor.
+        let op = FixedShape { shape: &[] };
+        let result = op.infer_shapes(&[], &mut sym_gen).unwrap();
+        assert_eq!(result[0], sym_shape!());
     }
 
     #[test]

--- a/src/ops/random.rs
+++ b/src/ops/random.rs
@@ -1,9 +1,10 @@
 use fastrand::Rng;
 use fastrand_contrib::RngExt;
+use rten_shape_inference::ops as shape_ops;
 use rten_tensor::prelude::*;
 use rten_tensor::{Tensor, TensorView};
 
-use crate::infer_shapes::{InferShapes, UnaryOp};
+use crate::infer_shapes::{InferShapes, UnaryOp, impl_infer_shapes};
 use crate::operator::{
     IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType, OutputTypeList,
     OutputTypesContext,
@@ -51,7 +52,17 @@ impl Operator for RandomUniform {
     fn output_types(&self, _ctx: &OutputTypesContext) -> Option<OutputTypeList> {
         Some([OutputType::Fixed(ValueType::Tensor(DataType::Float))].into())
     }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        Some(self)
+    }
 }
+
+impl_infer_shapes!(
+    RandomUniform,
+    op,
+    shape_ops::FixedShape { shape: &op.shape }
+);
 
 #[derive(Debug)]
 pub struct RandomUniformLike {
@@ -146,7 +157,13 @@ impl Operator for RandomNormal {
     fn output_types(&self, _ctx: &OutputTypesContext) -> Option<OutputTypeList> {
         Some([OutputType::Fixed(ValueType::Tensor(DataType::Float))].into())
     }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        Some(self)
+    }
 }
+
+impl_infer_shapes!(RandomNormal, op, shape_ops::FixedShape { shape: &op.shape });
 
 #[derive(Debug)]
 pub struct RandomNormalLike {


### PR DESCRIPTION
Both operators take no inputs and produce a tensor whose shape comes from the `shape` attribute.