### PR TITLE
Pin rten-convert dependency versions in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
       run: |
         source .venv/bin/activate
         cd rten-convert
-        pip install -e .
-        pip install -r requirements.dev.txt
+        pip install -e . -c constraints.txt
+        pip install -r requirements.dev.txt -c constraints.txt
         make check
       if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/rten-convert/constraints.txt
+++ b/rten-convert/constraints.txt
@@ -1,0 +1,4 @@
+# Pinned versions of rten-convert's runtime dependencies, used in CI.
+flatbuffers==25.12.19
+numpy==2.4.0
+onnx==1.22.0


### PR DESCRIPTION
Add a pip constraints file pinning the runtime dependencies and use it in CI. This resolves an issue where typechecking broke after the recent numpy 2.5.0 release (see [logs](https://github.com/robertknight/rten/actions/runs/27936419733/job/82659068932?pr=1299))