### PR TITLE
Implement DFT operator

### DIFF
--- a/rten-convert/rten_convert/converter.py
+++ b/rten-convert/rten_convert/converter.py
@@ -453,6 +453,19 @@ def op_node_from_onnx_operator(
             attr_reader.check_attr("exclusive", "int", 0)
             attr_reader.check_attr("reverse", "int", 0)
 
+        case "DFT":
+            attrs = sg.DFTAttrsT()
+            attrs.inverse = attr_reader.get_bool_attr("inverse", False)
+            attrs.onesided = attr_reader.get_bool_attr("onesided", False)
+            # `axis` was an attribute in opset 17 and became an optional input
+            # (index 2) in opset 20. Promote the attribute to a constant input.
+            #
+            # Known issue: If a pre-opset-20 model omits the attribute, its
+            # default of 1 is not applied here (the runtime will use the
+            # opset-20 default of -2). The two defaults coincide for the
+            # common case of rank-3 inputs.
+            attr_reader.generate_input_from_attr(2, "axis", "int")
+
         case "DequantizeLinear":
             attrs = sg.DequantizeLinearAttrsT()
             attrs.axis = attr_reader.get_attr("axis", "int", 1)

--- a/rten-convert/rten_convert/schema_generated.py
+++ b/rten-convert/rten_convert/schema_generated.py
@@ -144,6 +144,7 @@ class OperatorType(object):
     Sinh = 134
     Multinomial = 135
     ReverseSequence = 136
+    DFT = 137
 
 
 class RNNDirection(object):
@@ -241,6 +242,7 @@ class OperatorAttrs(object):
     STFTAttrs = 54
     MultinomialAttrs = 55
     ReverseSequenceAttrs = 56
+    DFTAttrs = 57
 
 def OperatorAttrsCreator(unionType, table):
     from flatbuffers.table import Table
@@ -358,6 +360,8 @@ def OperatorAttrsCreator(unionType, table):
         return MultinomialAttrsT.InitFromBuf(table.Bytes, table.Pos)
     if unionType == OperatorAttrs.ReverseSequenceAttrs:
         return ReverseSequenceAttrsT.InitFromBuf(table.Bytes, table.Pos)
+    if unionType == OperatorAttrs.DFTAttrs:
+        return DFTAttrsT.InitFromBuf(table.Bytes, table.Pos)
     return None
 
 
@@ -6233,6 +6237,100 @@ class ReverseSequenceAttrsT(object):
         return reverseSequenceAttrs
 
 
+class DFTAttrs(object):
+    __slots__ = ['_tab']
+
+    @classmethod
+    def GetRootAs(cls, buf, offset=0):
+        n = flatbuffers.encode.Get(flatbuffers.packer.uoffset, buf, offset)
+        x = DFTAttrs()
+        x.Init(buf, n + offset)
+        return x
+
+    @classmethod
+    def GetRootAsDFTAttrs(cls, buf, offset=0):
+        """This method is deprecated. Please switch to GetRootAs."""
+        return cls.GetRootAs(buf, offset)
+    @classmethod
+    def DFTAttrsBufferHasIdentifier(cls, buf, offset, size_prefixed=False):
+        return flatbuffers.util.BufferHasIdentifier(buf, offset, b"\x52\x54\x45\x4E", size_prefixed=size_prefixed)
+
+    # DFTAttrs
+    def Init(self, buf, pos):
+        self._tab = flatbuffers.table.Table(buf, pos)
+
+    # DFTAttrs
+    def Inverse(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
+        if o != 0:
+            return bool(self._tab.Get(flatbuffers.number_types.BoolFlags, o + self._tab.Pos))
+        return False
+
+    # DFTAttrs
+    def Onesided(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(6))
+        if o != 0:
+            return bool(self._tab.Get(flatbuffers.number_types.BoolFlags, o + self._tab.Pos))
+        return False
+
+def DFTAttrsStart(builder):
+    builder.StartObject(2)
+
+def DFTAttrsAddInverse(builder, inverse):
+    builder.PrependBoolSlot(0, inverse, 0)
+
+def DFTAttrsAddOnesided(builder, onesided):
+    builder.PrependBoolSlot(1, onesided, 0)
+
+def DFTAttrsEnd(builder):
+    return builder.EndObject()
+
+
+
+class DFTAttrsT(object):
+
+    # DFTAttrsT
+    def __init__(
+        self,
+        inverse = False,
+        onesided = False,
+    ):
+        self.inverse = inverse  # type: bool
+        self.onesided = onesided  # type: bool
+
+    @classmethod
+    def InitFromBuf(cls, buf, pos):
+        dftattrs = DFTAttrs()
+        dftattrs.Init(buf, pos)
+        return cls.InitFromObj(dftattrs)
+
+    @classmethod
+    def InitFromPackedBuf(cls, buf, pos=0):
+        n = flatbuffers.encode.Get(flatbuffers.packer.uoffset, buf, pos)
+        return cls.InitFromBuf(buf, pos+n)
+
+    @classmethod
+    def InitFromObj(cls, dftattrs):
+        x = DFTAttrsT()
+        x._UnPack(dftattrs)
+        return x
+
+    # DFTAttrsT
+    def _UnPack(self, dftattrs):
+        if dftattrs is None:
+            return
+        self.inverse = dftattrs.Inverse()
+        self.onesided = dftattrs.Onesided()
+
+    # DFTAttrsT
+    def Pack(self, builder):
+        DFTAttrsStart(builder)
+        DFTAttrsAddInverse(builder, self.inverse)
+        DFTAttrsAddOnesided(builder, self.onesided)
+        dftattrs = DFTAttrsEnd(builder)
+        return dftattrs
+
+
 class TopKAttrs(object):
     __slots__ = ['_tab']
 
@@ -6689,7 +6787,7 @@ class OperatorNodeT(object):
     ):
         self.type = type  # type: int
         self.attrsType = attrsType  # type: int
-        self.attrs = attrs  # type: Union[None, 'ArgMaxAttrsT', 'AveragePoolAttrsT', 'BatchNormalizationAttrsT', 'CastAttrsT', 'ConcatAttrsT', 'ConstantOfShapeAttrsT', 'ConvAttrsT', 'ConvTransposeAttrsT', 'FlattenAttrsT', 'GatherAttrsT', 'GemmAttrsT', 'GRUAttrsT', 'LeakyReluAttrsT', 'LSTMAttrsT', 'MaxPoolAttrsT', 'ReduceMeanAttrsT', 'ReshapeAttrsT', 'ResizeAttrsT', 'SplitAttrsT', 'SoftmaxAttrsT', 'TransposeAttrsT', 'ModAttrsT', 'ScatterElementsAttrsT', 'OneHotAttrsT', 'TopKAttrsT', 'HardSigmoidAttrsT', 'TriluAttrsT', 'ScatterNDAttrsT', 'NonMaxSuppressionAttrsT', 'LayerNormalizationAttrsT', 'RandomUniformAttrsT', 'EluAttrsT', 'RandomUniformLikeAttrsT', 'RandomNormalAttrsT', 'RandomNormalLikeAttrsT', 'GatherNDAttrsT', 'GeluAttrsT', 'EinsumAttrsT', 'IfAttrsT', 'PadAttrsT', 'DequantizeLinearAttrsT', 'QuantizeLinearAttrsT', 'DepthToSpaceAttrsT', 'CastLikeAttrsT', 'ShapeAttrsT', 'DropoutAttrsT', 'EyeLikeAttrsT', 'IsInfAttrsT', 'LoopAttrsT', 'SequenceEmptyAttrsT', 'ConcatFromSequenceAttrsT', 'SplitToSequenceAttrsT', 'GridSampleAttrsT', 'STFTAttrsT', 'MultinomialAttrsT', 'ReverseSequenceAttrsT']
+        self.attrs = attrs  # type: Union[None, 'ArgMaxAttrsT', 'AveragePoolAttrsT', 'BatchNormalizationAttrsT', 'CastAttrsT', 'ConcatAttrsT', 'ConstantOfShapeAttrsT', 'ConvAttrsT', 'ConvTransposeAttrsT', 'FlattenAttrsT', 'GatherAttrsT', 'GemmAttrsT', 'GRUAttrsT', 'LeakyReluAttrsT', 'LSTMAttrsT', 'MaxPoolAttrsT', 'ReduceMeanAttrsT', 'ReshapeAttrsT', 'ResizeAttrsT', 'SplitAttrsT', 'SoftmaxAttrsT', 'TransposeAttrsT', 'ModAttrsT', 'ScatterElementsAttrsT', 'OneHotAttrsT', 'TopKAttrsT', 'HardSigmoidAttrsT', 'TriluAttrsT', 'ScatterNDAttrsT', 'NonMaxSuppressionAttrsT', 'LayerNormalizationAttrsT', 'RandomUniformAttrsT', 'EluAttrsT', 'RandomUniformLikeAttrsT', 'RandomNormalAttrsT', 'RandomNormalLikeAttrsT', 'GatherNDAttrsT', 'GeluAttrsT', 'EinsumAttrsT', 'IfAttrsT', 'PadAttrsT', 'DequantizeLinearAttrsT', 'QuantizeLinearAttrsT', 'DepthToSpaceAttrsT', 'CastLikeAttrsT', 'ShapeAttrsT', 'DropoutAttrsT', 'EyeLikeAttrsT', 'IsInfAttrsT', 'LoopAttrsT', 'SequenceEmptyAttrsT', 'ConcatFromSequenceAttrsT', 'SplitToSequenceAttrsT', 'GridSampleAttrsT', 'STFTAttrsT', 'MultinomialAttrsT', 'ReverseSequenceAttrsT', 'DFTAttrsT']
         self.inputs = inputs  # type: Optional[List[int]]
         self.outputs = outputs  # type: Optional[List[int]]
 

--- a/rten-model-file/src/schema.fbs
+++ b/rten-model-file/src/schema.fbs
@@ -150,6 +150,7 @@ enum OperatorType: ubyte {
   Sinh,
   Multinomial,
   ReverseSequence,
+  DFT,
 }
 
 enum RNNDirection: ubyte {
@@ -258,6 +259,7 @@ union OperatorAttrs {
   STFTAttrs,
   MultinomialAttrs,
   ReverseSequenceAttrs,
+  DFTAttrs,
 }
 
 table ArgMaxAttrs {
@@ -579,6 +581,11 @@ table STFTAttrs {
 table ReverseSequenceAttrs {
   batch_axis:int = 1;
   time_axis:int = 0;
+}
+
+table DFTAttrs {
+  inverse:bool = false;
+  onesided:bool = false;
 }
 
 table TopKAttrs {

--- a/rten-model-file/src/schema_generated.rs
+++ b/rten-model-file/src/schema_generated.rs
@@ -11,13 +11,13 @@ pub const ENUM_MIN_OPERATOR_TYPE: u8 = 0;
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
-pub const ENUM_MAX_OPERATOR_TYPE: u8 = 136;
+pub const ENUM_MAX_OPERATOR_TYPE: u8 = 137;
 #[deprecated(
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 137] = [
+pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 138] = [
     OperatorType::Add,
     OperatorType::ArgMin,
     OperatorType::ArgMax,
@@ -155,6 +155,7 @@ pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 137] = [
     OperatorType::Sinh,
     OperatorType::Multinomial,
     OperatorType::ReverseSequence,
+    OperatorType::DFT,
 ];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -299,9 +300,10 @@ impl OperatorType {
     pub const Sinh: Self = Self(134);
     pub const Multinomial: Self = Self(135);
     pub const ReverseSequence: Self = Self(136);
+    pub const DFT: Self = Self(137);
 
     pub const ENUM_MIN: u8 = 0;
-    pub const ENUM_MAX: u8 = 136;
+    pub const ENUM_MAX: u8 = 137;
     pub const ENUM_VALUES: &'static [Self] = &[
         Self::Add,
         Self::ArgMin,
@@ -440,6 +442,7 @@ impl OperatorType {
         Self::Sinh,
         Self::Multinomial,
         Self::ReverseSequence,
+        Self::DFT,
     ];
     /// Returns the variant's name or "" if unknown.
     pub fn variant_name(self) -> Option<&'static str> {
@@ -581,6 +584,7 @@ impl OperatorType {
             Self::Sinh => Some("Sinh"),
             Self::Multinomial => Some("Multinomial"),
             Self::ReverseSequence => Some("ReverseSequence"),
+            Self::DFT => Some("DFT"),
             _ => None,
         }
     }
@@ -1216,13 +1220,13 @@ pub const ENUM_MIN_OPERATOR_ATTRS: u8 = 0;
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
-pub const ENUM_MAX_OPERATOR_ATTRS: u8 = 56;
+pub const ENUM_MAX_OPERATOR_ATTRS: u8 = 57;
 #[deprecated(
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_OPERATOR_ATTRS: [OperatorAttrs; 57] = [
+pub const ENUM_VALUES_OPERATOR_ATTRS: [OperatorAttrs; 58] = [
     OperatorAttrs::NONE,
     OperatorAttrs::ArgMaxAttrs,
     OperatorAttrs::AveragePoolAttrs,
@@ -1280,6 +1284,7 @@ pub const ENUM_VALUES_OPERATOR_ATTRS: [OperatorAttrs; 57] = [
     OperatorAttrs::STFTAttrs,
     OperatorAttrs::MultinomialAttrs,
     OperatorAttrs::ReverseSequenceAttrs,
+    OperatorAttrs::DFTAttrs,
 ];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -1344,9 +1349,10 @@ impl OperatorAttrs {
     pub const STFTAttrs: Self = Self(54);
     pub const MultinomialAttrs: Self = Self(55);
     pub const ReverseSequenceAttrs: Self = Self(56);
+    pub const DFTAttrs: Self = Self(57);
 
     pub const ENUM_MIN: u8 = 0;
-    pub const ENUM_MAX: u8 = 56;
+    pub const ENUM_MAX: u8 = 57;
     pub const ENUM_VALUES: &'static [Self] = &[
         Self::NONE,
         Self::ArgMaxAttrs,
@@ -1405,6 +1411,7 @@ impl OperatorAttrs {
         Self::STFTAttrs,
         Self::MultinomialAttrs,
         Self::ReverseSequenceAttrs,
+        Self::DFTAttrs,
     ];
     /// Returns the variant's name or "" if unknown.
     pub fn variant_name(self) -> Option<&'static str> {
@@ -1466,6 +1473,7 @@ impl OperatorAttrs {
             Self::STFTAttrs => Some("STFTAttrs"),
             Self::MultinomialAttrs => Some("MultinomialAttrs"),
             Self::ReverseSequenceAttrs => Some("ReverseSequenceAttrs"),
+            Self::DFTAttrs => Some("DFTAttrs"),
             _ => None,
         }
     }
@@ -9718,6 +9726,138 @@ impl ::core::fmt::Debug for ReverseSequenceAttrs<'_> {
         ds.finish()
     }
 }
+pub enum DFTAttrsOffset {}
+#[derive(Copy, Clone, PartialEq)]
+
+pub struct DFTAttrs<'a> {
+    pub _tab: ::flatbuffers::Table<'a>,
+}
+
+impl<'a> ::flatbuffers::Follow<'a> for DFTAttrs<'a> {
+    type Inner = DFTAttrs<'a>;
+    #[inline]
+    unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self {
+            _tab: unsafe { ::flatbuffers::Table::new(buf, loc) },
+        }
+    }
+}
+
+impl<'a> DFTAttrs<'a> {
+    pub const VT_INVERSE: ::flatbuffers::VOffsetT = 4;
+    pub const VT_ONESIDED: ::flatbuffers::VOffsetT = 6;
+
+    #[inline]
+    pub unsafe fn init_from_table(table: ::flatbuffers::Table<'a>) -> Self {
+        DFTAttrs { _tab: table }
+    }
+    #[allow(unused_mut)]
+    pub fn create<
+        'bldr: 'args,
+        'args: 'mut_bldr,
+        'mut_bldr,
+        A: ::flatbuffers::Allocator + 'bldr,
+    >(
+        _fbb: &'mut_bldr mut ::flatbuffers::FlatBufferBuilder<'bldr, A>,
+        args: &'args DFTAttrsArgs,
+    ) -> ::flatbuffers::WIPOffset<DFTAttrs<'bldr>> {
+        let mut builder = DFTAttrsBuilder::new(_fbb);
+        builder.add_onesided(args.onesided);
+        builder.add_inverse(args.inverse);
+        builder.finish()
+    }
+
+    #[inline]
+    pub fn inverse(&self) -> bool {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab
+                .get::<bool>(DFTAttrs::VT_INVERSE, Some(false))
+                .unwrap()
+        }
+    }
+    #[inline]
+    pub fn onesided(&self) -> bool {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab
+                .get::<bool>(DFTAttrs::VT_ONESIDED, Some(false))
+                .unwrap()
+        }
+    }
+}
+
+impl ::flatbuffers::Verifiable for DFTAttrs<'_> {
+    #[inline]
+    fn run_verifier(
+        v: &mut ::flatbuffers::Verifier,
+        pos: usize,
+    ) -> Result<(), ::flatbuffers::InvalidFlatbuffer> {
+        v.visit_table(pos)?
+            .visit_field::<bool>("inverse", Self::VT_INVERSE, false)?
+            .visit_field::<bool>("onesided", Self::VT_ONESIDED, false)?
+            .finish();
+        Ok(())
+    }
+}
+pub struct DFTAttrsArgs {
+    pub inverse: bool,
+    pub onesided: bool,
+}
+impl<'a> Default for DFTAttrsArgs {
+    #[inline]
+    fn default() -> Self {
+        DFTAttrsArgs {
+            inverse: false,
+            onesided: false,
+        }
+    }
+}
+
+pub struct DFTAttrsBuilder<'a: 'b, 'b, A: ::flatbuffers::Allocator + 'a> {
+    fbb_: &'b mut ::flatbuffers::FlatBufferBuilder<'a, A>,
+    start_: ::flatbuffers::WIPOffset<::flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b, A: ::flatbuffers::Allocator + 'a> DFTAttrsBuilder<'a, 'b, A> {
+    #[inline]
+    pub fn add_inverse(&mut self, inverse: bool) {
+        self.fbb_
+            .push_slot::<bool>(DFTAttrs::VT_INVERSE, inverse, false);
+    }
+    #[inline]
+    pub fn add_onesided(&mut self, onesided: bool) {
+        self.fbb_
+            .push_slot::<bool>(DFTAttrs::VT_ONESIDED, onesided, false);
+    }
+    #[inline]
+    pub fn new(
+        _fbb: &'b mut ::flatbuffers::FlatBufferBuilder<'a, A>,
+    ) -> DFTAttrsBuilder<'a, 'b, A> {
+        let start = _fbb.start_table();
+        DFTAttrsBuilder {
+            fbb_: _fbb,
+            start_: start,
+        }
+    }
+    #[inline]
+    pub fn finish(self) -> ::flatbuffers::WIPOffset<DFTAttrs<'a>> {
+        let o = self.fbb_.end_table(self.start_);
+        ::flatbuffers::WIPOffset::new(o.value())
+    }
+}
+
+impl ::core::fmt::Debug for DFTAttrs<'_> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+        let mut ds = f.debug_struct("DFTAttrs");
+        ds.field("inverse", &self.inverse());
+        ds.field("onesided", &self.onesided());
+        ds.finish()
+    }
+}
 pub enum TopKAttrsOffset {}
 #[derive(Copy, Clone, PartialEq)]
 
