### PR TITLE
Fix RotaryEmbedding ONNX loading

### DIFF
--- a/src/op_registry/onnx_registry.rs
+++ b/src/op_registry/onnx_registry.rs
@@ -1622,7 +1622,9 @@ impl_read_op!(
 
 impl_read_op!(RotaryEmbedding, |attrs: &Attrs| {
     let interleaved = attrs.get_as("interleaved").unwrap_or_default();
-    let num_heads = attrs.get_as_int::<usize>("num_heads")?;
+    let num_heads = attrs
+        .get_as_int::<usize>("num_heads")?
+        .ok_or_else(|| ReadOpError::attr_error("num_heads", "required attribute missing"))?;
     let rotary_embedding_dim = attrs
         .get_as_int::<usize>("rotary_embedding_dim")?
         .unwrap_or_default();
@@ -1826,7 +1828,8 @@ mod tests {
     use crate::model::onnx_builder::{NodeProtoExt, TensorData, create_node, create_tensor};
     use crate::operator::Operator;
     use crate::ops::{
-        ArgMax, ConstantOfShape, Conv, Padding, ResizeMode, RotaryEmbeddingMicrosoft, Upsample,
+        ArgMax, ConstantOfShape, Conv, Padding, ResizeMode, RotaryEmbedding,
+        RotaryEmbeddingMicrosoft, Upsample,
     };
     use crate::value::Scalar;
 
@@ -1881,6 +1884,60 @@ mod tests {
         let rotary = op.downcast_ref::<RotaryEmbeddingMicrosoft>().unwrap();
         assert_eq!(rotary.num_heads, Some(2));
         assert_eq!(rotary.name(), "com.microsoft.RotaryEmbedding");
+    }
+
+    #[test]
+    fn test_read_rotary_embedding_requires_num_heads() {
+        let reg = OnnxOpRegistry::with_all_ops();
+        let node = create_node("RotaryEmbedding");
+
+        let result = reg.read_op(&node, &FakeOpLoadContext::default());
+
+        assert!(matches!(
+            result,
+            Err(ReadOpError::AttrError { attr, .. }) if attr == "num_heads"
+        ));
+    }
+
+    #[test]
+    fn test_read_rotary_embedding_microsoft_allows_missing_num_heads() {
+        let reg = OnnxOpRegistry::with_all_ops();
+        let node = create_node("RotaryEmbedding").with_domain("com.microsoft");
+
+        let op = reg
+            .read_op(&node, &FakeOpLoadContext::default())
+            .unwrap()
+            .op;
+
+        let rotary = op.downcast_ref::<RotaryEmbeddingMicrosoft>().unwrap();
+        assert_eq!(rotary.num_heads, None);
+    }
+
+    #[test]
+    fn test_read_rotary_embedding_rejects_negative_num_heads() {
+        let reg = OnnxOpRegistry::with_all_ops();
+        let node = create_node("RotaryEmbedding").with_attr("num_heads", -1i64);
+
+        let result = reg.read_op(&node, &FakeOpLoadContext::default());
+
+        assert!(matches!(
+            result,
+            Err(ReadOpError::AttrError { attr, .. }) if attr == "num_heads"
+        ));
+    }
+
+    #[test]
+    fn test_read_rotary_embedding() {
+        let reg = OnnxOpRegistry::with_all_ops();
+        let node = create_node("RotaryEmbedding").with_attr("num_heads", 2i64);
+
+        let op = reg
+            .read_op(&node, &FakeOpLoadContext::default())
+            .unwrap()
+            .op;
+
+        let rotary = op.downcast_ref::<RotaryEmbedding>().unwrap();
+        assert_eq!(rotary.num_heads, 2);
     }
 
     #[test]

--- a/src/op_registry/onnx_registry.rs
+++ b/src/op_registry/onnx_registry.rs
@@ -1622,9 +1622,10 @@ impl_read_op!(
 
 impl_read_op!(RotaryEmbedding, |attrs: &Attrs| {
     let interleaved = attrs.get_as("interleaved").unwrap_or_default();
-    let num_heads = attrs
-        .get_as_int::<usize>("num_heads")?
-        .ok_or_else(|| ReadOpError::attr_error("num_heads", "required attribute missing"))?;
+
+    // Required for 3D input but optional for 4D, so we validate at runtime.
+    let num_heads = attrs.get_as_int::<usize>("num_heads")?.unwrap_or_default();
+
     let rotary_embedding_dim = attrs
         .get_as_int::<usize>("rotary_embedding_dim")?
         .unwrap_or_default();
@@ -1887,16 +1888,19 @@ mod tests {
     }
 
     #[test]
-    fn test_read_rotary_embedding_requires_num_heads() {
+    fn test_read_rotary_embedding_allows_missing_num_heads() {
+        // `num_heads` is only required for 3D input, which is validated at run
+        // time. A missing attribute loads with `num_heads` defaulting to 0.
         let reg = OnnxOpRegistry::with_all_ops();
         let node = create_node("RotaryEmbedding");
 
-        let result = reg.read_op(&node, &FakeOpLoadContext::default());
+        let op = reg
+            .read_op(&node, &FakeOpLoadContext::default())
+            .unwrap()
+            .op;
 
-        assert!(matches!(
-            result,
-            Err(ReadOpError::AttrError { attr, .. }) if attr == "num_heads"
-        ));
+        let rotary = op.downcast_ref::<RotaryEmbedding>().unwrap();
+        assert_eq!(rotary.num_heads, 0);
     }
 
     #[test]

--- a/src/op_registry/onnx_registry.rs
+++ b/src/op_registry/onnx_registry.rs
@@ -680,6 +680,22 @@ macro_rules! impl_read_op {
             }
         }
     };
+
+    ($domain:literal, $op_type:literal, $op:ident, $read:expr) => {
+        impl ReadOp for ops::$op {
+            fn id() -> OpId<'static> {
+                OpId::with_domain($domain, $op_type)
+            }
+
+            fn read(
+                op: &onnx::NodeProto,
+                ctx: &dyn OpLoadContext,
+            ) -> Result<ParsedOp<Self>, ReadOpError> {
+                let attrs = Attrs::new(&op.attribute, ctx.opset_version());
+                $read(&attrs).map(|op| ParsedOp::from(op).with_unused_attrs(attrs.unused_attrs()))
+            }
+        }
+    };
 }
 
 impl_read_op!(Abs);
@@ -1587,6 +1603,7 @@ impl_read_op!(Upsample, |attrs: &Attrs| {
 
 impl_read_op!(
     "com.microsoft",
+    "RotaryEmbedding",
     RotaryEmbeddingMicrosoft,
     |attrs: &Attrs| {
         let interleaved = attrs.get_as("interleaved").unwrap_or_default();
@@ -1807,7 +1824,10 @@ mod tests {
     use super::{ConstInput, OnnxOpRegistry, OpLoadContext, ReadOpError};
     use crate::graph::Graph;
     use crate::model::onnx_builder::{NodeProtoExt, TensorData, create_node, create_tensor};
-    use crate::ops::{ArgMax, ConstantOfShape, Conv, Padding, ResizeMode, Upsample};
+    use crate::operator::Operator;
+    use crate::ops::{
+        ArgMax, ConstantOfShape, Conv, Padding, ResizeMode, RotaryEmbeddingMicrosoft, Upsample,
+    };
     use crate::value::Scalar;
 
     #[derive(Default)]
@@ -1844,6 +1864,23 @@ mod tests {
             .unwrap()
             .op;
         assert_eq!(op.name(), "MatMul");
+    }
+
+    #[test]
+    fn test_read_domain_op_with_distinct_impl_name() {
+        let reg = OnnxOpRegistry::with_all_ops();
+        let node = create_node("RotaryEmbedding")
+            .with_domain("com.microsoft")
+            .with_attr("num_heads", 2i64);
+
+        let op = reg
+            .read_op(&node, &FakeOpLoadContext::default())
+            .unwrap()
+            .op;
+
+        let rotary = op.downcast_ref::<RotaryEmbeddingMicrosoft>().unwrap();
+        assert_eq!(rotary.num_heads, Some(2));
+        assert_eq!(rotary.name(), "com.microsoft.RotaryEmbedding");
     }
 
     #[test]

--- a/src/ops/embedding.rs
+++ b/src/ops/embedding.rs
@@ -23,9 +23,31 @@ fn rotary_embedding(
     num_heads: Option<usize>,
     rotary_embedding_dim: usize,
 ) -> Result<Tensor, OpError> {
+    let cache_rotary_embedding_dim = cos
+        .shape()
+        .last()
+        .copied()
+        .ok_or(OpError::InvalidValue("cos cache must not be scalar"))?
+        * 2;
+
     let reshaped_input = match input.shape() {
         &[batch, seq_len, hidden_size] => {
-            let num_heads = num_heads.unwrap_or(0);
+            let num_heads = match num_heads {
+                Some(0) | None => {
+                    let rotary_embedding_dim = if rotary_embedding_dim == 0 {
+                        cache_rotary_embedding_dim
+                    } else {
+                        rotary_embedding_dim
+                    };
+                    if hidden_size % rotary_embedding_dim != 0 {
+                        return Err(OpError::InvalidValue(
+                            "hidden_size must be divisible by rotary_embedding_dim",
+                        ));
+                    }
+                    hidden_size / rotary_embedding_dim
+                }
+                Some(num_heads) => num_heads,
+            };
             if num_heads == 0 {
                 return Err(OpError::InvalidValue(
                     "num_heads must not be 0 for 3 dimensioned input",
@@ -497,6 +519,31 @@ mod tests {
         let ctx = OpRunContext::new(&pool, &input_list);
 
         assert!(op.run(&ctx).is_err());
+    }
+
+    #[test]
+    fn infer_num_heads_from_cache_dim() {
+        let op = RotaryEmbeddingMicrosoft {
+            interleaved: false,
+            num_heads: Some(0),
+            rotary_embedding_dim: 0,
+        };
+
+        let input = Tensor::from([[[1., 2., 3., 4.]]]);
+        let position_ids = Tensor::from([[0i32]]);
+        let cos_cache = Tensor::from([[1.0, 1.0]]);
+        let sin_cache = Tensor::from([[0.0, 0.0]]);
+
+        let result: Tensor<f32> = op
+            .run_simple((
+                input.view(),
+                position_ids.view(),
+                cos_cache.view(),
+                sin_cache.view(),
+            ))
+            .unwrap();
+
+        expect_equal_with_tolerance(&input.view(), &result.view(), 1e-4, 0.0).unwrap();
     }
 
     // Exercises the Microsoft variant's distinctive paths: input ordering

--- a/src/ops/embedding.rs
+++ b/src/ops/embedding.rs
@@ -219,31 +219,36 @@ impl Operator for RotaryEmbeddingMicrosoft {
         let num_heads = match input.shape() {
             &[_, _, hidden_size] => match self.num_heads {
                 // The ONNX spec requires `num_heads` for rank-3 input. The
-                // Microsoft contrib op gives this attribute a default of 0,
-                // so infer it here before calling the shared implementation.
+                // Microsoft contrib op gives this attribute a default of 0, so
+                // infer it from the cos cache before calling the shared
+                // implementation. The cache's last dimension is
+                // `rotary_embedding_dim / 2`, which only equals `head_size / 2`
+                // for full rotation. With partial rotary embeddings the head
+                // size cannot be recovered from the cache, so `num_heads` must
+                // be provided explicitly.
                 Some(0) | None => {
-                    let cache_rotary_embedding_dim_half = cos
+                    if self.rotary_embedding_dim != 0 {
+                        return Err(OpError::InvalidValue(
+                            "num_heads must be specified when rotary_embedding_dim is set",
+                        ));
+                    }
+                    let head_size_half = cos
                         .shape()
                         .last()
                         .copied()
                         .ok_or(OpError::InvalidValue("cos cache must not be scalar"))?;
-                    if cache_rotary_embedding_dim_half == 0 {
+                    if head_size_half == 0 {
                         return Err(OpError::InvalidValue(
                             "Last dimension of cos cache must not be 0",
                         ));
                     }
-                    let cache_rotary_embedding_dim = cache_rotary_embedding_dim_half * 2;
-                    let rotary_embedding_dim = if self.rotary_embedding_dim == 0 {
-                        cache_rotary_embedding_dim
-                    } else {
-                        self.rotary_embedding_dim
-                    };
-                    if hidden_size % rotary_embedding_dim != 0 {
+                    let head_size = head_size_half * 2;
+                    if hidden_size % head_size != 0 {
                         return Err(OpError::InvalidValue(
-                            "hidden_size must be divisible by rotary_embedding_dim",
+                            "hidden_size must be divisible by head size",
                         ));
                     }
-                    hidden_size / rotary_embedding_dim
+                    hidden_size / head_size
                 }
                 Some(num_heads) => num_heads,
             },
@@ -566,6 +571,37 @@ mod tests {
             .unwrap();
 
         expect_equal_with_tolerance(&input.view(), &result.view(), 1e-4, 0.0).unwrap();
+    }
+
+    #[test]
+    fn test_reject_inferring_num_heads_with_partial_rotary_dim() {
+        // `num_heads` cannot be inferred from the cache when partial rotary
+        // embeddings are used, since the cache only encodes
+        // `rotary_embedding_dim / 2`, not `head_size / 2`.
+        let op = RotaryEmbeddingMicrosoft {
+            interleaved: false,
+            num_heads: None,
+            rotary_embedding_dim: 2,
+        };
+
+        let input = Tensor::from([[[1., 2., 3., 4.]]]);
+        let position_ids = Tensor::from([[0i32]]);
+        let cos_cache = Tensor::from([[1.0]]);
+        let sin_cache = Tensor::from([[0.0]]);
+
+        let result = op.run_simple::<_, Tensor<f32>>((
+            input.view(),
+            position_ids.view(),
+            cos_cache.view(),
+            sin_cache.view(),
+        ));
+
+        assert_eq!(
+            result,
+            Err(OpError::InvalidValue(
+                "num_heads must be specified when rotary_embedding_dim is set"
+            ))
+        );
     }
 
     #[test]

--- a/src/ops/embedding.rs
+++ b/src/ops/embedding.rs
@@ -1,4 +1,4 @@
-use rten_tensor::{AsView, Layout, NdTensorView, SliceRange, Tensor, TensorView};
+use rten_tensor::{AsView, Layout, NdTensor, NdTensorView, SliceRange, Tensor, TensorView};
 
 use crate::{
     buffer_pool::{AutoReturn, BufferPool},
@@ -206,15 +206,43 @@ impl Operator for RotaryEmbeddingMicrosoft {
 
         let input: TensorView<f32> = inputs.require_as(0)?;
         let position_ids: TensorView<i32> = inputs.require_as(1)?;
-        let position_ids = match position_ids.ndim() {
-            1 => position_ids.with_new_axis(0).nd_view(),
-            2 => position_ids.nd_view(),
-            _ => {
-                return Err(OpError::InvalidValue("position_ids must have 1 or 2 dims"));
-            }
-        };
         let cos: TensorView<f32> = inputs.require_as(2)?;
         let sin = inputs.require_as(3)?;
+
+        // The sequence length is needed to expand the offset form of
+        // `position_ids` below. The shared implementation re-validates the full
+        // input shape.
+        let (batch, seq_len) = match *input.shape() {
+            [batch, seq_len, _] => (batch, seq_len),
+            [batch, _, seq_len, _] => (batch, seq_len),
+            _ => {
+                return Err(OpError::IncompatibleInputShapes(
+                    "Input processed needs 3-4 dimensions",
+                ));
+            }
+        };
+
+        // `position_ids` has two forms, matching ONNX Runtime's contrib op:
+        //
+        //  - Format 1, shape `(batch, seq_len)`: the explicit position of each
+        //    token.
+        //  - Format 0, a scalar or 1-element tensor holding an offset `k`:
+        //    token `i` uses position `k + i`. This is used during generation,
+        //    where only the position of the sequence's first token is passed.
+        let offset_positions;
+        let position_ids = match (position_ids.ndim(), position_ids.item().copied()) {
+            (0 | 1, Some(offset)) => {
+                offset_positions =
+                    NdTensor::from_fn([batch, seq_len], |[_, pos]| offset + pos as i32);
+                offset_positions.view()
+            }
+            (2, _) => position_ids.nd_view(),
+            _ => {
+                return Err(OpError::InvalidValue(
+                    "position_ids must be a scalar, a 1-element vector or have 2 dims",
+                ));
+            }
+        };
 
         let num_heads = match input.shape() {
             &[_, _, hidden_size] => match self.num_heads {
@@ -658,9 +686,9 @@ mod tests {
     }
 
     // Exercises the Microsoft variant's distinctive paths: input ordering
-    // (input, position_ids, cos, sin) and 1D → 2D position_ids reshape. Input
-    // data ported from the `RotaryEmbedding_CustomRotaryDim_SmallData_Phi`
-    // case above.
+    // (input, position_ids, cos, sin) and explicit `(batch, seq_len)`
+    // position_ids. Input data ported from the
+    // `RotaryEmbedding_CustomRotaryDim_SmallData_Phi` case above.
     #[test]
     fn test_rotary_embedding_microsoft() {
         let op = RotaryEmbeddingMicrosoft {
@@ -673,7 +701,7 @@ mod tests {
             [-1.0408, 0.9166, -1.3042, -1.1097, -1.2188, 1.1676],
             [1.0076, -0.7529, -0.2250, -0.4327, -1.5071, -0.4586],
         ]]);
-        let position_ids = Tensor::from([0i32, 1]);
+        let position_ids = Tensor::from([[0i32, 1]]);
         let cos_cache = Tensor::from([[1.0000, 1.0000], [1.0000, 0.5403]]);
         let sin_cache = Tensor::from([[0.0000, 0.0000], [0.0000, 0.8415]]);
         let expected = Tensor::from([[
@@ -691,5 +719,89 @@ mod tests {
             .unwrap();
 
         expect_equal_with_tolerance(&expected.view(), &result.view(), 1e-4, 0.0).unwrap();
+    }
+
+    // The Microsoft contrib op accepts `position_ids` either as an explicit
+    // `(batch, seq_len)` tensor or as a scalar / 1-element "offset" `k`, in
+    // which case token `i` uses position `k + i`. Verify the offset form is
+    // equivalent to the corresponding explicit positions, as ONNX Runtime does.
+    #[test]
+    fn test_rotary_embedding_microsoft_position_offset() {
+        let op = RotaryEmbeddingMicrosoft {
+            interleaved: false,
+            num_heads: Some(1),
+            rotary_embedding_dim: 0,
+        };
+
+        // Input shape [batch=1, seq_len=3, hidden=2] (head_size=2).
+        let input = Tensor::from([[[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]]);
+        // Cache rows for positions 0..=4, distinct so the position matters.
+        let cos_cache = Tensor::from([[0.1], [0.2], [0.3], [0.4], [0.5]]);
+        let sin_cache = Tensor::from([[0.9], [0.8], [0.7], [0.6], [0.5]]);
+
+        let offset = 2i32;
+        // The offset form should expand to these explicit positions.
+        let explicit = Tensor::from([[2i32, 3, 4]]);
+        let expected: Tensor<f32> = op
+            .run_simple((
+                input.view(),
+                explicit.view(),
+                cos_cache.view(),
+                sin_cache.view(),
+            ))
+            .unwrap();
+
+        // 1-element vector `[2]` (shape `(1,)`).
+        let offset_1d = Tensor::from([offset]);
+        let result_1d: Tensor<f32> = op
+            .run_simple((
+                input.view(),
+                offset_1d.view(),
+                cos_cache.view(),
+                sin_cache.view(),
+            ))
+            .unwrap();
+        expect_equal_with_tolerance(&expected.view(), &result_1d.view(), 1e-5, 0.0).unwrap();
+
+        // Scalar `2` (shape `()`).
+        let offset_scalar = Tensor::from_scalar(offset);
+        let result_scalar: Tensor<f32> = op
+            .run_simple((
+                input.view(),
+                offset_scalar.view(),
+                cos_cache.view(),
+                sin_cache.view(),
+            ))
+            .unwrap();
+        expect_equal_with_tolerance(&expected.view(), &result_scalar.view(), 1e-5, 0.0).unwrap();
+    }
+
+    #[test]
+    fn test_reject_multi_element_1d_position_ids() {
+        // A 1D `position_ids` with more than one element is rejected, matching
+        // ONNX Runtime. The scalar / 1-element form is an offset, and explicit
+        // per-token positions must be 2D.
+        let op = RotaryEmbeddingMicrosoft {
+            interleaved: false,
+            num_heads: Some(1),
+            rotary_embedding_dim: 0,
+        };
+        let input = Tensor::from([[[1.0, 2.0], [3.0, 4.0]]]);
+        let position_ids = Tensor::from([0i32, 1]);
+        let cos_cache = Tensor::from([[0.1], [0.2]]);
+        let sin_cache = Tensor::from([[0.9], [0.8]]);
+
+        let result = op.run_simple::<_, Tensor<f32>>((
+            input.view(),
+            position_ids.view(),
+            cos_cache.view(),
+            sin_cache.view(),
+        ));
+        assert_eq!(
+            result,
+            Err(OpError::InvalidValue(
+                "position_ids must be a scalar, a 1-element vector or have 2 dims"
+            ))
+        );
     }
 }

--- a/src/ops/embedding.rs
+++ b/src/ops/embedding.rs
@@ -516,7 +516,7 @@ mod tests {
     }
 
     #[test]
-    fn reject_indivisible_hidden_size() {
+    fn test_reject_indivisible_hidden_size() {
         let op = RotaryEmbedding {
             interleaved: false,
             num_heads: 2,
@@ -538,7 +538,7 @@ mod tests {
     }
 
     #[test]
-    fn infer_num_heads_from_cache_dim() {
+    fn test_infer_num_heads_from_cache_dim() {
         let op = RotaryEmbeddingMicrosoft {
             interleaved: false,
             num_heads: Some(0),
@@ -563,7 +563,7 @@ mod tests {
     }
 
     #[test]
-    fn reject_zero_cache_dim_when_inferring_num_heads() {
+    fn test_reject_zero_cache_dim_when_inferring_num_heads() {
         let op = RotaryEmbeddingMicrosoft {
             interleaved: false,
             num_heads: None,
@@ -591,7 +591,7 @@ mod tests {
     }
 
     #[test]
-    fn reject_zero_or_odd_rotary_embedding_dim() {
+    fn test_reject_zero_or_odd_rotary_embedding_dim() {
         for rotary_embedding_dim in [0, 1] {
             let op = RotaryEmbedding {
                 interleaved: false,

--- a/src/ops/embedding.rs
+++ b/src/ops/embedding.rs
@@ -20,34 +20,11 @@ fn rotary_embedding(
     sin: TensorView<f32>,
     position_ids: Option<NdTensorView<i32, 2>>,
     interleaved: bool,
-    num_heads: Option<usize>,
+    num_heads: usize,
     rotary_embedding_dim: usize,
 ) -> Result<Tensor, OpError> {
-    let cache_rotary_embedding_dim = cos
-        .shape()
-        .last()
-        .copied()
-        .ok_or(OpError::InvalidValue("cos cache must not be scalar"))?
-        * 2;
-
     let reshaped_input = match input.shape() {
         &[batch, seq_len, hidden_size] => {
-            let num_heads = match num_heads {
-                Some(0) | None => {
-                    let rotary_embedding_dim = if rotary_embedding_dim == 0 {
-                        cache_rotary_embedding_dim
-                    } else {
-                        rotary_embedding_dim
-                    };
-                    if hidden_size % rotary_embedding_dim != 0 {
-                        return Err(OpError::InvalidValue(
-                            "hidden_size must be divisible by rotary_embedding_dim",
-                        ));
-                    }
-                    hidden_size / rotary_embedding_dim
-                }
-                Some(num_heads) => num_heads,
-            };
             if num_heads == 0 {
                 return Err(OpError::InvalidValue(
                     "num_heads must not be 0 for 3 dimensioned input",
@@ -83,6 +60,11 @@ fn rotary_embedding(
     } else {
         rotary_embedding_dim
     };
+    if rotary_embedding_dim == 0 || rotary_embedding_dim % 2 != 0 {
+        return Err(OpError::InvalidValue(
+            "rotary_embedding_dim must be a positive even number",
+        ));
+    }
 
     let x_rotate = reshaped_input.slice((.., .., .., ..rotary_embedding_dim));
     let x_not_rotate = reshaped_input.slice((.., .., .., rotary_embedding_dim..));
@@ -155,7 +137,7 @@ fn rotary_embedding(
 #[derive(Debug)]
 pub struct RotaryEmbedding {
     pub interleaved: bool,
-    pub num_heads: Option<usize>,
+    pub num_heads: usize,
     pub rotary_embedding_dim: usize,
 }
 
@@ -216,7 +198,7 @@ impl Operator for RotaryEmbeddingMicrosoft {
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let inputs = ctx.inputs();
 
-        let input = inputs.require_as(0)?;
+        let input: TensorView<f32> = inputs.require_as(0)?;
         let position_ids: TensorView<i32> = inputs.require_as(1)?;
         let position_ids = match position_ids.ndim() {
             1 => position_ids.with_new_axis(0).nd_view(),
@@ -225,8 +207,42 @@ impl Operator for RotaryEmbeddingMicrosoft {
                 return Err(OpError::InvalidValue("position_ids must have 1 or 2 dims"));
             }
         };
-        let cos = inputs.require_as(2)?;
+        let cos: TensorView<f32> = inputs.require_as(2)?;
         let sin = inputs.require_as(3)?;
+
+        let num_heads = match input.shape() {
+            &[_, _, hidden_size] => match self.num_heads {
+                // The ONNX spec requires `num_heads` for rank-3 input. The
+                // Microsoft contrib op gives this attribute a default of 0,
+                // so infer it here before calling the shared implementation.
+                Some(0) | None => {
+                    let cache_rotary_embedding_dim_half = cos
+                        .shape()
+                        .last()
+                        .copied()
+                        .ok_or(OpError::InvalidValue("cos cache must not be scalar"))?;
+                    if cache_rotary_embedding_dim_half == 0 {
+                        return Err(OpError::InvalidValue(
+                            "Last dimension of cos cache must not be 0",
+                        ));
+                    }
+                    let cache_rotary_embedding_dim = cache_rotary_embedding_dim_half * 2;
+                    let rotary_embedding_dim = if self.rotary_embedding_dim == 0 {
+                        cache_rotary_embedding_dim
+                    } else {
+                        self.rotary_embedding_dim
+                    };
+                    if hidden_size % rotary_embedding_dim != 0 {
+                        return Err(OpError::InvalidValue(
+                            "hidden_size must be divisible by rotary_embedding_dim",
+                        ));
+                    }
+                    hidden_size / rotary_embedding_dim
+                }
+                Some(num_heads) => num_heads,
+            },
+            _ => self.num_heads.unwrap_or_default(),
+        };
 
         let output = rotary_embedding(
             ctx.pool(),
@@ -235,7 +251,7 @@ impl Operator for RotaryEmbeddingMicrosoft {
             sin,
             Some(position_ids),
             self.interleaved,
-            self.num_heads,
+            num_heads,
             self.rotary_embedding_dim,
         )?;
 
@@ -331,7 +347,7 @@ mod tests {
                 .with_new_axis(0),
                 op: RotaryEmbedding {
                     interleaved: true,
-                    num_heads: Some(2),
+                    num_heads: 2,
                     rotary_embedding_dim: 0,
                 },
             },
@@ -377,7 +393,7 @@ mod tests {
                 ]]),
                 op: RotaryEmbedding {
                     interleaved: false,
-                    num_heads: Some(3),
+                    num_heads: 3,
                     rotary_embedding_dim: 0,
                 },
             },
@@ -397,7 +413,7 @@ mod tests {
                 ]]),
                 op: RotaryEmbedding {
                     interleaved: false,
-                    num_heads: Some(1),
+                    num_heads: 1,
                     rotary_embedding_dim: 4,
                 },
             },
@@ -433,7 +449,7 @@ mod tests {
                 ]]),
                 op: RotaryEmbedding {
                     interleaved: false,
-                    num_heads: Some(3),
+                    num_heads: 3,
                     rotary_embedding_dim: 0,
                 },
             },
@@ -467,7 +483,7 @@ mod tests {
                 ]]),
                 op: RotaryEmbedding {
                     interleaved: true,
-                    num_heads: Some(2),
+                    num_heads: 2,
                     rotary_embedding_dim: 0,
                 },
             },
@@ -503,7 +519,7 @@ mod tests {
     fn reject_indivisible_hidden_size() {
         let op = RotaryEmbedding {
             interleaved: false,
-            num_heads: Some(2),
+            num_heads: 2,
             rotary_embedding_dim: 0,
         };
 
@@ -544,6 +560,59 @@ mod tests {
             .unwrap();
 
         expect_equal_with_tolerance(&input.view(), &result.view(), 1e-4, 0.0).unwrap();
+    }
+
+    #[test]
+    fn reject_zero_cache_dim_when_inferring_num_heads() {
+        let op = RotaryEmbeddingMicrosoft {
+            interleaved: false,
+            num_heads: None,
+            rotary_embedding_dim: 0,
+        };
+
+        let input = Tensor::from([[[1., 2., 3., 4.]]]);
+        let position_ids = Tensor::from([[0i32]]);
+        let cos_cache = Tensor::<f32>::zeros(&[1, 0]);
+        let sin_cache = Tensor::<f32>::zeros(&[1, 0]);
+
+        let result = op.run_simple::<_, Tensor<f32>>((
+            input.view(),
+            position_ids.view(),
+            cos_cache.view(),
+            sin_cache.view(),
+        ));
+
+        assert_eq!(
+            result,
+            Err(OpError::InvalidValue(
+                "Last dimension of cos cache must not be 0"
+            ))
+        );
+    }
+
+    #[test]
+    fn reject_zero_or_odd_rotary_embedding_dim() {
+        for rotary_embedding_dim in [0, 1] {
+            let op = RotaryEmbedding {
+                interleaved: false,
+                num_heads: 1,
+                rotary_embedding_dim,
+            };
+
+            let input = Tensor::from([[[1.]]]);
+            let cos_cache = Tensor::<f32>::zeros(&[1, 0]);
+            let sin_cache = Tensor::<f32>::zeros(&[1, 0]);
+
+            let result =
+                op.run_simple::<_, Tensor<f32>>((input.view(), cos_cache.view(), sin_cache.view()));
+
+            assert_eq!(
+                result,
+                Err(OpError::InvalidValue(
+                    "rotary_embedding_dim must be a positive even number"
+                ))
+            );
+        }
     }
 
     // Exercises the Microsoft variant's distinctive paths: input ordering

--- a/src/ops/embedding.rs
+++ b/src/ops/embedding.rs
@@ -55,14 +55,20 @@ fn rotary_embedding(
         }
     };
 
+    let head_size = reshaped_input.shape()[3];
     let rotary_embedding_dim = if rotary_embedding_dim == 0 {
-        reshaped_input.shape()[3]
+        head_size
     } else {
         rotary_embedding_dim
     };
     if rotary_embedding_dim == 0 || rotary_embedding_dim % 2 != 0 {
         return Err(OpError::InvalidValue(
             "rotary_embedding_dim must be a positive even number",
+        ));
+    }
+    if rotary_embedding_dim > head_size {
+        return Err(OpError::InvalidValue(
+            "rotary_embedding_dim must not exceed head size",
         ));
     }
 


### PR DESCRIPTION
The rotary embedding name caused some issues with the operator name. This adds a branch into the macro rule to allow overloading the name (which opens up reusing the same operator under different names if it exists as a contrib and stabilised op for more code reuse).

I can also probably tweak this around by adding the microsoft one in a different namespace or something if you'd prefer that. 