### PR TITLE
Implement Eq and Hash for TensorBase

### DIFF
--- a/rten-tensor/src/tensor.rs
+++ b/rten-tensor/src/tensor.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 use std::fmt::Debug;
+use std::hash::{Hash, Hasher};
 use std::mem::MaybeUninit;
 use std::ops::{Index, IndexMut, Range};
 use std::sync::Arc;
@@ -2504,6 +2505,17 @@ impl<T: PartialEq, S: Storage<Elem = T>, L: Layout + Clone, V: AsView<Elem = T>>
 {
     fn eq(&self, other: &V) -> bool {
         self.shape().as_ref() == other.shape().as_ref() && self.iter().eq(other.iter())
+    }
+}
+
+impl<T: Eq, S: Storage<Elem = T>, L: Layout + Clone> Eq for TensorBase<S, L> {}
+
+impl<T: Hash, S: Storage<Elem = T>, L: Layout + Clone> Hash for TensorBase<S, L> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.shape().as_ref().hash(state);
+        for elem in self.iter() {
+            elem.hash(state);
+        }
     }
 }
 

--- a/rten-tensor/src/tensor/tests.rs
+++ b/rten-tensor/src/tensor/tests.rs
@@ -1,8 +1,11 @@
 use std::borrow::Cow;
 use std::cell::RefCell;
+use std::collections::HashSet;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
-use super::{AsView, NdTensor, NdTensorView, NdTensorViewMut, Tensor};
+use super::{AsView, NdTensor, NdTensorView, NdTensorViewMut, Tensor, TensorView};
 use crate::errors::{ExpandError, FromDataError};
 use crate::layout::{DynLayout, MatrixLayout, MutLayout};
 use crate::prelude::*;
@@ -378,6 +381,27 @@ fn test_data_truncates_slice() {
 }
 
 #[test]
+fn test_eq() {
+    // Equal shape and elements.
+    let a = NdTensor::from([[1, 2], [3, 4]]);
+    let b = NdTensor::from([[1, 2], [3, 4]]);
+    assert_eq!(a, b);
+
+    // Same elements, different shape.
+    let c = NdTensor::from([1, 2, 3, 4]);
+    assert_ne!(a, c);
+
+    // Same shape, different elements.
+    let d = NdTensor::from([[1, 2], [3, 5]]);
+    assert_ne!(a, d);
+
+    // Same shape and elements, different storage order.
+    let row_major = NdTensor::from([[1, 2], [3, 4]]);
+    let col_major = NdTensor::from([[1, 3], [2, 4]]);
+    assert_eq!(row_major, col_major.transposed());
+}
+
+#[test]
 fn test_fill() {
     let data = vec![1., 2., 3., 4.];
     let mut tensor = NdTensor::from_data([2, 2], data);
@@ -681,6 +705,36 @@ fn test_has_capacity() {
         assert!(tensor.has_capacity(1, i));
     }
     assert!(!tensor.has_capacity(1, 4));
+}
+
+#[test]
+fn test_hash() {
+    fn hash(tensor: TensorView<i32>) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        tensor.hash(&mut hasher);
+        hasher.finish()
+    }
+
+    // Same shape and elements
+    let a = Tensor::from([[1, 2], [3, 4]]);
+    let b = Tensor::from([[1, 2], [3, 4]]);
+    assert_eq!(hash(a.view()), hash(b.view()));
+
+    // Same shape and elements, different storage order.
+    let col_major = Tensor::from([[1, 3], [2, 4]]);
+    let transposed = col_major.transposed();
+    assert_eq!(a, transposed);
+    assert_eq!(hash(a.view()), hash(transposed));
+
+    // Same elements but a different shape.
+    let flat = Tensor::from([1, 2, 3, 4]);
+    assert_ne!(hash(a.view()), hash(flat.view()));
+
+    // Test use in a HashSet
+    let mut set = HashSet::new();
+    set.insert(NdTensor::from([[1, 2], [3, 4]]));
+    assert!(set.contains(&NdTensor::from([[1, 2], [3, 4]])));
+    assert!(!set.contains(&NdTensor::from([[1, 2], [3, 5]])));
 }
 
 #[test]


### PR DESCRIPTION
Add `Eq` and `Hash` impls for TensorBase, where the element type implements the corresponding trait. Both are consistent with the `PartialEq` impl which compares the shape and logical order of elements.

I implemented this as part of exploring supporting symbolic tensors with rank >= 2 in shape inference, but it is independently useful.

Drafted by Claude and then I pruned a lot of redundant comments.