### PR TITLE
Support Upsample operator

### DIFF
--- a/rten-shape-inference/src/ops.rs
+++ b/rten-shape-inference/src/ops.rs
@@ -34,7 +34,7 @@ pub use layout::{
 };
 pub use matmul::{Gemm, MatMul, MatMulNBits};
 pub use pad::Pad;
-pub use resize::Resize;
+pub use resize::{Resize, Upsample};
 pub use rnn::{Direction, GRU, LSTM};
 pub use slice::Slice;
 pub use split::Split;

--- a/rten-shape-inference/src/ops/resize.rs
+++ b/rten-shape-inference/src/ops/resize.rs
@@ -54,6 +54,45 @@ impl InferShapes for Resize {
     }
 }
 
+/// Upsample operator.
+///
+/// This is a deprecated operator that has been replaced by [`Resize`]. See
+/// <https://onnx.ai/onnx/operators/onnx__Upsample.html>.
+pub struct Upsample;
+
+// Input position of the `scales` input. The data input is at the same position
+// (`DATA`) as for `Resize`.
+const UPSAMPLE_SCALES: usize = 1;
+
+impl InferShapes for Upsample {
+    fn infer_shapes(
+        &self,
+        inputs: &[SymTensor],
+        sym_gen: &mut SymbolGen,
+    ) -> Result<Vec<SymTensor>, InferShapesError> {
+        let data = inputs
+            .get(DATA)
+            .ok_or(InferShapesError::IncorrectInputCount)?;
+
+        let Some(data_dims) = data.shape() else {
+            return Ok([SymTensor::unknown("unknown input shape")].into());
+        };
+
+        let input_scales = optional_input(inputs, UPSAMPLE_SCALES).and_then(|s| s.as_vector());
+
+        let out_shape: Vec<SymExpr> = if let Some(scales) = input_scales {
+            data_dims
+                .zip(scales.iter())
+                .map(|(in_dim, scale)| in_dim * scale.clone())
+                .collect()
+        } else {
+            sym_gen.gen_shape(data_dims.len())
+        };
+
+        Ok([SymTensor::from_shape(out_shape)].into())
+    }
+}
+
 /// Get an optional input.
 ///
 /// As a special case this treats an empty vector as missing. In opset < 13, the
