### PR TITLE
Add Multinomial operator

### DIFF
--- a/rten-convert/rten_convert/converter.py
+++ b/rten-convert/rten_convert/converter.py
@@ -601,6 +601,18 @@ def op_node_from_onnx_operator(
             attrs = sg.ModAttrsT()
             attrs.fmod = bool(attr_reader.get_attr("fmod", "int", 0))
 
+        case "Multinomial":
+            attrs = sg.MultinomialAttrsT()
+            # Only int32 and int64 output types are supported. RTen represents
+            # both as int32. The default is int32.
+            attr_reader.check_attr(
+                "dtype",
+                "int",
+                (TensorProto.DataType.INT32, TensorProto.DataType.INT64),
+            )
+            attrs.sampleSize = attr_reader.get_attr("sample_size", "int", 1)
+            attrs.seed = attr_reader.get_attr("seed", "float", None)
+
         case "NonMaxSuppression":
             attrs = sg.NonMaxSuppressionAttrsT()
             center_point_box = attr_reader.get_attr("center_point_box", "int", 0)

--- a/rten-convert/rten_convert/schema_generated.py
+++ b/rten-convert/rten_convert/schema_generated.py
@@ -142,6 +142,7 @@ class OperatorType(object):
     Atanh = 132
     Cosh = 133
     Sinh = 134
+    Multinomial = 135
 
 
 class RNNDirection(object):
@@ -237,6 +238,7 @@ class OperatorAttrs(object):
     SplitToSequenceAttrs = 52
     GridSampleAttrs = 53
     STFTAttrs = 54
+    MultinomialAttrs = 55
 
 def OperatorAttrsCreator(unionType, table):
     from flatbuffers.table import Table
@@ -350,6 +352,8 @@ def OperatorAttrsCreator(unionType, table):
         return GridSampleAttrsT.InitFromBuf(table.Bytes, table.Pos)
     if unionType == OperatorAttrs.STFTAttrs:
         return STFTAttrsT.InitFromBuf(table.Bytes, table.Pos)
+    if unionType == OperatorAttrs.MultinomialAttrs:
+        return MultinomialAttrsT.InitFromBuf(table.Bytes, table.Pos)
     return None
 
 
@@ -4097,6 +4101,104 @@ class ModAttrsT(object):
         return modAttrs
 
 
+class MultinomialAttrs(object):
+    __slots__ = ['_tab']
+
+    @classmethod
+    def GetRootAs(cls, buf, offset=0):
+        n = flatbuffers.encode.Get(flatbuffers.packer.uoffset, buf, offset)
+        x = MultinomialAttrs()
+        x.Init(buf, n + offset)
+        return x
+
+    @classmethod
+    def GetRootAsMultinomialAttrs(cls, buf, offset=0):
+        """This method is deprecated. Please switch to GetRootAs."""
+        return cls.GetRootAs(buf, offset)
+    @classmethod
+    def MultinomialAttrsBufferHasIdentifier(cls, buf, offset, size_prefixed=False):
+        return flatbuffers.util.BufferHasIdentifier(buf, offset, b"\x52\x54\x45\x4E", size_prefixed=size_prefixed)
+
+    # MultinomialAttrs
+    def Init(self, buf, pos):
+        self._tab = flatbuffers.table.Table(buf, pos)
+
+    # MultinomialAttrs
+    def SampleSize(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
+        if o != 0:
+            return self._tab.Get(flatbuffers.number_types.Int32Flags, o + self._tab.Pos)
+        return 0
+
+    # MultinomialAttrs
+    def Seed(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(6))
+        if o != 0:
+            return self._tab.Get(flatbuffers.number_types.Float32Flags, o + self._tab.Pos)
+        return None
+
+def MultinomialAttrsStart(builder):
+    builder.StartObject(2)
+
+def MultinomialAttrsAddSampleSize(builder, sampleSize):
+    builder.PrependInt32Slot(0, sampleSize, 0)
+
+def MultinomialAttrsAddSeed(builder, seed):
+    builder.PrependFloat32Slot(1, seed, None)
+
+def MultinomialAttrsEnd(builder):
+    return builder.EndObject()
+
+
+try:
+    from typing import Optional
+except:
+    pass
+
+class MultinomialAttrsT(object):
+
+    # MultinomialAttrsT
+    def __init__(
+        self,
+        sampleSize = 0,
+        seed = None,
+    ):
+        self.sampleSize = sampleSize  # type: int
+        self.seed = seed  # type: Optional[float]
+
+    @classmethod
+    def InitFromBuf(cls, buf, pos):
+        multinomialAttrs = MultinomialAttrs()
+        multinomialAttrs.Init(buf, pos)
+        return cls.InitFromObj(multinomialAttrs)
+
+    @classmethod
+    def InitFromPackedBuf(cls, buf, pos=0):
+        n = flatbuffers.encode.Get(flatbuffers.packer.uoffset, buf, pos)
+        return cls.InitFromBuf(buf, pos+n)
+
+    @classmethod
+    def InitFromObj(cls, multinomialAttrs):
+        x = MultinomialAttrsT()
+        x._UnPack(multinomialAttrs)
+        return x
+
+    # MultinomialAttrsT
+    def _UnPack(self, multinomialAttrs):
+        if multinomialAttrs is None:
+            return
+        self.sampleSize = multinomialAttrs.SampleSize()
+        self.seed = multinomialAttrs.Seed()
+
+    # MultinomialAttrsT
+    def Pack(self, builder):
+        MultinomialAttrsStart(builder)
+        MultinomialAttrsAddSampleSize(builder, self.sampleSize)
+        MultinomialAttrsAddSeed(builder, self.seed)
+        multinomialAttrs = MultinomialAttrsEnd(builder)
+        return multinomialAttrs
+
+
 class NonMaxSuppressionAttrs(object):
     __slots__ = ['_tab']
 
@@ -6489,7 +6591,7 @@ class OperatorNodeT(object):
     ):
         self.type = type  # type: int
         self.attrsType = attrsType  # type: int
-        self.attrs = attrs  # type: Union[None, 'ArgMaxAttrsT', 'AveragePoolAttrsT', 'BatchNormalizationAttrsT', 'CastAttrsT', 'ConcatAttrsT', 'ConstantOfShapeAttrsT', 'ConvAttrsT', 'ConvTransposeAttrsT', 'FlattenAttrsT', 'GatherAttrsT', 'GemmAttrsT', 'GRUAttrsT', 'LeakyReluAttrsT', 'LSTMAttrsT', 'MaxPoolAttrsT', 'ReduceMeanAttrsT', 'ReshapeAttrsT', 'ResizeAttrsT', 'SplitAttrsT', 'SoftmaxAttrsT', 'TransposeAttrsT', 'ModAttrsT', 'ScatterElementsAttrsT', 'OneHotAttrsT', 'TopKAttrsT', 'HardSigmoidAttrsT', 'TriluAttrsT', 'ScatterNDAttrsT', 'NonMaxSuppressionAttrsT', 'LayerNormalizationAttrsT', 'RandomUniformAttrsT', 'EluAttrsT', 'RandomUniformLikeAttrsT', 'RandomNormalAttrsT', 'RandomNormalLikeAttrsT', 'GatherNDAttrsT', 'GeluAttrsT', 'EinsumAttrsT', 'IfAttrsT', 'PadAttrsT', 'DequantizeLinearAttrsT', 'QuantizeLinearAttrsT', 'DepthToSpaceAttrsT', 'CastLikeAttrsT', 'ShapeAttrsT', 'DropoutAttrsT', 'EyeLikeAttrsT', 'IsInfAttrsT', 'LoopAttrsT', 'SequenceEmptyAttrsT', 'ConcatFromSequenceAttrsT', 'SplitToSequenceAttrsT', 'GridSampleAttrsT', 'STFTAttrsT']
+        self.attrs = attrs  # type: Union[None, 'ArgMaxAttrsT', 'AveragePoolAttrsT', 'BatchNormalizationAttrsT', 'CastAttrsT', 'ConcatAttrsT', 'ConstantOfShapeAttrsT', 'ConvAttrsT', 'ConvTransposeAttrsT', 'FlattenAttrsT', 'GatherAttrsT', 'GemmAttrsT', 'GRUAttrsT', 'LeakyReluAttrsT', 'LSTMAttrsT', 'MaxPoolAttrsT', 'ReduceMeanAttrsT', 'ReshapeAttrsT', 'ResizeAttrsT', 'SplitAttrsT', 'SoftmaxAttrsT', 'TransposeAttrsT', 'ModAttrsT', 'ScatterElementsAttrsT', 'OneHotAttrsT', 'TopKAttrsT', 'HardSigmoidAttrsT', 'TriluAttrsT', 'ScatterNDAttrsT', 'NonMaxSuppressionAttrsT', 'LayerNormalizationAttrsT', 'RandomUniformAttrsT', 'EluAttrsT', 'RandomUniformLikeAttrsT', 'RandomNormalAttrsT', 'RandomNormalLikeAttrsT', 'GatherNDAttrsT', 'GeluAttrsT', 'EinsumAttrsT', 'IfAttrsT', 'PadAttrsT', 'DequantizeLinearAttrsT', 'QuantizeLinearAttrsT', 'DepthToSpaceAttrsT', 'CastLikeAttrsT', 'ShapeAttrsT', 'DropoutAttrsT', 'EyeLikeAttrsT', 'IsInfAttrsT', 'LoopAttrsT', 'SequenceEmptyAttrsT', 'ConcatFromSequenceAttrsT', 'SplitToSequenceAttrsT', 'GridSampleAttrsT', 'STFTAttrsT', 'MultinomialAttrsT']
         self.inputs = inputs  # type: Optional[List[int]]
         self.outputs = outputs  # type: Optional[List[int]]
 

--- a/rten-model-file/src/schema.fbs
+++ b/rten-model-file/src/schema.fbs
@@ -148,6 +148,7 @@ enum OperatorType: ubyte {
   Atanh,
   Cosh,
   Sinh,
+  Multinomial,
 }
 
 enum RNNDirection: ubyte {
@@ -254,6 +255,7 @@ union OperatorAttrs {
   SplitToSequenceAttrs,
   GridSampleAttrs,
   STFTAttrs,
+  MultinomialAttrs,
 }
 
 table ArgMaxAttrs {
@@ -450,6 +452,11 @@ table MaxPoolAttrs {
 
 table ModAttrs {
   fmod:bool;
+}
+
+table MultinomialAttrs {
+  sample_size:int;
+  seed:float = null;
 }
 
 enum NMSBoxOrder: ubyte {

--- a/rten-model-file/src/schema_generated.rs
+++ b/rten-model-file/src/schema_generated.rs
@@ -11,13 +11,13 @@ pub const ENUM_MIN_OPERATOR_TYPE: u8 = 0;
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
-pub const ENUM_MAX_OPERATOR_TYPE: u8 = 134;
+pub const ENUM_MAX_OPERATOR_TYPE: u8 = 135;
 #[deprecated(
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 135] = [
+pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 136] = [
     OperatorType::Add,
     OperatorType::ArgMin,
     OperatorType::ArgMax,
@@ -153,6 +153,7 @@ pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 135] = [
     OperatorType::Atanh,
     OperatorType::Cosh,
     OperatorType::Sinh,
+    OperatorType::Multinomial,
 ];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -295,9 +296,10 @@ impl OperatorType {
     pub const Atanh: Self = Self(132);
     pub const Cosh: Self = Self(133);
     pub const Sinh: Self = Self(134);
+    pub const Multinomial: Self = Self(135);
 
     pub const ENUM_MIN: u8 = 0;
-    pub const ENUM_MAX: u8 = 134;
+    pub const ENUM_MAX: u8 = 135;
     pub const ENUM_VALUES: &'static [Self] = &[
         Self::Add,
         Self::ArgMin,
@@ -434,6 +436,7 @@ impl OperatorType {
         Self::Atanh,
         Self::Cosh,
         Self::Sinh,
+        Self::Multinomial,
     ];
     /// Returns the variant's name or "" if unknown.
     pub fn variant_name(self) -> Option<&'static str> {
@@ -573,6 +576,7 @@ impl OperatorType {
             Self::Atanh => Some("Atanh"),
             Self::Cosh => Some("Cosh"),
             Self::Sinh => Some("Sinh"),
+            Self::Multinomial => Some("Multinomial"),
             _ => None,
         }
     }
@@ -1208,13 +1212,13 @@ pub const ENUM_MIN_OPERATOR_ATTRS: u8 = 0;
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
-pub const ENUM_MAX_OPERATOR_ATTRS: u8 = 54;
+pub const ENUM_MAX_OPERATOR_ATTRS: u8 = 55;
 #[deprecated(
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_OPERATOR_ATTRS: [OperatorAttrs; 55] = [
+pub const ENUM_VALUES_OPERATOR_ATTRS: [OperatorAttrs; 56] = [
     OperatorAttrs::NONE,
     OperatorAttrs::ArgMaxAttrs,
     OperatorAttrs::AveragePoolAttrs,
@@ -1270,6 +1274,7 @@ pub const ENUM_VALUES_OPERATOR_ATTRS: [OperatorAttrs; 55] = [
     OperatorAttrs::SplitToSequenceAttrs,
     OperatorAttrs::GridSampleAttrs,
     OperatorAttrs::STFTAttrs,
+    OperatorAttrs::MultinomialAttrs,
 ];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -1332,9 +1337,10 @@ impl OperatorAttrs {
     pub const SplitToSequenceAttrs: Self = Self(52);
     pub const GridSampleAttrs: Self = Self(53);
     pub const STFTAttrs: Self = Self(54);
+    pub const MultinomialAttrs: Self = Self(55);
 
     pub const ENUM_MIN: u8 = 0;
-    pub const ENUM_MAX: u8 = 54;
+    pub const ENUM_MAX: u8 = 55;
     pub const ENUM_VALUES: &'static [Self] = &[
         Self::NONE,
         Self::ArgMaxAttrs,
@@ -1391,6 +1397,7 @@ impl OperatorAttrs {
         Self::SplitToSequenceAttrs,
         Self::GridSampleAttrs,
         Self::STFTAttrs,
+        Self::MultinomialAttrs,
     ];
     /// Returns the variant's name or "" if unknown.
     pub fn variant_name(self) -> Option<&'static str> {
@@ -1450,6 +1457,7 @@ impl OperatorAttrs {
             Self::SplitToSequenceAttrs => Some("SplitToSequenceAttrs"),
             Self::GridSampleAttrs => Some("GridSampleAttrs"),
             Self::STFTAttrs => Some("STFTAttrs"),
+            Self::MultinomialAttrs => Some("MultinomialAttrs"),
             _ => None,
         }
     }
@@ -6915,6 +6923,136 @@ impl ::core::fmt::Debug for ModAttrs<'_> {
         ds.finish()
     }
 }
+pub enum MultinomialAttrsOffset {}
+#[derive(Copy, Clone, PartialEq)]
+
+pub struct MultinomialAttrs<'a> {
+    pub _tab: ::flatbuffers::Table<'a>,
+}
+
+impl<'a> ::flatbuffers::Follow<'a> for MultinomialAttrs<'a> {
+    type Inner = MultinomialAttrs<'a>;
+    #[inline]
+    unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self {
+            _tab: unsafe { ::flatbuffers::Table::new(buf, loc) },
+        }
+    }
+}
+
+impl<'a> MultinomialAttrs<'a> {
+    pub const VT_SAMPLE_SIZE: ::flatbuffers::VOffsetT = 4;
+    pub const VT_SEED: ::flatbuffers::VOffsetT = 6;
+
+    #[inline]
+    pub unsafe fn init_from_table(table: ::flatbuffers::Table<'a>) -> Self {
+        MultinomialAttrs { _tab: table }
+    }
+    #[allow(unused_mut)]
+    pub fn create<
+        'bldr: 'args,
+        'args: 'mut_bldr,
+        'mut_bldr,
+        A: ::flatbuffers::Allocator + 'bldr,
+    >(
+        _fbb: &'mut_bldr mut ::flatbuffers::FlatBufferBuilder<'bldr, A>,
+        args: &'args MultinomialAttrsArgs,
+    ) -> ::flatbuffers::WIPOffset<MultinomialAttrs<'bldr>> {
+        let mut builder = MultinomialAttrsBuilder::new(_fbb);
+        if let Some(x) = args.seed {
+            builder.add_seed(x);
+        }
+        builder.add_sample_size(args.sample_size);
+        builder.finish()
+    }
+
+    #[inline]
+    pub fn sample_size(&self) -> i32 {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab
+                .get::<i32>(MultinomialAttrs::VT_SAMPLE_SIZE, Some(0))
+                .unwrap()
+        }
+    }
+    #[inline]
+    pub fn seed(&self) -> Option<f32> {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe { self._tab.get::<f32>(MultinomialAttrs::VT_SEED, None) }
+    }
+}
+
+impl ::flatbuffers::Verifiable for MultinomialAttrs<'_> {
+    #[inline]
+    fn run_verifier(
+        v: &mut ::flatbuffers::Verifier,
+        pos: usize,
+    ) -> Result<(), ::flatbuffers::InvalidFlatbuffer> {
+        v.visit_table(pos)?
+            .visit_field::<i32>("sample_size", Self::VT_SAMPLE_SIZE, false)?
+            .visit_field::<f32>("seed", Self::VT_SEED, false)?
+            .finish();
+        Ok(())
+    }
+}
+pub struct MultinomialAttrsArgs {
+    pub sample_size: i32,
+    pub seed: Option<f32>,
+}
+impl<'a> Default for MultinomialAttrsArgs {
+    #[inline]
+    fn default() -> Self {
+        MultinomialAttrsArgs {
+            sample_size: 0,
+            seed: None,
+        }
+    }
+}
+
+pub struct MultinomialAttrsBuilder<'a: 'b, 'b, A: ::flatbuffers::Allocator + 'a> {
+    fbb_: &'b mut ::flatbuffers::FlatBufferBuilder<'a, A>,
+    start_: ::flatbuffers::WIPOffset<::flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b, A: ::flatbuffers::Allocator + 'a> MultinomialAttrsBuilder<'a, 'b, A> {
+    #[inline]
+    pub fn add_sample_size(&mut self, sample_size: i32) {
+        self.fbb_
+            .push_slot::<i32>(MultinomialAttrs::VT_SAMPLE_SIZE, sample_size, 0);
+    }
+    #[inline]
+    pub fn add_seed(&mut self, seed: f32) {
+        self.fbb_
+            .push_slot_always::<f32>(MultinomialAttrs::VT_SEED, seed);
+    }
+    #[inline]
+    pub fn new(
+        _fbb: &'b mut ::flatbuffers::FlatBufferBuilder<'a, A>,
+    ) -> MultinomialAttrsBuilder<'a, 'b, A> {
+        let start = _fbb.start_table();
+        MultinomialAttrsBuilder {
+            fbb_: _fbb,
+            start_: start,
+        }
+    }
+    #[inline]
+    pub fn finish(self) -> ::flatbuffers::WIPOffset<MultinomialAttrs<'a>> {
+        let o = self.fbb_.end_table(self.start_);
+        ::flatbuffers::WIPOffset::new(o.value())
+    }
+}
+
+impl ::core::fmt::Debug for MultinomialAttrs<'_> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+        let mut ds = f.debug_struct("MultinomialAttrs");
+        ds.field("sample_size", &self.sample_size());
+        ds.field("seed", &self.seed());
+        ds.finish()
+    }
+}
 pub enum NonMaxSuppressionAttrsOffset {}
 #[derive(Copy, Clone, PartialEq)]
 
