### PR TITLE
Validate operator output counts when deserializing ONNX ops

### DIFF
--- a/src/graph/tests.rs
+++ b/src/graph/tests.rs
@@ -74,6 +74,10 @@ impl<Op: Operator> Operator for TrackUsage<Op> {
         self.inner.max_inputs()
     }
 
+    fn max_outputs(&self) -> Option<usize> {
+        self.inner.max_outputs()
+    }
+
     fn output_types(&self, _ctx: &OutputTypesContext) -> Option<OutputTypeList> {
         self.inner.output_types(_ctx)
     }
@@ -124,6 +128,10 @@ impl<F: Fn(&OpRunContext) -> Result<OutputList, OpError>> Operator for RunFn<F> 
     }
 
     fn max_inputs(&self) -> Option<usize> {
+        None
+    }
+
+    fn max_outputs(&self) -> Option<usize> {
         None
     }
 
@@ -984,6 +992,10 @@ impl Operator for Split {
         Some(1)
     }
 
+    fn max_outputs(&self) -> Option<usize> {
+        Some(2)
+    }
+
     fn output_types(&self, _ctx: &OutputTypesContext) -> Option<OutputTypeList> {
         None
     }
@@ -1271,6 +1283,10 @@ impl Operator for Subgraph {
     }
 
     fn max_inputs(&self) -> Option<usize> {
+        None
+    }
+
+    fn max_outputs(&self) -> Option<usize> {
         None
     }
 