@@ -11044,6 +11184,21 @@ impl<'a> OperatorNode<'a> {
             None
         }
     }
+
+    #[inline]
+    #[allow(non_snake_case)]
+    pub fn attrs_as_dftattrs(&self) -> Option<DFTAttrs<'a>> {
+        if self.attrs_type() == OperatorAttrs::DFTAttrs {
+            self.attrs().map(|t| {
+                // Safety:
+                // Created from a valid Table for this object
+                // Which contains a valid union in this slot
+                unsafe { DFTAttrs::init_from_table(t) }
+            })
+        } else {
+            None
+        }
+    }
 }
 
 impl ::flatbuffers::Verifiable for OperatorNode<'_> {
@@ -11112,6 +11267,7 @@ impl ::flatbuffers::Verifiable for OperatorNode<'_> {
           OperatorAttrs::STFTAttrs => v.verify_union_variant::<::flatbuffers::ForwardsUOffset<STFTAttrs>>("OperatorAttrs::STFTAttrs", pos),
           OperatorAttrs::MultinomialAttrs => v.verify_union_variant::<::flatbuffers::ForwardsUOffset<MultinomialAttrs>>("OperatorAttrs::MultinomialAttrs", pos),
           OperatorAttrs::ReverseSequenceAttrs => v.verify_union_variant::<::flatbuffers::ForwardsUOffset<ReverseSequenceAttrs>>("OperatorAttrs::ReverseSequenceAttrs", pos),
