### PR TITLE
Add shape inference for GridSample operator

### DIFF
--- a/rten-shape-inference/src/ops.rs
+++ b/rten-shape-inference/src/ops.rs
@@ -296,6 +296,48 @@ impl InferShapes for GatherND {
     }
 }
 
+/// GridSample operator.
+///
+/// See <https://onnx.ai/onnx/operators/onnx__GridSample.html>.
+pub struct GridSample;
+
+impl InferShapes for GridSample {
+    fn infer_shapes(
+        &self,
+        inputs: &[SymTensor],
+        _sym_gen: &mut SymbolGen,
+    ) -> Result<Vec<SymTensor>, InferShapesError> {
+        let [data, grid] = inputs else {
+            return Err(InferShapesError::IncorrectInputCount);
+        };
+
+        let Some(data_dims) = data.shape() else {
+            return Ok([SymTensor::unknown("unknown input shape")].into());
+        };
+        let Some(grid_dims) = grid.shape() else {
+            return Ok([SymTensor::unknown("unknown grid shape")].into());
+        };
+
+        // data is (N, C, D1, D2) and grid is (N, D1_out, D2_out, ..., r) where
+        // D1..Dn are the spatial dims.
+        let data_shape: Vec<_> = data_dims.collect();
+        let grid_shape: Vec<_> = grid_dims.collect();
+        if data_shape.len() < 3 || data_shape.len() != grid_shape.len() {
+            return Err(InferShapesError::IncorrectRank);
+        }
+
+        // Output is (N, C, D1_out, D2_out, ...).
+        let spatial_dims = data_shape.len() - 2;
+        let out_shape = data_shape
+            .into_iter()
+            .take(2) // (N, C)
+            .chain(grid_shape.into_iter().skip(1).take(spatial_dims))
+            .collect();
+
+        Ok([SymTensor::from_shape(out_shape)].into())
+    }
+}
+
 /// NonZero operator.
 ///
 /// See <https://onnx.ai/onnx/operators/onnx__NonZero.html>.
@@ -505,7 +547,7 @@ mod tests {
 
     use super::{
         ConstantOfShape, Dropout, DynamicQuantizeLinear, FixedShape, Gather, GatherElements,
-        GatherND, NonZero, Range, TopK, Where,
+        GatherND, GridSample, NonZero, Range, TopK, Where,
     };
 
     #[test]
@@ -683,6 +725,43 @@ mod tests {
         let op = FixedShape { shape: &[] };
         let result = op.infer_shapes(&[], &mut sym_gen).unwrap();
         assert_eq!(result[0], sym_shape!());
+    }
+
+    #[test]
+    fn test_grid_sample() {
+        let mut sym_gen = SymbolGen::new();
+
+        // 2D sampling: data is (N, C, H, W), grid is (N, H_out, W_out, 2).
+        let data = sym_shape!("batch", 3, 224, 224);
+        let grid = sym_shape!("batch", 32, 64, 2);
+        let result = GridSample
+            .infer_shapes(&[data, grid], &mut sym_gen)
+            .unwrap();
+        assert_eq!(result[0], sym_shape!("batch", 3, 32, 64));
+
+        // 1D sampling: data is (N, C, W), grid is (N, W_out, 1).
+        let data = sym_shape!("batch", 3, 224);
+        let grid = sym_shape!("batch", 32, 1);
+        let result = GridSample
+            .infer_shapes(&[data, grid], &mut sym_gen)
+            .unwrap();
+        assert_eq!(result[0], sym_shape!("batch", 3, 32));
+
+        // Unknown input shape.
+        let data = SymTensor::unknown("unknown");
+        let grid = sym_shape!(1, 32, 64, 2);
+        let result = GridSample
+            .infer_shapes(&[data, grid], &mut sym_gen)
+            .unwrap();
+        assert_eq!(result[0].ndim(), None);
+
+        // Wrong rank.
+        let data = sym_shape!(1, 3, 224);
+        let grid = sym_shape!(1, 32, 64, 2);
+        let err = GridSample
+            .infer_shapes(&[data, grid], &mut sym_gen)
+            .unwrap_err();
+        assert_eq!(err, InferShapesError::IncorrectRank);
     }
 
     #[test]

--- a/src/ops/grid_sample.rs
+++ b/src/ops/grid_sample.rs
@@ -1,7 +1,9 @@
+use rten_shape_inference::ops as shape_ops;
 use rten_tensor::prelude::*;
 use rten_tensor::{NdTensor, NdTensorView};
 
 use crate::buffer_pool::BufferPool;
+use crate::infer_shapes::{InferShapes, impl_infer_shapes};
 use crate::operator::{
     IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType, OutputTypeList,
     OutputTypesContext,
@@ -145,7 +147,13 @@ impl Operator for GridSample {
     fn output_types(&self, _ctx: &OutputTypesContext) -> Option<OutputTypeList> {
         Some([OutputType::CopyFromInput(0)].into())
     }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        Some(self)
+    }
 }
+
+impl_infer_shapes!(GridSample, _op, shape_ops::GridSample);
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Shape inference supports any number of spatial dimensions (>= 1), although the operator implementation currently only supports 2D.