@@ -75,7 +114,7 @@ mod tests {
     use crate::sym_gen::SymbolGen;
     use crate::sym_tensor::{SymTensor, sym_shape, sym_vec};
 
-    use super::Resize;
+    use super::{Resize, Upsample};
 
     #[test]
     fn test_resize_sizes() {
@@ -159,5 +198,36 @@ mod tests {
             .err()
             .unwrap();
         assert_eq!(err, InferShapesError::IncorrectInputCount);
+    }
+
+    #[test]
+    fn test_upsample() {
+        let data = sym_shape!("batch", 3, 224, 224);
+        let scales = sym_vec!(1, 1, 2, 2);
+
+        let mut sym_gen = SymbolGen::new();
+        let result = Upsample
+            .infer_shapes(&[data, scales], &mut sym_gen)
+            .unwrap();
+        assert_eq!(
+            result[0].clone().simplify(),
+            sym_shape!("batch", 3, 448, 448)
+        );
+    }
+
+    #[test]
+    fn test_upsample_unknown_scales() {
+        let data = sym_shape!(1, 3, 224, 224);
+        let scales = SymTensor::unknown("unknown");
+
+        let mut sym_gen = SymbolGen::new();
+        let result = Upsample
+            .infer_shapes(&[data, scales], &mut sym_gen)
+            .unwrap();
+        let shape: Vec<_> = result[0].shape().unwrap().collect();
+        assert_eq!(shape.len(), 4);
+        for dim in &shape {
+            assert!(matches!(dim, SymExpr::Var(_)));
+        }
     }
 }

--- a/src/infer_shapes.rs
+++ b/src/infer_shapes.rs
@@ -354,13 +354,13 @@ fn const_to_sym_scalar(constant: &graph::Constant) -> Option<SymExpr> {
 fn const_to_sym_vector(constant: &graph::Constant) -> Option<Vec<SymExpr>> {
     let int_vec: Option<&[i32]> = constant.as_vector();
     if let Some(int_vec) = int_vec {
-        return Some(int_vec.into_iter().copied().map(SymExpr::Value).collect());
+        return Some(int_vec.iter().copied().map(SymExpr::Value).collect());
     }
 
     let float_vec: Option<&[f32]> = constant.as_vector();
     if let Some(float_vec) = float_vec {
         return float_vec
-            .into_iter()
+            .iter()
             .map(|&f| f32_to_int_checked(f).map(SymExpr::Value))
             .collect();
     }

--- a/src/model/onnx_builder.rs
+++ b/src/model/onnx_builder.rs
@@ -11,6 +11,7 @@ use crate::model::external_data::DataLocation;
 pub enum AttrValue {
     Bool(bool),
     Float(f32),
+    Floats(Vec<f32>),
     Graph(onnx::GraphProto),
     Int(i64),
     Ints(Vec<i64>),
@@ -20,6 +21,7 @@ pub enum AttrValue {
 
 enum_from!(AttrValue, Bool, bool);
 enum_from!(AttrValue, Float, f32);
+enum_from!(AttrValue, Floats, Vec<f32>);
 enum_from!(AttrValue, Graph, onnx::GraphProto);
 enum_from!(AttrValue, Int, i64);
 enum_from!(AttrValue, Ints, Vec<i64>);
@@ -32,6 +34,7 @@ pub fn create_attr(name: &str, value: AttrValue) -> onnx::AttributeProto {
     match value {
         AttrValue::Bool(val) => attr.i = Some(val as i64),
         AttrValue::Float(val) => attr.f = Some(val),
+        AttrValue::Floats(val) => attr.floats = val,
         AttrValue::Graph(val) => attr.g = Some(val),
         AttrValue::Int(val) => attr.i = Some(val),
         AttrValue::Ints(val) => attr.ints = val,

--- a/src/model/onnx_loader.rs
+++ b/src/model/onnx_loader.rs
@@ -705,6 +705,7 @@ fn constant_from_attr_value(val: ConstInput) -> Constant {
             Constant::new(None, Tensor::from(vals).into_arc())
         }
         ConstInput::Float(float) => Constant::new(None, Tensor::from(float).into_arc()),
+        ConstInput::Floats(floats) => Constant::new(None, Tensor::from(floats).into_arc()),
     }
 }
 

--- a/src/op_registry/onnx_registry.rs
+++ b/src/op_registry/onnx_registry.rs
@@ -234,6 +234,7 @@ impl OnnxOpRegistry {
         register_op!(Transpose);
         register_op!(Trilu);
         register_op!(Unsqueeze);
+        register_op!(Upsample);
         register_op!(Where);
         register_op!(Xor);
 
@@ -301,6 +302,7 @@ pub trait OpLoadContext {
 pub enum ConstInput {
     Ints(Vec<i64>),
     Float(f32),
+    Floats(Vec<f32>),
 }
 
 /// Result of deserializing an ONNX operator and converting it to RTen's
@@ -1509,6 +1511,29 @@ impl_read_op!(Resize, |attrs: &Attrs| {
     })
 });
 
+impl_read_op!(Upsample, |attrs: &Attrs| {
+    let mode = attrs
+        .get("mode")
+        .map(|v| {
+            v.as_string_enum(|val| match val {
+                "nearest" => Some(ResizeMode::Nearest),
+                "linear" => Some(ResizeMode::Linear),
+                _ => None,
+            })
+        })
+        .transpose()?
+        .unwrap_or(ResizeMode::Nearest);
+
+    // `scales` is a required attribute in opset 7. In opset 9+ it is passed as
+    // the second input.
+    let mut const_inputs = Vec::new();
+    if let Some(scales) = attrs.get("scales") {
+        const_inputs.push((1, ConstInput::Floats(scales.as_floats().to_vec())));
+    }
+
+    Ok(ParsedOp::new(ops::Upsample { mode }).with_inputs(const_inputs))
+});
+
 impl_read_op!(
     "com.microsoft",
     RotaryEmbeddingMicrosoft,
@@ -1726,7 +1751,7 @@ mod tests {
     use super::{ConstInput, OnnxOpRegistry, OpLoadContext, ReadOpError};
     use crate::graph::Graph;
     use crate::model::onnx_builder::{NodeProtoExt, TensorData, create_node, create_tensor};
-    use crate::ops::{ArgMax, ConstantOfShape, Conv, Padding};
+    use crate::ops::{ArgMax, ConstantOfShape, Conv, Padding, ResizeMode, Upsample};
     use crate::value::Scalar;
 
     struct FakeOpLoadContext;
@@ -1764,6 +1789,22 @@ mod tests {
         let argmax_op = op.downcast_ref::<ArgMax>().unwrap();
         assert_eq!(argmax_op.axis, 1);
         assert_eq!(argmax_op.keep_dims, true);
+    }
+
+    #[test]
+    fn test_read_upsample() {
+        let reg = OnnxOpRegistry::with_all_ops();
+
+        // `mode` defaults to nearest.
+        let node = create_node("Upsample");
+        let op = reg.read_op(&node, &FakeOpLoadContext).unwrap().op;
+        let upsample = op.downcast_ref::<Upsample>().unwrap();
+        assert!(matches!(upsample.mode, ResizeMode::Nearest));
+
+        let node = create_node("Upsample").with_attr("mode", "linear".to_string());
+        let op = reg.read_op(&node, &FakeOpLoadContext).unwrap().op;
+        let upsample = op.downcast_ref::<Upsample>().unwrap();
+        assert!(matches!(upsample.mode, ResizeMode::Linear));
     }
 
     #[test]
@@ -1961,6 +2002,10 @@ mod tests {
             Case {
                 op: create_node("Unsqueeze").with_attr("axes", vec![-1]),
                 expected_inputs: [(1, ConstInput::Ints([-1].into()))].into(),
+            },
+            Case {
+                op: create_node("Upsample").with_attr("scales", vec![1.0f32, 1.0, 2.0, 2.0]),
+                expected_inputs: [(1, ConstInput::Floats([1.0, 1.0, 2.0, 2.0].into()))].into(),
             },
         ];
 

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -101,7 +101,7 @@ pub(crate) use {
         ArgMax, ArgMin, CumSum, NonZero, ReduceL1, ReduceL2, ReduceMax, ReduceMean, ReduceMin,
         ReduceProd, ReduceSum, ReduceSumSquare, TopK,
     },
-    resize::Resize,
+    resize::{Resize, Upsample},
     rnn::{GRU, LSTM},
     sequence::{
         ConcatFromSequence, SequenceAt, SequenceConstruct, SequenceEmpty, SequenceErase,

--- a/src/ops/resize.rs
+++ b/src/ops/resize.rs
@@ -551,6 +551,52 @@ impl Operator for Resize {
 
 impl_infer_shapes!(Resize, _op, shape_ops::Resize);
 
+/// Upsample operator.
+///
+/// This is a deprecated operator that has been replaced by [`Resize`]. It is
+/// supported for compatibility with older ONNX models. See
+/// <https://onnx.ai/onnx/operators/onnx__Upsample.html>.
+#[derive(Debug)]
+pub struct Upsample {
+    pub mode: ResizeMode,
+}
+
+impl Operator for Upsample {
+    fn name(&self) -> &str {
+        "Upsample"
+    }
+
+    fn max_inputs(&self) -> Option<usize> {
+        Some(2)
+    }
+
+    fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+        let inputs = ctx.inputs();
+        let input = inputs.require_as(0)?;
+        let scales: NdTensorView<f32, 1> = inputs.require_as(1)?;
+
+        resize(
+            ctx.pool(),
+            input,
+            ResizeTarget::Scales(scales),
+            self.mode,
+            CoordTransformMode::Asymmetric,
+            NearestMode::Floor,
+        )
+        .into_op_result()
+    }
+
+    fn output_types(&self, _ctx: &OutputTypesContext) -> Option<OutputTypeList> {
+        Some([OutputType::CopyFromInput(0)].into())
+    }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        Some(self)
+    }
+}
+
+impl_infer_shapes!(Upsample, _op, shape_ops::Upsample);
+
 #[cfg(test)]
 mod tests {
     use rten_tensor::prelude::*;
@@ -559,9 +605,12 @@ mod tests {
     use rten_testing::TestCases;
 
     use crate::buffer_pool::BufferPool;
+    use crate::operator::OperatorExt;
     use crate::operator::{InputList, OpError, OpRunContext, Operator};
     use crate::ops::tests::expect_eq_1e4;
-    use crate::ops::{CoordTransformMode, NearestMode, Resize, ResizeMode, ResizeTarget, resize};
+    use crate::ops::{
+        CoordTransformMode, NearestMode, Resize, ResizeMode, ResizeTarget, Upsample, resize,
+    };
 
     // Reference values for these tests can be computed with either OpenCV
     // (`cv2.resize`) or PyTorch (`torch.nn.functional.interpolate`).
@@ -1010,6 +1059,53 @@ mod tests {
                     panic!("Expected error but got output");
                 }
             }
+        })
+    }
+
+    #[test]
+    fn test_upsample() {
+        #[derive(Debug)]
+        struct Case {
+            mode: ResizeMode,
+            scales: Tensor,
+            expected: Tensor,
+        }
+
+        let image = Tensor::from_data(&[1, 1, 2, 2], vec![0.2, 0.7, 0.3, 0.8]);
+
+        let cases = [
+            // Nearest resize
+            Case {
+                mode: ResizeMode::Nearest,
+                scales: Tensor::from([1., 1., 2., 2.]),
+                expected: Tensor::from([
+                    [0.2, 0.2, 0.7, 0.7],
+                    [0.2, 0.2, 0.7, 0.7],
+                    [0.3, 0.3, 0.8, 0.8],
+                    [0.3, 0.3, 0.8, 0.8],
+                ])
+                .with_new_axis(0) // C
+                .with_new_axis(0), // N
+            },
+            // Bilinear resize
+            Case {
+                mode: ResizeMode::Linear,
+                scales: Tensor::from([1., 1., 2., 2.]),
+                expected: Tensor::from([
+                    [0.2, 0.45, 0.7, 0.7],
+                    [0.25, 0.5, 0.75, 0.75],
+                    [0.3, 0.55, 0.8, 0.8],
+                    [0.3, 0.55, 0.8, 0.8],
+                ])
+                .with_new_axis(0) // C
+                .with_new_axis(0), // N
+            },
+        ];
+
+        cases.test_each(|case| {
+            let op = Upsample { mode: case.mode };
+            let result: Tensor = op.run_simple((&image, &case.scales)).unwrap();
+            expect_eq_1e4(&result, &case.expected).unwrap();
         })
     }
 }


### PR DESCRIPTION
This adds support for the deprecated [Upsample](https://onnx.ai/onnx/operators/onnx__Upsample.html) operator, supporting opset v7 and later. The implementation delegates to the Resize operator implementation, which is the operator that replaced Upsample.