### PR TITLE
Add shape inference for Einsum operator

### DIFF
--- a/rten-shape-inference/src/einsum_parser.rs
+++ b/rten-shape-inference/src/einsum_parser.rs
@@ -17,6 +17,9 @@ pub enum ParseError {
     InvalidOutputTerm,
     /// The output term contains a repeated label.
     RepeatedOutputLabels,
+    /// The output term contains a label which does not appear in any input
+    /// term.
+    UnknownOutputLabel,
 }
 
 impl ParseError {
@@ -27,6 +30,9 @@ impl ParseError {
             ParseError::InvalidInputTerm => "Input term is invalid",
             ParseError::InvalidOutputTerm => "Output term is invalid",
             ParseError::RepeatedOutputLabels => "Einsum output term contains repeated labels",
+            ParseError::UnknownOutputLabel => {
+                "Einsum output term contains a label not present in any input term"
+            }
         }
     }
 }
@@ -84,6 +90,12 @@ impl EinsumExpr {
         }
         if contains_repeated_chars(&output) {
             return Err(ParseError::RepeatedOutputLabels);
+        }
+        if output
+            .chars()
+            .any(|c| c.is_ascii_lowercase() && !inputs.iter().any(|term| term.contains(c)))
+        {
+            return Err(ParseError::UnknownOutputLabel);
         }
 
         Ok(EinsumExpr { inputs, output })
@@ -353,6 +365,11 @@ mod tests {
             Case {
                 equation: "ij->ii",
                 expected: Err(ParseError::RepeatedOutputLabels),
+            },
+            // Output label which does not appear in any input term.
+            Case {
+                equation: "ij->ik",
+                expected: Err(ParseError::UnknownOutputLabel),
             },
         ];
 