+          OperatorAttrs::DFTAttrs => v.verify_union_variant::<::flatbuffers::ForwardsUOffset<DFTAttrs>>("OperatorAttrs::DFTAttrs", pos),
           _ => Ok(()),
         }
      })?
@@ -11752,6 +11908,16 @@ impl ::core::fmt::Debug for OperatorNode<'_> {
             }
             OperatorAttrs::ReverseSequenceAttrs => {
                 if let Some(x) = self.attrs_as_reverse_sequence_attrs() {
+                    ds.field("attrs", &x)
+                } else {
+                    ds.field(
+                        "attrs",
+                        &"InvalidFlatbuffer: Union discriminant does not match value.",
+                    )
+                }
+            }
+            OperatorAttrs::DFTAttrs => {
+                if let Some(x) = self.attrs_as_dftattrs() {
                     ds.field("attrs", &x)
                 } else {
                     ds.field(

--- a/rten-shape-inference/src/ops.rs
+++ b/rten-shape-inference/src/ops.rs
@@ -27,7 +27,7 @@ pub use binary::{Add, Div, Equal, Mul, Sub};
 pub use concat::{Concat, Tile};
 pub use conv_pool::{Conv, ConvTranspose, GlobalPool, Padding, Pool};
 pub use einsum::Einsum;
-pub use fft::STFT;
+pub use fft::{DFT, STFT};
 pub use generate::OneHot;
 pub use layout::{
     DepthToSpace, Expand, Flatten, Reshape, Shape, Size, Squeeze, Transpose, Unsqueeze,

--- a/rten-shape-inference/src/ops/fft.rs
+++ b/rten-shape-inference/src/ops/fft.rs
@@ -1,4 +1,4 @@
-use crate::infer_shapes::{InferShapes, InferShapesError};
+use crate::infer_shapes::{InferShapes, InferShapesError, resolve_axis};
 use crate::sym_expr::SymExpr;
 use crate::sym_gen::SymbolGen;
 use crate::sym_tensor::SymTensor;
@@ -71,6 +71,81 @@ impl InferShapes for STFT {
     }
 }
 
+/// DFT operator.
+///
+/// See <https://onnx.ai/onnx/operators/onnx__DFT.html>.
+pub struct DFT {
+    pub inverse: bool,
+    pub onesided: bool,
+}
+
+impl InferShapes for DFT {
+    fn infer_shapes(
+        &self,
+        inputs: &[SymTensor],
+        _sym_gen: &mut SymbolGen,
+    ) -> Result<Vec<SymTensor>, InferShapesError> {
+        let [input, ..] = inputs else {
+            return Err(InferShapesError::IncorrectInputCount);
+        };
+        let dft_length = inputs.get(1);
+
+        // The inverse one-sided transform (IRFFT) is unsupported.
+        if self.inverse && self.onesided {
+            return Err(InferShapesError::InvalidValue);
+        }
+
+        // `axis` is an optional input (input 2). It must be a known constant to
+        // determine the output shape; otherwise the shape is unknown. The
+        // default of -2 matches the `axis` input added in opset 20.
+        let axis = match inputs.get(2) {
+            None => -2,
+            Some(axis) => match axis.as_scalar() {
+                Some(&SymExpr::Value(val)) => val,
+                _ => return Ok([SymTensor::unknown("DFT axis is not constant")].into()),
+            },
+        };
+
+        let Some(dims) = input.shape() else {
+            return Ok([SymTensor::unknown("unknown DFT input shape")].into());
+        };
+        let mut shape: Vec<SymExpr> = dims.collect();
+        let ndim = shape.len();
+        if ndim < 2 {
+            return Err(InferShapesError::InvalidValue);
+        }
+        let complex_dim = ndim - 1;
+
+        // Resolve the signal axis. The final (complex) dimension is excluded.
+        let dft_axis = resolve_axis(ndim, axis).map_err(|_| InferShapesError::InvalidValue)?;
+        if dft_axis == complex_dim {
+            return Err(InferShapesError::InvalidValue);
+        }
+
+        let signal_len = shape[dft_axis].clone();
+
+        // `n_fft` comes from the `dft_length` input if it's a known scalar.
+        let n_fft = if let Some(dl) = dft_length
+            && let Some(val) = dl.as_scalar()
+        {
+            val.clone()
+        } else {
+            signal_len
+        };
+
+        let out_len = if self.onesided {
+            n_fft / SymExpr::Value(2) + SymExpr::Value(1)
+        } else {
+            n_fft
+        };
+
+        shape[dft_axis] = out_len;
+        shape[complex_dim] = SymExpr::Value(2);
+
+        Ok([SymTensor::from_shape(shape)].into())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use rten_testing::TestCases;
@@ -80,7 +155,7 @@ mod tests {
     use crate::sym_gen::SymbolGen;
     use crate::sym_tensor::{SymTensor, sym_scalar, sym_shape, sym_vec};
 
-    use super::STFT;
+    use super::{DFT, STFT};
 
     fn infer_stft(
         onesided: bool,
@@ -216,6 +291,101 @@ mod tests {
         let mut sym_gen = SymbolGen::new();
         let result = STFT { onesided: true }
             .infer_shapes(&[sym_shape!("batch", 8), sym_scalar!(4)], &mut sym_gen);
+        assert_eq!(result, Err(InferShapesError::InvalidValue));
+    }
+
+    fn infer_dft(
+        axis: i32,
+        inverse: bool,
+        onesided: bool,
+        input: SymTensor,
+        dft_length: Option<SymTensor>,
+    ) -> SymTensor {
+        // `axis` is input 2. `dft_length` (input 1) is optional, so a
+        // placeholder is needed when it is absent.
+        let inputs = vec![
+            input,
+            dft_length.unwrap_or_else(|| SymTensor::unknown("no dft_length")),
+            SymTensor::from_scalar(SymExpr::Value(axis)),
+        ];
+        let mut sym_gen = SymbolGen::new();
+        let mut result = DFT { inverse, onesided }
+            .infer_shapes(&inputs, &mut sym_gen)
+            .unwrap();
+        result.remove(0).simplify()
+    }
+
+    #[test]
+    fn test_dft() {
+        #[derive(Debug)]
+        struct Case {
+            axis: i32,
+            inverse: bool,
+            onesided: bool,
+            input: SymTensor,
+            dft_length: Option<SymTensor>,
+            expected: SymTensor,
+        }
+
+        let cases = [
+            // Two-sided forward transform.
+            Case {
+                axis: -2,
+                inverse: false,
+                onesided: false,
+                input: sym_shape!("batch", 8, 1),
+                dft_length: None,
+                expected: sym_shape!("batch", 8, 2),
+            },
+            // One-sided forward transform.
+            Case {
+                axis: -2,
+                inverse: false,
+                onesided: true,
+                input: sym_shape!("batch", 8, 1),
+                dft_length: None,
+                expected: sym_shape!("batch", 5, 2),
+            },
+            // `dft_length` overrides the signal length.
+            Case {
+                axis: -2,
+                inverse: false,
+                onesided: true,
+                input: sym_shape!("batch", 8, 1),
+                dft_length: Some(sym_scalar!(16)),
+                expected: sym_shape!("batch", 9, 2),
+            },
+            // Inverse transform has the same shape as the input.
+            Case {
+                axis: -2,
+                inverse: true,
+                onesided: false,
+                input: sym_shape!("batch", 8, 2),
+                dft_length: None,
+                expected: sym_shape!("batch", 8, 2),
+            },
+        ];
+
+        cases.test_each(|case| {
+            let out = infer_dft(
+                case.axis,
+                case.inverse,
+                case.onesided,
+                case.input.clone(),
+                case.dft_length.clone(),
+            );
+            assert_eq!(out, case.expected);
+        });
+    }
+
+    #[test]
+    fn test_dft_inverse_onesided_invalid() {
+        let mut sym_gen = SymbolGen::new();
+        let result = DFT {
+            inverse: true,
+            onesided: true,
+        }
+        .infer_shapes(&[sym_shape!("batch", 8, 2)], &mut sym_gen);
         assert_eq!(result, Err(InferShapesError::InvalidValue));
     }
 }

--- a/rten-shape-inference/src/ops/fft.rs
+++ b/rten-shape-inference/src/ops/fft.rs
@@ -90,10 +90,7 @@ impl InferShapes for DFT {
         };
         let dft_length = inputs.get(1);
 
-        // The inverse one-sided transform (IRFFT) is unsupported.
-        if self.inverse && self.onesided {
-            return Err(InferShapesError::InvalidValue);
-        }
+        let irfft = self.inverse && self.onesided;
 
         // `axis` is an optional input (input 2). It must be a known constant to
         // determine the output shape; otherwise the shape is unknown. The
@@ -124,23 +121,34 @@ impl InferShapes for DFT {
 
         let signal_len = shape[dft_axis].clone();
 
-        // `n_fft` comes from the `dft_length` input if it's a known scalar.
+        // `n_fft` (the real signal length) comes from the `dft_length` input if
+        // it's a known scalar. For IRFFT the input is the half spectrum of
+        // length `floor(n_fft / 2) + 1`, so the default is `2 * (signal_len - 1)`.
         let n_fft = if let Some(dl) = dft_length
             && let Some(val) = dl.as_scalar()
         {
             val.clone()
+        } else if irfft {
+            (signal_len - SymExpr::Value(1)) * SymExpr::Value(2)
         } else {
             signal_len
         };
 
-        let out_len = if self.onesided {
-            n_fft / SymExpr::Value(2) + SymExpr::Value(1)
+        // IRFFT returns the full real signal (component dim of size 1); a
+        // forward one-sided transform returns the unique half of the spectrum.
+        let (out_len, n_components) = if irfft {
+            (n_fft, SymExpr::Value(1))
+        } else if self.onesided {
+            (
+                n_fft / SymExpr::Value(2) + SymExpr::Value(1),
+                SymExpr::Value(2),
+            )
         } else {
-            n_fft
+            (n_fft, SymExpr::Value(2))
         };
 
         shape[dft_axis] = out_len;
-        shape[complex_dim] = SymExpr::Value(2);
+        shape[complex_dim] = n_components;
 
         Ok([SymTensor::from_shape(shape)].into())
     }
@@ -364,6 +372,25 @@ mod tests {
                 dft_length: None,
                 expected: sym_shape!("batch", 8, 2),
             },
+            // Inverse one-sided transform (IRFFT). The half spectrum of length
+            // 5 reconstructs a real signal of length `2 * (5 - 1) = 8`.
+            Case {
+                axis: -2,
+                inverse: true,
+                onesided: true,
+                input: sym_shape!("batch", 5, 2),
+                dft_length: None,
+                expected: sym_shape!("batch", 8, 1),
+            },
+            // IRFFT with an explicit `dft_length`.
+            Case {
+                axis: -2,
+                inverse: true,
+                onesided: true,
+                input: sym_shape!("batch", 5, 2),
+                dft_length: Some(sym_scalar!(7)),
+                expected: sym_shape!("batch", 7, 1),
+            },
         ];
 
         cases.test_each(|case| {
@@ -376,16 +403,5 @@ mod tests {
             );
             assert_eq!(out, case.expected);
         });
-    }
-
-    #[test]
-    fn test_dft_inverse_onesided_invalid() {
-        let mut sym_gen = SymbolGen::new();
-        let result = DFT {
-            inverse: true,
-            onesided: true,
-        }
-        .infer_shapes(&[sym_shape!("batch", 8, 2)], &mut sym_gen);
-        assert_eq!(result, Err(InferShapesError::InvalidValue));
     }
 }

--- a/src/model/onnx_loader.rs
+++ b/src/model/onnx_loader.rs
@@ -736,6 +736,10 @@ fn load_constant_from_constant_op(
 
 fn constant_from_attr_value(val: ConstInput) -> Constant {
     match val {
+        ConstInput::Int(val) => Constant::new(
+            None,
+            Tensor::from(saturating_cast_i64_to_i32(val)).into_arc(),
+        ),
         ConstInput::Ints(vals) => {
             let vals: Vec<i32> = vals.into_iter().map(saturating_cast_i64_to_i32).collect();
             Constant::new(None, Tensor::from(vals).into_arc())

--- a/src/op_registry.rs
+++ b/src/op_registry.rs
@@ -234,6 +234,7 @@ pub mod op_types {
     declare_op!(ConvTranspose);
     declare_op!(Cos);
     declare_op!(CumSum);
+    declare_op!(DFT, feature = "fft");
     declare_op!(DequantizeLinear);
     declare_op!(DepthToSpace);
     declare_op!(Div);

--- a/src/op_registry/onnx_registry.rs
+++ b/src/op_registry/onnx_registry.rs
@@ -123,6 +123,7 @@ impl OnnxOpRegistry {
         register_op!(Cos);
         register_op!(Cosh);
         register_op!(CumSum);
+        register_op!(DFT, feature = "fft");
         register_op!(DequantizeLinear);
         register_op!(DepthToSpace);
         register_op!(Div);
@@ -305,6 +306,10 @@ pub trait OpLoadContext {
 /// Value for an operator input created from an attribute (`onnx::AttributeProto`).
 #[derive(Debug, PartialEq)]
 pub enum ConstInput {
+    // Only constructed by feature-gated deserializers (eg. DFT), so it may be
+    // unused depending on the enabled features.
+    #[allow(dead_code)]
+    Int(i64),
     Ints(Vec<i64>),
     Float(f32),
     Floats(Vec<f32>),
@@ -965,6 +970,25 @@ impl_read_op!(CumSum, |attrs: &Attrs| {
     attrs.check_eq("exclusive", 0)?;
     attrs.check_eq("reverse", 0)?;
     Ok(ops::CumSum {})
+});
+
+#[cfg(feature = "fft")]
+impl_read_op!(DFT, |attrs: &Attrs| {
+    let inverse = attrs.get_as("inverse").unwrap_or(false);
+    let onesided = attrs.get_as("onesided").unwrap_or(false);
+
+    // `axis` was an attribute with default 1 in opset 17 and became an optional
+    // input with default -2 in opset 20.
+    let axis = attrs.get_as_int::<i32>("axis")?.or_else(|| {
+        let pre_opset_20 = attrs.opset_version().is_some_and(|v| v < 20);
+        pre_opset_20.then_some(1)
+    });
+    let mut const_inputs = Vec::new();
+    if let Some(axis) = axis {
+        const_inputs.push((2, ConstInput::Int(i64::from(axis))));
+    }
+
+    Ok(ParsedOp::new(ops::DFT { inverse, onesided }).with_inputs(const_inputs))
 });
 
 impl_read_op!(DequantizeLinear, |attrs: &Attrs| {
@@ -2067,6 +2091,61 @@ mod tests {
             let reg = OnnxOpRegistry::with_all_ops();
             let op = reg
                 .read_op(&case.op, &FakeOpLoadContext::default())
+                .unwrap();
+            assert_eq!(op.const_inputs, case.expected_inputs);
+        });
+    }
+
+    #[cfg(feature = "fft")]
+    #[test]
+    fn test_dft_axis() {
+        #[derive(Debug)]
+        struct Case {
+            opset_version: Option<u16>,
+            axis: Option<i64>,
+            expected_inputs: Vec<(u32, ConstInput)>,
+        }
+
+        let cases = [
+            // Explicit `axis` attribute is promoted regardless of opset.
+            Case {
+                opset_version: Some(18),
+                axis: Some(-2),
+                expected_inputs: [(2, ConstInput::Int(-2))].into(),
+            },
+            // Absent `axis` in a pre-opset-20 model uses the default of 1.
+            Case {
+                opset_version: Some(17),
+                axis: None,
+                expected_inputs: [(2, ConstInput::Int(1))].into(),
+            },
+            // Absent `axis` in opset 20+ is left to the operator (default -2).
+            Case {
+                opset_version: Some(20),
+                axis: None,
+                expected_inputs: [].into(),
+            },
+            // Absent `axis` with an unknown opset is left to the operator.
+            Case {
+                opset_version: None,
+                axis: None,
+                expected_inputs: [].into(),
+            },
+        ];
+
+        cases.test_each(|case| {
+            let mut node = create_node("DFT");
+            if let Some(axis) = case.axis {
+                node = node.with_attr("axis", axis);
+            }
+            let reg = OnnxOpRegistry::with_all_ops();
+            let op = reg
+                .read_op(
+                    &node,
+                    &FakeOpLoadContext {
+                        opset_version: case.opset_version,
+                    },
+                )
                 .unwrap();
             assert_eq!(op.const_inputs, case.expected_inputs);
         });

--- a/src/op_registry/rten_registry.rs
+++ b/src/op_registry/rten_registry.rs
@@ -119,6 +119,7 @@ impl RtenOpRegistry {
         register_op!(Cos);
         register_op!(Cosh);
         register_op!(CumSum);
+        register_op!(DFT, feature = "fft");
         register_op!(DequantizeLinear);
         register_op!(DepthToSpace);
         register_op!(Div);
@@ -523,6 +524,13 @@ impl_read_op!(
 impl_read_op!(Cos);
 impl_read_op!(Cosh);
 impl_read_op!(CumSum);
+#[cfg(feature = "fft")]
+impl_read_op!(DFT, attrs_as_dftattrs, |attrs: sg::DFTAttrs| {
+    Ok(ops::DFT {
+        inverse: attrs.inverse(),
+        onesided: attrs.onesided(),
+    })
+});
 impl_read_op!(DequantizeLinear, attrs_as_dequantize_linear_attrs, axis);
 impl_read_op!(
     DepthToSpace,

--- a/src/ops/fft.rs
+++ b/src/ops/fft.rs
@@ -192,6 +192,10 @@ impl_infer_shapes!(
 /// the real values (size 1) or interleaved real and imaginary values (size 2)
 /// of a complex signal.
 ///
+/// With `onesided` set, a forward transform (RFFT) returns the non-redundant
+/// half of the conjugate-symmetric spectrum, and an inverse transform (IRFFT)
+/// reconstructs the full real signal from such a half spectrum.
+///
 /// See <https://onnx.ai/onnx/operators/onnx__DFT.html>.
 pub fn dft(
     pool: &BufferPool,
@@ -214,12 +218,17 @@ pub fn dft(
         ));
     }
 
-    if inverse && onesided {
-        return Err(OpError::UnsupportedValue(
-            "DFT inverse one-sided transform (IRFFT) is not supported",
+    // A one-sided inverse transform (IRFFT) reconstructs a real signal from a
+    // conjugate-symmetric half spectrum, so it requires complex input. A
+    // one-sided forward transform (RFFT) produces such a spectrum from a real
+    // signal, so it requires real input.
+    let irfft = inverse && onesided;
+    if irfft && n_components != 2 {
+        return Err(OpError::InvalidValue(
+            "Inverse one-sided DFT (IRFFT) requires complex input",
         ));
     }
-    if onesided && n_components == 2 {
+    if onesided && !inverse && n_components == 2 {
         return Err(OpError::InvalidValue(
             "DFT cannot be one-sided if input is complex",
         ));
@@ -236,21 +245,32 @@ pub fn dft(
 
     let signal_len = input.size(dft_axis);
 
-    // The length (`N`) of the DFT. The input signal is zero-padded or truncated
-    // to this length along the DFT axis.
+    // The length (`N`) of the DFT, ie. the length of the real signal. The input
+    // signal is zero-padded or truncated to this length along the DFT axis.
+    //
+    // For IRFFT the input is the half spectrum of length `floor(N/2) + 1`, so
+    // the default `N` is `2 * (signal_len - 1)`. Matches NumPy's `irfft`.
     let n_fft = match dft_length {
         Some(len) if len >= 1 => len as usize,
         Some(_) => return Err(OpError::InvalidValue("dft_length must be >= 1")),
+        None if irfft => 2 * signal_len.saturating_sub(1),
         None => signal_len,
     };
 
-    // Number of output values along the DFT axis.
+    // Number of output values along the DFT axis. RFFT returns only the unique
+    // half of the conjugate-symmetric spectrum.
     //
     // If the signal is empty (`n_fft == 0`), the one-sided output has a single
-    // frequency bin filled with zeros. This matches ONNX Runtime; NumPy raises
-    // an error for zero-point transforms instead. Revisit if the spec or ONNX
-    // Runtime define this case more precisely.
-    let out_len = if onesided { n_fft / 2 + 1 } else { n_fft };
+    // frequency bin filled with zeros. This matches ONNX Runtime, although
+    // NumPy raises an error.
+    let out_len = if onesided && !inverse {
+        n_fft / 2 + 1
+    } else {
+        n_fft
+    };
+
+    // IRFFT returns a real signal, all other cases return complex.
+    let out_components = if irfft { 1 } else { 2 };
 
     // Permute the input so the DFT axis and complex dimension are the last two,
     // leaving lanes of shape `[n_fft][n_components]` that are contiguous in
@@ -266,7 +286,7 @@ pub fn dft(
 
     let mut out_shape: Vec<usize> = input.shape().to_vec();
     out_shape[ndim - 2] = out_len;
-    out_shape[ndim - 1] = 2;
+    out_shape[ndim - 1] = out_components;
     let mut output = Tensor::zeros_in(pool, out_shape.as_slice());
     let out_data = output.data_mut().unwrap();
 
@@ -295,18 +315,44 @@ pub fn dft(
     for lane in 0..num_lanes {
         let in_base = lane * signal_len * n_components;
 
-        // Zero-pad or truncate the signal to `n_fft` values.
         buf.clear();
-        buf.extend((0..signal_len.min(n_fft)).map(|k| get(in_base, k)));
-        buf.resize(n_fft, Complex32::default());
+        let n_in = signal_len.min(n_fft);
+        if irfft {
+            // Reconstruct the full conjugate-symmetric spectrum from the half
+            // spectrum: `X[N-k] = conj(X[k])`. For even `N` the Nyquist bin
+            // (`k == N/2`) is its own mirror and is left as the input value.
+            buf.resize(n_fft, Complex32::default());
+            for k in 0..n_in {
+                buf[k] = get(in_base, k);
+            }
+            let conj_end = if n_fft % 2 == 0 {
+                n_in.saturating_sub(1)
+            } else {
+                n_in
+            };
+            for k in 1..conj_end {
+                buf[n_fft - k] = get(in_base, k).conj();
+            }
+        } else {
+            // Zero-pad or truncate the signal to `n_fft` values.
+            buf.extend((0..n_in).map(|k| get(in_base, k)));
+            buf.resize(n_fft, Complex32::default());
+        }
 
         fft.process_with_scratch(&mut buf, &mut scratch);
 
-        let out_base = lane * out_len * 2;
-        for (i, val) in buf.iter().take(out_len).enumerate() {
-            let val = val * scale;
-            out_data[out_base + i * 2] = val.re;
-            out_data[out_base + i * 2 + 1] = val.im;
+        let out_base = lane * out_len * out_components;
+        if irfft {
+            // IRFFT discards the imaginary part, which is zero up to rounding.
+            for (i, val) in buf.iter().take(out_len).enumerate() {
+                out_data[out_base + i] = val.re * scale;
+            }
+        } else {
+            for (i, val) in buf.iter().take(out_len).enumerate() {
+                let val = val * scale;
+                out_data[out_base + i * 2] = val.re;
+                out_data[out_base + i * 2 + 1] = val.im;
+            }
         }
     }
 
@@ -686,13 +732,33 @@ mod tests {
                 .into_dyn()),
                 ..Default::default()
             },
-            // Combining `inverse` and `onesided` is disallowed by the spec.
+            // Inverse one-sided real-to-complex (`np.fft.irfft`). The half
+            // spectrum is `rfft([1, 2, 3, 4])` and the default `dft_length`
+            // reconstructs the original length-4 signal.
+            Case {
+                input: Tensor::from([[[10., 0.], [-2., 2.], [-2., 0.]]]).into_dyn(),
+                inverse: true,
+                onesided: true,
+                expected: Ok(Tensor::from([[[1.], [2.], [3.], [4.]]]).into_dyn()),
+                ..Default::default()
+            },
+            // Inverse one-sided with an explicit odd `dft_length`
+            // (`np.fft.irfft(rfft([1, 2, 3]), n=3)`).
+            Case {
+                input: Tensor::from([[[6., 0.], [-1.5, 0.8660254]]]).into_dyn(),
+                dft_length: Some(3),
+                inverse: true,
+                onesided: true,
+                expected: Ok(Tensor::from([[[1.], [2.], [3.]]]).into_dyn()),
+                ..Default::default()
+            },
+            // IRFFT requires complex input.
             Case {
                 input: real_signal.clone(),
                 inverse: true,
                 onesided: true,
-                expected: Err(OpError::UnsupportedValue(
-                    "DFT inverse one-sided transform (IRFFT) is not supported",
+                expected: Err(OpError::InvalidValue(
+                    "Inverse one-sided DFT (IRFFT) requires complex input",
                 )),
                 ..Default::default()
             },

--- a/src/ops/fft.rs
+++ b/src/ops/fft.rs
@@ -1,15 +1,16 @@
 use rten_shape_inference::ops as shape_ops;
 use rten_tensor::prelude::*;
-use rten_tensor::{NdTensor, NdTensorView, TensorView};
+use rten_tensor::{NdTensor, NdTensorView, Tensor, TensorView};
 use rustfft::FftPlanner;
 use rustfft::num_complex::Complex32;
 
-use crate::buffer_pool::BufferPool;
+use crate::buffer_pool::{AutoReturn, BufferPool};
 use crate::infer_shapes::{InferShapes, impl_infer_shapes};
 use crate::operator::{
     IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType, OutputTypeList,
     OutputTypesContext,
 };
+use crate::ops::resolve_axis;
 
 enum FftType {
     /// FFT with real input signal.
@@ -183,13 +184,212 @@ impl_infer_shapes!(
     }
 );
 
+/// Compute the Discrete Fourier Transform of `input` along `axis`.
+///
+/// `input` has shape `[...][n_signal][n_components]` where the DFT is performed
+/// along the dimension given by `axis` and the final dimension contains either
+/// the real values (size 1) or interleaved real and imaginary values (size 2)
+/// of a complex signal.
+///
+/// See <https://onnx.ai/onnx/operators/onnx__DFT.html>.
+pub fn dft(
+    pool: &BufferPool,
+    input: TensorView<f32>,
+    dft_length: Option<i32>,
+    axis: isize,
+    inverse: bool,
+    onesided: bool,
+) -> Result<Tensor<f32>, OpError> {
+    let ndim = input.ndim();
+    if ndim < 2 {
+        return Err(OpError::InvalidValue("DFT input must have at least 2 dims"));
+    }
+
+    let complex_dim = ndim - 1;
+    let n_components = input.size(complex_dim);
+    if n_components != 1 && n_components != 2 {
+        return Err(OpError::InvalidValue(
+            "Last dimension of DFT input must have size 1 or 2",
+        ));
+    }
+
+    if inverse && onesided {
+        return Err(OpError::UnsupportedValue(
+            "DFT inverse one-sided transform (IRFFT) is not supported",
+        ));
+    }
+    if onesided && n_components == 2 {
+        return Err(OpError::InvalidValue(
+            "DFT cannot be one-sided if input is complex",
+        ));
+    }
+
+    // Resolve the signal axis. Per the spec the accepted range is
+    // `[-r, -2] ∪ [0, r-2]`, ie. the final (complex) dimension is excluded.
+    let dft_axis = resolve_axis(ndim, axis)?;
+    if dft_axis == complex_dim {
+        return Err(OpError::InvalidValue(
+            "DFT axis cannot be the complex dimension",
+        ));
+    }
+
+    let signal_len = input.size(dft_axis);
+
+    // The length (`N`) of the DFT. The input signal is zero-padded or truncated
+    // to this length along the DFT axis.
+    let n_fft = match dft_length {
+        Some(len) if len >= 1 => len as usize,
+        Some(_) => return Err(OpError::InvalidValue("dft_length must be >= 1")),
+        None => signal_len,
+    };
+
+    // Number of output values along the DFT axis.
+    //
+    // If the signal is empty (`n_fft == 0`), the one-sided output has a single
+    // frequency bin filled with zeros. This matches ONNX Runtime; NumPy raises
+    // an error for zero-point transforms instead. Revisit if the spec or ONNX
+    // Runtime define this case more precisely.
+    let out_len = if onesided { n_fft / 2 + 1 } else { n_fft };
+
+    // Permute the input so the DFT axis and complex dimension are the last two,
+    // leaving lanes of shape `[n_fft][n_components]` that are contiguous in
+    // memory.
+    let perm: Vec<usize> = (0..ndim)
+        .filter(|&d| d != dft_axis && d != complex_dim)
+        .chain([dft_axis, complex_dim])
+        .collect();
+    let input = input.permuted(perm.as_slice());
+    let input = input.to_contiguous_in(pool).auto_return(pool);
+    let in_data = input.data();
+    let num_lanes: usize = input.shape()[..ndim - 2].iter().product();
+
+    let mut out_shape: Vec<usize> = input.shape().to_vec();
+    out_shape[ndim - 2] = out_len;
+    out_shape[ndim - 1] = 2;
+    let mut output = Tensor::zeros_in(pool, out_shape.as_slice());
+    let out_data = output.data_mut().unwrap();
+
+    let mut planner = FftPlanner::new();
+    let fft = if inverse {
+        planner.plan_fft_inverse(n_fft)
+    } else {
+        planner.plan_fft_forward(n_fft)
+    };
+    // ONNX defines the inverse transform with a `1/N` normalization factor,
+    // which `rustfft` does not apply.
+    let scale = if inverse { 1.0 / n_fft as f32 } else { 1.0 };
+
+    let mut buf: Vec<Complex32> = Vec::with_capacity(n_fft);
+    let get = |base: usize, i: usize| {
+        let re = in_data[base + i * n_components];
+        let im = if n_components == 2 {
+            in_data[base + i * n_components + 1]
+        } else {
+            0.
+        };
+        Complex32 { re, im }
+    };
+
+    for lane in 0..num_lanes {
+        let in_base = lane * signal_len * n_components;
+
+        // Zero-pad or truncate the signal to `n_fft` values.
+        buf.clear();
+        buf.extend((0..signal_len.min(n_fft)).map(|k| get(in_base, k)));
+        buf.resize(n_fft, Complex32::default());
+
+        fft.process(&mut buf);
+
+        let out_base = lane * out_len * 2;
+        for (i, val) in buf.iter().take(out_len).enumerate() {
+            let val = val * scale;
+            out_data[out_base + i * 2] = val.re;
+            out_data[out_base + i * 2 + 1] = val.im;
+        }
+    }
+
+    // If the DFT axis was already the second-from-last dimension, `perm` is
+    // the identity and the output needs no further reordering.
+    if dft_axis == ndim - 2 {
+        return Ok(output);
+    }
+
+    // Restore the original axis order.
+    let output = output.auto_return(pool);
+    let mut inv_perm = vec![0usize; ndim];
+    for (new_pos, &old_dim) in perm.iter().enumerate() {
+        inv_perm[old_dim] = new_pos;
+    }
+    Ok(output.permuted(inv_perm.as_slice()).to_tensor_in(pool))
+}
+
+/// Default signal axis for the [`DFT`] operator.
+///
+/// This is the second-from-last axis, ie. the last axis excluding the complex
+/// component dimension. It matches the default of the `axis` input added in
+/// opset 20.
+const DFT_DEFAULT_AXIS: i32 = -2;
+
+#[allow(clippy::upper_case_acronyms)]
+#[derive(Debug)]
+pub struct DFT {
+    /// Whether to perform the inverse transform.
+    pub inverse: bool,
+    /// Whether to return only the non-redundant half of a conjugate-symmetric
+    /// spectrum.
+    pub onesided: bool,
+}
+
+impl Operator for DFT {
+    fn name(&self) -> &str {
+        "DFT"
+    }
+
+    fn max_inputs(&self) -> Option<usize> {
+        Some(3)
+    }
+
+    fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+        let input = ctx.inputs().require_as(0)?;
+        let dft_length = ctx.inputs().get_as(1)?;
+        let axis = ctx.inputs().get_as::<i32>(2)?.unwrap_or(DFT_DEFAULT_AXIS) as isize;
+
+        dft(
+            ctx.pool(),
+            input,
+            dft_length,
+            axis,
+            self.inverse,
+            self.onesided,
+        )
+        .into_op_result()
+    }
+
+    fn output_types(&self, _ctx: &OutputTypesContext) -> Option<OutputTypeList> {
+        Some([OutputType::CopyFromInput(0)].into())
+    }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        Some(self)
+    }
+}
+
+impl_infer_shapes!(
+    DFT,
+    op,
+    shape_ops::DFT {
+        inverse: op.inverse,
+        onesided: op.onesided,
+    }
+);
+
 #[cfg(test)]
 mod tests {
     use rten_tensor::prelude::*;
     use rten_tensor::{NdTensor, Tensor};
     use rten_testing::TestCases;
 
-    use super::STFT;
+    use super::{DFT, STFT};
     use crate::operator::{InputList, OpError, OperatorExt};
     use crate::ops::tests::{IntoNDim, expect_eq_1e4};
 
@@ -401,6 +601,178 @@ mod tests {
                 frame_length.as_ref().map(|fl| fl.view().into()),
             ]);
             let result: Result<NdTensor<f32, 4>, _> = STFT {
+                onesided: case.onesided,
+            }
+            .run_simple(inputs);
+
+            match (&result, &case.expected) {
+                (Ok(result), Ok(expected)) => {
+                    expect_eq_1e4(result, expected).unwrap();
+                }
+                _ => assert_eq!(result, case.expected),
+            }
+        });
+    }
+
+    #[test]
+    fn test_dft() {
+        // Reference results are computed with NumPy's `np.fft` module.
+        #[derive(Debug)]
+        struct Case {
+            // Input of shape `[batch, signal, component]` (or higher rank).
+            input: Tensor,
+            dft_length: Option<i32>,
+            axis: i32,
+            inverse: bool,
+            onesided: bool,
+            expected: Result<Tensor, OpError>,
+        }
+
+        impl Default for Case {
+            fn default() -> Case {
+                Case {
+                    input: Tensor::from(0.),
+                    dft_length: None,
+                    axis: -2,
+                    inverse: false,
+                    onesided: false,
+                    expected: Err(OpError::InvalidValue("Invalid expectation")),
+                }
+            }
+        }
+
+        // Real signal `[1, 2, 3, 4]` with shape `[1, 4, 1]`.
+        let real_signal = Tensor::from([[[1.], [2.], [3.], [4.]]]).into_dyn();
+
+        // Complex signal `[1, 2+1j, 3-1j, 4+2j]` with shape `[1, 4, 2]`.
+        let complex_signal = Tensor::from([[[1., 0.], [2., 1.], [3., -1.], [4., 2.]]]).into_dyn();
+
+        let cases = [
+            // One-sided real-to-complex (`np.fft.rfft`).
+            Case {
+                input: real_signal.clone(),
+                onesided: true,
+                expected: Ok(Tensor::from([[[10., 0.], [-2., 2.], [-2., 0.]]]).into_dyn()),
+                ..Default::default()
+            },
+            // Two-sided real-to-complex (`np.fft.fft`).
+            Case {
+                input: real_signal.clone(),
+                expected: Ok(
+                    Tensor::from([[[10., 0.], [-2., 2.], [-2., 0.], [-2., -2.]]]).into_dyn(),
+                ),
+                ..Default::default()
+            },
+            // Complex-to-complex (`np.fft.fft`).
+            Case {
+                input: complex_signal.clone(),
+                expected: Ok(
+                    Tensor::from([[[10., 2.], [-3., 3.], [-2., -4.], [-1., -1.]]]).into_dyn(),
+                ),
+                ..Default::default()
+            },
+            // Inverse complex-to-complex (`np.fft.ifft`).
+            Case {
+                input: complex_signal.clone(),
+                inverse: true,
+                expected: Ok(Tensor::from([[
+                    [2.5, 0.5],
+                    [-0.25, -0.25],
+                    [-0.5, -1.],
+                    [-0.75, 0.75],
+                ]])
+                .into_dyn()),
+                ..Default::default()
+            },
+            // Combining `inverse` and `onesided` is disallowed by the spec.
+            Case {
+                input: real_signal.clone(),
+                inverse: true,
+                onesided: true,
+                expected: Err(OpError::UnsupportedValue(
+                    "DFT inverse one-sided transform (IRFFT) is not supported",
+                )),
+                ..Default::default()
+            },
+            // One-sided transform of a complex input is disallowed, as the
+            // spectrum is not conjugate-symmetric.
+            Case {
+                input: complex_signal.clone(),
+                onesided: true,
+                expected: Err(OpError::InvalidValue(
+                    "DFT cannot be one-sided if input is complex",
+                )),
+                ..Default::default()
+            },
+            // Zero-padding via `dft_length` (`np.fft.rfft(x, n=6)`).
+            Case {
+                input: real_signal.clone(),
+                dft_length: Some(6),
+                onesided: true,
+                expected: Ok(Tensor::from([[
+                    [10., 0.],
+                    [-3.5, -4.330127],
+                    [2.5, 0.866025],
+                    [-2., 0.],
+                ]])
+                .into_dyn()),
+                ..Default::default()
+            },
+            // Truncation via `dft_length` (`np.fft.rfft(x, n=2)`).
+            Case {
+                input: real_signal.clone(),
+                dft_length: Some(2),
+                onesided: true,
+                expected: Ok(Tensor::from([[[3., 0.], [-1., 0.]]]).into_dyn()),
+                ..Default::default()
+            },
+            // Transform along a non-default axis of a higher-rank input. The
+            // size-2 dimension is a "feature" axis with the DFT performed along
+            // the size-4 axis. This exercises the axis permutation.
+            //
+            // Feature 0 is `rfft([1, 2, 3, 4])` and feature 1 is
+            // `rfft([4, 3, 2, 1])`.
+            Case {
+                // Shape `[1, 4, 2, 1]`: `[batch, signal, feature, component]`.
+                input: Tensor::from_data(&[1, 4, 2, 1], vec![1., 4., 2., 3., 3., 2., 4., 1.]),
+                axis: 1,
+                onesided: true,
+                // Shape `[1, 3, 2, 2]`: `[batch, freq, feature, component]`.
+                expected: Ok(Tensor::from_data(
+                    &[1, 3, 2, 2],
+                    vec![10., 0., 10., 0., -2., 2., 2., -2., -2., 0., 2., 0.],
+                )),
+                ..Default::default()
+            },
+            // Invalid component count.
+            Case {
+                input: Tensor::from([[[1., 2., 3.]]]).into_dyn(),
+                expected: Err(OpError::InvalidValue(
+                    "Last dimension of DFT input must have size 1 or 2",
+                )),
+                ..Default::default()
+            },
+            // Invalid `dft_length`.
+            Case {
+                input: real_signal.clone(),
+                dft_length: Some(0),
+                expected: Err(OpError::InvalidValue("dft_length must be >= 1")),
+                ..Default::default()
+            },
+        ];
+
+        cases.test_each(|case| {
+            // `axis` is passed as an input (input 2). `dft_length` (input 1) is
+            // optional, so a `None` placeholder is used when it is unset.
+            let dft_length = case.dft_length.map(Tensor::from);
+            let axis = Tensor::from(case.axis);
+            let inputs = InputList::from_iter([
+                Some(case.input.view().into()),
+                dft_length.as_ref().map(|d| d.view().into()),
+                Some(axis.view().into()),
+            ]);
+            let result: Result<Tensor, _> = DFT {
+                inverse: case.inverse,
                 onesided: case.onesided,
             }
             .run_simple(inputs);

--- a/src/ops/fft.rs
+++ b/src/ops/fft.rs
@@ -298,6 +298,7 @@ pub fn dft(
     };
     // ONNX defines the inverse transform with a `1/N` normalization factor,
     // which `rustfft` does not apply.
+    // See https://docs.rs/rustfft/latest/rustfft/#normalization.
     let scale = if inverse { 1.0 / n_fft as f32 } else { 1.0 };
 
     let mut buf: Vec<Complex32> = Vec::with_capacity(n_fft);
@@ -690,33 +691,39 @@ mod tests {
         }
 
         // Real signal `[1, 2, 3, 4]` with shape `[1, 4, 1]`.
-        let real_signal = Tensor::from([[[1.], [2.], [3.], [4.]]]).into_dyn();
+        let real_signal = Tensor::from([[[1.], [2.], [3.], [4.]]]);
 
         // Complex signal `[1, 2+1j, 3-1j, 4+2j]` with shape `[1, 4, 2]`.
-        let complex_signal = Tensor::from([[[1., 0.], [2., 1.], [3., -1.], [4., 2.]]]).into_dyn();
+        let complex_signal = Tensor::from([[[1., 0.], [2., 1.], [3., -1.], [4., 2.]]]);
 
         let cases = [
             // One-sided real-to-complex (`np.fft.rfft`).
             Case {
                 input: real_signal.clone(),
                 onesided: true,
-                expected: Ok(Tensor::from([[[10., 0.], [-2., 2.], [-2., 0.]]]).into_dyn()),
+                expected: Ok(Tensor::from([[[10., 0.], [-2., 2.], [-2., 0.]]])),
                 ..Default::default()
             },
             // Two-sided real-to-complex (`np.fft.fft`).
             Case {
                 input: real_signal.clone(),
-                expected: Ok(
-                    Tensor::from([[[10., 0.], [-2., 2.], [-2., 0.], [-2., -2.]]]).into_dyn(),
-                ),
+                expected: Ok(Tensor::from([[
+                    [10., 0.],
+                    [-2., 2.],
+                    [-2., 0.],
+                    [-2., -2.],
+                ]])),
                 ..Default::default()
             },
             // Complex-to-complex (`np.fft.fft`).
             Case {
                 input: complex_signal.clone(),
-                expected: Ok(
-                    Tensor::from([[[10., 2.], [-3., 3.], [-2., -4.], [-1., -1.]]]).into_dyn(),
-                ),
+                expected: Ok(Tensor::from([[
+                    [10., 2.],
+                    [-3., 3.],
+                    [-2., -4.],
+                    [-1., -1.],
+                ]])),
                 ..Default::default()
             },
             // Inverse complex-to-complex (`np.fft.ifft`).
@@ -728,28 +735,27 @@ mod tests {
                     [-0.25, -0.25],
                     [-0.5, -1.],
                     [-0.75, 0.75],
-                ]])
-                .into_dyn()),
+                ]])),
                 ..Default::default()
             },
             // Inverse one-sided real-to-complex (`np.fft.irfft`). The half
             // spectrum is `rfft([1, 2, 3, 4])` and the default `dft_length`
             // reconstructs the original length-4 signal.
             Case {
-                input: Tensor::from([[[10., 0.], [-2., 2.], [-2., 0.]]]).into_dyn(),
+                input: Tensor::from([[[10., 0.], [-2., 2.], [-2., 0.]]]),
                 inverse: true,
                 onesided: true,
-                expected: Ok(Tensor::from([[[1.], [2.], [3.], [4.]]]).into_dyn()),
+                expected: Ok(Tensor::from([[[1.], [2.], [3.], [4.]]])),
                 ..Default::default()
             },
             // Inverse one-sided with an explicit odd `dft_length`
             // (`np.fft.irfft(rfft([1, 2, 3]), n=3)`).
             Case {
-                input: Tensor::from([[[6., 0.], [-1.5, 0.8660254]]]).into_dyn(),
+                input: Tensor::from([[[6., 0.], [-1.5, 0.8660254]]]),
                 dft_length: Some(3),
                 inverse: true,
                 onesided: true,
-                expected: Ok(Tensor::from([[[1.], [2.], [3.]]]).into_dyn()),
+                expected: Ok(Tensor::from([[[1.], [2.], [3.]]])),
                 ..Default::default()
             },
             // IRFFT requires complex input.
@@ -782,8 +788,7 @@ mod tests {
                     [-3.5, -4.330127],
                     [2.5, 0.866025],
                     [-2., 0.],
-                ]])
-                .into_dyn()),
+                ]])),
                 ..Default::default()
             },
             // Truncation via `dft_length` (`np.fft.rfft(x, n=2)`).
@@ -791,7 +796,7 @@ mod tests {
                 input: real_signal.clone(),
                 dft_length: Some(2),
                 onesided: true,
-                expected: Ok(Tensor::from([[[3., 0.], [-1., 0.]]]).into_dyn()),
+                expected: Ok(Tensor::from([[[3., 0.], [-1., 0.]]])),
                 ..Default::default()
             },
             // Transform along a non-default axis of a higher-rank input. The
@@ -814,7 +819,7 @@ mod tests {
             },
             // Invalid component count.
             Case {
-                input: Tensor::from([[[1., 2., 3.]]]).into_dyn(),
+                input: Tensor::from([[[1., 2., 3.]]]),
                 expected: Err(OpError::InvalidValue(
                     "Last dimension of DFT input must have size 1 or 2",
                 )),
@@ -830,8 +835,6 @@ mod tests {
         ];
 
         cases.test_each(|case| {
-            // `axis` is passed as an input (input 2). `dft_length` (input 1) is
-            // optional, so a `None` placeholder is used when it is unset.
             let dft_length = case.dft_length.map(Tensor::from);
             let axis = Tensor::from(case.axis);
             let inputs = InputList::from_iter([

--- a/src/ops/fft.rs
+++ b/src/ops/fft.rs
@@ -104,6 +104,7 @@ pub fn stft(
 
     let mut planner = FftPlanner::new();
     let fft = planner.plan_fft_forward(n_fft);
+    let mut scratch = vec![Complex32::default(); fft.get_inplace_scratch_len()];
 
     for (signal_batch, mut out_batch) in signal.axis_iter(0).zip(output.axis_iter_mut(0)) {
         for (frame, mut out_frame) in out_batch.axis_iter_mut(0).enumerate() {
@@ -119,7 +120,7 @@ pub fn stft(
                 Complex32 { re, im }
             }));
 
-            fft.process(&mut tmp_buf);
+            fft.process_with_scratch(&mut tmp_buf, &mut scratch);
 
             for (bin, val) in tmp_buf.iter().take(out_frame.size(0)).enumerate() {
                 out_frame[[bin, 0]] = val.re;
@@ -280,6 +281,7 @@ pub fn dft(
     let scale = if inverse { 1.0 / n_fft as f32 } else { 1.0 };
 
     let mut buf: Vec<Complex32> = Vec::with_capacity(n_fft);
+    let mut scratch = vec![Complex32::default(); fft.get_inplace_scratch_len()];
     let get = |base: usize, i: usize| {
         let re = in_data[base + i * n_components];
         let im = if n_components == 2 {
@@ -298,7 +300,7 @@ pub fn dft(
         buf.extend((0..signal_len.min(n_fft)).map(|k| get(in_base, k)));
         buf.resize(n_fft, Complex32::default());
 
-        fft.process(&mut buf);
+        fft.process_with_scratch(&mut buf, &mut scratch);
 
         let out_base = lane * out_len * 2;
         for (i, val) in buf.iter().take(out_len).enumerate() {

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -62,7 +62,7 @@ pub(crate) mod transform_inputs;
 // Operator structs. These are re-exported for internal use by the model loader
 // and tests.
 #[cfg(feature = "fft")]
-pub(crate) use fft::STFT;
+pub(crate) use fft::{DFT, STFT};
 #[cfg(feature = "random")]
 pub(crate) use random::{
     Dropout, Multinomial, RandomNormal, RandomNormalLike, RandomUniform, RandomUniformLike,
@@ -149,7 +149,7 @@ pub use pooling::{average_pool, global_average_pool, max_pool};
 pub use quantize::{dequantize_linear, dynamic_quantize_linear, quantize_linear};
 
 #[cfg(feature = "fft")]
-pub use fft::stft;
+pub use fft::{dft, stft};
 
 pub use reduce::{
     arg_max, arg_min, cum_sum, nonzero, reduce_l1, reduce_l2, reduce_max, reduce_mean, reduce_min,


### PR DESCRIPTION
Implement the [DFT](https://onnx.ai/onnx/operators/onnx__DFT.html) operator. Like the existing STFT op, this uses RustFFT for the implementation and requires the `fft` crate feature.

The implementation includes support for combining `onesided=1` and `inverse=1` (ala. `numpy.fft.irfft`) which was only very recently added to the spec and ONNX Runtime, see https://github.com/microsoft/onnxruntime/pull/27028.

This operator was tested with the [un-optimized BirdNET](https://huggingface.co/justinchuby/BirdNET-onnx/blob/main/model.onnx) model. That model runs in ~17ms iter in RTen and ~33ms iter in ONNX Runtime. The ORT implementation spends much more time in DFT ops (22ms vs 5ms) and Slice ops (4ms vs 0ms).