### PR TITLE
Allow operators to test which individual outputs are requested

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1091,7 +1091,7 @@ impl Graph {
                 .with_first_input_omitted(in_place_input.is_some());
             let mut ctx = OpRunContext::new(pool, &inputs);
             ctx.set_name(op_node.name());
-            ctx.set_num_outputs(op_node.output_ids().len() as u32);
+            ctx.set_outputs(op_node.output_mask());
 
             let op_result = if let Some((_id, value)) = in_place_input {
                 let input_dtype = value.dtype();

--- a/src/graph/node.rs
+++ b/src/graph/node.rs
@@ -2,6 +2,7 @@ use std::borrow::Cow;
 use std::fmt;
 use std::sync::Arc;
 
+use rten_base::bit_set::BitSet;
 use rten_tensor::prelude::*;
 use rten_tensor::{ArcTensor, DynLayout, TensorView};
 
@@ -118,6 +119,10 @@ pub struct OperatorNode {
     name: Option<String>,
     inputs: Box<[Option<NodeId>]>,
     outputs: Box<[Option<NodeId>]>,
+
+    // Cached mask indicating which positions in `outputs` are set.
+    output_mask: BitSet,
+
     operator: Arc<dyn Operator + Send + Sync>,
 
     // Cached names of nodes captured by operator's subgraphs.
@@ -138,10 +143,19 @@ impl OperatorNode {
             }
         }
 
+        // Pre-compute mask of used outputs.
+        let mut output_mask = BitSet::ones(output_ids.len() as u32);
+        for (i, id) in output_ids.iter().enumerate() {
+            if id.is_none() {
+                output_mask.delete(i as u32);
+            }
+        }
+
         OperatorNode {
             name: name.map(|s| s.to_owned()),
             inputs: input_ids.into(),
             outputs: output_ids.into(),
+            output_mask,
             operator,
             capture_names: capture_names.into(),
         }
@@ -157,6 +171,11 @@ impl OperatorNode {
 
     pub fn output_ids(&self) -> &[Option<NodeId>] {
         &self.outputs
+    }
+
+    /// Return a bit mask indicating which outputs are used.
+    pub fn output_mask(&self) -> BitSet {
+        self.output_mask
     }
 
     /// Return the names of nodes captured by this operator's subgraphs.

--- a/src/graph/tests.rs
+++ b/src/graph/tests.rs
@@ -2,6 +2,7 @@ use std::error::Error;
 use std::sync::atomic::{AtomicI32, Ordering};
 use std::sync::{Arc, Mutex};
 
+use rten_base::bit_set::BitSet;
 use rten_tensor::prelude::*;
 use rten_tensor::test_util::{expect_equal, expect_equal_with_tolerance};
 use rten_tensor::{Tensor, TensorView};
@@ -101,25 +102,23 @@ impl<Op: Operator> Operator for TrackUsage<Op> {
 /// Operator that wraps a function.
 ///
 /// Useful for tests that want to inspect operator inputs.
-struct RunFn<V: Into<Value>, F: Fn(&OpRunContext) -> Result<V, OpError> + 'static> {
+struct RunFn<F: Fn(&OpRunContext) -> Result<OutputList, OpError> + 'static> {
     run: F,
 }
 
-impl<V: Into<Value>, F: Fn(&OpRunContext) -> Result<V, OpError>> RunFn<V, F> {
+impl<F: Fn(&OpRunContext) -> Result<OutputList, OpError>> RunFn<F> {
     fn new(run: F) -> Self {
         Self { run }
     }
 }
 
-impl<V: Into<Value>, F: Fn(&OpRunContext) -> Result<V, OpError>> std::fmt::Debug for RunFn<V, F> {
+impl<F: Fn(&OpRunContext) -> Result<OutputList, OpError>> std::fmt::Debug for RunFn<F> {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(fmt, "RunFn")
     }
 }
 
-impl<V: Into<Value> + 'static, F: Fn(&OpRunContext) -> Result<V, OpError>> Operator
-    for RunFn<V, F>
-{
+impl<F: Fn(&OpRunContext) -> Result<OutputList, OpError>> Operator for RunFn<F> {
     fn name(&self) -> &str {
         "RunFn"
     }
@@ -133,7 +132,7 @@ impl<V: Into<Value> + 'static, F: Fn(&OpRunContext) -> Result<V, OpError>> Opera
     }
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
-        (self.run)(ctx).map(|v| [v.into()].into())
+        (self.run)(ctx).map(|v| v.into())
     }
 
     fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
@@ -1718,19 +1717,37 @@ fn test_prepack_weights() {
 }
 
 #[test]
-fn test_run_context_num_outputs() {
+fn test_run_context_outputs() {
     let mut g = Graph::new();
     let input_id = g.add_value(Some("input"), None, None);
-    let (_, op_out) = g.add_simple_op(
-        "test_op",
-        RunFn::new(|ctx| {
-            assert_eq!(ctx.num_outputs(), Some(1));
-            Ok(Tensor::from_scalar(0.))
-        }),
-        &[input_id],
+    let out_0 = g.add_value(Some("out_0"), None, None);
+    let out_1 = g.add_value(Some("out_1"), None, None);
+    g.add_op(
+        Some("test_op"),
+        Arc::new(RunFn::new(|ctx| {
+            let mut expected = BitSet::ones(4);
+            expected.delete(1);
+            expected.delete(2);
+            assert_eq!(ctx.outputs(), Some(expected));
+            Ok([
+                // Expected output.
+                Tensor::from(1.).into(),
+                // Dummy values for unused outputs. This should use `None`,
+                // but `OutputList` can't represent non-present values yet.
+                Tensor::from(0.).into(),
+                Tensor::from(0.).into(),
+                // Expected output.
+                Tensor::from(2.).into(),
+            ]
+            .into_iter()
+            .collect())
+        })),
+        &[Some(input_id)],
+        // Operator has 4 outputs, only two are used.
+        &[Some(out_0), None, None, Some(out_1)],
     );
     let input = Tensor::from([1, 2, 3]);
-    g.run(vec![(input_id, input.into())], &[op_out], None, None)
+    g.run(vec![(input_id, input.into())], &[out_0, out_1], None, None)
         .unwrap();
 }
 
@@ -1742,7 +1759,7 @@ fn test_run_context_name() {
         "test_op",
         RunFn::new(|ctx| {
             assert_eq!(ctx.name(), Some("test_op"));
-            Ok(Tensor::from_scalar(0.))
+            Ok([Tensor::from_scalar(0.).into()].into_iter().collect())
         }),
         &[input_id],
     );

--- a/src/model/onnx_builder.rs
+++ b/src/model/onnx_builder.rs
@@ -99,6 +99,7 @@ pub trait NodeProtoExt {
     fn with_domain(self, domain: &str) -> Self;
     fn with_name(self, name: &str) -> Self;
     fn with_input(self, name: &str) -> Self;
+    fn with_output(self, name: &str) -> Self;
 }
 
 impl NodeProtoExt for onnx::NodeProto {
@@ -119,6 +120,11 @@ impl NodeProtoExt for onnx::NodeProto {
 
     fn with_input(mut self, name: &str) -> Self {
         self.input.push(name.to_string());
+        self
+    }
+
+    fn with_output(mut self, name: &str) -> Self {
+        self.output.push(name.to_string());
         self
     }
 }

--- a/src/model/onnx_loader.rs
+++ b/src/model/onnx_loader.rs
@@ -999,6 +999,22 @@ fn add_operator(
         ));
     }
 
+    // We set a limit of 32 outputs per operator so we can represent the used
+    // positions conveniently in a u32 mask.
+    //
+    // TODO: We should also allow individual operators to declare the maximum
+    // number of outputs they support.
+    let max_outputs = u32::BITS as usize;
+    if outputs.len() >= max_outputs {
+        return Err(load_error!(
+            OperatorInvalid,
+            onnx_op.name.as_deref(),
+            "operator has {} outputs but maximum is {}",
+            outputs.len(),
+            max_outputs
+        ));
+    }
+
     let mut name = onnx_op.name.as_deref();
 
     // It is possible for ONNX operators to have a name that conflicts with a
@@ -1438,6 +1454,28 @@ mod tests {
         assert_eq!(
             err.to_string(),
             "in node \"relu_op\": operator error: operator has 2 inputs but maximum is 1"
+        );
+    }
+
+    #[test]
+    fn test_too_many_outputs_for_operator() {
+        let mut node = create_node("Split").with_input("x").with_name("split_op");
+
+        for i in 0..33 {
+            let name = format!("y_{}", i);
+            node = node.with_output(&name);
+        }
+
+        let graph = onnx::GraphProto::default()
+            .with_input(create_value_info("x"))
+            .with_input(create_value_info("y"))
+            .with_node(node);
+
+        let err = load_model(graph.into_model(), None).err().unwrap();
+
+        assert_eq!(
+            err.to_string(),
+            "in node \"split_op\": operator error: operator has 33 outputs but maximum is 32"
         );
     }
 

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -7,6 +7,7 @@ use std::error::Error;
 use std::fmt;
 use std::fmt::{Debug, Display};
 
+use rten_base::bit_set::BitSet;
 use rten_gemm::PackedBMatrix;
 use rten_tensor::errors::DimensionError;
 use rten_tensor::{Layout, Storage, TensorBase};
@@ -262,7 +263,7 @@ pub(crate) use check_eq;
 pub struct OpRunContext<'a, 'i> {
     pool: &'a BufferPool,
     inputs: &'a InputList<'i>,
-    n_outputs: Option<u32>,
+    outputs: Option<BitSet>,
     name: Option<&'a str>,
 }
 
@@ -271,7 +272,7 @@ impl<'a, 'i> OpRunContext<'a, 'i> {
         OpRunContext {
             pool,
             inputs,
-            n_outputs: None,
+            outputs: None,
             name: None,
         }
     }
@@ -299,19 +300,18 @@ impl<'a, 'i> OpRunContext<'a, 'i> {
         self.inputs
     }
 
-    /// Set the requested number of outputs.
+    /// Set a mask indicating which outputs are requested.
     ///
     /// This can be used to skip generating outputs that are unused, or in
     /// the rare cases that the output count cannot be determined from the
     /// operator's inputs and attributes alone.
-    pub fn set_num_outputs(&mut self, n: u32) {
-        self.n_outputs = Some(n);
+    pub fn set_outputs(&mut self, mask: BitSet) {
+        self.outputs = Some(mask);
     }
 
-    /// Return the number of requested outputs or `None` if this has not been
-    /// specified.
-    pub fn num_outputs(&self) -> Option<u32> {
-        self.n_outputs
+    /// Return a mask indicating the requested outputs of `None` if not specified.
+    pub fn outputs(&self) -> Option<BitSet> {
+        self.outputs
     }
 
     /// Set the name of the current node in the graph.

--- a/src/ops/split.rs
+++ b/src/ops/split.rs
@@ -116,7 +116,7 @@ impl Operator for Split {
         //
         // See https://github.com/robertknight/rten/issues/689.
         let splits = ctx.inputs().get_as(1)?;
-        let num_outputs = self.num_outputs.or(ctx.num_outputs());
+        let num_outputs = self.num_outputs.or(ctx.outputs().map(|o| o.len()));
 
         let split_sizes = if let Some(splits) = splits {
             SplitSizes::Sizes(splits)
@@ -157,6 +157,7 @@ impl_infer_shapes!(
 
 #[cfg(test)]
 mod tests {
+    use rten_base::bit_set::BitSet;
     use rten_tensor::prelude::*;
     use rten_tensor::{NdTensor, Tensor};
     use rten_testing::TestCases;
@@ -247,7 +248,7 @@ mod tests {
             let pool = BufferPool::new();
             let mut ctx = OpRunContext::new(&pool, &inputs);
             if let Some(n_outputs) = case.graph_outputs {
-                ctx.set_num_outputs(n_outputs);
+                ctx.set_outputs(BitSet::ones(n_outputs));
             }
             let results = split_op.run(&ctx).unwrap();
             let results: Vec<Tensor> = results.into_iter().map(|o| o.try_into().unwrap()).collect();


### PR DESCRIPTION
Previously an operator could check how many output slots its graph node had via `OpRunContext::num_outputs` but had no way to test whether individual outputs were needed.

This PR changes the representation of used outputs to a u32 bit mask, accessible via `OpRunContext::outputs`. This sets an implementation limit of 32 outputs per operator, which I think should be sufficient. We can revise in future if not. The limit is checked when a model is loaded.

When returning outputs, operators do not have a way to return "not set" for a value, so at present they must return dummy values.

This change was prompted by https://github.com/robertknight/rten/pull/1279, where `SkipSimplifiedLayerNormalization` operators need outputs 1 and 4 but not 2 or 3.