--- a/rten-shape-inference/src/einsum_parser.rs
+++ b/rten-shape-inference/src/einsum_parser.rs
@@ -1,0 +1,537 @@
+//! Parser for Einsum equations.
+
+use std::error::Error;
+use std::fmt;
+
+/// Error produced when parsing an invalid Einsum equation with
+/// [`EinsumExpr::parse`].
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ParseError {
+    /// The equation has no input terms (the left-hand side is empty).
+    NoInputTerms,
+    /// An input term contains characters other than lowercase ASCII letters
+    /// or more than one ellipsis (`...`).
+    InvalidInputTerm,
+    /// The output term contains characters other than lowercase ASCII letters
+    /// or more than one ellipsis (`...`).
+    InvalidOutputTerm,
+    /// The output term contains a repeated label.
+    RepeatedOutputLabels,
+}
+
+impl ParseError {
+    /// Return a human-readable description of the error.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ParseError::NoInputTerms => "Einsum equation must have at least one term",
+            ParseError::InvalidInputTerm => "Input term is invalid",
+            ParseError::InvalidOutputTerm => "Output term is invalid",
+            ParseError::RepeatedOutputLabels => "Einsum output term contains repeated labels",
+        }
+    }
+}
+
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl Error for ParseError {}
+
+/// A parsed equation for an Einsum operator.
+///
+/// Einsum expressions have the form `abc,def,...->xyz` where the `->xyz` part
+/// is optional. If omitted, it is inferred as the alphabetically ordered set of
+/// letters from the left hand side that do not repeat.
+///
+/// See <https://onnx.ai/onnx/operators/onnx__Einsum.html>.
+#[derive(Clone, Debug, PartialEq)]
+pub struct EinsumExpr {
+    /// Terms describing the dimension labels of each input.
+    pub inputs: Vec<String>,
+    /// Term describing the dimension labels of the output.
+    pub output: String,
+}
+
+impl EinsumExpr {
+    /// Parse an Einsum expression.
+    ///
+    /// The expression must contain at least one input term.
+    pub fn parse(expr: &str) -> Result<EinsumExpr, ParseError> {
+        let mut parts = expr.trim().splitn(2, "->").map(|part| part.trim());
+
+        let lhs = match parts.next() {
+            Some(lhs) if !lhs.is_empty() => lhs,
+            _ => return Err(ParseError::NoInputTerms),
+        };
+
+        let inputs: Vec<String> = lhs
+            .split(',')
+            .map(|term| non_whitespace_chars(term).collect())
+            .collect();
+        if inputs.iter().any(|term| !is_valid_term(term)) {
+            return Err(ParseError::InvalidInputTerm);
+        }
+
+        let output: String = match parts.next() {
+            Some(rhs) => non_whitespace_chars(rhs).collect(),
+            None => default_output(&inputs),
+        };
+
+        if !is_valid_term(&output) {
+            return Err(ParseError::InvalidOutputTerm);
+        }
+        if contains_repeated_chars(&output) {
+            return Err(ParseError::RepeatedOutputLabels);
+        }
+
+        Ok(EinsumExpr { inputs, output })
+    }
+
+    /// Return the dimensions in the expression which are summed over.
+    pub fn reduced_dims(&self) -> Vec<char> {
+        let mut terms = Vec::new();
+        for in_term in &self.inputs {
+            for in_ch in in_term.chars() {
+                if !terms.contains(&in_ch) && !self.output.contains(in_ch) {
+                    terms.push(in_ch);
+                }
+            }
+        }
+        terms
+    }
+
+    /// Check operator inputs are compatible with the parsed equation and
+    /// calculate the number of dimensions represented by `...` in input terms.
+    ///
+    /// Returns the number of dimensions represented by `...` in input terms.
+    pub fn validate_inputs(
+        &self,
+        input_ndims: impl ExactSizeIterator<Item = Option<usize>>,
+    ) -> Result<usize, ValidateError> {
+        if input_ndims.len() != self.inputs.len() {
+            return Err(ValidateError::IncorrectInputCount);
+        }
+
+        let mut broadcast_ndim = None;
+        for (term, ndim) in self.inputs.iter().zip(input_ndims) {
+            let has_ellipsis = term.contains("...");
+            let Some(ndim) = ndim else {
+                // Without the rank we can neither rank-check a non-ellipsis
+                // term nor count an ellipsis term's broadcast dimensions.
+                if has_ellipsis {
+                    return Err(ValidateError::UnknownRank);
+                }
+                continue;
+            };
+
+            // `term` contains at most one "..." occurrence (validated during
+            // parsing). For an ellipsis term the remaining labels are the
+            // non-broadcast dimensions, and the input may have additional dims
+            // which the ellipsis stands for. A term without an ellipsis must
+            // have exactly one label per dimension.
+            let non_broadcast = if has_ellipsis {
+                term.len() - "...".len()
+            } else {
+                term.len()
+            };
+            let rank_ok = if has_ellipsis {
+                ndim >= non_broadcast
+            } else {
+                ndim == non_broadcast
+            };
+            if !rank_ok {
+                return Err(ValidateError::RankMismatch);
+            }
+
+            if ndim > MAX_DIMS {
+                return Err(ValidateError::TooManyDims);
+            }
+
+            if has_ellipsis {
+                let this_broadcast = ndim - non_broadcast;
+                match broadcast_ndim {
+                    None => broadcast_ndim = Some(this_broadcast),
+                    Some(b) if b == this_broadcast => {}
+                    Some(_) => return Err(ValidateError::BroadcastMismatch),
+                }
+            }
+        }
+        Ok(broadcast_ndim.unwrap_or(0))
+    }
+}
+
+/// Error produced by [`EinsumExpr::validate_inputs`].
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ValidateError {
+    /// The number of inputs does not match the number of input terms in the
+    /// equation.
+    IncorrectInputCount,
+    /// An input term contains an ellipsis but the corresponding input's rank is
+    /// unknown, so the broadcast count cannot be determined.
+    UnknownRank,
+    /// An input's rank is incompatible with its term.
+    RankMismatch,
+    /// An input has more than [`MAX_DIMS`] dimensions.
+    TooManyDims,
+    /// Inputs whose terms contain an ellipsis disagree on the number of
+    /// dimensions the ellipsis represents.
+    BroadcastMismatch,
+}
+
+/// Compute the default output term for an equation with no explicit `->` part.
+///
+/// The default consists of (1) the broadcast (ellipsis) dimensions if any input
+/// has an ellipsis, followed by (2) the lowercase-letter labels which appear
+/// exactly once across all input terms, in alphabetical order.
+fn default_output(inputs: &[String]) -> String {
+    const N_LETTERS: usize = 26;
+
+    // Count occurrences of each lowercase ASCII letter.
+    let mut char_count = [0; N_LETTERS];
+    for ch in inputs
+        .iter()
+        .flat_map(|term| term.chars().filter(|c| c.is_ascii_lowercase()))
+    {
+        char_count[(ch as u8 - b'a') as usize] += 1;
+    }
+
+    // Generate output as the ellipsis (if any) followed by alphabetically
+    // ordered letters which appear only once in the input.
+    let mut output = String::with_capacity(N_LETTERS);
+    if inputs.iter().any(|term| term.contains("...")) {
+        output.push_str("...");
+    }
+    for i in 0..N_LETTERS as u8 {
+        if char_count[i as usize] == 1 {
+            output.push((b'a' + i) as char);
+        }
+    }
+    output
+}
+
+/// Return true if `term` is a valid sequence of dimension labels: lowercase
+/// ASCII letters with at most one ellipsis (`...`).
+fn is_valid_term(term: &str) -> bool {
+    if let Some((lhs, rhs)) = term.split_once("...") {
+        is_valid_term(lhs) && !rhs.contains("...") && is_valid_term(rhs)
+    } else {
+        term.chars().all(|c| c.is_ascii_lowercase())
+    }
+}
+
+/// Maximum number of dimensions an ellipsis (`...`) can represent.
+///
+/// [`expand_ellipsis`] replaces an ellipsis with single ASCII digits
+/// (`'0'..='9'`) used as placeholder labels, which limits the count to 10.
+pub const MAX_DIMS: usize = 10;
+
+/// Replace an ellipsis representing a fixed number of dimensions with a sequence
+/// of digit labels.
+///
+/// Digits are used because they are not allowed as dimension labels in input
+/// Einsum equations.
+///
+/// eg. `expand_ellipsis("i...j", 3)` returns `"i012j"`.
+pub fn expand_ellipsis(term: &str, broadcast_ndim: usize) -> String {
+    assert!(broadcast_ndim <= MAX_DIMS);
+    if let Some((lhs, rhs)) = term.split_once("...") {
+        lhs.chars()
+            .chain((0..broadcast_ndim as u8).map(|i| (b'0' + i) as char))
+            .chain(rhs.chars())
+            .collect()
+    } else {
+        term.to_string()
+    }
+}
+
+fn non_whitespace_chars(s: &str) -> impl Iterator<Item = char> + '_ {
+    s.chars().filter(|c| !c.is_ascii_whitespace())
+}
+
+fn contains_repeated_chars(term: &str) -> bool {
+    term.chars()
+        .filter(|c| *c != '.')
+        .any(|c1| term.chars().filter(|c2| c1 == *c2).count() > 1)
+}
+
+#[cfg(test)]
+mod tests {
+    use rten_testing::TestCases;
+
+    use super::{EinsumExpr, ParseError, ValidateError, expand_ellipsis};
+
+    fn expr(inputs: &[&str], output: &str) -> EinsumExpr {
+        EinsumExpr {
+            inputs: inputs.iter().map(|s| s.to_string()).collect(),
+            output: output.to_string(),
+        }
+    }
+
+    #[test]
+    fn test_parse() {
+        #[derive(Debug)]
+        struct Case<'a> {
+            equation: &'a str,
+            expected: Result<EinsumExpr, ParseError>,
+        }
+
+        let cases = [
+            // Explicit output.
+            Case {
+                equation: "ij->ij",
+                expected: Ok(expr(&["ij"], "ij")),
+            },
+            // Transpose.
+            Case {
+                equation: "ij->ji",
+                expected: Ok(expr(&["ij"], "ji")),
+            },
+            // Multiple input terms.
+            Case {
+                equation: "ij,jk->ik",
+                expected: Ok(expr(&["ij", "jk"], "ik")),
+            },
+            // Whitespace is stripped from terms.
+            Case {
+                equation: " i j , j k -> i k ",
+                expected: Ok(expr(&["ij", "jk"], "ik")),
+            },
+            // Implicit output: unique labels in alphabetical order, repeated
+            // labels (j) dropped.
+            Case {
+                equation: "ij,jk",
+                expected: Ok(expr(&["ij", "jk"], "ik")),
+            },
+            // Implicit output with an ellipsis: "..." is prepended.
+            Case {
+                equation: "...ij",
+                expected: Ok(expr(&["...ij"], "...ij")),
+            },
+            // Implicit output that reduces every label to a scalar.
+            Case {
+                equation: "i,i",
+                expected: Ok(expr(&["i", "i"], "")),
+            },
+            // Ellipsis in input and output terms.
+            Case {
+                equation: "...ij->...ji",
+                expected: Ok(expr(&["...ij"], "...ji")),
+            },
+            // Empty equation.
+            Case {
+                equation: "",
+                expected: Err(ParseError::NoInputTerms),
+            },
+            // Whitespace-only equation.
+            Case {
+                equation: "  ",
+                expected: Err(ParseError::NoInputTerms),
+            },
+            // Upper-case letters in an input term.
+            Case {
+                equation: "IJ,JK",
+                expected: Err(ParseError::InvalidInputTerm),
+            },
+            // A period that is not part of an ellipsis.
+            Case {
+                equation: "i.j",
+                expected: Err(ParseError::InvalidInputTerm),
+            },
+            // More than one ellipsis in a term.
+            Case {
+                equation: "i...j...",
+                expected: Err(ParseError::InvalidInputTerm),
+            },
+            // Invalid output term.
+            Case {
+                equation: "ij,jk->IK",
+                expected: Err(ParseError::InvalidOutputTerm),
+            },
+            // Repeated labels in the output term.
+            Case {
+                equation: "ij->ii",
+                expected: Err(ParseError::RepeatedOutputLabels),
+            },
+        ];
+
+        cases.test_each(|case| {
+            assert_eq!(EinsumExpr::parse(case.equation), case.expected);
+        });
+    }
+
+    #[test]
+    fn test_reduced_dims() {
+        #[derive(Debug)]
+        struct Case<'a> {
+            equation: &'a str,
+            reduced: Vec<char>,
+        }
+
+        let cases = [
+            // Matmul reduces the shared `j` label.
+            Case {
+                equation: "ij,jk->ik",
+                reduced: vec!['j'],
+            },
+            // Nothing is reduced for a transpose.
+            Case {
+                equation: "ij->ji",
+                reduced: vec![],
+            },
+            // All labels are reduced for a full reduction.
+            Case {
+                equation: "ij->",
+                reduced: vec!['i', 'j'],
+            },
+            // Labels only count once even if they appear in multiple inputs.
+            Case {
+                equation: "ij,ij->",
+                reduced: vec!['i', 'j'],
+            },
+        ];
+
+        cases.test_each(|case| {
+            let expr = EinsumExpr::parse(case.equation).unwrap();
+            assert_eq!(expr.reduced_dims(), case.reduced);
+        });
+    }
+
+    #[test]
+    fn test_validate_inputs() {
+        #[derive(Debug)]
+        struct Case<'a> {
+            equation: &'a str,
+            input_ndims: &'a [Option<usize>],
+            expected: Result<usize, ValidateError>,
+        }
+
+        let cases = [
+            // No ellipsis: broadcast count is zero when ranks match the terms.
+            Case {
+                equation: "ij,jk->ik",
+                input_ndims: &[Some(2), Some(2)],
+                expected: Ok(0),
+            },
+            // A non-ellipsis term must have one label per input dimension.
+            Case {
+                equation: "ij,jk->ik",
+                input_ndims: &[Some(2), Some(3)],
+                expected: Err(ValidateError::RankMismatch),
+            },
+            // A single ellipsis input determines the count.
+            Case {
+                equation: "...ij->...ji",
+                input_ndims: &[Some(4)],
+                expected: Ok(2),
+            },
+            // Multiple ellipsis inputs which agree.
+            Case {
+                equation: "...ij,...jk->...ik",
+                input_ndims: &[Some(4), Some(4)],
+                expected: Ok(2),
+            },
+            // Ellipsis standing for zero dimensions.
+            Case {
+                equation: "...ij->...ij",
+                input_ndims: &[Some(2)],
+                expected: Ok(0),
+            },
+            // Unknown rank for an ellipsis input.
+            Case {
+                equation: "...ij->...ji",
+                input_ndims: &[None],
+                expected: Err(ValidateError::UnknownRank),
+            },
+            // Unknown rank for a non-ellipsis input doesn't matter.
+            Case {
+                equation: "...ij,jk->...ik",
+                input_ndims: &[Some(3), None],
+                expected: Ok(1),
+            },
+            // Input has fewer dims than its ellipsis term's non-ellipsis labels.
+            Case {
+                equation: "...ij->...ji",
+                input_ndims: &[Some(1)],
+                expected: Err(ValidateError::RankMismatch),
+            },
+            // Ellipsis inputs disagree on the broadcast count.
+            Case {
+                equation: "...,...->...",
+                input_ndims: &[Some(1), Some(2)],
+                expected: Err(ValidateError::BroadcastMismatch),
+            },
+            // Number of inputs doesn't match the number of terms.
+            Case {
+                equation: "ij,jk->ik",
+                input_ndims: &[Some(2)],
+                expected: Err(ValidateError::IncorrectInputCount),
+            },
+            // An input has more than `MAX_DIMS` dimensions (non-ellipsis term).
+            Case {
+                equation: "abcdefghijk",
+                input_ndims: &[Some(11)],
+                expected: Err(ValidateError::TooManyDims),
+            },
+            // An input has more than `MAX_DIMS` dimensions (ellipsis term).
+            Case {
+                equation: "...",
+                input_ndims: &[Some(11)],
+                expected: Err(ValidateError::TooManyDims),
+            },
+        ];
+
+        cases.test_each(|case| {
+            let expr = EinsumExpr::parse(case.equation).unwrap();
+            assert_eq!(
+                expr.validate_inputs(case.input_ndims.iter().copied()),
+                case.expected
+            );
+        });
+    }
+
+    #[test]
+    fn test_expand_ellipsis() {
+        #[derive(Debug)]
+        struct Case<'a> {
+            term: &'a str,
+            broadcast_ndim: usize,
+            expected: &'a str,
+        }
+
+        let cases = [
+            // Ellipsis between labels expands to digit placeholders.
+            Case {
+                term: "i...j",
+                broadcast_ndim: 3,
+                expected: "i012j",
+            },
+            // An ellipsis standing for zero dimensions is removed.
+            Case {
+                term: "i...j",
+                broadcast_ndim: 0,
+                expected: "ij",
+            },
+            // A term with no ellipsis is unchanged.
+            Case {
+                term: "ij",
+                broadcast_ndim: 2,
+                expected: "ij",
+            },
+            // Leading ellipsis.
+            Case {
+                term: "...ij",
+                broadcast_ndim: 2,
+                expected: "01ij",
+            },
+        ];
+
+        cases.test_each(|case| {
+            assert_eq!(
+                expand_ellipsis(case.term, case.broadcast_ndim),
+                case.expected
+            );
+        });
+    }
+}

