### PR TITLE
Enable shape inference by default

### DIFF
--- a/rten-cli/src/main.rs
+++ b/rten-cli/src/main.rs
@@ -42,8 +42,7 @@ struct Args {
     #[argh(option)]
     check_outputs: Option<String>,
 
-    /// run shape and type inference (experimental). This can enable more
-    /// optimizations (see https://github.com/robertknight/rten/pull/1124).
+    /// set shape and type inference mode.
     ///
     /// Can be "off", "on" (best-effort) or "strict". If "strict", model will
     /// fail to load if shape inference is not complete.
@@ -102,8 +101,8 @@ struct Args {
 
 #[derive(Clone, Copy, Default, PartialEq)]
 enum InferShapesMode {
-    #[default]
     Off,
+    #[default] // Matches ModelOptions defaults.
     On,
     Strict,
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -693,7 +693,7 @@ impl ModelOptions {
             optimize: true,
             prepack_weights: false,
             external_data: HashMap::new(),
-            infer_shapes: ShapeInferenceMode::Off,
+            infer_shapes: ShapeInferenceMode::On,
         }
     }
 
@@ -718,9 +718,12 @@ impl ModelOptions {
 
     /// Set whether shape and type inference is run as part of optimization.
     ///
-    /// This is an experimental option that is needed to enable certain more
-    /// complex fusions to work. It will eventually be enabled by default. See
-    /// <https://github.com/robertknight/rten/pull/1124>.
+    /// Shape inference is needed for some optimizations in order to verify that
+    /// they are safe, by checking the shape and/or type of various values. By
+    /// default shape inference is [enabled](ShapeInferenceMode::On) but will
+    /// fail gracefully if the shapes of some values cannot be inferred. To
+    /// enforce that shape inference is fully successful, [strict
+    /// mode](ShapeInferenceMode::Strict) can be enabled.
     pub fn shape_inference(&mut self, mode: ShapeInferenceMode) -> &mut Self {
         self.infer_shapes = mode;
         self


### PR DESCRIPTION
Shape and type inference is now more mature, so enable it by default in best-effort mode. This ensures that models are loaded with all available optimizations by default.

If shape inference causes issues, consumers can disable it via `ModelOptions::shape_inference(ShapeInferenceMode::Off)`.