### PR TITLE
Add `TensorBase::into_{rank, permuted, owned, shape}` methods

### DIFF
--- a/rten-tensor/src/tensor.rs
+++ b/rten-tensor/src/tensor.rs
@@ -731,6 +731,28 @@ impl<S: Storage, L: Layout> TensorBase<S, L> {
         Some(layout)
     }
 
+    /// Convert this tensor into a tensor with rank `N`.
+    ///
+    /// Returns None if the rank is not N.
+    pub fn into_rank<const N: usize>(self) -> Option<TensorBase<S, NdLayout<N>>> {
+        let layout = self.nd_layout()?;
+        Some(TensorBase {
+            data: self.data,
+            layout,
+        })
+    }
+
+    /// Convert this tensor into one with dimensions re-ordered.
+    pub fn into_permuted(self, order: L::Index<'_>) -> TensorBase<S, L>
+    where
+        L: MutLayout,
+    {
+        TensorBase {
+            layout: self.layout.permuted(order),
+            data: self.data,
+        }
+    }
+
     /// Return a raw pointer to the tensor's underlying data.
     pub fn data_ptr(&self) -> *const S::Elem {
         self.data.as_ptr()

--- a/rten-tensor/src/tensor.rs
+++ b/rten-tensor/src/tensor.rs
@@ -1523,13 +1523,22 @@ impl<'a, T, L: Layout> TensorBase<CowData<'a, T>, L> {
         L: MutLayout,
         T: Clone,
     {
+        self.into_owned_in(GlobalAlloc::new())
+    }
+
+    /// Variant of [`into_owned`](Self) that takes an allocator.
+    pub fn into_owned_in<A: Alloc>(self, alloc: A) -> TensorBase<Vec<T>, L>
+    where
+        L: MutLayout,
+        T: Clone,
+    {
         match self.data {
             CowData::Owned(data) => TensorBase {
                 data,
                 layout: self.layout,
             },
             CowData::Borrowed(_) => {
-                let data = self.to_vec();
+                let data = self.to_vec_in(alloc);
                 let layout = L::from_shape(self.shape());
                 TensorBase { data, layout }
             }

--- a/rten-tensor/src/tensor.rs
+++ b/rten-tensor/src/tensor.rs
@@ -1501,7 +1501,7 @@ impl<T, L: Clone + Layout> TensorBase<Vec<T>, L> {
     }
 }
 
-impl<T, L: Layout> TensorBase<CowData<'_, T>, L> {
+impl<'a, T, L: Layout> TensorBase<CowData<'a, T>, L> {
     /// Consume self and return the underlying data in whatever order the
     /// elements are currently stored, if the storage is owned, or `None` if
     /// it is borrowed.
@@ -1512,6 +1512,72 @@ impl<T, L: Layout> TensorBase<CowData<'_, T>, L> {
                 Some(vec)
             }
             CowData::Borrowed(_) => None,
+        }
+    }
+
+    /// Convert this copy-on-write tensor into an owned tensor.
+    ///
+    /// This is cheap if the data is already owned or requires a copy otherwise.
+    pub fn into_owned(self) -> TensorBase<Vec<T>, L>
+    where
+        L: MutLayout,
+        T: Clone,
+    {
+        match self.data {
+            CowData::Owned(data) => TensorBase {
+                data,
+                layout: self.layout,
+            },
+            CowData::Borrowed(_) => {
+                let data = self.to_vec();
+                let layout = L::from_shape(self.shape());
+                TensorBase { data, layout }
+            }
+        }
+    }
+
+    /// Consume self and return a new contiguous tensor with the given shape.
+    ///
+    /// This avoids copying the data if it is already contiguous.
+    pub fn into_shape<S: Clone + IntoLayout>(
+        self,
+        shape: S,
+    ) -> TensorBase<CowData<'a, T>, S::Layout>
+    where
+        T: Clone,
+        L: MutLayout,
+    {
+        self.into_shape_in(GlobalAlloc::new(), shape)
+    }
+
+    /// Variant of [`into_shape`](Self::into_shape) which takes an allocator.
+    pub fn into_shape_in<A: Alloc, S: Clone + IntoLayout>(
+        self,
+        alloc: A,
+        shape: S,
+    ) -> TensorBase<CowData<'a, T>, S::Layout>
+    where
+        T: Clone,
+        L: MutLayout,
+    {
+        if let Ok(layout) = self.layout.reshaped_for_view(shape.clone()) {
+            TensorBase {
+                data: self.data,
+                layout,
+            }
+        } else {
+            let Ok(layout) = self.layout.reshaped_for_copy(shape.clone()) else {
+                panic!(
+                    "element count mismatch reshaping {:?} to {:?}",
+                    self.shape(),
+                    shape
+                );
+            };
+
+            TensorBase {
+                data: CowData::Owned(self.to_vec_in(alloc)),
+                layout,
+            }
         }
     }
 }

--- a/rten-tensor/src/tensor/tests.rs
+++ b/rten-tensor/src/tensor/tests.rs
@@ -874,6 +874,50 @@ fn test_into_dyn() {
 }
 
 #[test]
+fn test_into_owned() {
+    // Borrowed data is copied into an owned tensor.
+    let tensor = NdTensor::from_data([2, 2], vec![1, 2, 3, 4]);
+    let owned = tensor.as_cow().into_owned();
+    assert_eq!(owned.shape(), [2, 2]);
+    assert_eq!(owned.data(), Some([1, 2, 3, 4].as_slice()));
+
+    // Borrowed non-contiguous data is copied in logical order.
+    let mut tensor = NdTensor::from_data([2, 2], vec![1, 2, 3, 4]);
+    tensor.transpose();
+    let owned = tensor.as_cow().into_owned();
+    assert_eq!(owned.shape(), [2, 2]);
+    assert_eq!(owned.data(), Some([1, 3, 2, 4].as_slice()));
+
+    // Owned data is preserved without copying.
+    let tensor = NdTensor::from_data([2, 2], vec![1, 2, 3, 4]);
+    let ptr = tensor.data().unwrap().as_ptr();
+    let owned = tensor.into_cow().into_owned();
+    assert_eq!(owned.shape(), [2, 2]);
+    assert_eq!(owned.data().unwrap().as_ptr(), ptr);
+}
+
+#[test]
+fn test_into_permuted() {
+    let tensor = NdTensor::from_data([2, 3], vec![1, 2, 3, 4, 5, 6]);
+    let permuted = tensor.into_permuted([1, 0]);
+    assert_eq!(permuted.shape(), [3, 2]);
+    assert_eq!(permuted.to_vec(), &[1, 4, 2, 5, 3, 6]);
+}
+
+#[test]
+fn test_into_rank() {
+    let tensor = Tensor::from_data(&[2, 2], vec![1, 2, 3, 4]);
+
+    // Converting to the matching rank succeeds and preserves the data.
+    let nd = tensor.clone().into_rank::<2>().unwrap();
+    assert_eq!(nd.shape(), [2, 2]);
+    assert_eq!(nd.data(), Some([1, 2, 3, 4].as_slice()));
+
+    // Converting to a different rank returns `None`.
+    assert!(tensor.into_rank::<3>().is_none());
+}
+
+#[test]
 fn test_into_shape() {
     // Contiguous tensor.
     let tensor = NdTensor::from_data([2, 2], vec![1., 2., 3., 4.]);
@@ -887,6 +931,48 @@ fn test_into_shape() {
     let reshaped = tensor.into_shape([4]);
     assert_eq!(reshaped.shape(), [4]);
     assert_eq!(reshaped.data(), Some([1., 3., 2., 4.].as_slice()));
+}
+
+#[test]
+fn test_into_shape_cow() {
+    // Contiguous tensor is reshaped without copying.
+    let tensor = NdTensor::from_data([2, 2], vec![1, 2, 3, 4]);
+    let ptr = tensor.data().unwrap().as_ptr();
+    let reshaped = tensor.into_cow().into_shape([4]);
+    assert_eq!(reshaped.shape(), [4]);
+    assert_eq!(reshaped.data().unwrap().as_ptr(), ptr);
+
+    // Non-contiguous tensor is copied into logical order.
+    let mut tensor = NdTensor::from_data([2, 2], vec![1, 2, 3, 4]);
+    tensor.transpose();
+    let reshaped = tensor.into_cow().into_shape([4]);
+    assert_eq!(reshaped.shape(), [4]);
+    assert_eq!(reshaped.data(), Some([1, 3, 2, 4].as_slice()));
+}
+
+#[test]
+#[should_panic(expected = "element count mismatch reshaping [16] to [2, 2]")]
+fn test_into_shape_cow_invalid() {
+    NdTensor::arange(0, 16, None).into_cow().into_shape([2, 2]);
+}
+
+#[test]
+fn test_into_shape_in() {
+    let alloc = FakeAlloc::new();
+
+    // A contiguous reshape can re-use the existing storage.
+    let tensor = NdTensor::arange(0, 4, None);
+    let reshaped = tensor.into_cow().into_shape_in(&alloc, [2, 2]);
+    assert_eq!(reshaped.shape(), [2, 2]);
+    assert_eq!(alloc.count(), 0);
+
+    // A non-contiguous reshape allocates once via the supplied allocator.
+    let mut tensor = NdTensor::arange(0, 4, None).into_shape([2, 2]);
+    tensor.transpose();
+    let reshaped = tensor.into_cow().into_shape_in(&alloc, [4]);
+    assert_eq!(reshaped.shape(), [4]);
+    assert_eq!(reshaped.data(), Some([0, 2, 1, 3].as_slice()));
+    assert_eq!(alloc.count(), 1);
 }
 
 #[test]


### PR DESCRIPTION
Add some additional tensor methods that are useful for working with maybe-owned tensors (`CowNdTensor` etc.).

Available for all storage and layout types:

- `into_rank` converts a dynamic-rank tensor to static rank
- `into_permuted` re-orders dimensions

Available for tensors with maybe-owned storage:

- `into_owned` converts a maybe-owned tensor to owned
- `into_shape` is added for maybe-owned tensors. Previously it was only available for owned.