### PR TITLE
Allow ONNX operator deserializers to query opset version

### DIFF
--- a/rten-onnx/src/onnx.rs
+++ b/rten-onnx/src/onnx.rs
@@ -407,6 +407,41 @@ impl DecodeMessage for StringStringEntryProto {
 }
 
 #[derive(Clone, Debug, Default)]
+pub struct OperatorSetIdProto {
+    pub domain: Option<String>,
+    pub version: Option<i64>,
+}
+
+impl OperatorSetIdProto {
+    const DOMAIN: u64 = 1;
+    const VERSION: u64 = 2;
+}
+
+impl DecodeMessage for OperatorSetIdProto {
+    type Types = OwnedValues;
+
+    fn decode_fields<R: ReadValue<Types = Self::Types>>(
+        mut fields: Fields<R>,
+    ) -> Result<Self, ProtobufError> {
+        let mut msg = Self::default();
+        while let Some(mut field) = fields.next()? {
+            match field.number() {
+                Self::DOMAIN => {
+                    msg.domain = Some(field.read_string()?);
+                }
+                Self::VERSION => {
+                    msg.version = Some(field.get_int64()?);
+                }
+                _ => {
+                    field.skip()?;
+                }
+            }
+        }
+        Ok(msg)
+    }
+}
+
+#[derive(Clone, Debug, Default)]
 pub struct TensorShapeProto {
     pub dim: Vec<Dimension>,
 }