@@ -10736,6 +10874,21 @@ impl<'a> OperatorNode<'a> {
             None
         }
     }
+
+    #[inline]
+    #[allow(non_snake_case)]
+    pub fn attrs_as_multinomial_attrs(&self) -> Option<MultinomialAttrs<'a>> {
+        if self.attrs_type() == OperatorAttrs::MultinomialAttrs {
+            self.attrs().map(|t| {
+                // Safety:
+                // Created from a valid Table for this object
+                // Which contains a valid union in this slot
+                unsafe { MultinomialAttrs::init_from_table(t) }
+            })
+        } else {
+            None
+        }
+    }
 }
 
 impl ::flatbuffers::Verifiable for OperatorNode<'_> {
@@ -10802,6 +10955,7 @@ impl ::flatbuffers::Verifiable for OperatorNode<'_> {
           OperatorAttrs::SplitToSequenceAttrs => v.verify_union_variant::<::flatbuffers::ForwardsUOffset<SplitToSequenceAttrs>>("OperatorAttrs::SplitToSequenceAttrs", pos),
           OperatorAttrs::GridSampleAttrs => v.verify_union_variant::<::flatbuffers::ForwardsUOffset<GridSampleAttrs>>("OperatorAttrs::GridSampleAttrs", pos),
           OperatorAttrs::STFTAttrs => v.verify_union_variant::<::flatbuffers::ForwardsUOffset<STFTAttrs>>("OperatorAttrs::STFTAttrs", pos),
