### PR TITLE
Refactor `OpRunContext::outputs` to return a non-optional value

### DIFF
--- a/rten-base/src/bit_set.rs
+++ b/rten-base/src/bit_set.rs
@@ -4,15 +4,34 @@ pub struct BitSet(u32);
 impl BitSet {
     pub const BITS: usize = u32::BITS as usize;
 
+    /// Return a bit set with all positions cleared.
+    pub fn new() -> Self {
+        Self(0)
+    }
+
     /// Return a bit set with the first `n` positions set.
     pub fn ones(n: u32) -> Self {
         let bits = if n >= 32 { u32::MAX } else { (1 << n) - 1 };
         Self(bits)
     }
 
+    /// Return a bit set with given indices set.
+    pub fn from_indices<I: IntoIterator<Item = u32>>(indices: I) -> Self {
+        let mut bits = Self(0);
+        for pos in indices {
+            bits.set(pos);
+        }
+        bits
+    }
+
     /// Unset the bit at position `pos`.
     pub fn delete(&mut self, pos: u32) {
         self.0 &= !(1 << pos)
+    }
+
+    /// Set the bit at position `pos`.
+    pub fn set(&mut self, pos: u32) {
+        self.0 |= 1 << pos;
     }
 
     /// Return true if position `pos` is set.
@@ -21,7 +40,7 @@ impl BitSet {
     }
 
     /// Return the number of bits set.
-    pub fn len(&self) -> u32 {
+    pub fn count_true(&self) -> u32 {
         self.0.count_ones()
     }
 
@@ -49,25 +68,26 @@ mod tests {
     #[test]
     fn test_bit_set() {
         let mut set = BitSet::ones(5);
-        assert_eq!(set.len(), 5);
+        assert_eq!(set.count_true(), 5);
         assert!(!set.is_empty());
         for i in 0..5 {
             assert!(set.get(i));
             set.delete(i);
             assert!(!set.get(i));
         }
-        assert_eq!(set.len(), 0);
+        assert_eq!(set.count_true(), 0);
         assert!(set.is_empty());
 
         let all_zeros = BitSet::default();
-        assert_eq!(all_zeros.len(), 0);
+        assert_eq!(all_zeros.count_true(), 0);
+        assert_eq!(BitSet::new(), all_zeros);
     }
 
     #[test]
     fn test_bit_set_ones() {
         for i in 0..=32 {
             let all_ones = BitSet::ones(i);
-            assert_eq!(all_ones.len(), i);
+            assert_eq!(all_ones.count_true(), i);
         }
     }
 
@@ -79,5 +99,13 @@ mod tests {
 
         let positions: Vec<usize> = set.iter().collect();
         assert_eq!(positions, [1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn test_bit_set_from_indices() {
+        let set = BitSet::from_indices([0, 3]);
+        for i in 0..BitSet::BITS {
+            assert_eq!(set.get(i as u32), i == 0 || i == 3);
+        }
     }
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1089,9 +1089,8 @@ impl Graph {
             let inputs = InputList::from_optional(&op_inputs)
                 .with_prepacked(&get_prepacked)
                 .with_first_input_omitted(in_place_input.is_some());
-            let mut ctx = OpRunContext::new(pool, &inputs);
+            let mut ctx = OpRunContext::new(pool, &inputs, op_node.output_mask());
             ctx.set_name(op_node.name());
-            ctx.set_outputs(op_node.output_mask());
 
             let op_result = if let Some((_id, value)) = in_place_input {
                 let input_dtype = value.dtype();

--- a/src/graph/tests.rs
+++ b/src/graph/tests.rs
@@ -1725,10 +1725,7 @@ fn test_run_context_outputs() {
     g.add_op(
         Some("test_op"),
         Arc::new(RunFn::new(|ctx| {
-            let mut expected = BitSet::ones(4);
-            expected.delete(1);
-            expected.delete(2);
-            assert_eq!(ctx.outputs(), Some(expected));
+            assert_eq!(ctx.outputs(), BitSet::from_indices([0, 3]));
             Ok([
                 // Expected output.
                 Tensor::from(1.).into(),

--- a/src/op_registry/onnx_registry.rs
+++ b/src/op_registry/onnx_registry.rs
@@ -1895,7 +1895,7 @@ mod tests {
             .with_attr("unused_b", false);
 
         let op = reg.read_op(&node, &FakeOpLoadContext::default()).unwrap();
-        assert_eq!(op.unused_attrs.len(), 2);
+        assert_eq!(op.unused_attrs.count_true(), 2);
         let unused_attrs: Vec<_> = op
             .unused_attrs
             .iter()

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -263,16 +263,20 @@ pub(crate) use check_eq;
 pub struct OpRunContext<'a, 'i> {
     pool: &'a BufferPool,
     inputs: &'a InputList<'i>,
-    outputs: Option<BitSet>,
+    outputs: BitSet,
     name: Option<&'a str>,
 }
 
 impl<'a, 'i> OpRunContext<'a, 'i> {
-    pub fn new(pool: &'a BufferPool, inputs: &'a InputList<'i>) -> Self {
+    /// Create a new context.
+    ///
+    /// `outputs` is a mask indicating which of the operator's outputs are
+    /// requested.
+    pub fn new(pool: &'a BufferPool, inputs: &'a InputList<'i>, outputs: BitSet) -> Self {
         OpRunContext {
             pool,
             inputs,
-            outputs: None,
+            outputs,
             name: None,
         }
     }
@@ -300,17 +304,12 @@ impl<'a, 'i> OpRunContext<'a, 'i> {
         self.inputs
     }
 
-    /// Set a mask indicating which outputs are requested.
+    /// Return a mask indicating the requested outputs.
     ///
     /// This can be used to skip generating outputs that are unused, or in
     /// the rare cases that the output count cannot be determined from the
     /// operator's inputs and attributes alone.
-    pub fn set_outputs(&mut self, mask: BitSet) {
-        self.outputs = Some(mask);
-    }
-
-    /// Return a mask indicating the requested outputs of `None` if not specified.
-    pub fn outputs(&self) -> Option<BitSet> {
+    pub fn outputs(&self) -> BitSet {
         self.outputs
     }
 
@@ -524,7 +523,7 @@ pub trait OperatorExt: Operator {
     {
         let pool = BufferPool::new();
         let inputs = inputs.into();
-        let ctx = OpRunContext::new(&pool, &inputs);
+        let ctx = OpRunContext::new(&pool, &inputs, BitSet::ones(1));
         let mut outputs = self.run(&ctx)?;
         Ok(outputs.remove(0).try_into()?)
     }
@@ -540,7 +539,7 @@ pub trait OperatorExt: Operator {
     {
         let pool = BufferPool::new();
         let inputs = inputs.into();
-        let ctx = OpRunContext::new(&pool, &inputs);
+        let ctx = OpRunContext::new(&pool, &inputs, BitSet::ones(1));
         let output = self.run_in_place(mut_input.into(), &ctx)?;
         let typed_output = output.try_into()?;
         Ok(typed_output)

--- a/src/ops/binary_elementwise.rs
+++ b/src/ops/binary_elementwise.rs
@@ -1231,6 +1231,7 @@ impl Operator for Where {
 mod tests {
     use std::error::Error;
 
+    use rten_base::bit_set::BitSet;
     use rten_tensor::prelude::*;
     use rten_tensor::test_util::{eq_with_nans, expect_equal};
     use rten_tensor::{Scalar, Tensor};
@@ -1384,7 +1385,7 @@ mod tests {
         // Run `Add` operator in place with inputs that support in-place addition.
         let op = Add {};
         let inputs: InputList = (&b).into();
-        let ctx = OpRunContext::new(&pool, &inputs);
+        let ctx = OpRunContext::new(&pool, &inputs, BitSet::ones(1));
         let result = op.run_in_place(Value::FloatTensor(a_copy), &ctx).unwrap();
         expect_equal(&result.as_tensor_view().unwrap(), &expected.view())?;
 

--- a/src/ops/control_flow.rs
+++ b/src/ops/control_flow.rs
@@ -312,6 +312,7 @@ where
 
 #[cfg(test)]
 mod tests {
+    use rten_base::bit_set::BitSet;
     use rten_tensor::Tensor;
 
     use crate::buffer_pool::BufferPool;
@@ -351,7 +352,10 @@ mod tests {
             );
 
             let pool = BufferPool::new();
-            let ctx = OpRunContext::new(&pool, &input_list);
+            // A `Loop` produces one output per body output, except the first
+            // body output which is the loop condition.
+            let num_outputs = self.op.body.output_ids().len().saturating_sub(1) as u32;
+            let ctx = OpRunContext::new(&pool, &input_list, BitSet::ones(num_outputs));
             let captures = CaptureEnv::empty();
             let weight_caches = None;
             let profiler = None;

--- a/src/ops/embedding.rs
+++ b/src/ops/embedding.rs
@@ -231,14 +231,16 @@ impl Operator for RotaryEmbeddingMicrosoft {
 
 #[cfg(test)]
 mod tests {
+    use rten_base::bit_set::BitSet;
+    use rten_tensor::{Tensor, test_util::expect_equal_with_tolerance};
+    use rten_testing::TestCases;
+
     use crate::{
         BufferPool,
         operator::{InputList, OperatorExt},
     };
 
     use super::*;
-    use rten_tensor::{Tensor, test_util::expect_equal_with_tolerance};
-    use rten_testing::TestCases;
 
     // Test rotary embedding using ported test cases from
     // https://github.com/microsoft/onnxruntime/blob/e3c34da40639669f3dbb7ae95db0662afbec8cc9/onnxruntime/test/providers/cpu/llm/rotary_embedding_op_test.cc#L509
@@ -494,7 +496,7 @@ mod tests {
         input_list.push(sin_cache.view());
 
         let pool = BufferPool::new();
-        let ctx = OpRunContext::new(&pool, &input_list);
+        let ctx = OpRunContext::new(&pool, &input_list, BitSet::ones(1));
 
         assert!(op.run(&ctx).is_err());
     }

--- a/src/ops/matmul.rs
+++ b/src/ops/matmul.rs
@@ -953,6 +953,7 @@ impl Operator for MatMulNBits {
 mod tests {
     use std::error::Error;
 
+    use rten_base::bit_set::BitSet;
     use rten_bench::run_bench;
     use rten_gemm::{
         BiasVector, BlockQuantizedMatrix, GemmExecutor, GemmInT, GemmInputA, GemmInputB,
@@ -1356,7 +1357,7 @@ mod tests {
                 inputs.push(bias.view());
             }
 
-            let ctx = OpRunContext::new(&pool, &inputs);
+            let ctx = OpRunContext::new(&pool, &inputs, BitSet::ones(1));
             let mut result = op.run(&ctx).unwrap();
             let result: Tensor<f32> = result.remove(0).try_into().unwrap();
 
@@ -1688,7 +1689,7 @@ mod tests {
         };
         let inputs =
             InputList::from(&[a.view().into(), b.view().into()]).with_prepacked(&get_prepacked);
-        let ctx = OpRunContext::new(&pool, &inputs);
+        let ctx = OpRunContext::new(&pool, &inputs, BitSet::ones(1));
         let mut result = op.run(&ctx).unwrap();
         let result: Tensor<i32> = result.remove(0).try_into().unwrap();
 

--- a/src/ops/random.rs
+++ b/src/ops/random.rs
@@ -391,6 +391,7 @@ impl_infer_shapes!(Dropout, _op, shape_ops::Dropout);
 
 #[cfg(test)]
 mod tests {
+    use rten_base::bit_set::BitSet;
     use rten_tensor::Tensor;
     use rten_tensor::prelude::*;
     use rten_testing::TestCases;
@@ -778,7 +779,7 @@ mod tests {
                 training_mode_input.as_ref().map(|tm| tm.view().into()),
             ]);
             let pool = BufferPool::new();
-            let ctx = OpRunContext::new(&pool, &inputs);
+            let ctx = OpRunContext::new(&pool, &inputs, BitSet::ones(2));
             let mut outputs = op.run(&ctx).unwrap();
             let output: Tensor<f32> = outputs.remove(0).try_into().unwrap();
             assert_eq!(output, data);
@@ -827,7 +828,7 @@ mod tests {
                 Some(training_mode_input.view().into()),
             ]);
             let pool = BufferPool::new();
-            let ctx = OpRunContext::new(&pool, &inputs);
+            let ctx = OpRunContext::new(&pool, &inputs, BitSet::ones(2));
 
             let mut outputs = op.run(&ctx).unwrap();
             let output: Tensor<f32> = outputs.remove(0).try_into().unwrap();

--- a/src/ops/resize.rs
+++ b/src/ops/resize.rs
@@ -599,6 +599,7 @@ impl_infer_shapes!(Upsample, _op, shape_ops::Upsample);
 
 #[cfg(test)]
 mod tests {
+    use rten_base::bit_set::BitSet;
     use rten_tensor::prelude::*;
     use rten_tensor::test_util::expect_equal;
     use rten_tensor::{NdTensor, NdTensorView, Tensor};
@@ -1043,7 +1044,7 @@ mod tests {
                 case.sizes.as_ref().map(|t| t.into()),
             ];
             let inputs = InputList::from_optional(&inputs);
-            let ctx = OpRunContext::new(&pool, &inputs);
+            let ctx = OpRunContext::new(&pool, &inputs, BitSet::ones(1));
             let result = op.run(&ctx);
             match (&case.expected, result) {
                 (CaseOutput::Shape(shape), Ok(out)) => {

--- a/src/ops/slice.rs
+++ b/src/ops/slice.rs
@@ -167,7 +167,7 @@ impl Operator for Slice {
             }
 
             let input_list = InputList::from(&inputs);
-            let ctx = OpRunContext::new(ctx.pool(), &input_list);
+            let ctx = OpRunContext::new(ctx.pool(), &input_list, ctx.outputs());
             return self.run(&ctx).map(|mut outputs| outputs.remove(0));
         }
 

--- a/src/ops/split.rs
+++ b/src/ops/split.rs
@@ -111,21 +111,18 @@ impl Operator for Split {
         // In Split v18+, the operator should specify either a vector of split
         // sizes or a count of outputs to produce. Older versions of the Split
         // operator could omit both of these, in which case the number of
-        // outputs was determined by looking at the operator node's number of
-        // outputs.
+        // outputs is determined by the number of outputs the node has in the
+        // graph.
         //
         // See https://github.com/robertknight/rten/issues/689.
         let splits = ctx.inputs().get_as(1)?;
-        let num_outputs = self.num_outputs.or(ctx.outputs().map(|o| o.len()));
-
         let split_sizes = if let Some(splits) = splits {
             SplitSizes::Sizes(splits)
-        } else if let Some(num_outputs) = num_outputs {
-            SplitSizes::NumSplits(num_outputs)
         } else {
-            return Err(OpError::InvalidValue(
-                "Either `num_outputs` or `splits` must be set",
-            ));
+            SplitSizes::NumSplits(
+                self.num_outputs
+                    .unwrap_or_else(|| ctx.outputs().count_true()),
+            )
         };
 
         map_value_view!(input, x, {
@@ -246,10 +243,8 @@ mod tests {
                 case.splits.as_ref().map(|s| s.view().into()),
             ]);
             let pool = BufferPool::new();
-            let mut ctx = OpRunContext::new(&pool, &inputs);
-            if let Some(n_outputs) = case.graph_outputs {
-                ctx.set_outputs(BitSet::ones(n_outputs));
-            }
+            let output_mask = case.graph_outputs.map(BitSet::ones).unwrap_or_default();
+            let ctx = OpRunContext::new(&pool, &inputs, output_mask);
             let results = split_op.run(&ctx).unwrap();
             let results: Vec<Tensor> = results.into_iter().map(|o| o.try_into().unwrap()).collect();
 

--- a/src/ops/transform_inputs.rs
+++ b/src/ops/transform_inputs.rs
@@ -115,7 +115,7 @@ impl Operator for TransformInputs {
             };
             transform.transform(input)?;
         }
-        let inner_ctx = OpRunContext::new(ctx.pool(), &inputs);
+        let inner_ctx = OpRunContext::new(ctx.pool(), &inputs, ctx.outputs());
         self.inner.run(&inner_ctx)
     }
 
@@ -139,7 +139,7 @@ impl Operator for TransformInputs {
             };
             transform.transform(input)?;
         }
-        let inner_ctx = OpRunContext::new(ctx.pool(), &inputs);
+        let inner_ctx = OpRunContext::new(ctx.pool(), &inputs, ctx.outputs());
         self.inner.run_in_place(input, &inner_ctx)
     }
 

--- a/src/ops/variadic_elementwise.rs
+++ b/src/ops/variadic_elementwise.rs
@@ -208,6 +208,7 @@ impl Operator for Sum {
 
 #[cfg(test)]
 mod tests {
+    use rten_base::bit_set::BitSet;
     use rten_tensor::prelude::*;
     use rten_tensor::test_util::eq_with_nans;
     use rten_tensor::{Tensor, TensorView};
@@ -222,7 +223,7 @@ mod tests {
         let inputs: Vec<ValueView> = inputs.iter().cloned().map(|i| i.into()).collect();
         let inputs = InputList::from(inputs.as_slice());
         let pool = BufferPool::new();
-        let ctx = OpRunContext::new(&pool, &inputs);
+        let ctx = OpRunContext::new(&pool, &inputs, BitSet::ones(1));
         let mut outputs = op.run(&ctx).unwrap();
         outputs.remove(0).try_into().unwrap()
     }


### PR DESCRIPTION
When running a model we always know how many outputs an operator has, so simplify the type of `OpRunContext::outputs` to a non-optional value. This avoids the ambiguity of what it means when this value was not set - should an operator produce just the first output, or all outputs?