### PR TITLE
Add shape inference for NonMaxSuppression operator

### DIFF
--- a/rten-shape-inference/src/ops.rs
+++ b/rten-shape-inference/src/ops.rs
@@ -379,6 +379,23 @@ impl InferShapes for FixedShape<'_> {
     }
 }
 
+/// NonMaxSuppression operator.
+///
+/// See <https://onnx.ai/onnx/operators/onnx__NonMaxSuppression.html>.
+pub struct NonMaxSuppression;
+
+impl InferShapes for NonMaxSuppression {
+    fn infer_shapes(
+        &self,
+        _inputs: &[SymTensor],
+        sym_gen: &mut SymbolGen,
+    ) -> Result<Vec<SymTensor>, InferShapesError> {
+        // Output is `(num_selected, 3)`. `num_selected` is data-dependent.
+        let out_shape = vec![sym_gen.gen_positive(), SymExpr::Value(3)];
+        Ok([SymTensor::from_shape(out_shape)].into())
+    }
+}
+
 /// Range operator.
 ///
 /// See <https://onnx.ai/onnx/operators/onnx__Range.html>.
@@ -547,7 +564,7 @@ mod tests {
 
     use super::{
         ConstantOfShape, Dropout, DynamicQuantizeLinear, FixedShape, Gather, GatherElements,
-        GatherND, GridSample, NonZero, Range, TopK, Where,
+        GatherND, GridSample, NonMaxSuppression, NonZero, Range, TopK, Where,
     };
 
     #[test]
@@ -781,6 +798,22 @@ mod tests {
         let result = NonZero.infer_shapes(&[data], &mut sym_gen).unwrap();
         let shape: Vec<_> = result[0].shape().unwrap().collect();
         assert_eq!(shape.len(), 2);
+    }
+
+    #[test]
+    fn test_non_max_suppression() {
+        let mut sym_gen = SymbolGen::new();
+
+        // Output is `(num_selected, 3)` with a symbolic first dim.
+        let boxes = sym_shape!(1, 100, 4);
+        let scores = sym_shape!(1, 80, 100);
+        let result = NonMaxSuppression
+            .infer_shapes(&[boxes, scores], &mut sym_gen)
+            .unwrap();
+        let shape: Vec<_> = result[0].shape().unwrap().collect();
+        assert_eq!(shape.len(), 2);
+        assert!(matches!(shape[0], SymExpr::Var(_)));
+        assert_eq!(shape[1], SymExpr::Value(3));
     }
 
     #[test]

--- a/src/ops/non_max_suppression.rs
+++ b/src/ops/non_max_suppression.rs
@@ -1,7 +1,9 @@
+use rten_shape_inference::ops as shape_ops;
 use rten_tensor::prelude::*;
 use rten_tensor::{NdTensor, NdTensorView};
 
 use crate::buffer_pool::BufferPool;
+use crate::infer_shapes::{InferShapes, impl_infer_shapes};
 use crate::operator::{
     IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType, OutputTypeList,
     OutputTypesContext,
@@ -224,7 +226,13 @@ impl Operator for NonMaxSuppression {
     fn output_types(&self, _ctx: &OutputTypesContext) -> Option<OutputTypeList> {
         Some([OutputType::Fixed(ValueType::Tensor(DataType::Int32))].into())
     }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        Some(self)
+    }
 }
+
+impl_infer_shapes!(NonMaxSuppression, _op, shape_ops::NonMaxSuppression);
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
The output is a 2D tensor of shape `(num_selected, 3)` where `num_selected` is data-dependent and is represented by a fresh symbol. The second dimension (batch_idx, class_idx, box_idx) is fixed at 3.