--- a/rten-shape-inference/src/lib.rs
+++ b/rten-shape-inference/src/lib.rs
@@ -60,6 +60,7 @@
 //! named symbols, or composite expressions involving these. Values are
 //! represented by [`SymTensor`] and expressions by [`SymExpr`].
 
+pub mod einsum_parser;
 mod infer_shapes;
 pub mod ops;
 mod sym_expr;

--- a/rten-shape-inference/src/ops.rs
+++ b/rten-shape-inference/src/ops.rs
@@ -11,6 +11,7 @@ use crate::sym_tensor::{Constant, SymTensor};
 mod binary;
 mod concat;
 mod conv_pool;
+mod einsum;
 mod generate;
 mod layout;
 mod matmul;
@@ -24,6 +25,7 @@ mod unary;
 pub use binary::{Add, Div, Equal, Mul, Sub};
 pub use concat::{Concat, Tile};
 pub use conv_pool::{Conv, ConvTranspose, GlobalPool, Padding, Pool};
+pub use einsum::Einsum;
 pub use generate::OneHot;
 pub use layout::{
     DepthToSpace, Expand, Flatten, Reshape, Shape, Size, Squeeze, Transpose, Unsqueeze,

--- a/rten-shape-inference/src/ops/einsum.rs
+++ b/rten-shape-inference/src/ops/einsum.rs
@@ -1,0 +1,202 @@
+use crate::einsum_parser::{EinsumExpr, ValidateError, expand_ellipsis};
+use crate::infer_shapes::{InferShapes, InferShapesError};
+use crate::sym_expr::SymExpr;
+use crate::sym_gen::SymbolGen;
+use crate::sym_tensor::SymTensor;
+
+/// Einsum operator.
+///
+/// See <https://onnx.ai/onnx/operators/onnx__Einsum.html>.
+pub struct Einsum<'a> {
+    pub equation: &'a str,
+}
+
+impl InferShapes for Einsum<'_> {
+    fn infer_shapes(
+        &self,
+        inputs: &[SymTensor],
+        sym_gen: &mut SymbolGen,
+    ) -> Result<Vec<SymTensor>, InferShapesError> {
+        let Ok(expr) = EinsumExpr::parse(self.equation) else {
+            return Err(InferShapesError::InvalidValue);
+        };
+
+        // Validate the inputs and determine the number of dimensions
+        // represented by `...` across inputs which contain an ellipsis.
+        let broadcast_ndim = match expr.validate_inputs(inputs.iter().map(|input| input.ndim())) {
+            Ok(n) => n,
+            // We can't determine the rank of the output without knowing the
+            // rank of an ellipsis input.
+            Err(ValidateError::UnknownRank) => {
+                return Ok([SymTensor::unknown("unknown einsum input shape")].into());
+            }
+            Err(ValidateError::IncorrectInputCount) => {
+                return Err(InferShapesError::IncorrectInputCount);
+            }
+            Err(ValidateError::RankMismatch) => return Err(InferShapesError::IncorrectRank),
+            Err(ValidateError::TooManyDims) => return Err(InferShapesError::InvalidValue),
+            Err(ValidateError::BroadcastMismatch) => {
+                return Err(InferShapesError::IncompatibleShapes);
+            }
+        };
+
+        // Expand "..." in each input and output term to digit placeholders.
+        let expanded_inputs: Vec<String> = expr
+            .inputs
+            .iter()
+            .map(|t| expand_ellipsis(t, broadcast_ndim))
+            .collect();
+        let expanded_output = expand_ellipsis(&expr.output, broadcast_ndim);
+
+        let out_shape: Vec<SymExpr> = expanded_output
+            .chars()
+            .map(|output_ch| {
+                let mut out_dim: Option<SymExpr> = None;
+                for (term, input) in expanded_inputs.iter().zip(inputs) {
+                    let Some(dims) = input.shape() else {
+                        continue;
+                    };
+                    debug_assert_eq!(term.chars().count(), dims.len());
+                    for (ch, dim) in term.chars().zip(dims) {
+                        if ch != output_ch {
+                            continue;
+                        }
+                        if let Some(out_dim) = out_dim.as_mut() {
+                            *out_dim = out_dim.broadcast(&dim);
+                        } else {
+                            out_dim = Some(dim);
+                        }
+                    }
+                }
+                out_dim.unwrap_or(sym_gen.gen_positive())
+            })
+            .collect();
+
+        Ok([SymTensor::from_shape(out_shape)].into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rten_testing::TestCases;
+
+    use crate::infer_shapes::InferShapes;
+    use crate::sym_expr::SymExpr;
+    use crate::sym_gen::SymbolGen;
+    use crate::sym_tensor::{SymTensor, sym_shape};
+
+    use super::Einsum;
+
+    fn infer(equation: &str, inputs: &[SymTensor]) -> SymTensor {
+        let mut sym_gen = SymbolGen::new();
+        Einsum { equation }
+            .infer_shapes(inputs, &mut sym_gen)
+            .unwrap()
+            .remove(0)
+            // Simplify broadcasts in shape expression.
+            .simplify()
+    }
+
+    #[test]
+    fn test_einsum() {
+        #[derive(Debug)]
+        struct Case<'a> {
+            equation: &'a str,
+            inputs: Vec<SymTensor>,
+            expected: SymTensor,
+        }
+
+        let cases = [
+            // Identity.
+            Case {
+                equation: "ij->ij",
+                inputs: vec![sym_shape!(2, 3)],
+                expected: sym_shape!(2, 3),
+            },
+            // Transpose.
+            Case {
+                equation: "ij->ji",
+                inputs: vec![sym_shape!(2, 3)],
+                expected: sym_shape!(3, 2),
+            },
+            // No `->`: implicit output is the alphabetically-sorted set of
+            // unique labels (here "ik" — j is repeated and so dropped).
+            Case {
+                equation: "ij,jk",
+                inputs: vec![sym_shape!(2, 3), sym_shape!(3, 4)],
+                expected: sym_shape!(2, 4),
+            },
+            // Matmul.
+            Case {
+                equation: "ij,jk->ik",
+                inputs: vec![sym_shape!("M", "K"), sym_shape!("K", "N")],
+                expected: sym_shape!("M", "N"),
+            },
+            // Reduction.
+            Case {
+                equation: "ij->i",
+                inputs: vec![sym_shape!("M", "N")],
+                expected: sym_shape!("M"),
+            },
+            // Diagonal of a square matrix.
+            Case {
+                equation: "ii->i",
+                inputs: vec![sym_shape!(4, 4)],
+                expected: sym_shape!(4),
+            },
+            // Scalar output.
+            Case {
+                equation: "i,i->",
+                inputs: vec![sym_shape!(4), sym_shape!(4)],
+                expected: sym_shape!(),
+            },
+            // `...ij->...ji` — ellipsis stands for leading batch dims; the
+            // trailing two dims are transposed.
+            Case {
+                equation: "...ij->...ji",
+                inputs: vec![sym_shape!("A", "B", 3, 4)],
+                expected: sym_shape!("A", "B", 4, 3),
+            },
+            // No `->` and inputs have ellipsis: implicit output is `...` plus
+            // sorted unique letters.
+            Case {
+                equation: "...ij",
+                inputs: vec![sym_shape!(2, "I", "J")],
+                expected: sym_shape!(2, "I", "J"),
+            },
+            // Outer product.
+            Case {
+                equation: "i,j->ij",
+                inputs: vec![sym_shape!(4), sym_shape!(5)],
+                expected: sym_shape!(4, 5),
+            },
+        ];
+
+        cases.test_each(|case| {
+            assert_eq!(infer(case.equation, &case.inputs), case.expected);
+        });
+    }
+
+    #[test]
+    fn test_einsum_unknown_input_shape() {
+        // Without ellipsis, an unknown input doesn't prevent us from
+        // determining the rank when other inputs cover the output labels.
+        let a = sym_shape!("M", "K");
+        let b = SymTensor::unknown("unknown");
+        let result = infer("ij,jk->ik", &[a, b]);
+        let shape: Vec<_> = result.shape().unwrap().collect();
+        assert_eq!(shape.len(), 2);
+        assert_eq!(shape[0], SymExpr::from("M"));
+        // The size for 'k' isn't known.
+        assert!(matches!(shape[1], SymExpr::Var(_)));
+    }
+
+    #[test]
+    fn test_einsum_unknown_ellipsis_input() {
+        // When the operand expanding `...` has unknown rank, the output
+        // shape is reported as unknown.
+        let x = SymTensor::unknown("unknown");
+        let result = infer("...ij->...ji", &[x]);
+        assert_eq!(result.ndim(), None);
+    }
+}

