### PR TITLE
Validate shape and dtype of model inputs

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -680,6 +680,74 @@ impl Graph {
         self.create_plan(inputs, outputs, opts)
     }
 
+    /// Check that supplied input values match the shape and dtype specified
+    /// in the graph's metadata for the input node.
+    ///
+    /// Symbolic dimensions in the expected shape can match any size.
+    fn validate_inputs(&self, inputs: &[(NodeId, ValueOrView)]) -> Result<(), RunError> {
+        let error = |node_id: NodeId, error: String| -> RunError {
+            RunErrorImpl::InvalidInput {
+                name: self.node_name(node_id),
+                error,
+            }
+            .into()
+        };
+
+        for (node_id, input) in inputs {
+            let Some(Node::Value(value_node)) = self.get_node(*node_id) else {
+                continue;
+            };
+            let value = input.as_view();
+
+            if let Some(expected_dtype) = value_node.dtype() {
+                let dtype = value.dtype();
+                if dtype != expected_dtype {
+                    return Err(error(
+                        *node_id,
+                        format!("expected type {} but got {}", expected_dtype, dtype),
+                    ));
+                }
+            }
+
+            // Shape metadata describes tensor inputs. Sequences don't have a
+            // shape of their own.
+            if matches!(value, ValueView::Sequence(_)) {
+                continue;
+            }
+
+            let Some(expected_shape) = value_node.shape() else {
+                continue;
+            };
+
+            let shape = value.shape();
+            if shape.len() != expected_shape.len() {
+                return Err(error(
+                    *node_id,
+                    format!(
+                        "expected tensor with {} dims but got {}",
+                        expected_shape.len(),
+                        shape.len()
+                    ),
+                ));
+            }
+            for (dim, (expected_size, size)) in expected_shape.iter().zip(shape.iter()).enumerate()
+            {
+                if let Dimension::Fixed(expected_size) = expected_size
+                    && expected_size != size
+                {
+                    return Err(error(
+                        *node_id,
+                        format!(
+                            "expected dim {} to have size {} but got {}",
+                            dim, expected_size, size
+                        ),
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+
     /// Compute a set of output values given a set of inputs, using the
     /// processing steps and constant values defined by the graph.
     pub fn run(
@@ -689,6 +757,7 @@ impl Graph {
         weight_cache: Option<&WeightCache>,
         opts: Option<RunOptions>,
     ) -> Result<Vec<Value>, RunError> {
+        self.validate_inputs(&inputs)?;
         let input_ids: Vec<_> = inputs.iter().map(|(node_id, _)| *node_id).collect();
         let plan = self.get_cached_plan(&input_ids, outputs, false /* is_subgraph */)?;
         let opts = opts.unwrap_or_default();
@@ -1217,6 +1286,7 @@ impl Graph {
         outputs: &[NodeId],
         opts: Option<RunOptions>,
     ) -> Result<Vec<(NodeId, Value)>, RunError> {
+        self.validate_inputs(&inputs)?;
         let input_ids: Vec<_> = inputs.iter().map(|(id, _)| id).copied().collect();
         let planner = Planner::with_graph(self);
         let plan = planner.create_plan(

--- a/src/graph/run_error.rs
+++ b/src/graph/run_error.rs
@@ -90,6 +90,8 @@ impl From<RunErrorImpl> for RunError {
 pub enum RunErrorKind {
     /// An input or output node was not found.
     NodeNotFound,
+    /// An input value did not match the shape or dtype expected by the model.
+    InvalidInput,
     /// Failed to construct an execution plan that would generate the requested
     /// outputs from the inputs.
     PlanningError,
@@ -105,6 +107,15 @@ pub(crate) enum RunErrorImpl {
 
     /// No node with a given name could be found
     InvalidNodeName(String),
+
+    /// An input value did not match the shape or dtype expected by the model.
+    InvalidInput {
+        /// Name of the input node.
+        name: String,
+
+        /// Error details.
+        error: String,
+    },
 
     /// A plan could not be constructed that would generate the requested output
     /// from the input.
@@ -149,6 +160,7 @@ impl RunErrorImpl {
 
         match self {
             Self::InvalidNodeId | Self::InvalidNodeName(_) => Kind::NodeNotFound,
+            Self::InvalidInput { .. } => Kind::InvalidInput,
             Self::PlanningError(_) => Kind::PlanningError,
             Self::OperatorError { .. } | Self::OutputMismatch { .. } => Kind::OperatorError,
             Self::SubgraphError { error, .. } => error.kind(),
@@ -159,6 +171,7 @@ impl RunErrorImpl {
         match self {
             Self::InvalidNodeId => [None].into(),
             Self::InvalidNodeName(name) => [Some(name.as_str())].into(),
+            Self::InvalidInput { name, .. } => [Some(name.as_str())].into(),
             Self::PlanningError(_) => [None].into(),
             Self::OperatorError { name, .. } => [Some(name.as_str())].into(),
             Self::OutputMismatch { name, .. } => [Some(name.as_str())].into(),
@@ -176,6 +189,9 @@ impl Display for RunErrorImpl {
         match self {
             Self::InvalidNodeId => write!(f, "node ID is invalid"),
             Self::InvalidNodeName(name) => write!(f, "no node found with name {}", name),
+            Self::InvalidInput { name, error } => {
+                write!(f, "input \"{}\" is invalid: {}", name, error)
+            }
             Self::PlanningError(err) => write!(f, "planning error: {}", err),
             Self::OperatorError {
                 name,

--- a/src/graph/tests.rs
+++ b/src/graph/tests.rs
@@ -5,6 +5,7 @@ use std::sync::{Arc, Mutex};
 use rten_tensor::prelude::*;
 use rten_tensor::test_util::{expect_equal, expect_equal_with_tolerance};
 use rten_tensor::{Tensor, TensorView};
+use rten_testing::TestCases;
 
 use smallvec::{SmallVec, smallvec};
 
@@ -275,6 +276,97 @@ fn test_graph_node_shapes() {
         )
     );
     assert_eq!(g.get_node(relu_op_id).and_then(|n| n.shape()), None);
+}
+
+#[test]
+fn test_graph_run_invalid_input() {
+    #[derive(Debug)]
+    struct Case {
+        expected_shape: Option<Vec<Dimension>>,
+        expected_dtype: Option<ValueType>,
+        input: Value,
+        expected_error: Option<&'static str>,
+    }
+
+    let cases = [
+        // Input matches expected shape and dtype.
+        Case {
+            expected_shape: Some(vec![
+                Dimension::Symbolic("N".to_string()),
+                Dimension::Fixed(2),
+            ]),
+            expected_dtype: Some(ValueType::Tensor(DataType::Float)),
+            input: Tensor::<f32>::zeros(&[3, 2]).into(),
+            expected_error: None,
+        },
+        // Input node has no shape or dtype metadata.
+        Case {
+            expected_shape: None,
+            expected_dtype: None,
+            input: Tensor::<f32>::zeros(&[3]).into(),
+            expected_error: None,
+        },
+        // Wrong dtype.
+        Case {
+            expected_shape: None,
+            expected_dtype: Some(ValueType::Tensor(DataType::Float)),
+            input: Tensor::<i32>::zeros(&[3, 2]).into(),
+            expected_error: Some(
+                "input \"input\" is invalid: expected type tensor(f32) but got tensor(i32)",
+            ),
+        },
+        // Wrong rank.
+        Case {
+            expected_shape: Some(vec![
+                Dimension::Symbolic("N".to_string()),
+                Dimension::Fixed(2),
+            ]),
+            expected_dtype: None,
+            input: Tensor::<f32>::zeros(&[3]).into(),
+            expected_error: Some(
+                "input \"input\" is invalid: expected tensor with 2 dims but got 1",
+            ),
+        },
+        // Wrong size for fixed dimension.
+        Case {
+            expected_shape: Some(vec![
+                Dimension::Symbolic("N".to_string()),
+                Dimension::Fixed(2),
+            ]),
+            expected_dtype: None,
+            input: Tensor::<f32>::zeros(&[3, 4]).into(),
+            expected_error: Some(
+                "input \"input\" is invalid: expected dim 1 to have size 2 but got 4",
+            ),
+        },
+    ];
+
+    cases.test_each(|case| {
+        let mut g = Graph::new();
+        let input_id = g.add_value(
+            Some("input"),
+            case.expected_shape.clone(),
+            case.expected_dtype,
+        );
+        let (_, op_out) = g.add_simple_op("relu", Relu {}, &[input_id]);
+
+        let result = g.run(
+            vec![(input_id, case.input.as_view().into())],
+            &[op_out],
+            None,
+            None,
+        );
+
+        match (&result, case.expected_error) {
+            (Ok(_), None) => {}
+            (Err(err), Some(expected_error)) => {
+                assert_eq!(err.kind(), RunErrorKind::InvalidInput);
+                assert_eq!(err.to_string(), expected_error);
+            }
+            (Ok(_), Some(_)) => panic!("expected run to fail"),
+            (Err(err), None) => panic!("expected run to succeed but got error: {}", err),
+        }
+    })
 }
 
 #[test]

--- a/src/model.rs
+++ b/src/model.rs
@@ -472,6 +472,9 @@ impl Model {
     ///
     /// The input and output nodes are specified via IDs looked up via
     /// [`node_id`](Model::node_id).
+    ///
+    /// Input values are validated against the shape and dtype specified in the
+    /// model, which can be queried via [`Model::node_info`].
     pub fn run(
         &self,
         inputs: Vec<(NodeId, ValueOrView)>,


### PR DESCRIPTION
Validate the shape and dtypes of inputs against input metadata when running models. Validation errors are reported via an error with kind `RunErrorKind::InvalidInput`.

Previously inputs with incorrect shapes and types could cause confusing errors from operators in the middle of the graph. See issue #1256 for an example. This now fails early with an error such as:

    input "x_lens" is invalid: expected tensor with 1 dims but got 0

This behavior matches ONNX Runtime, which rejects such inputs at session run time.

The ONNX specification requires inputs to declare their shape and dtype, so all ONNX models _should_ have the necessary metadata. However rten will load models where this metadata is not present, and some old `.rten` format models don't have it, in which case it is simply not checked.

There is currently no opt-out from shape and dtype validation, that could be added as a new configuration option to `RunOptions` in future.