### PR TITLE
Add `Tensor::from_fn_in`

### DIFF
--- a/rten-tensor/src/tensor.rs
+++ b/rten-tensor/src/tensor.rs
@@ -1247,6 +1247,20 @@ impl<T, L: Clone + Layout> TensorBase<Vec<T>, L> {
     /// [`from_simple_fn`](TensorBase::from_simple_fn) instead, as it is faster.
     pub fn from_fn<F: FnMut(L::Index<'_>) -> T, Idx>(
         shape: L::Index<'_>,
+        f: F,
+    ) -> TensorBase<Vec<T>, L>
+    where
+        L::Indices: Iterator<Item = Idx>,
+        Idx: AsIndex<L>,
+        L: MutLayout,
+    {
+        Self::from_fn_in(GlobalAlloc::new(), shape, f)
+    }
+
+    /// Variant of [`from_fn`](TensorBase::from_fn) that takes an allocator.
+    pub fn from_fn_in<A: Alloc, F: FnMut(L::Index<'_>) -> T, Idx>(
+        alloc: A,
+        shape: L::Index<'_>,
         mut f: F,
     ) -> TensorBase<Vec<T>, L>
     where
@@ -1255,7 +1269,8 @@ impl<T, L: Clone + Layout> TensorBase<Vec<T>, L> {
         L: MutLayout,
     {
         let layout = L::from_shape(shape);
-        let data: Vec<T> = layout.indices().map(|idx| f(idx.as_index())).collect();
+        let mut data = alloc.alloc(layout.len());
+        data.extend(layout.indices().map(|idx| f(idx.as_index())));
         TensorBase { data, layout }
     }
 

--- a/rten-tensor/src/tensor/tests.rs
+++ b/rten-tensor/src/tensor/tests.rs
@@ -430,6 +430,19 @@ fn test_from_fn() {
 }
 
 #[test]
+fn test_from_fn_in() {
+    let pool = FakeAlloc::new();
+
+    let x = NdTensor::from_fn_in(&pool, [2, 2], |[y, x]| y * 10 + x);
+    assert_eq!(x.data(), Some([0, 1, 10, 11].as_slice()));
+
+    let x = Tensor::from_fn_in(&pool, &[2, 2], |index| index[0] * 10 + index[1]);
+    assert_eq!(x.data(), Some([0, 1, 10, 11].as_slice()));
+
+    assert_eq!(pool.count(), 2);
+}
+
+#[test]
 fn test_from_nested_array() {
     // Scalar
     let x = NdTensor::from(5);


### PR DESCRIPTION
Add a variant of `Tensor::from_fn` that takes an allocator, similar to `from_simple_fn_in`. I initially added this when working on the DFT and ReverseSequence ops. I didn't end up using it, but it still seems like an independently useful API.