### PR TITLE
Implement ReverseSequence operator

### DIFF
--- a/rten-convert/rten_convert/converter.py
+++ b/rten-convert/rten_convert/converter.py
@@ -672,6 +672,11 @@ def op_node_from_onnx_operator(
             attrs = sg.ReshapeAttrsT()
             attrs.allowZero = bool(attr_reader.get_attr("allowzero", "int", 0))
 
+        case "ReverseSequence":
+            attrs = sg.ReverseSequenceAttrsT()
+            attrs.batchAxis = attr_reader.get_attr("batch_axis", "int", 1)
+            attrs.timeAxis = attr_reader.get_attr("time_axis", "int", 0)
+
         case "Resize":
             attrs = sg.ResizeAttrsT()
             attrs.mode = attr_reader.get_enum_attr(

--- a/rten-convert/rten_convert/schema_generated.py
+++ b/rten-convert/rten_convert/schema_generated.py
@@ -143,6 +143,7 @@ class OperatorType(object):
     Cosh = 133
     Sinh = 134
     Multinomial = 135
+    ReverseSequence = 136
 
 
 class RNNDirection(object):
@@ -239,6 +240,7 @@ class OperatorAttrs(object):
     GridSampleAttrs = 53
     STFTAttrs = 54
     MultinomialAttrs = 55
+    ReverseSequenceAttrs = 56
 
 def OperatorAttrsCreator(unionType, table):
     from flatbuffers.table import Table
@@ -354,6 +356,8 @@ def OperatorAttrsCreator(unionType, table):
         return STFTAttrsT.InitFromBuf(table.Bytes, table.Pos)
     if unionType == OperatorAttrs.MultinomialAttrs:
         return MultinomialAttrsT.InitFromBuf(table.Bytes, table.Pos)
+    if unionType == OperatorAttrs.ReverseSequenceAttrs:
+        return ReverseSequenceAttrsT.InitFromBuf(table.Bytes, table.Pos)
     return None
 
 
@@ -6135,6 +6139,100 @@ class STFTAttrsT(object):
         return stftattrs
 
 
+class ReverseSequenceAttrs(object):
+    __slots__ = ['_tab']
+
+    @classmethod
+    def GetRootAs(cls, buf, offset=0):
+        n = flatbuffers.encode.Get(flatbuffers.packer.uoffset, buf, offset)
+        x = ReverseSequenceAttrs()
+        x.Init(buf, n + offset)
+        return x
+
+    @classmethod
+    def GetRootAsReverseSequenceAttrs(cls, buf, offset=0):
+        """This method is deprecated. Please switch to GetRootAs."""
+        return cls.GetRootAs(buf, offset)
+    @classmethod
+    def ReverseSequenceAttrsBufferHasIdentifier(cls, buf, offset, size_prefixed=False):
+        return flatbuffers.util.BufferHasIdentifier(buf, offset, b"\x52\x54\x45\x4E", size_prefixed=size_prefixed)
+
+    # ReverseSequenceAttrs
+    def Init(self, buf, pos):
+        self._tab = flatbuffers.table.Table(buf, pos)
+
+    # ReverseSequenceAttrs
+    def BatchAxis(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
+        if o != 0:
+            return self._tab.Get(flatbuffers.number_types.Int32Flags, o + self._tab.Pos)
+        return 1
+
+    # ReverseSequenceAttrs
+    def TimeAxis(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(6))
+        if o != 0:
+            return self._tab.Get(flatbuffers.number_types.Int32Flags, o + self._tab.Pos)
+        return 0
+
+def ReverseSequenceAttrsStart(builder):
+    builder.StartObject(2)
+
+def ReverseSequenceAttrsAddBatchAxis(builder, batchAxis):
+    builder.PrependInt32Slot(0, batchAxis, 1)
+
+def ReverseSequenceAttrsAddTimeAxis(builder, timeAxis):
+    builder.PrependInt32Slot(1, timeAxis, 0)
+
+def ReverseSequenceAttrsEnd(builder):
+    return builder.EndObject()
+
+
+
+class ReverseSequenceAttrsT(object):
+
+    # ReverseSequenceAttrsT
+    def __init__(
+        self,
+        batchAxis = 1,
+        timeAxis = 0,
+    ):
+        self.batchAxis = batchAxis  # type: int
+        self.timeAxis = timeAxis  # type: int
+
+    @classmethod
+    def InitFromBuf(cls, buf, pos):
+        reverseSequenceAttrs = ReverseSequenceAttrs()
+        reverseSequenceAttrs.Init(buf, pos)
+        return cls.InitFromObj(reverseSequenceAttrs)
+
+    @classmethod
+    def InitFromPackedBuf(cls, buf, pos=0):
+        n = flatbuffers.encode.Get(flatbuffers.packer.uoffset, buf, pos)
+        return cls.InitFromBuf(buf, pos+n)
+
+    @classmethod
+    def InitFromObj(cls, reverseSequenceAttrs):
+        x = ReverseSequenceAttrsT()
+        x._UnPack(reverseSequenceAttrs)
+        return x
+
+    # ReverseSequenceAttrsT
+    def _UnPack(self, reverseSequenceAttrs):
+        if reverseSequenceAttrs is None:
+            return
+        self.batchAxis = reverseSequenceAttrs.BatchAxis()
+        self.timeAxis = reverseSequenceAttrs.TimeAxis()
+
+    # ReverseSequenceAttrsT
+    def Pack(self, builder):
+        ReverseSequenceAttrsStart(builder)
+        ReverseSequenceAttrsAddBatchAxis(builder, self.batchAxis)
+        ReverseSequenceAttrsAddTimeAxis(builder, self.timeAxis)
+        reverseSequenceAttrs = ReverseSequenceAttrsEnd(builder)
+        return reverseSequenceAttrs
+
+
 class TopKAttrs(object):
     __slots__ = ['_tab']
 
@@ -6591,7 +6689,7 @@ class OperatorNodeT(object):
     ):
         self.type = type  # type: int
         self.attrsType = attrsType  # type: int
-        self.attrs = attrs  # type: Union[None, 'ArgMaxAttrsT', 'AveragePoolAttrsT', 'BatchNormalizationAttrsT', 'CastAttrsT', 'ConcatAttrsT', 'ConstantOfShapeAttrsT', 'ConvAttrsT', 'ConvTransposeAttrsT', 'FlattenAttrsT', 'GatherAttrsT', 'GemmAttrsT', 'GRUAttrsT', 'LeakyReluAttrsT', 'LSTMAttrsT', 'MaxPoolAttrsT', 'ReduceMeanAttrsT', 'ReshapeAttrsT', 'ResizeAttrsT', 'SplitAttrsT', 'SoftmaxAttrsT', 'TransposeAttrsT', 'ModAttrsT', 'ScatterElementsAttrsT', 'OneHotAttrsT', 'TopKAttrsT', 'HardSigmoidAttrsT', 'TriluAttrsT', 'ScatterNDAttrsT', 'NonMaxSuppressionAttrsT', 'LayerNormalizationAttrsT', 'RandomUniformAttrsT', 'EluAttrsT', 'RandomUniformLikeAttrsT', 'RandomNormalAttrsT', 'RandomNormalLikeAttrsT', 'GatherNDAttrsT', 'GeluAttrsT', 'EinsumAttrsT', 'IfAttrsT', 'PadAttrsT', 'DequantizeLinearAttrsT', 'QuantizeLinearAttrsT', 'DepthToSpaceAttrsT', 'CastLikeAttrsT', 'ShapeAttrsT', 'DropoutAttrsT', 'EyeLikeAttrsT', 'IsInfAttrsT', 'LoopAttrsT', 'SequenceEmptyAttrsT', 'ConcatFromSequenceAttrsT', 'SplitToSequenceAttrsT', 'GridSampleAttrsT', 'STFTAttrsT', 'MultinomialAttrsT']
+        self.attrs = attrs  # type: Union[None, 'ArgMaxAttrsT', 'AveragePoolAttrsT', 'BatchNormalizationAttrsT', 'CastAttrsT', 'ConcatAttrsT', 'ConstantOfShapeAttrsT', 'ConvAttrsT', 'ConvTransposeAttrsT', 'FlattenAttrsT', 'GatherAttrsT', 'GemmAttrsT', 'GRUAttrsT', 'LeakyReluAttrsT', 'LSTMAttrsT', 'MaxPoolAttrsT', 'ReduceMeanAttrsT', 'ReshapeAttrsT', 'ResizeAttrsT', 'SplitAttrsT', 'SoftmaxAttrsT', 'TransposeAttrsT', 'ModAttrsT', 'ScatterElementsAttrsT', 'OneHotAttrsT', 'TopKAttrsT', 'HardSigmoidAttrsT', 'TriluAttrsT', 'ScatterNDAttrsT', 'NonMaxSuppressionAttrsT', 'LayerNormalizationAttrsT', 'RandomUniformAttrsT', 'EluAttrsT', 'RandomUniformLikeAttrsT', 'RandomNormalAttrsT', 'RandomNormalLikeAttrsT', 'GatherNDAttrsT', 'GeluAttrsT', 'EinsumAttrsT', 'IfAttrsT', 'PadAttrsT', 'DequantizeLinearAttrsT', 'QuantizeLinearAttrsT', 'DepthToSpaceAttrsT', 'CastLikeAttrsT', 'ShapeAttrsT', 'DropoutAttrsT', 'EyeLikeAttrsT', 'IsInfAttrsT', 'LoopAttrsT', 'SequenceEmptyAttrsT', 'ConcatFromSequenceAttrsT', 'SplitToSequenceAttrsT', 'GridSampleAttrsT', 'STFTAttrsT', 'MultinomialAttrsT', 'ReverseSequenceAttrsT']
         self.inputs = inputs  # type: Optional[List[int]]
         self.outputs = outputs  # type: Optional[List[int]]
 

--- a/rten-model-file/src/schema.fbs
+++ b/rten-model-file/src/schema.fbs
@@ -149,6 +149,7 @@ enum OperatorType: ubyte {
   Cosh,
   Sinh,
   Multinomial,
+  ReverseSequence,
 }
 
 enum RNNDirection: ubyte {
@@ -256,6 +257,7 @@ union OperatorAttrs {
   GridSampleAttrs,
   STFTAttrs,
   MultinomialAttrs,
+  ReverseSequenceAttrs,
 }
 
 table ArgMaxAttrs {
@@ -572,6 +574,11 @@ table SplitToSequenceAttrs {
 
 table STFTAttrs {
   onesided:bool = true;
+}
+
+table ReverseSequenceAttrs {
+  batch_axis:int = 1;
+  time_axis:int = 0;
 }
 
 table TopKAttrs {

--- a/rten-model-file/src/schema_generated.rs
+++ b/rten-model-file/src/schema_generated.rs
@@ -11,13 +11,13 @@ pub const ENUM_MIN_OPERATOR_TYPE: u8 = 0;
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
-pub const ENUM_MAX_OPERATOR_TYPE: u8 = 135;
+pub const ENUM_MAX_OPERATOR_TYPE: u8 = 136;
 #[deprecated(
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 136] = [
+pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 137] = [
     OperatorType::Add,
     OperatorType::ArgMin,
     OperatorType::ArgMax,
@@ -154,6 +154,7 @@ pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 136] = [
     OperatorType::Cosh,
     OperatorType::Sinh,
     OperatorType::Multinomial,
+    OperatorType::ReverseSequence,
 ];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -297,9 +298,10 @@ impl OperatorType {
     pub const Cosh: Self = Self(133);
     pub const Sinh: Self = Self(134);
     pub const Multinomial: Self = Self(135);
+    pub const ReverseSequence: Self = Self(136);
 
     pub const ENUM_MIN: u8 = 0;
-    pub const ENUM_MAX: u8 = 135;
+    pub const ENUM_MAX: u8 = 136;
     pub const ENUM_VALUES: &'static [Self] = &[
         Self::Add,
         Self::ArgMin,
@@ -437,6 +439,7 @@ impl OperatorType {
         Self::Cosh,
         Self::Sinh,
         Self::Multinomial,
+        Self::ReverseSequence,
     ];
     /// Returns the variant's name or "" if unknown.
     pub fn variant_name(self) -> Option<&'static str> {
@@ -577,6 +580,7 @@ impl OperatorType {
             Self::Cosh => Some("Cosh"),
             Self::Sinh => Some("Sinh"),
             Self::Multinomial => Some("Multinomial"),
+            Self::ReverseSequence => Some("ReverseSequence"),
             _ => None,
         }
     }
@@ -1212,13 +1216,13 @@ pub const ENUM_MIN_OPERATOR_ATTRS: u8 = 0;
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
-pub const ENUM_MAX_OPERATOR_ATTRS: u8 = 55;
+pub const ENUM_MAX_OPERATOR_ATTRS: u8 = 56;
 #[deprecated(
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_OPERATOR_ATTRS: [OperatorAttrs; 56] = [
+pub const ENUM_VALUES_OPERATOR_ATTRS: [OperatorAttrs; 57] = [
     OperatorAttrs::NONE,
     OperatorAttrs::ArgMaxAttrs,
     OperatorAttrs::AveragePoolAttrs,
@@ -1275,6 +1279,7 @@ pub const ENUM_VALUES_OPERATOR_ATTRS: [OperatorAttrs; 56] = [
     OperatorAttrs::GridSampleAttrs,
     OperatorAttrs::STFTAttrs,
     OperatorAttrs::MultinomialAttrs,
+    OperatorAttrs::ReverseSequenceAttrs,
 ];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -1338,9 +1343,10 @@ impl OperatorAttrs {
     pub const GridSampleAttrs: Self = Self(53);
     pub const STFTAttrs: Self = Self(54);
     pub const MultinomialAttrs: Self = Self(55);
+    pub const ReverseSequenceAttrs: Self = Self(56);
 
     pub const ENUM_MIN: u8 = 0;
-    pub const ENUM_MAX: u8 = 55;
+    pub const ENUM_MAX: u8 = 56;
     pub const ENUM_VALUES: &'static [Self] = &[
         Self::NONE,
         Self::ArgMaxAttrs,
@@ -1398,6 +1404,7 @@ impl OperatorAttrs {
         Self::GridSampleAttrs,
         Self::STFTAttrs,
         Self::MultinomialAttrs,
+        Self::ReverseSequenceAttrs,
     ];
     /// Returns the variant's name or "" if unknown.
     pub fn variant_name(self) -> Option<&'static str> {
@@ -1458,6 +1465,7 @@ impl OperatorAttrs {
             Self::GridSampleAttrs => Some("GridSampleAttrs"),
             Self::STFTAttrs => Some("STFTAttrs"),
             Self::MultinomialAttrs => Some("MultinomialAttrs"),
+            Self::ReverseSequenceAttrs => Some("ReverseSequenceAttrs"),
             _ => None,
         }
     }
@@ -9578,6 +9586,138 @@ impl ::core::fmt::Debug for STFTAttrs<'_> {
         ds.finish()
     }
 }
+pub enum ReverseSequenceAttrsOffset {}
+#[derive(Copy, Clone, PartialEq)]
+
+pub struct ReverseSequenceAttrs<'a> {
+    pub _tab: ::flatbuffers::Table<'a>,
+}
+
+impl<'a> ::flatbuffers::Follow<'a> for ReverseSequenceAttrs<'a> {
+    type Inner = ReverseSequenceAttrs<'a>;
+    #[inline]
+    unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self {
+            _tab: unsafe { ::flatbuffers::Table::new(buf, loc) },
+        }
+    }
+}
+
+impl<'a> ReverseSequenceAttrs<'a> {
+    pub const VT_BATCH_AXIS: ::flatbuffers::VOffsetT = 4;
+    pub const VT_TIME_AXIS: ::flatbuffers::VOffsetT = 6;
+
+    #[inline]
+    pub unsafe fn init_from_table(table: ::flatbuffers::Table<'a>) -> Self {
+        ReverseSequenceAttrs { _tab: table }
+    }
+    #[allow(unused_mut)]
+    pub fn create<
+        'bldr: 'args,
+        'args: 'mut_bldr,
+        'mut_bldr,
+        A: ::flatbuffers::Allocator + 'bldr,
+    >(
+        _fbb: &'mut_bldr mut ::flatbuffers::FlatBufferBuilder<'bldr, A>,
+        args: &'args ReverseSequenceAttrsArgs,
+    ) -> ::flatbuffers::WIPOffset<ReverseSequenceAttrs<'bldr>> {
+        let mut builder = ReverseSequenceAttrsBuilder::new(_fbb);
+        builder.add_time_axis(args.time_axis);
+        builder.add_batch_axis(args.batch_axis);
+        builder.finish()
+    }
+
+    #[inline]
+    pub fn batch_axis(&self) -> i32 {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab
+                .get::<i32>(ReverseSequenceAttrs::VT_BATCH_AXIS, Some(1))
+                .unwrap()
+        }
+    }
+    #[inline]
+    pub fn time_axis(&self) -> i32 {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab
+                .get::<i32>(ReverseSequenceAttrs::VT_TIME_AXIS, Some(0))
+                .unwrap()
+        }
+    }
+}
+
+impl ::flatbuffers::Verifiable for ReverseSequenceAttrs<'_> {
+    #[inline]
+    fn run_verifier(
+        v: &mut ::flatbuffers::Verifier,
+        pos: usize,
+    ) -> Result<(), ::flatbuffers::InvalidFlatbuffer> {
+        v.visit_table(pos)?
+            .visit_field::<i32>("batch_axis", Self::VT_BATCH_AXIS, false)?
+            .visit_field::<i32>("time_axis", Self::VT_TIME_AXIS, false)?
+            .finish();
+        Ok(())
+    }
+}
+pub struct ReverseSequenceAttrsArgs {
+    pub batch_axis: i32,
+    pub time_axis: i32,
+}
+impl<'a> Default for ReverseSequenceAttrsArgs {
+    #[inline]
+    fn default() -> Self {
+        ReverseSequenceAttrsArgs {
+            batch_axis: 1,
+            time_axis: 0,
+        }
+    }
+}
+
+pub struct ReverseSequenceAttrsBuilder<'a: 'b, 'b, A: ::flatbuffers::Allocator + 'a> {
+    fbb_: &'b mut ::flatbuffers::FlatBufferBuilder<'a, A>,
+    start_: ::flatbuffers::WIPOffset<::flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b, A: ::flatbuffers::Allocator + 'a> ReverseSequenceAttrsBuilder<'a, 'b, A> {
+    #[inline]
+    pub fn add_batch_axis(&mut self, batch_axis: i32) {
+        self.fbb_
+            .push_slot::<i32>(ReverseSequenceAttrs::VT_BATCH_AXIS, batch_axis, 1);
+    }
+    #[inline]
+    pub fn add_time_axis(&mut self, time_axis: i32) {
+        self.fbb_
+            .push_slot::<i32>(ReverseSequenceAttrs::VT_TIME_AXIS, time_axis, 0);
+    }
+    #[inline]
+    pub fn new(
+        _fbb: &'b mut ::flatbuffers::FlatBufferBuilder<'a, A>,
+    ) -> ReverseSequenceAttrsBuilder<'a, 'b, A> {
+        let start = _fbb.start_table();
+        ReverseSequenceAttrsBuilder {
+            fbb_: _fbb,
+            start_: start,
+        }
+    }
+    #[inline]
+    pub fn finish(self) -> ::flatbuffers::WIPOffset<ReverseSequenceAttrs<'a>> {
+        let o = self.fbb_.end_table(self.start_);
+        ::flatbuffers::WIPOffset::new(o.value())
+    }
+}
+
+impl ::core::fmt::Debug for ReverseSequenceAttrs<'_> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+        let mut ds = f.debug_struct("ReverseSequenceAttrs");
+        ds.field("batch_axis", &self.batch_axis());
+        ds.field("time_axis", &self.time_axis());
+        ds.finish()
+    }
+}
 pub enum TopKAttrsOffset {}
 #[derive(Copy, Clone, PartialEq)]
 
