### PR TITLE
Add shape inference for NonZero operator

### DIFF
--- a/rten-shape-inference/src/ops.rs
+++ b/rten-shape-inference/src/ops.rs
@@ -256,6 +256,32 @@ impl InferShapes for GatherElements {
     }
 }
 
+/// NonZero operator.
+///
+/// See <https://onnx.ai/onnx/operators/onnx__NonZero.html>.
+pub struct NonZero;
+
+impl InferShapes for NonZero {
+    fn infer_shapes(
+        &self,
+        inputs: &[SymTensor],
+        sym_gen: &mut SymbolGen,
+    ) -> Result<Vec<SymTensor>, InferShapesError> {
+        let [data] = inputs else {
+            return Err(InferShapesError::IncorrectInputCount);
+        };
+
+        // Output is a 2D tensor of shape `(input.ndim(), num_nonzero)`.
+        let first_dim = data
+            .ndim()
+            .map(|n| SymExpr::Value(n as i32))
+            .unwrap_or_else(|| sym_gen.gen_positive());
+        let out_shape = vec![first_dim, sym_gen.gen_positive()];
+
+        Ok([SymTensor::from_shape(out_shape)].into())
+    }
+}
+
 /// Operator which produces a tensor of a fixed shape.
 pub struct FixedShape<'a> {
     pub shape: &'a [usize],
@@ -438,8 +464,8 @@ mod tests {
     use crate::sym_tensor::{SymTensor, sym_elems, sym_shape, sym_vec};
 
     use super::{
-        Concat, ConstantOfShape, DynamicQuantizeLinear, FixedShape, Gather, GatherElements, Range,
-        TopK, Where,
+        Concat, ConstantOfShape, DynamicQuantizeLinear, FixedShape, Gather, GatherElements,
+        NonZero, Range, TopK, Where,
     };
 
     fn extract_shape(mut result: Vec<SymTensor>) -> Vec<SymExpr> {
@@ -588,6 +614,25 @@ mod tests {
         let op = FixedShape { shape: &[] };
         let result = op.infer_shapes(&[], &mut sym_gen).unwrap();
         assert_eq!(result[0], sym_shape!());
+    }
+
+    #[test]
+    fn test_non_zero() {
+        let mut sym_gen = SymbolGen::new();
+
+        // Known input shape, output is 2D with first dim = ndim.
+        let data = sym_shape!("batch", 16, 32);
+        let result = NonZero.infer_shapes(&[data], &mut sym_gen).unwrap();
+        let shape: Vec<_> = result[0].shape().unwrap().collect();
+        assert_eq!(shape.len(), 2);
+        assert_eq!(shape[0], SymExpr::Value(3));
+        assert!(matches!(shape[1], SymExpr::Var(_)));
+
+        // Unknown input shape, output is still 2D.
+        let data = SymTensor::unknown("unknown");
+        let result = NonZero.infer_shapes(&[data], &mut sym_gen).unwrap();
+        let shape: Vec<_> = result[0].shape().unwrap().collect();
+        assert_eq!(shape.len(), 2);
     }
 
     #[test]

--- a/src/ops/reduce.rs
+++ b/src/ops/reduce.rs
@@ -317,7 +317,13 @@ impl Operator for NonZero {
     fn output_types(&self, _ctx: &OutputTypesContext) -> Option<OutputTypeList> {
         Some([OutputType::Fixed(ValueType::Tensor(DataType::Int32))].into())
     }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        Some(self)
+    }
 }
+
+impl_infer_shapes!(NonZero, _op, shape_ops::NonZero);
 
 /// Manages a scratch buffer allocated from a pool.
 struct TempBuffer<'a, T> {


### PR DESCRIPTION
The output is a 2D tensor of shape `(input.ndim(), num_nonzero)`. The first dimension is determined by the input rank; the number of non-zero elements is data-dependent so it is represented as a fresh symbolic dimension.