+          OperatorAttrs::MultinomialAttrs => v.verify_union_variant::<::flatbuffers::ForwardsUOffset<MultinomialAttrs>>("OperatorAttrs::MultinomialAttrs", pos),
           _ => Ok(()),
         }
      })?
@@ -11422,6 +11576,16 @@ impl ::core::fmt::Debug for OperatorNode<'_> {
             }
             OperatorAttrs::STFTAttrs => {
                 if let Some(x) = self.attrs_as_stftattrs() {
+                    ds.field("attrs", &x)
+                } else {
+                    ds.field(
+                        "attrs",
+                        &"InvalidFlatbuffer: Union discriminant does not match value.",
+                    )
+                }
+            }
+            OperatorAttrs::MultinomialAttrs => {
+                if let Some(x) = self.attrs_as_multinomial_attrs() {
                     ds.field("attrs", &x)
                 } else {
                     ds.field(

--- a/rten-shape-inference/src/ops.rs
+++ b/rten-shape-inference/src/ops.rs
@@ -385,6 +385,37 @@ impl InferShapes for FixedShape<'_> {
     }
 }
 
+/// Multinomial operator.
+///
+/// See <https://onnx.ai/onnx/operators/onnx__Multinomial.html>.
+pub struct Multinomial {
+    /// Number of times to sample for each row of the input.
+    pub sample_size: usize,
+}
+
+impl InferShapes for Multinomial {
+    fn infer_shapes(
+        &self,
+        inputs: &[SymTensor],
+        sym_gen: &mut SymbolGen,
+    ) -> Result<Vec<SymTensor>, InferShapesError> {
+        let [input] = inputs else {
+            return Err(InferShapesError::IncorrectInputCount);
+        };
+
+        if input.ndim().is_some_and(|ndim| ndim != 2) {
+            return Err(InferShapesError::IncorrectRank);
+        }
+
+        // Input is `(batch_size, class_size)`, output is
+        // `(batch_size, sample_size)`.
+        let batch_size = input.size(0).unwrap_or_else(|| sym_gen.gen_positive());
+        let sample_size = SymExpr::Value(self.sample_size as i32);
+        let out_shape = vec![batch_size, sample_size];
+        Ok([SymTensor::from_shape(out_shape)].into())
+    }
+}
+
 /// NonMaxSuppression operator.
 ///
 /// See <https://onnx.ai/onnx/operators/onnx__NonMaxSuppression.html>.
@@ -570,7 +601,7 @@ mod tests {
 
     use super::{
         ConstantOfShape, Dropout, DynamicQuantizeLinear, FixedShape, Gather, GatherElements,
-        GatherND, GridSample, NonMaxSuppression, NonZero, Range, TopK, Where,
+        GatherND, GridSample, Multinomial, NonMaxSuppression, NonZero, Range, TopK, Where,
     };
 
     #[test]
@@ -617,6 +648,33 @@ mod tests {
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].ndim(), None);
         assert_eq!(result[1].ndim(), None);
+    }
+
+    #[test]
+    fn test_multinomial() {
+        let mut sym_gen = SymbolGen::new();
+
+        // Known batch size.
+        let data = sym_shape!("batch", 32);
+        let result = Multinomial { sample_size: 4 }
+            .infer_shapes(&[data], &mut sym_gen)
+            .unwrap();
+        assert_eq!(result, &[sym_shape!("batch", 4)]);
+
+        // Unknown input shape still yields a known sample size.
+        let data = SymTensor::unknown("unknown");
+        let result = Multinomial { sample_size: 4 }
+            .infer_shapes(&[data], &mut sym_gen)
+            .unwrap();
+        assert_eq!(result[0].ndim(), Some(2));
+        assert_eq!(result[0].size(1), Some(4.into()));
+
+        // Input with a known rank other than 2 is an error.
+        let data = sym_shape!("batch", 32, 8);
+        let err = Multinomial { sample_size: 4 }
+            .infer_shapes(&[data], &mut sym_gen)
+            .err();
+        assert_eq!(err, Some(InferShapesError::IncorrectRank));
     }
 
     #[test]

