### PR TITLE
Ignore trailing unused outputs when checking output count

### DIFF
--- a/src/graph/node.rs
+++ b/src/graph/node.rs
@@ -114,6 +114,17 @@ impl fmt::Debug for Dimension {
     }
 }
 
+/// Trim trailing `None`s from a slice.
+fn trim_none_suffix<T>(mut slice: &[Option<T>]) -> &[Option<T>] {
+    while let Some((last, prefix)) = slice.split_last() {
+        match last {
+            None => slice = prefix,
+            Some(_) => break,
+        }
+    }
+    slice
+}
+
 #[derive(Debug)]
 pub struct OperatorNode {
     name: Option<String>,
@@ -142,6 +153,9 @@ impl OperatorNode {
                 capture_names.extend(subgraph.capture_names().iter().map(|s| s.to_string()));
             }
         }
+
+        // Trim trailing empty IDs
+        let output_ids = trim_none_suffix(output_ids);
 
         // Pre-compute mask of used outputs.
         let mut output_mask = BitSet::ones(output_ids.len() as u32);

--- a/src/graph/tests.rs
+++ b/src/graph/tests.rs
@@ -205,6 +205,31 @@ fn test_graph_run() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
+fn test_op_node_trailing_unused_outputs() {
+    let mut g = Graph::new();
+
+    let input_id = g.add_value(Some("input"), None, None);
+    let relu_out_id = g.add_value(Some("relu_out"), None, None);
+
+    g.add_op(
+        Some("relu"),
+        Arc::new(Relu {}),
+        &[Some(input_id)],
+        // Add operator with unused output IDs. When checking actual vs
+        // expected outputs at runtime, these should be ignored.
+        &[Some(relu_out_id), None, None],
+    );
+
+    g.run(
+        vec![(input_id, Tensor::from(1.).into())],
+        &[relu_out_id],
+        None,
+        None,
+    )
+    .unwrap();
+}
+
+#[test]
 fn test_graph_node_debug_names() {
     let mut g = Graph::new();
 


### PR DESCRIPTION
When testing one of the Qwen models from https://github.com/robertknight/rten/issues/1207, the MultiHeadAttention operators have output lists with three entries, but only the first is non-empty. These got mapped to a 3-entry `Vec<Option<NodeId>>` when the model was loaded, with the last two entries being `None`. When the operator ran, it produced an `OutputList` with only one entry, and a [check in graph.rs](https://github.com/robertknight/rten/blob/656ee32b2263bf9d200f9ebc0498a6b27bcd8108/src/graph.rs#L1147) comparing the actual vs expected output count failed.

The issue is fixed by trimming trailing `None`s when constructing `OperatorNode`s, so `OperatorNode::output_ids` returns a trimmed slice.

The proper fix in future would be to change the `OutputList` type so it can represent unset optional outputs. A mask could then be constructed from this list and compared against `OperatorNode::output_mask`.