### PR TITLE
Deduplicate axes in Reduce ops and Squeeze

### DIFF
--- a/src/ops/layout.rs
+++ b/src/ops/layout.rs
@@ -540,21 +540,15 @@ pub fn squeeze_in_place<T: Clone>(
     input: &mut Tensor<T>,
     axes: Option<NdTensorView<i32, 1>>,
 ) -> Result<(), OpError> {
-    let axes = axes
-        .map(|axes| resolve_axes(input.ndim(), axes.iter()))
-        .transpose()?;
-    let sorted_axes = if let Some(mut axes) = axes {
+    let sorted_axes = if let Some(axes) = axes {
+        let axes = resolve_axes(input.ndim(), axes.iter())?;
         for &axis in axes.iter() {
-            if axis >= input.ndim() {
-                return Err(OpError::InvalidValue("Axis is invalid"));
-            }
             if input.size(axis) != 1 {
                 return Err(OpError::InvalidValue(
                     "Can only remove dimensions of size 1",
                 ));
             }
         }
-        axes.sort();
         axes
     } else {
         input
@@ -691,25 +685,22 @@ pub fn unsqueeze_in_place<T: Clone>(
     mut input: Tensor<T>,
     axes: &NdTensorView<i32, 1>,
 ) -> Result<Tensor<T>, OpError> {
-    let sorted_axes = if axes.len() == 1 {
-        let axis = resolve_axis(input.ndim() + 1, axes[0] as isize)?;
-        SmallVec::from_slice(&[axis])
-    } else {
-        let mut sorted_axes = resolve_axes(input.ndim() + axes.len(), axes.iter())?;
-        sorted_axes.sort_unstable();
+    let mut resolved_axes: SmallVec<[usize; 4]> = SmallVec::with_capacity(axes.len());
+    for axis in axes.iter() {
+        let resolved = resolve_axis(input.ndim() + axes.len(), *axis as isize)?;
+        resolved_axes.push(resolved);
+    }
+    resolved_axes.sort();
 
-        let axes_unique = sorted_axes
-            .iter()
-            .skip(1)
-            .zip(sorted_axes.iter())
-            .all(|(prev, current)| prev != current);
-        if !axes_unique {
-            return Err(OpError::InvalidValue("Axes must be unique"));
-        }
-        sorted_axes
-    };
+    if resolved_axes
+        .iter()
+        .zip(resolved_axes.iter().skip(1))
+        .any(|(prev, curr)| prev == curr)
+    {
+        return Err(OpError::InvalidValue("Axes must be unique"));
+    }
 
-    for axis in sorted_axes {
+    for axis in resolved_axes {
         input.insert_axis(axis);
     }
 

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -241,6 +241,8 @@ fn resolve_axis(ndim: usize, axis: isize) -> Result<usize, OpError> {
 /// indexes in a tensor with `ndim` dimensions.
 ///
 /// Negative axis values count backwards from the last dimension.
+///
+/// Returns the unique axes in ascending order.
 pub fn resolve_axes<'a, I: ExactSizeIterator<Item = &'a i32>>(
     ndim: usize,
     axes: I,
@@ -250,6 +252,8 @@ pub fn resolve_axes<'a, I: ExactSizeIterator<Item = &'a i32>>(
         let resolved = resolve_axis(ndim, *axis as isize)?;
         resolved_axes.push(resolved);
     }
+    resolved_axes.sort();
+    resolved_axes.dedup();
     Ok(resolved_axes)
 }
 
@@ -380,6 +384,8 @@ mod tests {
     use rten_tensor::prelude::*;
     use rten_tensor::test_util::{ExpectEqualError, expect_equal_with_tolerance};
 
+    use super::resolve_axes;
+
     /// Compare two f32 tensors with a higher absolute tolerance (1e-4) than
     /// the default (1e-5).
     ///
@@ -415,5 +421,23 @@ mod tests {
                 std::array::from_fn(|d| if d < new_dims { 1 } else { shape[d - new_dims] });
             self.into_shape(new_shape)
         }
+    }
+
+    #[test]
+    fn test_resolve_axes() {
+        let axes = resolve_axes(3, [0, 1, 2].iter()).unwrap();
+        assert_eq!(axes.as_slice(), [0, 1, 2]);
+
+        // Negative axes are resolved.
+        let axes = resolve_axes(3, [-1, -2, -3].iter()).unwrap();
+        assert_eq!(axes.as_slice(), [0, 1, 2]);
+
+        // Returned axes are sorted in ascending order.
+        let axes = resolve_axes(3, [-3, -2, -1].iter()).unwrap();
+        assert_eq!(axes.as_slice(), [0, 1, 2]);
+
+        // Only unique axes are returned.
+        let axes = resolve_axes(3, [1, -2].iter()).unwrap();
+        assert_eq!(axes.as_slice(), [1]);
     }
 }

--- a/src/ops/reduce.rs
+++ b/src/ops/reduce.rs
@@ -389,11 +389,10 @@ fn reduce<T: Copy>(
     keep_dims: bool,
     kernel: &dyn ReduceKernel<T>,
 ) -> Result<Tensor<T>, OpError> {
-    let mut resolved_axes = match axes {
+    let resolved_axes = match axes {
         Some(axes) if !axes.is_empty() => resolve_axes(input.ndim(), axes.iter())?,
         _ => (0..input.ndim()).collect(),
     };
-    resolved_axes.sort();
 
     // Temporary buffer where slices of the input to be reduced are packed first
     // if non-contiguous.


### PR DESCRIPTION
Treat the `axes` input to `Reduce*` and `Squeeze` as a set and deduplicate when resolving them. The `Unsqueeze` operator continues to report an error if there is a duplicate axis as required by the spec.

Fixes #1270