--- a/src/ops/einsum.rs
+++ b/src/ops/einsum.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
 
 use rten_base::num::AsUsize;
+use rten_shape_inference::einsum_parser::{EinsumExpr, ValidateError, expand_ellipsis};
+use rten_shape_inference::ops as shape_ops;
 use rten_tensor::layout::{MutLayout, OverlapPolicy};
 use rten_tensor::prelude::*;
 use rten_tensor::{Contiguous, DynLayout, Tensor, TensorView};
@@ -8,126 +10,13 @@ use rten_tensor::{Contiguous, DynLayout, Tensor, TensorView};
 use smallvec::SmallVec;
 
 use crate::buffer_pool::{AutoReturn, BufferPool, PoolRef};
+use crate::infer_shapes::{InferShapes, impl_infer_shapes};
 use crate::operator::{
     IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType, OutputTypeList,
     OutputTypesContext,
 };
 use crate::ops::layout::expand_to;
 use crate::ops::{matmul, mul, reduce_sum};
-
-/// A parsed equation for an Einsum operator.
-///
-/// Einsum expressions have the form `abc,def,...->xyz` where the `->xyz` part
-/// is optional. If ommitted, it is inferred as the alphabetically ordered
-/// set of letters from the left hand side that do not repeat.
-struct EinsumExpr {
-    inputs: Vec<String>,
-    output: String,
-}
-
-impl EinsumExpr {
-    /// Parse an [Einsum expression][einsum].
-    ///
-    /// The expression must contain at least one input term.
-    ///
-    /// [einsum]: https://onnx.ai/onnx/operators/onnx__Einsum.html
-    fn parse(expr: &str) -> Result<EinsumExpr, OpError> {
-        let mut parts = expr.trim().splitn(2, "->").map(|part| part.trim());
-
-        let lhs = match parts.next() {
-            Some(lhs) if !lhs.is_empty() => lhs,
-            _ => {
-                return Err(OpError::InvalidValue(
-                    "Einsum equation must have at least one term",
-                ));
-            }
-        };
-
-        let inputs: Vec<String> = lhs
-            .split(',')
-            .map(|term| non_whitespace_chars(term).collect())
-            .collect();
-        if inputs.iter().any(|term| !is_valid_einsum_term(term)) {
-            return Err(OpError::InvalidValue("Input term is invalid"));
-        }
-
-        let output: String = match parts.next() {
-            Some(rhs) => non_whitespace_chars(rhs).collect(),
-            None => {
-                const N_LETTERS: usize = 26;
-
-                // Count occurences of each lowercase ASCII letter.
-                let mut char_count = [0; N_LETTERS];
-                for ch in inputs
-                    .iter()
-                    .flat_map(|term| term.chars().filter(|c| c.is_ascii_lowercase()))
-                {
-                    let ascii_idx = ch as u8 - b'a';
-                    char_count[ascii_idx.as_usize()] += 1;
-                }
-
-                // Generate output as sequence of alphabetically ordered
-                // letters which appear only once in the input.
-                let mut output = String::with_capacity(N_LETTERS);
-
-                if inputs.iter().any(|term| term.contains("...")) {
-                    output.push_str("...");
-                }
-
-                for i in 0..N_LETTERS as u8 {
-                    if char_count[i.as_usize()] == 1 {
-                        let ascii_ch = b'a' + i;
-                        output.push(ascii_ch as char);
-                    }
-                }
-
-                output
-            }
-        };
-
-        if !is_valid_einsum_term(&output) {
-            return Err(OpError::InvalidValue("Output term is invalid"));
-        }
-        if contains_repeated_chars(&output) {
-            return Err(OpError::InvalidValue(
-                "Einsum output term contains repeated labels",
-            ));
-        }
-
-        Ok(EinsumExpr { inputs, output })
-    }
-
-    /// Return the dimensions in the expression which are summed over.
-    fn reduced_dims(&self) -> Vec<char> {
-        let mut terms = Vec::new();
-        for in_term in &self.inputs {
-            for in_ch in in_term.chars() {
-                if !terms.contains(&in_ch) && !self.output.contains(in_ch) {
-                    terms.push(in_ch);
-                }
-            }
-        }
-        terms
-    }
-}
-
-fn is_valid_einsum_term(term: &str) -> bool {
-    if let Some((lhs, rhs)) = term.split_once("...") {
-        is_valid_einsum_term(lhs) && !rhs.contains("...") && is_valid_einsum_term(rhs)
-    } else {
-        term.chars().all(|c| c.is_ascii_lowercase())
-    }
-}
-
-fn non_whitespace_chars(s: &str) -> impl Iterator<Item = char> + '_ {
-    s.chars().filter(|c| !c.is_ascii_whitespace())
-}
-
-fn contains_repeated_chars(term: &str) -> bool {
-    term.chars()
-        .filter(|c| *c != '.')
-        .any(|c1| term.chars().filter(|c2| c1 == *c2).count() > 1)
-}
 
 #[derive(Debug)]
 pub struct Einsum {
@@ -155,61 +44,48 @@ impl Operator for Einsum {
     fn output_types(&self, _ctx: &OutputTypesContext) -> Option<OutputTypeList> {
         Some([OutputType::CopyFromInput(0)].into())
     }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        Some(self)
+    }
 }
