### PR TITLE
Fuse Conv + Add into Conv with bias

### DIFF
--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -24,8 +24,8 @@ mod pattern_matcher;
 use diagnostics::{DiagnosticLevel, Diagnostics};
 
 use fusions::{
-    AddSoftmaxFusion, ApproxGeluFusion, CastElimination, ComputeShapeFusion, Fusion, FusionError,
-    FusionVisitor, GeluFusion, GroupedQueryAttentionMatMulFusion, IdentityFusion,
+    AddSoftmaxFusion, ApproxGeluFusion, CastElimination, ComputeShapeFusion, ConvAddFusion, Fusion,
+    FusionError, FusionVisitor, GeluFusion, GroupedQueryAttentionMatMulFusion, IdentityFusion,
     LayerNormalizationFusion, MatMulAddFusion, MatMulIntegerToFloatFusion, MatMulScaleFusion,
     PatternFusion, RMSNormalizationFusion, ReciprocalFusion, ReduceMeanAxesFusion,
     RepeatInterleaveFusion, SafeSoftmaxFusion, ShapeSliceToConstant, SiluFusion, SwishFusion,
@@ -251,10 +251,17 @@ impl GraphMutator {
         {
             match fusion {
                 Fusion::Op(fusion) => {
+                    // Create any new constants required by the fused op and
+                    // place their IDs in the input list.
+                    let mut input_ids = fusion.input_ids;
+                    for (index, constant) in fusion.new_constant_inputs {
+                        let const_id = self.add_constant_node(constant);
+                        input_ids[index] = Some(const_id);
+                    }
                     self.add_operator(
                         fusion.name.as_deref(),
                         fusion.fused_op,
-                        &fusion.input_ids,
+                        &input_ids,
                         &fusion.output_ids,
                     );
                 }
@@ -513,6 +520,9 @@ impl GraphOptimizer {
         fusions.push(MatMulAddFusion {}.into_visitor());
         fusions.push(MatMulScaleFusion {});
         fusions.push(MatMulIntegerToFloatFusion {}.into_visitor());
+
+        // Convolution fusions
+        fusions.push(ConvAddFusion {});
 
         // Attention fusions.
         //

--- a/src/optimize/fusions.rs
+++ b/src/optimize/fusions.rs
@@ -14,7 +14,7 @@ use crate::graph::{
 use crate::operator::Operator;
 use crate::ops::transform_inputs::TransformInputsBuilder;
 use crate::ops::{
-    AddSoftmax, Cast, ComputeShape, DynamicQuantizeLinear, FusedMatMul, Gelu,
+    AddSoftmax, Cast, ComputeShape, Conv, DynamicQuantizeLinear, FusedMatMul, Gelu,
     GroupedQueryAttentionMatMul, LayerNormalization, MatMulIntegerToFloat, Mul, RMSNormalization,
     Reciprocal, ReduceMean, RepeatInterleave, Shape, Silu, Softmax, Swish, SymbolInfo, Transpose,
 };
@@ -30,6 +30,15 @@ pub struct FusedOp {
 
     /// IDs of input value nodes.
     pub input_ids: Vec<Option<NodeId>>,
+
+    /// New constants to create and use as inputs to the fused operator.
+    ///
+    /// Each `(index, constant)` entry causes `constant` to be added to the
+    /// graph and its node ID placed at position `index` in [`input_ids`]. The
+    /// corresponding slot in [`input_ids`] should be `None`.
+    ///
+    /// [`input_ids`]: FusedOp::input_ids
+    pub new_constant_inputs: Vec<(usize, Constant)>,
 
     /// IDs of output value nodes.
     pub output_ids: Vec<Option<NodeId>>,
@@ -75,6 +84,7 @@ impl Fusion {
             name: name.map(|s| s.to_string()),
             fused_op,
             input_ids: input_ids.to_vec(),
+            new_constant_inputs: Vec::new(),
             output_ids: output_ids.to_vec(),
             unused_input_ids: unused_input_ids.to_vec(),
         })
@@ -1660,6 +1670,100 @@ impl PatternFusion for GroupedQueryAttentionMatMulFusion {
         })
     }
 }
+
+/// Fuse `Add(Conv(X, W), bias)` into `Conv(X, W, bias)`.
+pub struct ConvAddFusion {}
+
+impl FusionVisitor for ConvAddFusion {
+    type State = ();
+
+    fn name(&self) -> &str {
+        "ConvAddFusion"
+    }
+
+    fn prepare(&self, _: &Graph) {}
+
+    fn maybe_fuse(
+        &self,
+        _state: &(),
+        graph: &Graph,
+        _op_node_id: NodeId,
+        op_node: &OperatorNode,
+    ) -> Result<Fusion, FusionError> {
+        // Match an `Add` with two inputs.
+        if op_node.operator().name() != "Add" {
+            return Err(FusionError::NoMatch);
+        }
+        let [Some(lhs), Some(rhs)] = op_node.input_ids() else {
+            return Err(FusionError::NoMatch);
+        };
+        let (lhs, rhs) = (*lhs, *rhs);
+
+        // One input must be the output of a `Conv`, the other the bias. `Add`
+        // is commutative, so try both orderings.
+        let is_conv = |id: NodeId| {
+            graph
+                .get_source_node(id)
+                .filter(|(_, conv_op)| conv_op.operator().downcast_ref::<Conv>().is_some())
+        };
+        let ((_, conv_op), bias_id) = if let Some(conv) = is_conv(lhs) {
+            (conv, rhs)
+        } else if let Some(conv) = is_conv(rhs) {
+            (conv, lhs)
+        } else {
+            return Err(FusionError::NoMatch);
+        };
+
+        // The `Conv` must not already have a bias input.
+        let (conv_input, conv_weight) = match conv_op.input_ids() {
+            [Some(input), Some(weight)] | [Some(input), Some(weight), None] => (*input, *weight),
+            _ => return Err(FusionError::CheckFailed("conv already has a bias")),
+        };
+
+        // The bias must be an `f32` constant of shape `[1, out_channels, 1, 1]`.
+        let Some(Node::Constant(bias_const)) = graph.get_node(bias_id) else {
+            return Err(FusionError::NoMatch);
+        };
+        let &[1, channels, 1, 1] = bias_const.shape() else {
+            return Err(FusionError::CheckFailed("bias shape is not [1, C, 1, 1]"));
+        };
+        let Some(bias_view) = TypedConstant::<f32>::as_typed_view(bias_const) else {
+            return Err(FusionError::CheckFailed("bias is not an f32 constant"));
+        };
+
+        // The bias length must match the `Conv`'s output channel count so that
+        // reshaping `[1, C, 1, 1]` to `[C]` produces a valid per-channel bias.
+        let out_channels = graph
+            .get_node(conv_weight)
+            .and_then(|n| n.shape())
+            .and_then(|shape| match shape.first() {
+                Some(Dimension::Fixed(size)) => Some(*size),
+                _ => None,
+            })
+            .ok_or(FusionError::CheckFailed("unknown conv output channels"))?;
+        if channels != out_channels {
+            return Err(FusionError::CheckFailed("bias size != output channels"));
+        }
+
+        // Create the `[out_channels]` bias constant from the existing data.
+        let bias_data: Vec<f32> = bias_view.iter().copied().collect();
+        let bias_const: Constant = ConstantNode::new(
+            None,
+            ConstantNodeData::Arc(ArcTensor::from_data(&[channels], Arc::new(bias_data))),
+        )
+        .into();
+
+        Ok(Fusion::Op(FusedOp {
+            name: op_node.name().map(|s| s.to_string()),
+            fused_op: conv_op.clone_operator(),
+            input_ids: vec![Some(conv_input), Some(conv_weight), None],
+            new_constant_inputs: vec![(2, bias_const)],
+            output_ids: op_node.output_ids().to_vec(),
+            unused_input_ids: Vec::new(),
+        }))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     // Tests for fusions are currently defined in the main `optimize.rs` module.

--- a/src/optimize/tests.rs
+++ b/src/optimize/tests.rs
@@ -15,10 +15,10 @@ use crate::graph::{
 };
 use crate::infer_shapes::InferShapeOptions;
 use crate::ops::{
-    Add, Cast, ComputeShape, DynamicQuantizeLinear, Erf, Expand, FusedMatMul, Gather, Gelu,
+    Add, Cast, ComputeShape, Conv, DynamicQuantizeLinear, Erf, Expand, FusedMatMul, Gather, Gelu,
     GroupedQueryAttentionMatMul, Identity, IsNaN, LayerNormalization, MatMul, MatMulInteger, Neg,
-    Pow, RMSNormalization, ReduceMean, RepeatInterleave, Reshape, Shape, Sigmoid, Slice, Softmax,
-    Sqrt, Swish, Tanh, Transpose, Unsqueeze, Where,
+    Padding, Pow, RMSNormalization, ReduceMean, RepeatInterleave, Reshape, Shape, Sigmoid, Slice,
+    Softmax, Sqrt, Swish, Tanh, Transpose, Unsqueeze, Where,
 };
 use crate::value::{DataType, Value, ValueType};
 
@@ -367,6 +367,70 @@ fn test_fuse_matmul_add() {
 
     let (_, op) = graph.get_source_node(graph.output_ids()[0]).unwrap();
     assert_eq!(op.operator().name(), "FusedMatMul");
+}
+
+#[test]
+fn test_fuse_conv_add() {
+    let out_channels = 4;
+    let graph = {
+        let x = Expr::value("x");
+        let weight = Expr::constant(Tensor::<f32>::zeros(&[out_channels, 3, 3, 3]));
+        let conv = x.apply(
+            Conv {
+                groups: 1,
+                dilations: vec![1, 1],
+                padding: Padding::zero::<2>(),
+                strides: vec![1, 1],
+            },
+            &[weight],
+            &[OutputMeta::NoMeta],
+        );
+        // Per-channel bias broadcast over a NCHW Conv output.
+        let bias = Tensor::<f32>::zeros(&[1, out_channels, 1, 1]);
+        (conv + bias).build_graph(["x"])
+    };
+
+    let graph = optimize_graph(graph).unwrap();
+
+    let (_, op) = graph.get_source_node(graph.output_ids()[0]).unwrap();
+    assert_eq!(op.operator().name(), "Conv");
+
+    // The fused Conv should have a 1D bias input of shape `[out_channels]`.
+    let bias_id = op.input_ids()[2].expect("conv should have a bias input");
+    let bias = graph
+        .get_node(bias_id)
+        .and_then(|n| n.as_constant())
+        .expect("bias should be a constant");
+    assert_eq!(bias.shape(), [out_channels]);
+}
+
+#[test]
+fn test_no_fuse_conv_add_non_channel_bias() {
+    // A value added to the Conv output which broadcasts over a non-channel
+    // axis (here the last/width axis, shape `[1, 1, 1, 4]`) is a valid add but
+    // not a per-channel bias, so it must not be fused into the Conv.
+    let graph = {
+        let x = Expr::value("x");
+        let weight = Expr::constant(Tensor::<f32>::zeros(&[4, 3, 3, 3]));
+        let conv = x.apply(
+            Conv {
+                groups: 1,
+                dilations: vec![1, 1],
+                padding: Padding::zero::<2>(),
+                strides: vec![1, 1],
+            },
+            &[weight],
+            &[OutputMeta::NoMeta],
+        );
+        // Non-1 dimension is at index 3, not the channel index (1).
+        let addend = Tensor::<f32>::zeros(&[1, 1, 1, 4]);
+        (conv + addend).build_graph(["x"])
+    };
+
+    let graph = optimize_graph(graph).unwrap();
+
+    let (_, op) = graph.get_source_node(graph.output_ids()[0]).unwrap();
+    assert_eq!(op.operator().name(), "Add");
 }
 
 #[test]


### PR DESCRIPTION
Add a fusion that fuses `Add(Conv(X, W), bias)` into `Conv(X, W, bias)`. The `bias` input to `Add` must be a constant with shape `[1, C, 1, 1]` and this is converted into a new constant with shape `[C]`.

Tested with the [PP-OCRv6_medium_rec](https://huggingface.co/PaddlePaddle/PP-OCRv6_medium_rec_onnx) model, where it is a small win, ~3% of inference time or so.

Caveats:
- This only supports 2D convolution.  It could be extended to 1D in future
- The implementation copies the bias data, it could just create a new constant that shares the weights but has a different layout. Bias vectors are small, so this is expected to be cheap