### PR TITLE
Handle all outputs in SkipSimplifiedLayerNormalization shape inference

### DIFF
--- a/rten-shape-inference/src/ops.rs
+++ b/rten-shape-inference/src/ops.rs
@@ -510,6 +510,37 @@ impl InferShapes for Range {
     }
 }
 
+/// SkipSimplifiedLayerNormalization operator.
+///
+/// See <https://github.com/microsoft/onnxruntime/blob/main/docs/ContribOperators.md#com.microsoft.SkipSimplifiedLayerNormalization>.
+pub struct SkipSimplifiedLayerNormalization;
+
+impl InferShapes for SkipSimplifiedLayerNormalization {
+    fn infer_shapes(
+        &self,
+        inputs: &[SymTensor],
+        _sym_gen: &mut SymbolGen,
+    ) -> Result<Vec<SymTensor>, InferShapesError> {
+        let Some(data) = inputs.first() else {
+            return Err(InferShapesError::IncorrectInputCount);
+        };
+
+        let shape = if let Some(dims) = data.shape() {
+            SymTensor::from_shape(dims.collect())
+        } else {
+            SymTensor::unknown("unknown input shape")
+        };
+
+        // Outputs are `output`, `mean`, `inv_std_var` and `input_skip_bias_sum`.
+        //
+        // `output` and `input_skip_bias_sum` have the same shape as the input.
+        // `mean` and `inv_std_var` are not computed by the rten implementation
+        // and are returned as empty placeholders.
+        let placeholder = SymTensor::from_fixed_shape(&[0]);
+        Ok([shape.clone(), placeholder.clone(), placeholder, shape].into())
+    }
+}
+
 /// TopK operator.
 ///
 /// See <https://onnx.ai/onnx/operators/onnx__TopK.html>.
@@ -624,8 +655,8 @@ mod tests {
 
     use super::{
         ConstantOfShape, Dropout, DynamicQuantizeLinear, FixedShape, Gather, GatherElements,
-        GatherND, GridSample, Identity, Multinomial, NonMaxSuppression, NonZero, Range, TopK,
-        Where,
+        GatherND, GridSample, Identity, Multinomial, NonMaxSuppression, NonZero, Range,
+        SkipSimplifiedLayerNormalization, TopK, Where,
     };
 
     #[test]
@@ -713,6 +744,44 @@ mod tests {
             .infer_shapes(&[data], &mut sym_gen)
             .err();
         assert_eq!(err, Some(InferShapesError::IncorrectRank));
+    }
+
+    #[test]
+    fn test_skip_simplified_layer_normalization() {
+        let mut sym_gen = SymbolGen::new();
+
+        // `output` and `input_skip_bias_sum` match the input shape, while
+        // `mean` and `inv_std_var` are empty placeholders.
+        let data = sym_shape!("batch", "seq", 32);
+        let result = SkipSimplifiedLayerNormalization
+            .infer_shapes(&[data], &mut sym_gen)
+            .unwrap();
+        assert_eq!(
+            result,
+            &[
+                sym_shape!("batch", "seq", 32),
+                sym_shape!(0),
+                sym_shape!(0),
+                sym_shape!("batch", "seq", 32),
+            ]
+        );
+
+        // Unknown input shape.
+        let data = SymTensor::unknown("unknown");
+        let result = SkipSimplifiedLayerNormalization
+            .infer_shapes(&[data], &mut sym_gen)
+            .unwrap();
+        assert_eq!(result.len(), 4);
+        assert_eq!(result[0].ndim(), None);
+        assert_eq!(result[1], sym_shape!(0));
+        assert_eq!(result[2], sym_shape!(0));
+        assert_eq!(result[3].ndim(), None);
+
+        // Missing input.
+        let err = SkipSimplifiedLayerNormalization
+            .infer_shapes(&[], &mut sym_gen)
+            .err();
+        assert_eq!(err, Some(InferShapesError::IncorrectInputCount));
     }
 
     #[test]

--- a/src/ops/norm.rs
+++ b/src/ops/norm.rs
@@ -2,6 +2,7 @@ use std::mem::MaybeUninit;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use rayon::prelude::*;
+use rten_shape_inference::ops as shape_ops;
 use rten_simd::SimdOp;
 use rten_tensor::prelude::*;
 use rten_tensor::{NdTensorView, Tensor, TensorView};
@@ -652,12 +653,18 @@ impl Operator for SkipSimplifiedLayerNormalization {
         Ok(outputs)
     }
 
-    fn output_types(&self, _ctx: &OutputTypesContext) -> Option<OutputTypeList> {
-        Some([OutputType::CopyFromInput(0)].into())
+    fn output_types(&self, ctx: &OutputTypesContext) -> Option<OutputTypeList> {
+        let mut types = OutputTypeList::from([OutputType::CopyFromInput(0)]);
+        if ctx.num_outputs > 1 {
+            types.push(OutputType::CopyFromInput(0));
+            types.push(OutputType::CopyFromInput(0));
+            types.push(OutputType::CopyFromInput(0));
+        }
+        Some(types)
     }
 
     fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
-        Some(&UnaryOp)
+        Some(&shape_ops::SkipSimplifiedLayerNormalization)
     }
 }
 


### PR DESCRIPTION
This op previously used UnaryOp for shape inference, which only produced a shape for the first output. Add a dedicated `SkipSimplifiedLayerNormalization` shape inference impl that handles all four outputs: `output` and `input_skip_bias_sum` take the input shape, while the `mean` and `inv_std_var` placeholders are empty.

Also update type inference to return types for all outputs.