+
+impl_infer_shapes!(
+    Einsum,
+    op,
+    shape_ops::Einsum {
+        equation: &op.equation,
+    }
+);
 
 pub fn einsum(
     pool: &BufferPool,
     inputs: &[TensorView],
     equation_str: &str,
 ) -> Result<Tensor, OpError> {
-    let equation = EinsumExpr::parse(equation_str)?;
-    if equation.inputs.len() != inputs.len() {
-        return Err(OpError::InvalidValue(
-            "Number of terms in Einsum equation does not match input tensor count",
-        ));
-    }
+    let equation =
+        EinsumExpr::parse(equation_str).map_err(|err| OpError::InvalidValue(err.as_str()))?;
 
-    // Maximum number of dimensions allowed. This value is chosen to make it
-    // easy to use single digits to represent broadcasting dimensions in terms.
-    const MAX_DIMS: usize = 10;
-
-    // Number of dimensions represented by "..." in equation. This must be the
-    // same for every term.
-    let mut broadcast_ndim = None;
-    for (term, view) in equation.inputs.iter().zip(inputs) {
-        let non_broadcast_ndim = term.split("...").fold(0, |len, term| len + term.len());
-        if view.ndim() < non_broadcast_ndim {
-            return Err(OpError::InvalidValue(
-                "Einsum term dimension count does not match input tensor",
-            ));
-        }
-        if non_broadcast_ndim > MAX_DIMS || view.ndim() > MAX_DIMS {
-            return Err(OpError::UnsupportedValue(
-                "Einsum input or term has too many dimensions",
-            ));
-        }
-
-        if term.contains("...") {
-            let new_broadcast_ndim = (view.ndim() - non_broadcast_ndim) as u8;
-            match broadcast_ndim {
-                None => {
-                    broadcast_ndim = Some(new_broadcast_ndim);
-                }
-                Some(b) if b == new_broadcast_ndim => {}
-                _ => {
-                    return Err(OpError::InvalidValue(
-                        "Number of broadcast dims does not match across inputs",
-                    ));
-                }
+    let broadcast_ndim = equation
+        .validate_inputs(inputs.iter().map(|view| Some(view.ndim())))
+        .map_err(|err| match err {
+            ValidateError::IncorrectInputCount => OpError::InvalidValue(
+                "Number of terms in Einsum equation does not match input tensor count",
+            ),
+            ValidateError::TooManyDims => {
+                OpError::UnsupportedValue("Einsum input or term has too many dimensions")
             }
-        } else if term.len() != view.ndim() {
-            return Err(OpError::InvalidValue(
-                "Einsum term dimension count does not match input tensor",
-            ));
-        }
-    }
+            ValidateError::BroadcastMismatch => {
+                OpError::InvalidValue("Number of broadcast dims does not match across inputs")
+            }
+            ValidateError::RankMismatch => {
+                OpError::InvalidValue("Einsum term dimension count does not match input tensor")
+            }
+            // Should not happen as the rank of every input is known.
+            ValidateError::UnknownRank => unreachable!(),
+        })? as u8;
 
-    let path = einsum_path(&equation, broadcast_ndim.unwrap_or(0));
+    let path = einsum_path(&equation, broadcast_ndim);
 
     let mut output: Option<PoolRef<Tensor>> = None;
     for step in &path {
@@ -574,36 +450,15 @@ impl EinsumStep {
     }
 }
 
-/// Replace an ellipsis representing a fixed number of dimensions with a
-/// sequence of numbers.
-///
-/// Numbers are used because they are not allowed as dimension labels in
-/// input Einsum equations.
-///
-/// eg. `replace_ellipsis("i...j", 3)` returns `"i012j"`.
-fn replace_ellipsis(term: &str, broadcast_ndim: u8) -> String {
-    assert!(broadcast_ndim <= 10);
-
-    let zero = b'0';
-    if let Some((lhs, rhs)) = term.split_once("...") {
-        lhs.chars()
-            .chain((0..broadcast_ndim).map(|i| (zero + i) as char))
-            .chain(rhs.chars())
-            .collect()
-    } else {
-        term.to_string()
-    }
-}
-
 /// Convert an Einsum expression with many inputs into a sequence of steps which
 /// each processes one or two inputs.
 ///
 /// `broadcast_ndim` specifies how many dimensions ellipses in input and output
 /// terms stand for. The ellipses are replaced with digit labels in the path.
 fn einsum_path(expr: &EinsumExpr, broadcast_ndim: u8) -> Vec<EinsumStep> {
-    let output = replace_ellipsis(&expr.output, broadcast_ndim);
+    let output = expand_ellipsis(&expr.output, broadcast_ndim as usize);
     let input_term = |term: &str, index: u32| EinsumTerm {
-        term: replace_ellipsis(term, broadcast_ndim),
+        term: expand_ellipsis(term, broadcast_ndim as usize),
         input: EinsumInput::Index(index),
     };
 


### PR DESCRIPTION
Implement shape inference for the Einsum operator. Both the operator implementation and shape inference need to parse einsum expressions and check operator inputs are compatible with the parsed expression, so the existing parsing logic has been extracted to a shared module in `rten_shape_inference::einsum_parser`.

When reviewing the code I noticed an existing bug where the Einsum operator silently accepted equations where the output term contained dimensions that did not appear in any input. This is now fixed in the shared parser.