@@ -10889,6 +11029,21 @@ impl<'a> OperatorNode<'a> {
             None
         }
     }
+
+    #[inline]
+    #[allow(non_snake_case)]
+    pub fn attrs_as_reverse_sequence_attrs(&self) -> Option<ReverseSequenceAttrs<'a>> {
+        if self.attrs_type() == OperatorAttrs::ReverseSequenceAttrs {
+            self.attrs().map(|t| {
+                // Safety:
+                // Created from a valid Table for this object
+                // Which contains a valid union in this slot
+                unsafe { ReverseSequenceAttrs::init_from_table(t) }
+            })
+        } else {
+            None
+        }
+    }
 }
 
 impl ::flatbuffers::Verifiable for OperatorNode<'_> {
@@ -10956,6 +11111,7 @@ impl ::flatbuffers::Verifiable for OperatorNode<'_> {
           OperatorAttrs::GridSampleAttrs => v.verify_union_variant::<::flatbuffers::ForwardsUOffset<GridSampleAttrs>>("OperatorAttrs::GridSampleAttrs", pos),
           OperatorAttrs::STFTAttrs => v.verify_union_variant::<::flatbuffers::ForwardsUOffset<STFTAttrs>>("OperatorAttrs::STFTAttrs", pos),
           OperatorAttrs::MultinomialAttrs => v.verify_union_variant::<::flatbuffers::ForwardsUOffset<MultinomialAttrs>>("OperatorAttrs::MultinomialAttrs", pos),
