### PR TITLE
Support 1D convolutions in Conv + Add fusion

### DIFF
--- a/src/optimize/fusions.rs
+++ b/src/optimize/fusions.rs
@@ -1720,36 +1720,41 @@ impl FusionVisitor for ConvAddFusion {
             _ => return Err(FusionError::CheckFailed("conv already has a bias")),
         };
 
-        // The bias must be an `f32` constant of shape `[1, out_channels, 1, 1]`.
+        // Determine the `Conv`'s rank and output channel count from the weights,
+        // which have shape `[out_channels, in_channels / groups, ...kernel]`.
+        let weight_shape = graph
+            .get_node(conv_weight)
+            .and_then(|n| n.shape())
+            .ok_or(FusionError::CheckFailed("unknown conv weight shape"))?;
+        let out_channels = match weight_shape.first() {
+            Some(Dimension::Fixed(size)) => *size,
+            _ => return Err(FusionError::CheckFailed("unknown conv output channels")),
+        };
+        let conv_rank = weight_shape.len();
+
+        // Check bias is a constant with shape `[1, out_channels, ...]` that
+        // can be reshaped to `[out_channels]`.
         let Some(Node::Constant(bias_const)) = graph.get_node(bias_id) else {
             return Err(FusionError::NoMatch);
         };
-        let &[1, channels, 1, 1] = bias_const.shape() else {
-            return Err(FusionError::CheckFailed("bias shape is not [1, C, 1, 1]"));
-        };
+        let bias_shape = bias_const.shape();
+        let is_per_channel_bias = bias_shape.len() == conv_rank
+            && bias_shape
+                .iter()
+                .enumerate()
+                .all(|(axis, &size)| size == if axis == 1 { out_channels } else { 1 });
+        if !is_per_channel_bias {
+            return Err(FusionError::CheckFailed("bias is not a per-channel bias"));
+        }
         let Some(bias_view) = TypedConstant::<f32>::as_typed_view(bias_const) else {
             return Err(FusionError::CheckFailed("bias is not an f32 constant"));
         };
 
-        // The bias length must match the `Conv`'s output channel count so that
-        // reshaping `[1, C, 1, 1]` to `[C]` produces a valid per-channel bias.
-        let out_channels = graph
-            .get_node(conv_weight)
-            .and_then(|n| n.shape())
-            .and_then(|shape| match shape.first() {
-                Some(Dimension::Fixed(size)) => Some(*size),
-                _ => None,
-            })
-            .ok_or(FusionError::CheckFailed("unknown conv output channels"))?;
-        if channels != out_channels {
-            return Err(FusionError::CheckFailed("bias size != output channels"));
-        }
-
-        // Create the `[out_channels]` bias constant from the existing data.
+        // Create the `[out_channels]` bias constant.
         let bias_data: Vec<f32> = bias_view.iter().copied().collect();
         let bias_const: Constant = ConstantNode::new(
             None,
-            ConstantNodeData::Arc(ArcTensor::from_data(&[channels], Arc::new(bias_data))),
+            ConstantNodeData::Arc(ArcTensor::from_data(&[out_channels], Arc::new(bias_data))),
         )
         .into();
 

--- a/src/optimize/tests.rs
+++ b/src/optimize/tests.rs
@@ -371,37 +371,57 @@ fn test_fuse_matmul_add() {
 
 #[test]
 fn test_fuse_conv_add() {
-    let out_channels = 4;
-    let graph = {
-        let x = Expr::value("x");
-        let weight = Expr::constant(Tensor::<f32>::zeros(&[out_channels, 3, 3, 3]));
-        let conv = x.apply(
-            Conv {
-                groups: 1,
-                dilations: vec![1, 1],
-                padding: Padding::zero::<2>(),
-                strides: vec![1, 1],
-            },
-            &[weight],
-            &[OutputMeta::NoMeta],
-        );
-        // Per-channel bias broadcast over a NCHW Conv output.
-        let bias = Tensor::<f32>::zeros(&[1, out_channels, 1, 1]);
-        (conv + bias).build_graph(["x"])
-    };
+    #[derive(Debug)]
+    struct Case {
+        // Number of spatial dimensions: 1 for a 1D conv (`[N, C, L]`), 2 for a
+        // 2D conv (`[N, C, H, W]`).
+        spatial_dims: usize,
+    }
 
-    let graph = optimize_graph(graph).unwrap();
+    let cases = [Case { spatial_dims: 1 }, Case { spatial_dims: 2 }];
 
-    let (_, op) = graph.get_source_node(graph.output_ids()[0]).unwrap();
-    assert_eq!(op.operator().name(), "Conv");
+    cases.test_each(|&Case { spatial_dims }| {
+        let out_channels = 4;
+        let graph = {
+            let x = Expr::value("x");
 
-    // The fused Conv should have a 1D bias input of shape `[out_channels]`.
-    let bias_id = op.input_ids()[2].expect("conv should have a bias input");
-    let bias = graph
-        .get_node(bias_id)
-        .and_then(|n| n.as_constant())
-        .expect("bias should be a constant");
-    assert_eq!(bias.shape(), [out_channels]);
+            // Weight shape is `[out_channels, in_channels, ...kernel]`.
+            let mut weight_shape = vec![out_channels, 3];
+            weight_shape.extend(std::iter::repeat_n(3, spatial_dims));
+            let weight = Expr::constant(Tensor::<f32>::zeros(&weight_shape));
+
+            let conv = x.apply(
+                Conv {
+                    groups: 1,
+                    dilations: vec![1; spatial_dims],
+                    padding: Padding::Same,
+                    strides: vec![1; spatial_dims],
+                },
+                &[weight],
+                &[OutputMeta::NoMeta],
+            );
+
+            // Per-channel bias broadcast over the conv output: `[1, C, 1, ...]`.
+            let mut bias_shape = vec![1, out_channels];
+            bias_shape.extend(std::iter::repeat_n(1, spatial_dims));
+            let bias = Tensor::<f32>::zeros(&bias_shape);
+
+            (conv + bias).build_graph(["x"])
+        };
+
+        let graph = optimize_graph(graph).unwrap();
+
+        let (_, op) = graph.get_source_node(graph.output_ids()[0]).unwrap();
+        assert_eq!(op.operator().name(), "Conv");
+
+        // The fused Conv should have a 1D bias input of shape `[out_channels]`.
+        let bias_id = op.input_ids()[2].expect("conv should have a bias input");
+        let bias = graph
+            .get_node(bias_id)
+            .and_then(|n| n.as_constant())
+            .expect("bias should be a constant");
+        assert_eq!(bias.shape(), [out_channels]);
+    });
 }
 
 #[test]


### PR DESCRIPTION
Generalize https://github.com/robertknight/rten/pull/1265 to support 1D convolutions (and 3D, although the `Conv` operator doesn't support that yet).