### PR TITLE
Make `TensorBase::into_rank` return a result instead of an option

### DIFF
--- a/rten-tensor/src/tensor.rs
+++ b/rten-tensor/src/tensor.rs
@@ -720,23 +720,24 @@ impl<S: Storage, L: Layout> TensorBase<S, L> {
 
     /// Attempt to convert this tensor's layout to a static-rank layout with `N`
     /// dimensions.
-    fn nd_layout<const N: usize>(&self) -> Option<NdLayout<N>> {
+    fn nd_layout<const N: usize>(&self) -> Result<NdLayout<N>, DimensionError> {
         if self.ndim() != N {
-            return None;
+            return Err(DimensionError {
+                actual: self.ndim(),
+                expected: N,
+            });
         }
         let shape: [usize; N] = std::array::from_fn(|i| self.size(i));
         let strides: [usize; N] = std::array::from_fn(|i| self.stride(i));
         let layout = NdLayout::from_shape_and_strides(shape, strides, OverlapPolicy::AllowOverlap)
             .expect("invalid layout");
-        Some(layout)
+        Ok(layout)
     }
 
     /// Convert this tensor into a tensor with rank `N`.
-    ///
-    /// Returns None if the rank is not N.
-    pub fn into_rank<const N: usize>(self) -> Option<TensorBase<S, NdLayout<N>>> {
+    pub fn into_rank<const N: usize>(self) -> Result<TensorBase<S, NdLayout<N>>, DimensionError> {
         let layout = self.nd_layout()?;
-        Some(TensorBase {
+        Ok(TensorBase {
             data: self.data,
             layout,
         })

--- a/rten-tensor/src/tensor/tests.rs
+++ b/rten-tensor/src/tensor/tests.rs
@@ -6,7 +6,7 @@ use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
 use super::{AsView, NdTensor, NdTensorView, NdTensorViewMut, Tensor, TensorView};
-use crate::errors::{ExpandError, FromDataError};
+use crate::errors::{DimensionError, ExpandError, FromDataError};
 use crate::layout::{DynLayout, MatrixLayout, MutLayout};
 use crate::prelude::*;
 use crate::rng::XorShiftRng;
@@ -914,7 +914,13 @@ fn test_into_rank() {
     assert_eq!(nd.data(), Some([1, 2, 3, 4].as_slice()));
 
     // Converting to a different rank returns `None`.
-    assert!(tensor.into_rank::<3>().is_none());
+    assert_eq!(
+        tensor.into_rank::<3>(),
+        Err(DimensionError {
+            actual: 2,
+            expected: 3
+        })
+    );
 }
 
 #[test]

--- a/src/ops/attention.rs
+++ b/src/ops/attention.rs
@@ -587,12 +587,12 @@ impl Operator for MultiHeadAttention {
                 }
                 key = concat(ctx.pool(), &[past_key.as_dyn(), key.as_dyn()], 2)?
                     .into_rank::<4>()
-                    .expect("should have rank 4")
+                    .unwrap()
                     .into_cow()
                     .auto_return(ctx.pool());
                 value = concat(ctx.pool(), &[past_value.as_dyn(), value.as_dyn()], 2)?
                     .into_rank::<4>()
-                    .expect("should have rank 4")
+                    .unwrap()
                     .into_cow()
                     .auto_return(ctx.pool());
             }
@@ -685,7 +685,7 @@ impl Operator for MultiHeadAttention {
         // Compute attention outputs.
         let context = matmul(ctx.pool(), scores.as_dyn(), value.as_dyn(), None)?
             .into_rank::<4>()
-            .expect("should have rank 4")
+            .unwrap()
             .auto_return(ctx.pool());
         let output = context
             .permuted([0, 2, 1, 3])


### PR DESCRIPTION
This is more convenient for consumers as, in the event of a rank mismatch, `unwrap()` will produce a more helpful error that includes both the actual and expected dimension count.