+          OperatorAttrs::ReverseSequenceAttrs => v.verify_union_variant::<::flatbuffers::ForwardsUOffset<ReverseSequenceAttrs>>("OperatorAttrs::ReverseSequenceAttrs", pos),
           _ => Ok(()),
         }
      })?
@@ -11586,6 +11742,16 @@ impl ::core::fmt::Debug for OperatorNode<'_> {
             }
             OperatorAttrs::MultinomialAttrs => {
                 if let Some(x) = self.attrs_as_multinomial_attrs() {
+                    ds.field("attrs", &x)
+                } else {
+                    ds.field(
+                        "attrs",
+                        &"InvalidFlatbuffer: Union discriminant does not match value.",
+                    )
+                }
+            }
+            OperatorAttrs::ReverseSequenceAttrs => {
+                if let Some(x) = self.attrs_as_reverse_sequence_attrs() {
                     ds.field("attrs", &x)
                 } else {
                     ds.field(

--- a/src/op_registry.rs
+++ b/src/op_registry.rs
@@ -308,6 +308,7 @@ pub mod op_types {
     declare_op!(Relu);
     declare_op!(Reshape);
     declare_op!(Resize);
+    declare_op!(ReverseSequence);
     declare_op!(Round);
     declare_op!(ScatterElements);
     declare_op!(ScatterND);

--- a/src/op_registry/onnx_registry.rs
+++ b/src/op_registry/onnx_registry.rs
@@ -200,6 +200,7 @@ impl OnnxOpRegistry {
         register_op!(Relu);
         register_op!(Reshape);
         register_op!(Resize);
+        register_op!(ReverseSequence);
         register_op!(RotaryEmbedding);
         register_op!(Round);
         register_op!(ScatterElements);
@@ -1508,6 +1509,15 @@ impl_read_op!(Resize, |attrs: &Attrs| {
         mode,
         nearest_mode,
         coord_mode,
+    })
+});
+
+impl_read_op!(ReverseSequence, |attrs: &Attrs| {
+    let batch_axis = attrs.get_as_int("batch_axis")?.unwrap_or(1);
+    let time_axis = attrs.get_as_int("time_axis")?.unwrap_or(0);
+    Ok(ops::ReverseSequence {
+        batch_axis,
+        time_axis,
     })
 });
 

--- a/src/op_registry/rten_registry.rs
+++ b/src/op_registry/rten_registry.rs
@@ -195,6 +195,7 @@ impl RtenOpRegistry {
         register_op!(Relu);
         register_op!(Reshape);
         register_op!(Resize);
+        register_op!(ReverseSequence);
         register_op!(Round);
         register_op!(ScatterElements);
         register_op!(ScatterND);
@@ -952,6 +953,16 @@ impl_read_op!(Resize, attrs_as_resize_attrs, |attrs: sg::ResizeAttrs| {
         nearest_mode,
     })
 });
+impl_read_op!(
+    ReverseSequence,
+    attrs_as_reverse_sequence_attrs,
+    |attrs: sg::ReverseSequenceAttrs| {
+        Ok(ops::ReverseSequence {
+            batch_axis: attrs.batch_axis(),
+            time_axis: attrs.time_axis(),
+        })
+    }
+);
 impl_read_op!(Round);
 impl_read_op!(
     ScatterElements,

--- a/src/ops/gather.rs
+++ b/src/ops/gather.rs
@@ -17,7 +17,7 @@ use crate::operator::{
 };
 use crate::ops::reduce::{cmp_nan_greater, cmp_nan_less};
 use crate::ops::{map_value_view, resolve_axis, resolve_index};
-use crate::value::ValueView;
+use crate::value::{Value, ValueView};
 
 const INVALID_INDEX_ERR: OpError = OpError::InvalidValue("Entry in `indices` is out of range");
 
@@ -679,6 +679,140 @@ impl Operator for ScatterND {
     }
 }
 
+/// Order of the batch and time axes for [`ReverseSequence`].
+#[derive(Copy, Clone, Debug)]
+enum SequenceLayout {
+    /// Batch axis is 0, time axis is 1.
+    BatchFirst,
+    /// Time axis is 0, batch axis is 1.
+    TimeFirst,
+}
+
+/// Reverse variable-length slices of `input` along the time axis.
+///
+/// For each batch element `b` (indexed along the batch axis), the first
+/// `seq_lens[b]` elements along the time axis are reversed. Elements beyond
+/// `seq_lens[b]` are copied unchanged.
+fn reverse_sequence<T: Copy>(
+    pool: &BufferPool,
+    input: TensorView<T>,
+    seq_lens: NdTensorView<i32, 1>,
+    layout: SequenceLayout,
+) -> Result<Tensor<T>, OpError> {
+    if input.ndim() < 2 {
+        return Err(OpError::InvalidValue(
+            "ReverseSequence input must have at least 2 dims",
+        ));
+    }
+
+    let (batch_size, time_size) = match layout {
+        SequenceLayout::BatchFirst => (input.size(0), input.size(1)),
+        SequenceLayout::TimeFirst => (input.size(1), input.size(0)),
+    };
+
+    if seq_lens.size(0) != batch_size {
+        return Err(OpError::InvalidValue(
+            "sequence_lens length must match the batch dimension size",
+        ));
+    }
+    for &len in seq_lens.iter() {
+        if len < 0 || len as usize > time_size {
+            return Err(OpError::InvalidValue(
+                "sequence_lens values must be in the range [0, time_size]",
+            ));
+        }
+    }
+
+    // The batch and time axes are the first two dimensions in some order, so
+    // for a contiguous input, each (batch, time) coordinate selects a
+    // contiguous inner block which can be copied as a unit.
+    let input = input.to_contiguous_in(pool).auto_return(pool);
+    let in_data = input.data();
+    let d0 = input.size(0);
+    let d1 = input.size(1);
+    let inner_size: usize = input.shape()[2..].iter().product();
+
+    let mut out_data = pool.alloc(in_data.len());
+
+    // Write output blocks in order. Reversal happens when we pick the input
+    // chunk to copy at each step.
+    for i0 in 0..d0 {
+        for i1 in 0..d1 {
+            // Map physical output coords to logical (batch, time) coords.
+            let (batch, time) = match layout {
+                SequenceLayout::BatchFirst => (i0, i1),
+                SequenceLayout::TimeFirst => (i1, i0),
+            };
+            let seq_len = seq_lens[[batch]] as usize;
+
+            // Read from the mirrored position within the reversed prefix.
+            let src_time = if time < seq_len {
+                seq_len - 1 - time
+            } else {
+                time
+            };
+
+            // Map logical (batch, src_time) back to physical input coords.
+            let (src0, src1) = match layout {
+                SequenceLayout::BatchFirst => (i0, src_time),
+                SequenceLayout::TimeFirst => (src_time, i1),
+            };
+            let src_offset = (src0 * d1 + src1) * inner_size;
+            out_data.extend_from_slice(&in_data[src_offset..src_offset + inner_size]);
+        }
+    }
+
+    Ok(Tensor::from_data(input.shape(), out_data))
+}
+
+#[derive(Debug)]
+pub struct ReverseSequence {
+    pub batch_axis: i32,
+    pub time_axis: i32,
+}
+
+impl Operator for ReverseSequence {
+    fn name(&self) -> &str {
+        "ReverseSequence"
+    }
+
+    fn max_inputs(&self) -> Option<usize> {
+        Some(2)
+    }
+
+    fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+        let input = ctx.inputs().require(0)?;
+        let seq_lens: NdTensorView<i32, 1> = ctx.inputs().require_as(1)?;
+
+        // `batch_axis` and `time_axis` must each be 0 or 1 and refer to
+        // different dimensions.
+        let layout = match (self.batch_axis, self.time_axis) {
+            (0, 1) => SequenceLayout::BatchFirst,
+            (1, 0) => SequenceLayout::TimeFirst,
+            _ => {
+                return Err(OpError::InvalidValue(
+                    "batch_axis and time_axis must be 0 and 1 in some order",
+                ));
+            }
+        };
+
+        let result = map_value_view!(input, input, {
+            reverse_sequence(ctx.pool(), input, seq_lens, layout).map(Value::from)
+        });
+        result.into_op_result()
+    }
+
+    fn output_types(&self, _ctx: &OutputTypesContext) -> Option<OutputTypeList> {
+        Some([OutputType::CopyFromInput(0)].into())
+    }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        // The output has the same shape as the (first) input, so we can reuse
+        // the shape inference for unary operators.
+        Some(&UnaryOp)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::error::Error;
@@ -690,9 +824,10 @@ mod tests {
     use rten_testing::TestCases;
 
     use crate::buffer_pool::BufferPool;
-    use crate::operator::OpError;
+    use crate::operator::{OpError, OperatorExt};
     use crate::ops::{
-        ScatterReduction, gather, gather_elements, gather_nd, scatter_elements, scatter_nd,
+        ReverseSequence, ScatterReduction, gather, gather_elements, gather_nd, scatter_elements,
+        scatter_nd,
     };
 
     #[test]
@@ -1324,5 +1459,103 @@ mod tests {
             );
             assert_eq!(result.as_ref(), Err(&case.expected));
         })
+    }
+
+    #[test]
+    fn test_reverse_sequence() {
+        #[derive(Debug)]
+        struct Case {
+            input: Tensor<f32>,
+            seq_lens: Tensor<i32>,
+            batch_axis: i32,
+            time_axis: i32,
+            expected: Result<Tensor<f32>, OpError>,
+        }
+
+        // 4x4 matrix with values 0..16.
+        let input = Tensor::from([
+            [0., 1., 2., 3.],
+            [4., 5., 6., 7.],
+            [8., 9., 10., 11.],
+            [12., 13., 14., 15.],
+        ]);
+
+        let cases = [
+            // time_axis=0, batch_axis=1 (reverse down columns).
+            Case {
+                input: input.clone(),
+                seq_lens: Tensor::from([4, 3, 2, 1]),
+                batch_axis: 1,
+                time_axis: 0,
+                expected: Ok(Tensor::from([
+                    [12., 9., 6., 3.],
+                    [8., 5., 2., 7.],
+                    [4., 1., 10., 11.],
+                    [0., 13., 14., 15.],
+                ])),
+            },
+            // time_axis=1, batch_axis=0 (reverse along rows).
+            Case {
+                input: input.clone(),
+                seq_lens: Tensor::from([1, 2, 3, 4]),
+                batch_axis: 0,
+                time_axis: 1,
+                expected: Ok(Tensor::from([
+                    [0., 1., 2., 3.],
+                    [5., 4., 6., 7.],
+                    [10., 9., 8., 11.],
+                    [15., 14., 13., 12.],
+                ])),
+            },
+            // 3D input, where each (batch, time) coordinate selects a
+            // contiguous block of elements rather than a single element.
+            Case {
+                input: Tensor::from([[[0., 1.], [2., 3.]], [[4., 5.], [6., 7.]]]),
+                seq_lens: Tensor::from([2, 1]),
+                batch_axis: 0,
+                time_axis: 1,
+                expected: Ok(Tensor::from([[[2., 3.], [0., 1.]], [[4., 5.], [6., 7.]]])),
+            },
+            // Mismatched `sequence_lens` length.
+            Case {
+                input: input.clone(),
+                seq_lens: Tensor::from([1, 2]),
+                batch_axis: 1,
+                time_axis: 0,
+                expected: Err(OpError::InvalidValue(
+                    "sequence_lens length must match the batch dimension size",
+                )),
+            },
+            // Out-of-range sequence length.
+            Case {
+                input: input.clone(),
+                seq_lens: Tensor::from([1, 2, 3, 5]),
+                batch_axis: 1,
+                time_axis: 0,
+                expected: Err(OpError::InvalidValue(
+                    "sequence_lens values must be in the range [0, time_size]",
+                )),
+            },
+            // Invalid axes.
+            Case {
+                input: input.clone(),
+                seq_lens: Tensor::from([4, 4, 4, 4]),
+                batch_axis: 0,
+                time_axis: 2,
+                expected: Err(OpError::InvalidValue(
+                    "batch_axis and time_axis must be 0 and 1 in some order",
+                )),
+            },
+        ];
+
+        cases.test_each(|case| {
+            let op = ReverseSequence {
+                batch_axis: case.batch_axis,
+                time_axis: case.time_axis,
+            };
+            let result: Result<Tensor<f32>, _> =
+                op.run_simple((case.input.view(), case.seq_lens.view()));
+            assert_eq!(result, case.expected);
+        });
     }
 }

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -81,7 +81,10 @@ pub(crate) use {
     convert::{Cast, CastLike},
     einsum::Einsum,
     embedding::{RotaryEmbedding, RotaryEmbeddingMicrosoft},
-    gather::{Gather, GatherElements, GatherND, ScatterElements, ScatterND, ScatterReduction},
+    gather::{
+        Gather, GatherElements, GatherND, ReverseSequence, ScatterElements, ScatterND,
+        ScatterReduction,
+    },
     generate::{ConstantOfShape, EyeLike, OneHot, Range},
     grid_sample::GridSample,
     identity::Identity,


### PR DESCRIPTION
Add support for the [ReverseSequence](https://onnx.ai/onnx/operators/onnx__ReverseSequence.html) operator. Although this has "Sequence" in the name, it operates on tensor values and so lives alongside the gather operators, which are its closest relatives.

This is one of two missing operators needed to run the un-optimized BirdNET [model.onnx](https://huggingface.co/justinchuby/BirdNET-onnx/blob/main/model.onnx) model. The other is DFT.