--- a/src/model.rs
+++ b/src/model.rs
@@ -1682,6 +1682,10 @@ mod tests {
                 high: 1.,
                 seed: None,
             });
+            add_operator!(Multinomial, [input_2d], {
+                sample_size: 4,
+                seed: None,
+            });
         }
 
         let range_start_node = graph_builder.add_value("range_start", None, None);
@@ -1856,6 +1860,7 @@ mod tests {
                 "Dropout_out_mask",
                 "Gemm_out",
                 "MatMul_out",
+                "Multinomial_out",
                 "Range_out",
                 "Split_out_1",
                 "Split_out_2",
@@ -1925,7 +1930,7 @@ mod tests {
 
         #[cfg(feature = "random")]
         {
-            outputs.extend(["Dropout_out", "Dropout_out_mask"]);
+            outputs.extend(["Dropout_out", "Dropout_out_mask", "Multinomial_out"]);
         }
 
         let input = Tensor::from_data(&[3, 3], vec![1., 2., 3., 4., 5., 6., 7., 8., 9.]);

--- a/src/model/rten_builder.rs
+++ b/src/model/rten_builder.rs
@@ -19,7 +19,9 @@ use crate::ops::{
 use crate::value::{DataType, Scalar};
 
 #[cfg(feature = "random")]
-use crate::ops::{Dropout, RandomNormal, RandomNormalLike, RandomUniform, RandomUniformLike};
+use crate::ops::{
+    Dropout, Multinomial, RandomNormal, RandomNormalLike, RandomUniform, RandomUniformLike,
+};
 
 /// Struct like `crate::ops::If` with subgraph attributes replaced by
 /// pre-serialized graphs.
@@ -102,6 +104,10 @@ pub enum OpType<'a> {
     Min,
     Mod(Mod),
     Mul,
+
+    #[cfg(feature = "random")]
+    Multinomial(Multinomial),
+
     Neg,
     NonMaxSuppression(NonMaxSuppression),
     NonZero,
@@ -739,6 +745,17 @@ impl<'mb, 'a> GraphBuilder<'mb, 'a> {
                 op_with_attrs!(Mod, ModAttrs, sg::ModAttrsArgs { fmod: args.fmod })
             }
             OpType::Mul => op!(Mul),
+
+            #[cfg(feature = "random")]
+            OpType::Multinomial(args) => {
+                op_with_attrs!(Multinomial, MultinomialAttrs, {
+                    sg::MultinomialAttrsArgs {
+                        sample_size: args.sample_size as i32,
+                        seed: args.seed,
+                    }
+                })
+            }
+
             OpType::Neg => op!(Neg),
             OpType::NonMaxSuppression(args) => {
                 op_with_attrs!(

--- a/src/op_registry.rs
+++ b/src/op_registry.rs
@@ -281,6 +281,7 @@ pub mod op_types {
     declare_op!(Min);
     declare_op!(Mod);
     declare_op!(Mul);
+    declare_op!(Multinomial, feature = "random");
     declare_op!(Neg);
     declare_op!(NonMaxSuppression);
     declare_op!(NonZero);

--- a/src/op_registry/onnx_registry.rs
+++ b/src/op_registry/onnx_registry.rs
@@ -171,6 +171,7 @@ impl OnnxOpRegistry {
         register_op!(Min);
         register_op!(Mod);
         register_op!(Mul);
+        register_op!(Multinomial, feature = "random");
         register_op!(Neg);
         register_op!(NonMaxSuppression);
         register_op!(NonZero);
@@ -1344,6 +1345,24 @@ impl_read_op!(RMSNormalization, |attrs: &Attrs| {
     attrs.check_eq("stash_type", 1)?;
 
     Ok(ops::RMSNormalization { axis, epsilon })
+});
+
+#[cfg(feature = "random")]
+impl_read_op!(Multinomial, |attrs: &Attrs| {
+    let dtype = attrs
+        .get_as_int::<i32>("dtype")?
+        .map(onnx::DataType)
+        .unwrap_or(onnx::DataType::INT32);
+    if !matches!(dtype, onnx::DataType::INT32 | onnx::DataType::INT64) {
+        return Err(ReadOpError::attr_error(
+            "dtype",
+            "only int32 and int64 output types are supported",
+        ));
+    }
+
+    let sample_size = attrs.get_as_int::<usize>("sample_size")?.unwrap_or(1);
+    let seed = attrs.get_as("seed");
+    Ok(ops::Multinomial { sample_size, seed })
 });
 
 #[cfg(feature = "random")]

--- a/src/op_registry/rten_registry.rs
+++ b/src/op_registry/rten_registry.rs
@@ -167,6 +167,7 @@ impl RtenOpRegistry {
         register_op!(Min);
         register_op!(Mod);
         register_op!(Mul);
+        register_op!(Multinomial, feature = "random");
         register_op!(Neg);
         register_op!(NonMaxSuppression);
         register_op!(NonZero);
@@ -826,6 +827,18 @@ impl_read_op!(
         Ok(ops::QuantizeLinear {
             axis: attrs.axis() as isize,
             output_dtype,
+        })
+    }
+);
+
+#[cfg(feature = "random")]
+impl_read_op!(
+    Multinomial,
+    attrs_as_multinomial_attrs,
+    |attrs: sg::MultinomialAttrs| {
+        Ok(ops::Multinomial {
+            sample_size: attrs.sample_size().max(0) as usize,
+            seed: attrs.seed(),
         })
     }
 );

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -65,7 +65,7 @@ pub(crate) mod transform_inputs;
 pub(crate) use fft::STFT;
 #[cfg(feature = "random")]
 pub(crate) use random::{
-    Dropout, RandomNormal, RandomNormalLike, RandomUniform, RandomUniformLike,
+    Dropout, Multinomial, RandomNormal, RandomNormalLike, RandomUniform, RandomUniformLike,
 };
 pub(crate) use {
     attention::{AddSoftmax, GroupedQueryAttentionMatMul, RepeatInterleave},

--- a/src/ops/random.rs
+++ b/src/ops/random.rs
@@ -2,14 +2,26 @@ use fastrand::Rng;
 use fastrand_contrib::RngExt;
 use rten_shape_inference::ops as shape_ops;
 use rten_tensor::prelude::*;
-use rten_tensor::{Tensor, TensorView};
+use rten_tensor::{NdTensorView, Tensor, TensorView};
 
+use crate::buffer_pool::AutoReturn;
 use crate::infer_shapes::{InferShapes, UnaryOp, impl_infer_shapes};
 use crate::operator::{
     IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType, OutputTypeList,
     OutputTypesContext,
 };
 use crate::value::{DataType, Value, ValueType};
+
+/// Create a random number generator, seeded with `seed` if it is provided.
+///
+/// The seed is an `f32` for consistency with the ONNX specification, which
+/// specifies random seeds for operators as floats.
+fn rng_from_seed(seed: Option<f32>) -> Rng {
+    match seed {
+        Some(seed) => Rng::with_seed(seed.to_bits() as u64),
+        None => Rng::new(),
+    }
+}
 
 #[derive(Debug)]
 pub struct RandomUniform {
@@ -41,11 +53,7 @@ impl Operator for RandomUniform {
         let scale_value = |val: f32| self.low + val * (self.high - self.low);
         let shape = self.shape.as_slice();
 
-        let mut rng = if let Some(seed) = self.seed {
-            Rng::with_seed(seed.to_bits() as u64)
-        } else {
-            Rng::new()
-        };
+        let mut rng = rng_from_seed(self.seed);
         Tensor::from_simple_fn_in(ctx.pool(), shape, || scale_value(rng.f32())).into_op_result()
     }
 
@@ -135,11 +143,7 @@ impl Operator for RandomNormal {
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let shape = self.shape.as_slice();
 
-        let mut rng = if let Some(seed) = self.seed {
-            Rng::with_seed(seed.to_bits() as u64)
-        } else {
-            Rng::new()
-        };
+        let mut rng = rng_from_seed(self.seed);
 
         // Use `Rng::f32_normal_approx` here rather than `Rng::f32_normal`
         // because the approximation is much faster and good enough for use
@@ -206,6 +210,92 @@ impl Operator for RandomNormalLike {
         Some(&UnaryOp)
     }
 }
+
+#[derive(Debug)]
+pub struct Multinomial {
+    /// Number of samples to draw for each row of the input.
+    pub sample_size: usize,
+
+    /// Random seed. See [`RandomUniform::seed`].
+    pub seed: Option<f32>,
+}
+
+impl Operator for Multinomial {
+    fn name(&self) -> &str {
+        "Multinomial"
+    }
+
+    fn max_inputs(&self) -> Option<usize> {
+        Some(1)
+    }
+
+    fn is_deterministic(&self) -> bool {
+        false
+    }
+
+    fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+        let pool = ctx.pool();
+        let input: NdTensorView<f32, 2> = ctx.inputs().require_as(0)?;
+        let [batch_size, class_size] = input.shape();
+
+        if class_size == 0 {
+            return Err(OpError::InvalidValue("input must have at least one class"));
+        }
+
+        let mut rng = rng_from_seed(self.seed);
+
+        let input = input.to_contiguous_in(pool).auto_return(pool);
+        let input = input.data();
+
+        let mut output = pool.alloc(batch_size * self.sample_size);
+        let mut cdf = pool.alloc(class_size).auto_return(pool);
+        for row in input.chunks(class_size) {
+            // Convert the unnormalized log probabilities for this row into a
+            // cumulative distribution. The maximum is subtracted before
+            // exponentiating, for numerical stability.
+            //
+            // `cdf` is left unnormalized to avoid a division per class. `sum`
+            // ends up as the total weight, which is folded into the sampling
+            // threshold below instead.
+            let max = row.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+            cdf.clear();
+            let mut sum = 0.;
+            for &logit in row {
+                sum += (logit - max).exp();
+                cdf.push(sum);
+            }
+
+            for _ in 0..self.sample_size {
+                // Scale the `[0, 1)` draw by `sum` to match the scale of `cdf`.
+                let threshold = rng.f32() * sum;
+                // Sample the first class whose cumulative probability exceeds
+                // the threshold. The last value in `cdf` is exactly `sum` and
+                // `rng.f32() < 1`, so the maximum value of `idx` is
+                // `class_size - 1`.
+                let idx = cdf.partition_point(|&c| c <= threshold);
+                output.push(idx as i32);
+            }
+        }
+
+        Tensor::from_data(&[batch_size, self.sample_size], output).into_op_result()
+    }
+
+    fn output_types(&self, _ctx: &OutputTypesContext) -> Option<OutputTypeList> {
+        Some([OutputType::Fixed(ValueType::Tensor(DataType::Int32))].into())
+    }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        Some(self)
+    }
+}
+
+impl_infer_shapes!(
+    Multinomial,
+    op,
+    shape_ops::Multinomial {
+        sample_size: op.sample_size
+    }
+);
 
 #[derive(Debug)]
 pub struct Dropout {
@@ -306,10 +396,12 @@ mod tests {
     use rten_testing::TestCases;
 
     use crate::buffer_pool::BufferPool;
-    use crate::operator::{InputList, OpRunContext, Operator, OperatorExt};
+    use crate::operator::{InputList, OpError, OpRunContext, Operator, OperatorExt};
     use crate::ops::operators::{FloatOperators, Operators};
 
-    use super::{Dropout, RandomNormal, RandomNormalLike, RandomUniform, RandomUniformLike};
+    use super::{
+        Dropout, Multinomial, RandomNormal, RandomNormalLike, RandomUniform, RandomUniformLike,
+    };
 
     #[test]
     fn test_random_uniform() {
@@ -522,6 +614,128 @@ mod tests {
         };
         let output: Tensor<f32> = op.run_simple(input.view()).unwrap();
         assert_eq!(output.shape(), &[5, 5]);
+    }
+
+    #[test]
+    fn test_multinomial() {
+        #[derive(Clone, Debug)]
+        struct Case {
+            // Per-class unnormalized log probabilities.
+            logits: Vec<f32>,
+            seed: Option<f32>,
+        }
+
+        let cases = [
+            // Non-uniform distribution.
+            Case {
+                logits: vec![1.0, 2.0, 3.0, 4.0],
+                seed: Some(0.5),
+            },
+            // Uniform distribution.
+            Case {
+                logits: vec![2.0, 2.0, 2.0, 2.0],
+                seed: Some(1.0),
+            },
+            // All zeros
+            Case {
+                logits: vec![0.0, 0.0, 0.0, 0.0],
+                seed: Some(1.0),
+            },
+            // Auto-generated seed.
+            Case {
+                logits: vec![-1.0, 0.0, 2.0],
+                seed: None,
+            },
+        ];
+
+        cases.test_each_clone(|Case { logits, seed }| {
+            let class_size = logits.len();
+            let sample_size = 5000;
+            let input = Tensor::from_data(&[1, class_size], logits.clone());
+
+            let op = Multinomial { sample_size, seed };
+            let output: Tensor<i32> = op.run_simple(input.view()).unwrap();
+            assert_eq!(output.shape(), &[1, sample_size]);
+
+            // Expected per-class probabilities, computed via softmax.
+            let max = logits.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+            let exp: Vec<f32> = logits.iter().map(|x| (x - max).exp()).collect();
+            let exp_sum: f32 = exp.iter().sum();
+            let expected: Vec<f32> = exp.iter().map(|x| x / exp_sum).collect();
+
+            // Count how often each class was sampled.
+            let mut counts = vec![0; class_size];
+            for &idx in output.iter() {
+                assert!(
+                    (idx as usize) < class_size,
+                    "sampled class {idx} out of range"
+                );
+                counts[idx as usize] += 1;
+            }
+
+            // Check that empirical frequencies approximately match the expected
+            // distribution.
+            for (cls, &count) in counts.iter().enumerate() {
+                let freq = count as f32 / sample_size as f32;
+                let delta = (freq - expected[cls]).abs();
+                assert!(
+                    delta <= 0.05,
+                    "class {cls} frequency {freq} too far from expected {}",
+                    expected[cls]
+                );
+            }
+        })
+    }
+
+    #[test]
+    fn test_multinomial_seed() {
+        let input = Tensor::from([[1.0f32, 2.0, 3.0]]);
+
+        // A fixed seed produces repeatable output.
+        let seeded = Multinomial {
+            sample_size: 20,
+            seed: Some(0.5),
+        };
+        let a: Tensor<i32> = seeded.run_simple(input.view()).unwrap();
+        let b: Tensor<i32> = seeded.run_simple(input.view()).unwrap();
+        assert_eq!(a, b);
+
+        // Without a seed, repeated runs (very likely) differ.
+        let unseeded = Multinomial {
+            sample_size: 20,
+            seed: None,
+        };
+        let a: Tensor<i32> = unseeded.run_simple(input.view()).unwrap();
+        let b: Tensor<i32> = unseeded.run_simple(input.view()).unwrap();
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn test_multinomial_empty_classes() {
+        // An input with zero classes has no distribution to sample from. This
+        // should report an error rather than panic.
+        let input = Tensor::<f32>::zeros(&[2, 0]);
+        let op = Multinomial {
+            sample_size: 4,
+            seed: None,
+        };
+        let result: Result<Tensor<i32>, _> = op.run_simple(input.view());
+        assert_eq!(
+            result.err(),
+            Some(OpError::InvalidValue("input must have at least one class"))
+        );
+    }
+
+    #[test]
+    fn test_multinomial_empty_batch() {
+        // An input with no rows yields an empty output without error.
+        let input = Tensor::<f32>::zeros(&[0, 3]);
+        let op = Multinomial {
+            sample_size: 4,
+            seed: None,
+        };
+        let output: Tensor<i32> = op.run_simple(input.view()).unwrap();
+        assert_eq!(output.shape(), &[0, 4]);
     }
 
     #[test]


### PR DESCRIPTION
Implement the ONNX [`Multinomial`](https://onnx.ai/onnx/operators/onnx__Multinomial.html) operator, which draws sampled class indices from per-row categorical distributions defined by unnormalized log probabilities (logits).

Both int32 and int64 output data types are accepted, but produce int32 output since RTen does not have a distinct int64 type. Other output types are rejected at model load time.

Fixes https://github.com/robertknight/rten/issues/1252