### PR TITLE
Remove default implementation for `Operator::as_infer_shapes`

### DIFF
--- a/src/graph/tests.rs
+++ b/src/graph/tests.rs
@@ -12,6 +12,7 @@ use super::{CachedPlan, CaptureEnv, PlanOptions};
 use crate::graph::{
     Dimension, Graph, Node, NodeId, RunError, RunErrorKind, RunOptions, TypedConstant,
 };
+use crate::infer_shapes::InferShapes;
 use crate::operator::{
     IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputTypeList, OutputTypesContext,
     PrepackedInput, SubgraphOperator,
@@ -90,6 +91,10 @@ impl<Op: Operator> Operator for TrackUsage<Op> {
         }
         self.inner.run_in_place(input, ctx)
     }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        self.inner.as_infer_shapes()
+    }
 }
 
 /// Operator that wraps a function.
@@ -128,6 +133,10 @@ impl<V: Into<Value> + 'static, F: Fn(&OpRunContext) -> Result<V, OpError>> Opera
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         (self.run)(ctx).map(|v| [v.into()].into())
+    }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        None
     }
 }
 
@@ -302,6 +311,10 @@ impl Operator for AddOne {
         let input: TensorView<f32> = ctx.inputs().require_as(0)?;
         let output_data: Vec<f32> = input.iter().map(|x| x + 1.0).collect();
         Tensor::<f32>::from_data(input.shape().into(), output_data).into_op_result()
+    }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        None
     }
 }
 
@@ -742,6 +755,10 @@ impl Operator for AddOneInPlace {
         }
         Ok(output.into())
     }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        None
+    }
 }
 
 #[test]
@@ -891,6 +908,10 @@ impl Operator for Split {
         let left_split = Tensor::from_vec(input.iter().take(left_split_len).copied().collect());
         let right_split = Tensor::from_vec(input.iter().skip(left_split_len).copied().collect());
         Ok(smallvec![left_split.into(), right_split.into()])
+    }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        None
     }
 }
 
@@ -1080,6 +1101,10 @@ impl Operator for Counter {
         let count = self.count.fetch_add(1, Ordering::SeqCst);
         Ok([Tensor::from(count).into()].into())
     }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        None
+    }
 }
 
 #[test]
@@ -1170,6 +1195,10 @@ impl Operator for Subgraph {
 
     fn as_subgraph_op(&self) -> Option<&dyn SubgraphOperator> {
         Some(self as &dyn SubgraphOperator)
+    }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        None
     }
 }
 
@@ -1537,6 +1566,10 @@ impl Operator for MatMulExpectPacked {
         let prepacked = ctx.inputs().get_prepacked(1);
         assert!(prepacked.is_some());
         self.inner.run(ctx)
+    }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        self.inner.as_infer_shapes()
     }
 }
 

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -456,9 +456,9 @@ pub trait Operator: Any + Debug {
     }
 
     /// Return the shape inference implementation for this operator.
-    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
-        None
-    }
+    ///
+    /// The implementation may return `None` if shape inference is unsupported.
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes>;
 }
 
 impl dyn Operator {

--- a/src/ops/attention.rs
+++ b/src/ops/attention.rs
@@ -8,6 +8,7 @@ use rten_tensor::{NdTensorView, Tensor, TensorView};
 use rten_vecmath::Softmax;
 
 use crate::buffer_pool::{AutoReturn, BufferPool};
+use crate::infer_shapes::InferShapes;
 use crate::operator::{
     IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType, OutputTypeList,
     OutputTypesContext,
@@ -147,6 +148,10 @@ impl Operator for AddSoftmax {
     fn output_types(&self, _ctx: &OutputTypesContext) -> Option<OutputTypeList> {
         Some([OutputType::CopyFromInput(0)].into())
     }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        None
+    }
 }
 
 fn repeat_interleave<T: Copy>(
@@ -207,6 +212,10 @@ impl Operator for RepeatInterleave {
 
     fn output_types(&self, _ctx: &OutputTypesContext) -> Option<OutputTypeList> {
         Some([OutputType::CopyFromInput(0)].into())
+    }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        None
     }
 }
 
@@ -294,6 +303,10 @@ impl Operator for GroupedQueryAttentionMatMul {
 
     fn output_types(&self, _ctx: &OutputTypesContext) -> Option<OutputTypeList> {
         Some([OutputType::CopyFromInput(0)].into())
+    }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        None
     }
 }
 

--- a/src/ops/compute_shape.rs
+++ b/src/ops/compute_shape.rs
@@ -5,6 +5,7 @@ use rten_shape_inference::{SymExpr, SymbolMap};
 use rten_tensor::Tensor;
 use rten_tensor::prelude::*;
 
+use crate::infer_shapes::InferShapes;
 use crate::operator::{
     IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType, OutputTypeList,
     OutputTypesContext,
@@ -77,6 +78,10 @@ impl Operator for ComputeShape {
 
     fn output_types(&self, _ctx: &OutputTypesContext) -> Option<OutputTypeList> {
         Some([OutputType::Fixed(ValueType::Tensor(DataType::Int32))].into())
+    }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        None
     }
 }
 

--- a/src/ops/control_flow.rs
+++ b/src/ops/control_flow.rs
@@ -3,6 +3,7 @@ use rten_tensor::{Tensor, TensorView};
 use smallvec::SmallVec;
 
 use crate::graph::{CaptureEnv, Graph, NodeId, RunError, RunOptions};