@@ -626,6 +661,7 @@ impl DecodeMessage for GraphProto {
 pub struct ModelProto {
     pub ir_version: Option<i64>,
     pub graph: Option<GraphProto>,
+    pub opset_import: Vec<OperatorSetIdProto>,
     pub metadata_props: Vec<StringStringEntryProto>,
     pub producer_name: Option<String>,
     pub producer_version: Option<String>,
@@ -636,6 +672,7 @@ impl ModelProto {
     const PRODUCER_NAME: u64 = 2;
     const PRODUCER_VERSION: u64 = 3;
     const GRAPH: u64 = 7;
+    const OPSET_IMPORT: u64 = 8;
     const METADATA_PROPS: u64 = 14;
 
     // The non-generic `parse_file` and `parse_buf` methods allow the parsing
@@ -668,6 +705,10 @@ impl DecodeMessage for ModelProto {
                 }
                 Self::GRAPH => {
                     msg.graph = Some(GraphProto::decode_field(&mut field)?);
+                }
+                Self::OPSET_IMPORT => {
+                    msg.opset_import
+                        .push(OperatorSetIdProto::decode_field(&mut field)?);
                 }
                 Self::PRODUCER_NAME => {
                     msg.producer_name = Some(field.read_string()?);
@@ -773,6 +814,12 @@ mod tests {
         let file = File::open(model_path).unwrap();
         let value_reader = ValueReader::from_file(file);
         let model = ModelProto::decode(value_reader).unwrap();
+
+        let default_opset = model
+            .opset_import
+            .iter()
+            .find(|os| os.domain.as_deref().unwrap_or_default().is_empty());
+        assert_eq!(default_opset.and_then(|os| os.version), Some(18));
 
         let graph = model.graph.unwrap();
         assert_eq!(graph.node.len(), 13);

--- a/src/model/onnx_loader.rs
+++ b/src/model/onnx_loader.rs
@@ -49,6 +49,8 @@ pub fn load(
     }
     .map_err(|err| LoadErrorImpl::ParseFailed(Box::new(err)))?;
 
+    let opset_versions = OpsetVersions::from_model(&model);
+
     let graph = if let Some(onnx_graph) = &model.graph {
         load_graph(
             onnx_graph,
@@ -56,6 +58,7 @@ pub fn load(
             options.optimize_mode(),
             None,
             loader,
+            opset_versions,
         )?
     } else {
         Graph::new()
@@ -73,6 +76,37 @@ pub fn load(
         graph,
         weight_cache,
     })
+}
+
+#[derive(Clone, Copy)]
+struct OpsetVersions<'a> {
+    imports: &'a [onnx::OperatorSetIdProto],
+}
+
+impl<'a> OpsetVersions<'a> {
+    /// Create from a model's opset imports.
+    fn from_model(model: &'a onnx::ModelProto) -> Self {
+        OpsetVersions {
+            imports: &model.opset_import,
+        }
+    }
+
+    /// Return the opset version for a domain.
+    ///
+    /// Returns `None` if the domain was not imported or its version was not
+    /// specified or out of range.
+    fn version(&self, domain: &str) -> Option<u16> {
+        fn normalize_domain(domain: &str) -> &str {
+            if domain.is_empty() { "ai.onnx" } else { domain }
+        }
+
+        let domain = normalize_domain(domain);
+        self.imports
+            .iter()
+            .find(|os| normalize_domain(os.domain.as_deref().unwrap_or_default()) == domain)
+            .and_then(|os| os.version)
+            .and_then(|version| u16::try_from(version).ok())
+    }
 }
 
 fn load_metadata(model: &onnx::ModelProto) -> ModelMetadata {
@@ -99,6 +133,7 @@ fn load_graph(
     optimize: OptimizeMode,
     capture_env: Option<&CaptureEnv>,
     loader: Option<&dyn DataLoader>,
+    opset_versions: OpsetVersions,
 ) -> Result<Graph, LoadError> {
     let approx_node_count = onnx_graph.node.len() + onnx_graph.value_info.len();
     let mut graph = Graph::with_capacity(approx_node_count);
@@ -248,6 +283,7 @@ fn load_graph(
                 optimize: optimize.clone(),
                 capture_env,
                 loader,
+                opset_versions,
             },
         )?;
     }
@@ -825,6 +861,9 @@ struct SubgraphOptions<'a> {
 
     /// Data source for tensors with data stored outside model.
     loader: Option<&'a dyn DataLoader>,
+
+    /// Opset versions the model uses.
+    opset_versions: OpsetVersions<'a>,
 }
 
 /// Load an ONNX operator and its subgraphs.
@@ -842,23 +881,42 @@ fn add_operator(
             optimize,
             capture_env,
             loader,
+            opset_versions,
         } = &subgraph_opts;
         let capture_env = CaptureEnv::new(*capture_env, graph, None, None, None);
-        load_graph(g, registry, optimize.clone(), Some(&capture_env), *loader)
+        load_graph(
+            g,
+            registry,
+            optimize.clone(),
+            Some(&capture_env),
+            *loader,
+            *opset_versions,
+        )
     };
 
     struct LoadContext<'a> {
         load_graph: &'a dyn Fn(&onnx::GraphProto) -> Result<Graph, LoadError>,
+        opset_versions: OpsetVersions<'a>,
+
+        /// Domain of the operator being loaded.
+        domain: &'a str,
     }
 
     impl OpLoadContext for LoadContext<'_> {
         fn load_graph(&self, graph: &onnx::GraphProto) -> Result<Graph, ReadOpError> {
             (self.load_graph)(graph).map_err(|err| ReadOpError::SubgraphError(err.into()))
         }
+
+        fn opset_version(&self) -> Option<u16> {
+            // Resolved on demand since most deserializers don't need it.
+            self.opset_versions.version(self.domain)
+        }
     }
 
     let ctx = LoadContext {
         load_graph: &load_subgraph,
+        opset_versions: subgraph_opts.opset_versions,
+        domain: onnx_op.domain.as_deref().unwrap_or_default(),
     };
 
     let node_ids_from_names = |names: &[String]| -> Vec<Option<NodeId>> {
@@ -958,8 +1016,9 @@ mod tests {
     use rten_base::half::{f16_to_f32, f32_to_f16};
     use rten_onnx::onnx;
     use rten_tensor::{Tensor, TensorView};
+    use rten_testing::TestCases;
 
-    use super::{Source, load};
+    use super::{OpsetVersions, Source, load};
     use crate::graph::{Constant, Dimension, Graph, TypedConstant};
     use crate::model::external_data::{DataLoader, DataLocation, MemLoader};
     use crate::model::onnx_builder::{
@@ -1287,6 +1346,74 @@ mod tests {
                 ("producer_version", "2.8.0"),
             ]
         );
+    }
+
+    #[test]
+    fn test_opset_versions() {
+        #[derive(Debug)]
+        struct Case {
+            // (domain, version) pairs for the model's `opset_import` field.
+            opset_imports: Vec<(Option<&'static str>, Option<i64>)>,
+            // (queried domain, expected version) pairs.
+            expected: Vec<(&'static str, Option<u16>)>,
+        }
+
+        let cases = [
+            // Default domain identified by an empty string. It can be queried
+            // by either the empty or "ai.onnx" name.
+            Case {
+                opset_imports: [(Some(""), Some(17))].into(),
+                expected: [("", Some(17)), ("ai.onnx", Some(17))].into(),
+            },
+            // Default domain identified by an unset domain field.
+            Case {
+                opset_imports: [(None, Some(18))].into(),
+                expected: [("", Some(18)), ("ai.onnx", Some(18))].into(),
+            },
+            // Default domain identified by its explicit "ai.onnx" name.
+            Case {
+                opset_imports: [(Some("ai.onnx"), Some(20))].into(),
+                expected: [("", Some(20)), ("ai.onnx", Some(20))].into(),
+            },
+            // Each imported domain reports its own version.
+            Case {
+                opset_imports: [(Some("ai.onnx.ml"), Some(3)), (Some(""), Some(19))].into(),
+                expected: [("ai.onnx.ml", Some(3)), ("", Some(19))].into(),
+            },
+            // Domains that were not imported report no version.
+            Case {
+                opset_imports: [(Some("com.example"), Some(5))].into(),
+                expected: [("com.example", Some(5)), ("", None)].into(),
+            },
+            // No opset imports.
+            Case {
+                opset_imports: [].into(),
+                expected: [("", None), ("ai.onnx", None)].into(),
+            },
+            // Versions outside the `u16` range are treated as unspecified.
+            Case {
+                opset_imports: [(Some(""), Some(-1))].into(),
+                expected: [("", None)].into(),
+            },
+            Case {
+                opset_imports: [(Some(""), Some(1 << 32))].into(),
+                expected: [("", None)].into(),
+            },
+        ];
+
+        cases.test_each(|case| {
+            let mut model = onnx::GraphProto::default().into_model();
+            for (domain, version) in &case.opset_imports {
+                let mut opset = onnx::OperatorSetIdProto::default();
+                opset.domain = domain.map(|d| d.to_string());
+                opset.version = *version;
+                model.opset_import.push(opset);
+            }
+            let opset_versions = OpsetVersions::from_model(&model);
+            for (domain, expected) in &case.expected {
+                assert_eq!(opset_versions.version(domain), *expected);
+            }
+        });
     }
 
     #[test]

--- a/src/op_registry/onnx_registry.rs
+++ b/src/op_registry/onnx_registry.rs
@@ -296,6 +296,10 @@ impl fmt::Display for OpId<'_> {
 pub trait OpLoadContext {
     /// Deserialize a graph definition.
     fn load_graph(&self, graph: &onnx::GraphProto) -> Result<Graph, ReadOpError>;
+
+    /// Return the opset version that the operator uses, or `None` if
+    /// unspecified or invalid.
+    fn opset_version(&self) -> Option<u16>;
 }
 
 /// Value for an operator input created from an attribute (`onnx::AttributeProto`).
@@ -398,10 +402,14 @@ pub trait ReadOp: Operator + Sized + Send + Sync {
 struct Attrs<'a> {
     attrs: &'a [onnx::AttributeProto],
     unused_attrs: Cell<BitSet>,
+
+    /// Opset version the operator uses.
+    #[allow(dead_code)] // May be unused depending on enabled features.
+    opset_version: Option<u16>,
 }
 
 impl<'a> Attrs<'a> {
-    fn new(attrs: &'a [onnx::AttributeProto]) -> Self {
+    fn new(attrs: &'a [onnx::AttributeProto], opset_version: Option<u16>) -> Self {
         // Assume there will be at most 32 attributes. If there are more, we'll
         // just ignore them.
         let n_attrs: u32 = attrs.len().min(BitSet::BITS).try_into().unwrap();
@@ -410,7 +418,15 @@ impl<'a> Attrs<'a> {
         Self {
             attrs,
             unused_attrs,
+            opset_version,
         }
+    }
+
+    /// Return the opset version the operator was exported against, or `None` if
+    /// it was not specified.
+    #[allow(dead_code)] // Only used by feature-gated deserializers (eg. DFT).
+    fn opset_version(&self) -> Option<u16> {
+        self.opset_version
     }
 
     /// Get an optional attribute.
@@ -619,9 +635,9 @@ macro_rules! impl_read_op {
 
             fn read(
                 op: &onnx::NodeProto,
-                _ctx: &dyn OpLoadContext,
+                ctx: &dyn OpLoadContext,
             ) -> Result<ParsedOp<Self>, ReadOpError> {
-                let attrs = Attrs::new(&op.attribute);
+                let attrs = Attrs::new(&op.attribute, ctx.opset_version());
                 Ok(ParsedOp::new(ops::$op {}).with_unused_attrs(attrs.unused_attrs()))
             }
         }
@@ -635,9 +651,9 @@ macro_rules! impl_read_op {
 
             fn read(
                 op: &onnx::NodeProto,
-                _ctx: &dyn OpLoadContext,
+                ctx: &dyn OpLoadContext,
             ) -> Result<ParsedOp<Self>, ReadOpError> {
-                let attrs = Attrs::new(&op.attribute);
+                let attrs = Attrs::new(&op.attribute, ctx.opset_version());
                 $read(&attrs).map(|op| ParsedOp::from(op).with_unused_attrs(attrs.unused_attrs()))
             }
         }
@@ -651,9 +667,9 @@ macro_rules! impl_read_op {
 
             fn read(
                 op: &onnx::NodeProto,
-                _ctx: &dyn OpLoadContext,
+                ctx: &dyn OpLoadContext,
             ) -> Result<ParsedOp<Self>, ReadOpError> {
-                let attrs = Attrs::new(&op.attribute);
+                let attrs = Attrs::new(&op.attribute, ctx.opset_version());
                 $read(&attrs).map(|op| ParsedOp::from(op).with_unused_attrs(attrs.unused_attrs()))
             }
         }
@@ -1095,7 +1111,7 @@ impl ReadOp for ops::If {
     }
 
     fn read(op: &onnx::NodeProto, ctx: &dyn OpLoadContext) -> Result<ParsedOp<Self>, ReadOpError> {
-        let attrs = Attrs::new(&op.attribute);
+        let attrs = Attrs::new(&op.attribute, ctx.opset_version());
         let then_branch = ctx.load_graph(attrs.require("then_branch")?.as_graph()?)?;
         let else_branch = ctx.load_graph(attrs.require("else_branch")?.as_graph()?)?;
         Ok(ops::If {
@@ -1147,7 +1163,7 @@ impl ReadOp for ops::Loop {
     }
 
     fn read(op: &onnx::NodeProto, ctx: &dyn OpLoadContext) -> Result<ParsedOp<Self>, ReadOpError> {
-        let attrs = Attrs::new(&op.attribute);
+        let attrs = Attrs::new(&op.attribute, ctx.opset_version());
         let body = ctx.load_graph(attrs.require("body")?.as_graph()?)?;
         Ok(ops::Loop { body }.into())
     }
@@ -1764,11 +1780,18 @@ mod tests {
     use crate::ops::{ArgMax, ConstantOfShape, Conv, Padding, ResizeMode, Upsample};
     use crate::value::Scalar;
 
-    struct FakeOpLoadContext;
+    #[derive(Default)]
+    struct FakeOpLoadContext {
+        opset_version: Option<u16>,
+    }
 
     impl OpLoadContext for FakeOpLoadContext {
         fn load_graph(&self, _graph: &onnx::GraphProto) -> Result<Graph, ReadOpError> {
             Ok(Graph::new())
+        }
+
+        fn opset_version(&self) -> Option<u16> {
+            self.opset_version
         }
     }
 
@@ -1778,12 +1801,18 @@ mod tests {
 
         // Supported op with no domain.
         let node = create_node("MatMul");
-        let op = reg.read_op(&node, &FakeOpLoadContext).unwrap().op;
+        let op = reg
+            .read_op(&node, &FakeOpLoadContext::default())
+            .unwrap()
+            .op;
         assert_eq!(op.name(), "MatMul");
 
         // Supported op with empty domain.
         let node = create_node("MatMul").with_domain("");
-        let op = reg.read_op(&node, &FakeOpLoadContext).unwrap().op;
+        let op = reg
+            .read_op(&node, &FakeOpLoadContext::default())
+            .unwrap()
+            .op;
         assert_eq!(op.name(), "MatMul");
     }
 
@@ -1794,7 +1823,10 @@ mod tests {
             .with_attr("axis", 1)
             .with_attr("keepdims", true);
 
-        let op = reg.read_op(&node, &FakeOpLoadContext).unwrap().op;
+        let op = reg
+            .read_op(&node, &FakeOpLoadContext::default())
+            .unwrap()
+            .op;
 
         let argmax_op = op.downcast_ref::<ArgMax>().unwrap();
         assert_eq!(argmax_op.axis, 1);
@@ -1807,12 +1839,18 @@ mod tests {
 
         // `mode` defaults to nearest.
         let node = create_node("Upsample");
-        let op = reg.read_op(&node, &FakeOpLoadContext).unwrap().op;
+        let op = reg
+            .read_op(&node, &FakeOpLoadContext::default())
+            .unwrap()
+            .op;
         let upsample = op.downcast_ref::<Upsample>().unwrap();
         assert!(matches!(upsample.mode, ResizeMode::Nearest));
 
         let node = create_node("Upsample").with_attr("mode", "linear".to_string());
-        let op = reg.read_op(&node, &FakeOpLoadContext).unwrap().op;
+        let op = reg
+            .read_op(&node, &FakeOpLoadContext::default())
+            .unwrap()
+            .op;
         let upsample = op.downcast_ref::<Upsample>().unwrap();
         assert!(matches!(upsample.mode, ResizeMode::Linear));
     }
@@ -1826,7 +1864,7 @@ mod tests {
             .with_attr("keepdims", true)
             .with_attr("unused_b", false);
 
-        let op = reg.read_op(&node, &FakeOpLoadContext).unwrap();
+        let op = reg.read_op(&node, &FakeOpLoadContext::default()).unwrap();
         assert_eq!(op.unused_attrs.len(), 2);
         let unused_attrs: Vec<_> = op
             .unused_attrs
@@ -1841,14 +1879,14 @@ mod tests {
         // Default domain, unknown op type.
         let reg = OnnxOpRegistry::with_all_ops();
         let node = create_node("UnsupportedOp");
-        let op = reg.read_op(&node, &FakeOpLoadContext);
+        let op = reg.read_op(&node, &FakeOpLoadContext::default());
         assert!(
             matches!(op, Err(ReadOpError::OperatorUnavailable { name }) if name == Some("UnsupportedOp".to_string()))
         );
 
         // Known op type, but custom domain.
         let node = create_node("MatMul").with_domain("com.foobar");
-        let op = reg.read_op(&node, &FakeOpLoadContext);
+        let op = reg.read_op(&node, &FakeOpLoadContext::default());
         assert!(
             matches!(op, Err(ReadOpError::OperatorUnavailable { name }) if name == Some("com.foobar/MatMul".to_string()))
         );
@@ -1859,7 +1897,10 @@ mod tests {
         let reg = OnnxOpRegistry::with_all_ops();
         let node = create_node("Conv").with_attr("kernel_shape", vec![3, 3]);
 
-        let op = reg.read_op(&node, &FakeOpLoadContext).unwrap().op;
+        let op = reg
+            .read_op(&node, &FakeOpLoadContext::default())
+            .unwrap()
+            .op;
         let conv_op = op.downcast_ref::<Conv>().unwrap();
 
         assert_eq!(conv_op.padding, Padding::Fixed([0, 0, 0, 0].into()));
@@ -1908,7 +1949,10 @@ mod tests {
                 node = node.with_attr("pads", pads.clone());
             }
 
-            let op = reg.read_op(&node, &FakeOpLoadContext).unwrap().op;
+            let op = reg
+                .read_op(&node, &FakeOpLoadContext::default())
+                .unwrap()
+                .op;
             let conv_op = op.downcast_ref::<Conv>().unwrap();
 
             assert_eq!(conv_op.padding, case.expected);
@@ -1968,7 +2012,7 @@ mod tests {
             let reg = OnnxOpRegistry::with_all_ops();
             let tensor = create_tensor("test", &[], case.dtype, case.data.clone());
             let node = create_node("ConstantOfShape").with_attr("value", tensor);
-            let op = reg.read_op(&node, &FakeOpLoadContext).unwrap();
+            let op = reg.read_op(&node, &FakeOpLoadContext::default()).unwrap();
             let cos_op = op.op.downcast_ref::<ConstantOfShape>().unwrap();
             assert_eq!(cos_op, &case.expected);
         });
@@ -2021,7 +2065,9 @@ mod tests {
 
         cases.test_each_value(|case| {
             let reg = OnnxOpRegistry::with_all_ops();
-            let op = reg.read_op(&case.op, &FakeOpLoadContext).unwrap();
+            let op = reg
+                .read_op(&case.op, &FakeOpLoadContext::default())
+                .unwrap();
             assert_eq!(op.const_inputs, case.expected_inputs);
         });
     }


### PR DESCRIPTION
This is a change extracted out of https://github.com/robertknight/rten/pull/1261 for easier review. It exposes the opset version to ONNX operator deserializers so they can adjust their behavior if needed. The initial use case will be for the DFT operator where the default value for the axis changed from 1 to -2 from opset 17 to 20. Most operators don't need to know the opset version since changes across versions tend to be additive: new types supported, new attributes or inputs added.