### PR TITLE
Generalize MatMulIntegerToFloat fusion

### DIFF
--- a/src/ops/matmul.rs
+++ b/src/ops/matmul.rs
@@ -706,29 +706,47 @@ impl Operator for MatMulInteger {
     }
 }
 
+#[derive(Clone, Debug)]
+enum OutputScale<'a> {
+    Scalar(f32),
+    Vector(NdTensorView<'a, f32, 1>),
+}
+
 /// Cast elements in `data` to f32 and scale by the per-column scales in `scale`.
 fn cast_scale(
     pool: &BufferPool,
     mut data: Tensor<i32>,
-    scale: NdTensorView<f32, 1>,
+    scale: OutputScale,
 ) -> Result<Tensor<f32>, OpError> {
-    if data.size(data.ndim() - 1) != scale.size(0) {
-        return Err(OpError::IncompatibleInputShapes(
-            "Scale length does not match tensor columns",
-        ));
-    }
+    match scale {
+        OutputScale::Vector(scale) => {
+            if data.size(data.ndim() - 1) != scale.size(0) {
+                return Err(OpError::IncompatibleInputShapes(
+                    "Scale length does not match tensor columns",
+                ));
+            }
 
-    let scale = scale.to_contiguous_in(pool);
-    let scale_data = scale.data();
+            let scale = scale.to_contiguous_in(pool);
+            let scale_data = scale.data();
 
-    // Convert i32 elements to f32 in-place and multiply by column scale.
-    let output_data = data.data_mut().expect("should be contiguous");
-    output_data.par_chunks_mut(scale.len()).for_each(|chunk| {
-        for (el, scale) in chunk.iter_mut().zip(scale_data) {
-            let scaled = *el as f32 * scale;
-            *el = scaled.cast_bytes();
+            // Convert i32 elements to f32 in-place and multiply by column scale.
+            let output_data = data.data_mut().expect("should be contiguous");
+            output_data.par_chunks_mut(scale.len()).for_each(|chunk| {
+                for (el, scale) in chunk.iter_mut().zip(scale_data) {
+                    let scaled = *el as f32 * scale;
+                    *el = scaled.cast_bytes();
+                }
+            });
         }
-    });
+        OutputScale::Scalar(scale) => {
+            // Convert i32 elements to f32 in-place and multiply by column scale.
+            let output_data = data.data_mut().expect("should be contiguous");
+            output_data.par_iter_mut().for_each(|el| {
+                let scaled = *el as f32 * scale;
+                *el = scaled.cast_bytes();
+            });
+        }
+    }
 
     // Transmute tensor from i32 to f32.
     let shape = data.shape().to_vec();
@@ -751,8 +769,15 @@ impl Operator for MatMulIntegerToFloat {
     }
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+        let scale: TensorView<f32> = ctx.inputs().require_as(4)?;
+        let scale = match scale.ndim() {
+            0 => OutputScale::Scalar(scale.item().copied().unwrap()),
+            1 => OutputScale::Vector(scale.into_rank().unwrap()),
+            _ => {
+                return Err(OpError::InvalidValue("scale should have rank 0 or 1"));
+            }
+        };
         let output: Tensor<i32> = self.matmul.run(ctx)?.remove(0).try_into().unwrap();
-        let scale = ctx.inputs().require_as(4)?;
         cast_scale(ctx.pool(), output, scale).into_op_result()
     }
 
@@ -972,7 +997,8 @@ mod tests {
 
     use super::{
         AccuracyLevel, FusedMatMul, MatMul, MatMulInteger, MatMulNBits, MatmulStrategy, OpError,
-        OpRunContext, cast_scale, gemm, matmul, matmul_fused, matmul_impl, matmul_integer,
+        OpRunContext, OutputScale, cast_scale, gemm, matmul, matmul_fused, matmul_impl,
+        matmul_integer,
     };
 
     fn gemm_tensors(c: &mut Tensor, a: &Tensor, b: &Tensor, alpha: f32, beta: f32) {
@@ -1084,21 +1110,26 @@ mod tests {
     #[test]
     fn test_cast_scale() {
         #[derive(Debug)]
-        struct Case {
+        struct Case<'a> {
             input: Tensor<i32>,
-            scales: NdTensor<f32, 1>,
+            scales: OutputScale<'a>,
             expected: Result<Tensor<f32>, OpError>,
         }
 
         let cases = [
             Case {
                 input: [[1, 2], [3, 4]].into(),
-                scales: [2., 3.].into(),
+                scales: OutputScale::Vector(NdTensorView::from(&[2., 3.])),
                 expected: Ok([[2., 6.], [6., 12.]].into()),
             },
             Case {
                 input: [[1, 2], [3, 4]].into(),
-                scales: [2., 3., 4.].into(),
+                scales: OutputScale::Scalar(2.),
+                expected: Ok([[2., 4.], [6., 8.]].into()),
+            },
+            Case {
+                input: [[1, 2], [3, 4]].into(),
+                scales: OutputScale::Vector(NdTensorView::from(&[2., 3., 4.])),
                 expected: Err(OpError::IncompatibleInputShapes(
                     "Scale length does not match tensor columns",
                 )),
@@ -1107,7 +1138,7 @@ mod tests {
 
         cases.test_each(|case| {
             let pool = BufferPool::new();
-            let result = cast_scale(&pool, case.input.clone(), case.scales.view());
+            let result = cast_scale(&pool, case.input.clone(), case.scales.clone());
             assert_eq!(result, case.expected);
         });
     }

--- a/src/optimize/fusions.rs
+++ b/src/optimize/fusions.rs
@@ -14,9 +14,9 @@ use crate::graph::{
 use crate::operator::Operator;
 use crate::ops::transform_inputs::TransformInputsBuilder;
 use crate::ops::{
-    AddSoftmax, Cast, ComputeShape, Conv, DynamicQuantizeLinear, FusedMatMul, Gelu,
-    GroupedQueryAttentionMatMul, LayerNormalization, MatMulIntegerToFloat, Mul, RMSNormalization,
-    Reciprocal, ReduceMean, RepeatInterleave, Shape, Silu, Softmax, Swish, SymbolInfo, Transpose,
+    AddSoftmax, Cast, ComputeShape, Conv, FusedMatMul, Gelu, GroupedQueryAttentionMatMul,
+    LayerNormalization, MatMulIntegerToFloat, RMSNormalization, Reciprocal, ReduceMean,
+    RepeatInterleave, Shape, Silu, Softmax, Swish, SymbolInfo, Transpose,
 };
 use crate::optimize::pattern_matcher::{Match, Pattern};
 use crate::value::ValueType;
@@ -990,48 +990,16 @@ impl PatternFusion for MatMulIntegerToFloatFusion {
     }
 
     fn maybe_fuse(&self, pat_match: &Match, graph: &Graph) -> Result<Self::Operator, FusionError> {
-        let a = pat_match.node_id("a").unwrap();
-        let a_zero = pat_match.node_id("a_zero").unwrap();
-
-        // Check that the candidate inputs are all outputs from a
-        // DynamicQuantizeLinear node. This allows us to be sure that the
-        // inputs will have the expected shape.
-        let (a_src_id, quantize_op) = graph.get_source_node(a).ok_or(FusionError::NoMatch)?;
-        let (a_zero_src_id, _) = graph.get_source_node(a_zero).ok_or(FusionError::NoMatch)?;
-
-        let [
-            Some(quant_out_data),
-            Some(quant_out_scale),
-            Some(quant_out_zero),
-        ] = quantize_op.output_ids()
-        else {
-            return Err(FusionError::NoMatch);
-        };
-
-        // The data and zero point should come from the same DynamicQuantizeLinear op.
-        if a_src_id != a_zero_src_id
-            || quantize_op
-                .operator()
-                .downcast_ref::<DynamicQuantizeLinear>()
-                .is_none()
-            || a != *quant_out_data
-            || a_zero != *quant_out_zero
-        {
-            return Err(FusionError::NoMatch);
-        }
-
-        // The scale should come from `Mul(dyn_scale, const_scale)` where
-        // `dyn_scale` is the scale output of the DynamicQuantizeLinear op and
-        // `const_scale` is a vector.
         let scale = pat_match.node_id("scale").unwrap();
-        let (_, scale_src) = graph.get_source_node(scale).ok_or(FusionError::NoMatch)?;
-        let [Some(dyn_scale), Some(const_scale)] = scale_src.input_ids() else {
-            return Err(FusionError::NoMatch);
-        };
-        if scale_src.operator().downcast_ref::<Mul>().is_none()
-            || graph.get_rank(*const_scale) != Some(1)
-            || quant_out_scale != dyn_scale
-        {
+        let scale_shape = graph
+            .get_node(scale)
+            .ok_or(FusionError::NoMatch)?
+            .shape()
+            .ok_or(FusionError::CheckFailed("unknown scale shape"))?;
+
+        // Fusion supports scalar or vector scale which can be broadcast to
+        // MatMulInteger output shape.
+        if scale_shape.len() > 1 {
             return Err(FusionError::NoMatch);
         }
 

--- a/src/optimize/tests.rs
+++ b/src/optimize/tests.rs
@@ -27,6 +27,18 @@ fn optimize_graph(graph: Graph) -> Result<Graph, OptimizeError> {
     optimizer.optimize(graph, None, OptimizeOptions::default())
 }
 
+fn optimize_graph_infer_shapes(graph: Graph) -> Result<Graph, OptimizeError> {
+    let optimizer = GraphOptimizer::new();
+    optimizer.optimize(
+        graph,
+        None,
+        OptimizeOptions {
+            infer_shapes: Some(InferShapeOptions { strict: false }),
+            ..Default::default()
+        },
+    )
+}
+
 fn arc_tensor_view(val: f32) -> ArcTensorView<f32> {
     let const_data = Vec::from(val.to_le_bytes());
     let const_storage = Arc::new(ConstantStorage::Buffer(const_data));
@@ -878,7 +890,11 @@ fn test_fuse_matmulinteger_cast_scale() {
         let quant = x.apply(
             DynamicQuantizeLinear {},
             &[],
-            &[OutputMeta::NoMeta, OutputMeta::NoMeta, OutputMeta::NoMeta],
+            &[
+                OutputMeta::NoMeta,
+                OutputMeta::Meta((DataType::Float, vec![])),
+                OutputMeta::NoMeta,
+            ],
         );
         let quant_x = quant.output(0);
         let quant_scale = quant.output(1);
@@ -898,7 +914,7 @@ fn test_fuse_matmulinteger_cast_scale() {
         expr.build_graph(["x"])
     };
 
-    let graph = optimize_graph(graph).unwrap();
+    let graph = optimize_graph_infer_shapes(graph).unwrap();
     let (_, op) = graph.get_source_node(graph.output_ids()[0]).unwrap();
 
     assert_eq!(op.operator().name(), "MatMulIntegerToFloat");


### PR DESCRIPTION
Generalize the fusion for `Mul(Cast<f32>(MatMulInteger(...)), scale)` to work when `scale` is a scalar or vector (previously it had to be a vector) and regardless of how `scale` was produced. Previously the fusion only worked when `scale` was specifically derived from `DynamicQuantizeLinear`, in order to know that it had the right shape. Now instead we rely on shape inference to confirm the rank. We don't verify the dimension size for the vector case under the assumption that the `Mul` would have failed if it was wrong, and the fused operation will also return an error in this case. This does mean enabling the fusion might require enabling shape inference when loading the model, whereas it didn't before.

This change enables the fusion to work in the quantized models from #1207.