--- a/src/model/onnx_loader.rs
+++ b/src/model/onnx_loader.rs
@@ -1001,11 +1001,11 @@ fn add_operator(
 
     // We set a limit of 32 outputs per operator so we can represent the used
     // positions conveniently in a u32 mask.
-    //
-    // TODO: We should also allow individual operators to declare the maximum
-    // number of outputs they support.
-    let max_outputs = u32::BITS as usize;
-    if outputs.len() >= max_outputs {
+    const MAX_OUTPUTS: usize = u32::BITS as usize;
+
+    let max_outputs = op.max_outputs().unwrap_or(MAX_OUTPUTS).min(MAX_OUTPUTS);
+
+    if outputs.len() > max_outputs {
         return Err(load_error!(
             OperatorInvalid,
             onnx_op.name.as_deref(),
@@ -1459,20 +1459,36 @@ mod tests {
 
     #[test]
     fn test_too_many_outputs_for_operator() {
+        // Test operator-specific limit.
+        let node = create_node("Relu")
+            .with_input("x")
+            .with_output("y0")
+            .with_output("y1")
+            .with_name("relu_op");
+
+        let model_proto = onnx::GraphProto::default()
+            .with_input(create_value_info("x"))
+            .with_node(node)
+            .into_model();
+
+        let err = load_model(model_proto, None).err().unwrap();
+
+        assert_eq!(
+            err.to_string(),
+            "in node \"relu_op\": operator error: operator has 2 outputs but maximum is 1"
+        );
+
+        // Test RTen's implementation limit that applies to all op types.
         let mut node = create_node("Split").with_input("x").with_name("split_op");
 
         for i in 0..33 {
             let name = format!("y_{}", i);
             node = node.with_output(&name);
         }
-
         let graph = onnx::GraphProto::default()
             .with_input(create_value_info("x"))
-            .with_input(create_value_info("y"))
             .with_node(node);
-
         let err = load_model(graph.into_model(), None).err().unwrap();
-
         assert_eq!(
             err.to_string(),
             "in node \"split_op\": operator error: operator has 33 outputs but maximum is 32"

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -378,6 +378,14 @@ pub trait Operator: Any + Debug {
     /// This can return `None` for variadic inputs with no limit.
     fn max_inputs(&self) -> Option<usize>;
 
+    /// Return the maximum number of outputs this operator can produce.
+    ///
+    /// The default is one. Operators can return `None` to indicate no limit
+    /// (eg. for variadic operators).
+    fn max_outputs(&self) -> Option<usize> {
+        Some(1)
+    }
+
     /// Return the rules for determining the types of this operator's outputs.
     fn output_types(&self, ctx: &OutputTypesContext) -> Option<OutputTypeList>;
 

--- a/src/ops/control_flow.rs
+++ b/src/ops/control_flow.rs
@@ -38,6 +38,10 @@ impl Operator for If {
         Some(1)
     }
 
+    fn max_outputs(&self) -> Option<usize> {
+        None
+    }
+
     fn run(&self, _ctx: &OpRunContext) -> Result<OutputList, OpError> {
         Err(OpError::InvalidValue(
             "operator must be run with `run_subgraph`",
@@ -129,6 +133,10 @@ impl Operator for Loop {
     }
 
     fn max_inputs(&self) -> Option<usize> {
+        None
+    }
+
+    fn max_outputs(&self) -> Option<usize> {
         None
     }
 

--- a/src/ops/norm.rs
+++ b/src/ops/norm.rs
@@ -255,6 +255,12 @@ impl Operator for BatchNormalization {
         Some(5)
     }
 
+    fn max_outputs(&self) -> Option<usize> {
+        // ONNX allows additional outputs in training mode (`running_mean`,
+        // `running_var`), but we only support inference.
+        Some(1)
+    }
+
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let inputs = ctx.inputs();
         let input = inputs.require_as(0)?;
@@ -515,6 +521,12 @@ impl Operator for LayerNormalization {
         Some(3)
     }
 
+    fn max_outputs(&self) -> Option<usize> {
+        // ONNX allows optional `Mean` and `InvStdDev` outputs, but we only
+        // produce the normalized output.
+        Some(1)
+    }
+
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let inputs = ctx.inputs();
         let input = inputs.require_as(0)?;
@@ -588,6 +600,10 @@ impl Operator for SkipSimplifiedLayerNormalization {
     }
 
     fn max_inputs(&self) -> Option<usize> {
+        Some(4)
+    }
+
+    fn max_outputs(&self) -> Option<usize> {
         Some(4)
     }
 

--- a/src/ops/pooling.rs
+++ b/src/ops/pooling.rs
@@ -620,6 +620,12 @@ impl Operator for MaxPool {
         Some(1)
     }
 
+    fn max_outputs(&self) -> Option<usize> {
+        // ONNX allows an optional `Indices` output, but we only produce the
+        // pooled output.
+        Some(1)
+    }
+
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let input = ctx.inputs().require_as(0)?;
         max_pool(

--- a/src/ops/quantize.rs
+++ b/src/ops/quantize.rs
@@ -438,6 +438,10 @@ impl Operator for DynamicQuantizeLinear {
         Some(1)
     }
 
+    fn max_outputs(&self) -> Option<usize> {
+        Some(3)
+    }
+
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let input = ctx.inputs().require_as(0)?;
 

--- a/src/ops/random.rs
+++ b/src/ops/random.rs
@@ -311,6 +311,10 @@ impl Operator for Dropout {
         Some(2)
     }
 
+    fn max_outputs(&self) -> Option<usize> {
+        Some(2)
+    }
+
     fn is_deterministic(&self) -> bool {
         self.seed.is_some()
     }

--- a/src/ops/reduce.rs
+++ b/src/ops/reduce.rs
@@ -1175,6 +1175,10 @@ impl Operator for TopK {
         Some(2)
     }
 
+    fn max_outputs(&self) -> Option<usize> {
+        Some(2)
+    }
+
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let inputs = ctx.inputs();
         let values = inputs.require(0)?;

--- a/src/ops/rnn.rs
+++ b/src/ops/rnn.rs
@@ -336,6 +336,10 @@ impl Operator for GRU {
         Some(6)
     }
 
+    fn max_outputs(&self) -> Option<usize> {
+        Some(2)
+    }
+
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let inputs = ctx.inputs();
         let input = inputs.require_as(0)?;
@@ -599,6 +603,10 @@ impl Operator for LSTM {
 
     fn max_inputs(&self) -> Option<usize> {
         Some(7)
+    }
+
+    fn max_outputs(&self) -> Option<usize> {
+        Some(3)
     }
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {

--- a/src/ops/split.rs
+++ b/src/ops/split.rs
@@ -105,6 +105,10 @@ impl Operator for Split {
         Some(2)
     }
 
+    fn max_outputs(&self) -> Option<usize> {
+        None
+    }
+
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let input = ctx.inputs().require(0)?;
 


### PR DESCRIPTION
Add a `Operator::max_outputs` trait method for operators to report the supported number of outputs. When deserializing an operator node, error if the output count exceeds the operator's `max_outputs`.

For some operators the implementation does not currently produce all the optional outputs defined in the spec. In that case `max_outputs` returns the number of _supported_ outputs. This will result in a clear error if attempting to load a model that uses those unimplemented outputs.