### PR TITLE
Implement Scatter op

### DIFF
--- a/src/op_registry/onnx_registry.rs
+++ b/src/op_registry/onnx_registry.rs
@@ -204,6 +204,7 @@ impl OnnxOpRegistry {
         register_op!(ReverseSequence);
         register_op!(RotaryEmbedding);
         register_op!(Round);
+        register_op!(Scatter);
         register_op!(ScatterElements);
         register_op!(ScatterND);
         register_op!(SequenceAt);
@@ -1631,6 +1632,11 @@ fn convert_scatter_reduction(
         _ => Err(ReadOpError::attr_error(attr, "unknown value")),
     }
 }
+
+impl_read_op!(Scatter, |attrs: &Attrs| {
+    let axis = attrs.get_as_int("axis")?.unwrap_or(0);
+    Ok(ops::Scatter { axis })
+});
 
 impl_read_op!(ScatterElements, |attrs: &Attrs| {
     let reduction = attrs.get_as("reduction");

--- a/src/ops/gather.rs
+++ b/src/ops/gather.rs
@@ -543,6 +543,44 @@ pub fn scatter_elements<
     Ok(output)
 }
 
+/// Deprecated alias for [`ScatterElements`].
+///
+/// See https://github.com/onnx/onnx/pull/2143.
+#[derive(Debug)]
+pub struct Scatter {
+    pub axis: isize,
+}
+
+impl Operator for Scatter {
+    fn name(&self) -> &str {
+        "Scatter"
+    }
+
+    fn max_inputs(&self) -> Option<usize> {
+        ScatterElements {
+            axis: self.axis,
+            reduction: None,
+        }
+        .max_inputs()
+    }
+
+    fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+        ScatterElements {
+            axis: self.axis,
+            reduction: None,
+        }
+        .run(ctx)
+    }
+
+    fn output_types(&self, _ctx: &OutputTypesContext) -> Option<OutputTypeList> {
+        Some([OutputType::CopyFromInput(0)].into())
+    }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        Some(&UnaryOp)
+    }
+}
+
 #[derive(Debug)]
 pub struct ScatterElements {
     pub axis: isize,

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -82,7 +82,7 @@ pub(crate) use {
     einsum::Einsum,
     embedding::{RotaryEmbedding, RotaryEmbeddingMicrosoft},
     gather::{
-        Gather, GatherElements, GatherND, ReverseSequence, ScatterElements, ScatterND,
+        Gather, GatherElements, GatherND, ReverseSequence, Scatter, ScatterElements, ScatterND,
         ScatterReduction,
     },
     generate::{ConstantOfShape, EyeLike, OneHot, Range},


### PR DESCRIPTION
This is a deprecated operator that was [renamed](https://github.com/onnx/onnx/pull/2143) to `ScatterElements` in opset 11. It is the same except it doesn't have the `reduction` attribute that was added to `ScatterElements` in later opsets.