+use crate::infer_shapes::InferShapes;
 use crate::operator::{
     OpError, OpRunContext, Operator, OutputList, OutputTypeList, OutputTypesContext,
     SubgraphOperator,
@@ -49,6 +50,11 @@ impl Operator for If {
 
     fn output_types(&self, _ctx: &OutputTypesContext) -> Option<OutputTypeList> {
         // Type inference is not implemented for ops with subgraphs yet.
+        None
+    }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        // Shape inference does not support ops with subgraphs yet.
         None
     }
 }
@@ -138,6 +144,11 @@ impl Operator for Loop {
 
     fn output_types(&self, _ctx: &OutputTypesContext) -> Option<OutputTypeList> {
         // Type inference is not implemented for ops with subgraphs yet.
+        None
+    }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        // Shape inference does not support ops with subgraphs yet.
         None
     }
 }

--- a/src/ops/matmul.rs
+++ b/src/ops/matmul.rs
@@ -501,6 +501,10 @@ impl Operator for FusedMatMul {
     fn output_types(&self, _ctx: &OutputTypesContext) -> Option<OutputTypeList> {
         Some([OutputType::CopyFromInput(0)].into())
     }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        None
+    }
 }
 
 /// Normalize a zero point input by converting it to a vector.
@@ -762,6 +766,10 @@ impl Operator for MatMulIntegerToFloat {
 
     fn output_types(&self, _ctx: &OutputTypesContext) -> Option<OutputTypeList> {
         Some([OutputType::Fixed(ValueType::Tensor(DataType::Float))].into())
+    }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        None
     }
 }
 

--- a/src/ops/sequence.rs
+++ b/src/ops/sequence.rs
@@ -2,6 +2,7 @@ use rten_tensor::prelude::*;
 use rten_tensor::{Tensor, TensorView};
 
 use crate::buffer_pool::BufferPool;
+use crate::infer_shapes::InferShapes;
 use crate::operator::{
     InputList, IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType,
     OutputTypeList, OutputTypesContext,
@@ -34,6 +35,11 @@ impl Operator for SequenceEmpty {
         let dtype = self.dtype.unwrap_or(DataType::Float);
         Some([OutputType::Fixed(ValueType::Sequence(dtype))].into())
     }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        // Shape inference does not support sequence types yet.
+        None
+    }
 }
 
 #[derive(Debug)]
@@ -61,6 +67,11 @@ impl Operator for SequenceAt {
 
     fn output_types(&self, _ctx: &OutputTypesContext) -> Option<OutputTypeList> {
         Some([OutputType::ElementTypeOfInputSequence(0)].into())
+    }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        // Shape inference does not support sequence types yet.
+        None
     }
 }
 
@@ -97,6 +108,11 @@ impl Operator for SequenceConstruct {
 
     fn output_types(&self, _ctx: &OutputTypesContext) -> Option<OutputTypeList> {
         Some([OutputType::SequenceWithElementTypeOfInput(0)].into())
+    }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        // Shape inference does not support sequence types yet.
+        None
     }
 }
 
@@ -152,6 +168,11 @@ impl Operator for SequenceErase {
 
     fn output_types(&self, _ctx: &OutputTypesContext) -> Option<OutputTypeList> {
         Some([OutputType::CopyFromInput(0)].into())
+    }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        // Shape inference does not support sequence types yet.
+        None
     }
 }
 
@@ -218,6 +239,11 @@ impl Operator for SequenceInsert {
     fn output_types(&self, _ctx: &OutputTypesContext) -> Option<OutputTypeList> {
         Some([OutputType::CopyFromInput(0)].into())
     }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        // Shape inference does not support sequence types yet.
+        None
+    }
 }
 
 #[derive(Debug)]
@@ -240,6 +266,11 @@ impl Operator for SequenceLength {
 
     fn output_types(&self, _ctx: &OutputTypesContext) -> Option<OutputTypeList> {
         Some([OutputType::Fixed(ValueType::Tensor(DataType::Int32))].into())
+    }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        // Shape inference does not support sequence types yet.
+        None
     }
 }
 
@@ -296,6 +327,11 @@ impl Operator for ConcatFromSequence {
 
     fn output_types(&self, _ctx: &OutputTypesContext) -> Option<OutputTypeList> {
         Some([OutputType::ElementTypeOfInputSequence(0)].into())
+    }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        // Shape inference does not support sequence types yet.
+        None
     }
 }
 
@@ -363,6 +399,11 @@ impl Operator for SplitToSequence {
 
     fn output_types(&self, _ctx: &OutputTypesContext) -> Option<OutputTypeList> {
         Some([OutputType::SequenceWithElementTypeOfInput(0)].into())
+    }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        // Shape inference does not support sequence types yet.
+        None
     }
 }
 

--- a/src/ops/transform_inputs.rs
+++ b/src/ops/transform_inputs.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use rten_tensor::prelude::*;
 
+use crate::infer_shapes::InferShapes;
 use crate::operator::{
     OpError, OpRunContext, Operator, OutputList, OutputTypeList, OutputTypesContext,
 };
@@ -144,6 +145,12 @@ impl Operator for TransformInputs {
 
     fn output_types(&self, _ctx: &OutputTypesContext) -> Option<OutputTypeList> {
         self.inner.output_types(_ctx)
+    }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        // `TransformInputs` can reorder inputs, so the inner operator's shape
+        // inference does not apply directly.
+        None
     }
 }
 


### PR DESCRIPTION
Shape inference is now implemented for all operators except:

 - Sequence ops
 - Control flow ops (If, Loop)
 - Internal ops created by the optimizer, after shape inference has run

This PR makes `as_infer_shapes` a required method for `Operator` impls, so that we remember to implement it for new operators. Implementations can still return `None` if shape inference is unsupported.