### PR TITLE
Support Scatter, Upsample and RotaryEmbedding in .rten format

### DIFF
--- a/rten-convert/rten_convert/attr_reader.py
+++ b/rten-convert/rten_convert/attr_reader.py
@@ -188,6 +188,10 @@ class AttributeReader:
             case "ints":
                 shape = [len(attr_val)]
                 data = np.array([attr_val]).astype(np.int32)
+
+            case "floats":
+                shape = [len(attr_val)]
+                data = np.array(attr_val).astype(np.float32)
             case _:
                 raise ConversionError(
                     f'Unable to generate input from "{attr_name}" attribute of type "{attr_type}"'

--- a/rten-convert/rten_convert/converter.py
+++ b/rten-convert/rten_convert/converter.py
@@ -726,6 +726,19 @@ def op_node_from_onnx_operator(
             if output_dtype is not None:
                 attrs.outputDtype = convert_data_type(output_dtype)
 
+        case "RotaryEmbedding":
+            attrs = sg.RotaryEmbeddingAttrsT()
+            attrs.interleaved = attr_reader.get_bool_attr("interleaved", False)
+            attrs.numHeads = attr_reader.get_attr("num_heads", "int", 0)
+            attrs.rotaryEmbeddingDim = attr_reader.get_attr(
+                "rotary_embedding_dim", "int", 0
+            )
+
+        case "Scatter":
+            # Deprecated alias for ScatterElements without a reduction.
+            attrs = sg.ScatterElementsAttrsT()
+            attrs.axis = attr_reader.get_attr("axis", "int", 0)
+
         case "ScatterElements":
             attrs = sg.ScatterElementsAttrsT()
             attrs.axis = attr_reader.get_attr("axis", "int", 0)
@@ -799,6 +812,14 @@ def op_node_from_onnx_operator(
 
         case "Unsqueeze":
             attr_reader.generate_input_from_attr(1, "axes", "ints")
+
+        case "Upsample":
+            attrs = sg.UpsampleAttrsT()
+            attrs.mode = attr_reader.get_enum_attr("mode", sg.ResizeMode, "nearest")
+
+            # `scales` was a required attribute in opset 7 and became the second
+            # input in opset 9.
+            attr_reader.generate_input_from_attr(1, "scales", "floats")
 
     if not hasattr(sg.OperatorType, op_type):
         raise UnsupportedOperatorError(op_type)

--- a/rten-convert/rten_convert/schema_generated.py
+++ b/rten-convert/rten_convert/schema_generated.py
@@ -145,6 +145,9 @@ class OperatorType(object):
     Multinomial = 135
     ReverseSequence = 136
     DFT = 137
+    Scatter = 138
+    Upsample = 139
+    RotaryEmbedding = 140
 
 
 class RNNDirection(object):
@@ -243,6 +246,8 @@ class OperatorAttrs(object):
     MultinomialAttrs = 55
     ReverseSequenceAttrs = 56
     DFTAttrs = 57
+    UpsampleAttrs = 58
+    RotaryEmbeddingAttrs = 59
 
 def OperatorAttrsCreator(unionType, table):
     from flatbuffers.table import Table
@@ -362,6 +367,10 @@ def OperatorAttrsCreator(unionType, table):
         return ReverseSequenceAttrsT.InitFromBuf(table.Bytes, table.Pos)
     if unionType == OperatorAttrs.DFTAttrs:
         return DFTAttrsT.InitFromBuf(table.Bytes, table.Pos)
+    if unionType == OperatorAttrs.UpsampleAttrs:
+        return UpsampleAttrsT.InitFromBuf(table.Bytes, table.Pos)
+    if unionType == OperatorAttrs.RotaryEmbeddingAttrs:
+        return RotaryEmbeddingAttrsT.InitFromBuf(table.Bytes, table.Pos)
     return None
 
 
@@ -5609,6 +5618,194 @@ class ScatterNDAttrsT(object):
         return scatterNdattrs
 
 
+class UpsampleAttrs(object):
+    __slots__ = ['_tab']
+
+    @classmethod
+    def GetRootAs(cls, buf, offset=0):
+        n = flatbuffers.encode.Get(flatbuffers.packer.uoffset, buf, offset)
+        x = UpsampleAttrs()
+        x.Init(buf, n + offset)
+        return x
+
+    @classmethod
+    def GetRootAsUpsampleAttrs(cls, buf, offset=0):
+        """This method is deprecated. Please switch to GetRootAs."""
+        return cls.GetRootAs(buf, offset)
+    @classmethod
+    def UpsampleAttrsBufferHasIdentifier(cls, buf, offset, size_prefixed=False):
+        return flatbuffers.util.BufferHasIdentifier(buf, offset, b"\x52\x54\x45\x4E", size_prefixed=size_prefixed)
+
+    # UpsampleAttrs
+    def Init(self, buf, pos):
+        self._tab = flatbuffers.table.Table(buf, pos)
+
+    # UpsampleAttrs
+    def Mode(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
+        if o != 0:
+            return self._tab.Get(flatbuffers.number_types.Uint8Flags, o + self._tab.Pos)
+        return 0
+
+def UpsampleAttrsStart(builder):
+    builder.StartObject(1)
+
+def UpsampleAttrsAddMode(builder, mode):
+    builder.PrependUint8Slot(0, mode, 0)
+
+def UpsampleAttrsEnd(builder):
+    return builder.EndObject()
+
+
+
+class UpsampleAttrsT(object):
+
+    # UpsampleAttrsT
+    def __init__(
+        self,
+        mode = 0,
+    ):
+        self.mode = mode  # type: int
+
+    @classmethod
+    def InitFromBuf(cls, buf, pos):
+        upsampleAttrs = UpsampleAttrs()
+        upsampleAttrs.Init(buf, pos)
+        return cls.InitFromObj(upsampleAttrs)
+
+    @classmethod
+    def InitFromPackedBuf(cls, buf, pos=0):
+        n = flatbuffers.encode.Get(flatbuffers.packer.uoffset, buf, pos)
+        return cls.InitFromBuf(buf, pos+n)
+
+    @classmethod
+    def InitFromObj(cls, upsampleAttrs):
+        x = UpsampleAttrsT()
+        x._UnPack(upsampleAttrs)
+        return x
+
+    # UpsampleAttrsT
+    def _UnPack(self, upsampleAttrs):
+        if upsampleAttrs is None:
+            return
+        self.mode = upsampleAttrs.Mode()
+
+    # UpsampleAttrsT
+    def Pack(self, builder):
+        UpsampleAttrsStart(builder)
+        UpsampleAttrsAddMode(builder, self.mode)
+        upsampleAttrs = UpsampleAttrsEnd(builder)
+        return upsampleAttrs
+
+
+class RotaryEmbeddingAttrs(object):
+    __slots__ = ['_tab']
+
+    @classmethod
+    def GetRootAs(cls, buf, offset=0):
+        n = flatbuffers.encode.Get(flatbuffers.packer.uoffset, buf, offset)
+        x = RotaryEmbeddingAttrs()
+        x.Init(buf, n + offset)
+        return x
+
+    @classmethod
+    def GetRootAsRotaryEmbeddingAttrs(cls, buf, offset=0):
+        """This method is deprecated. Please switch to GetRootAs."""
+        return cls.GetRootAs(buf, offset)
+    @classmethod
+    def RotaryEmbeddingAttrsBufferHasIdentifier(cls, buf, offset, size_prefixed=False):
+        return flatbuffers.util.BufferHasIdentifier(buf, offset, b"\x52\x54\x45\x4E", size_prefixed=size_prefixed)
+
+    # RotaryEmbeddingAttrs
+    def Init(self, buf, pos):
+        self._tab = flatbuffers.table.Table(buf, pos)
+
+    # RotaryEmbeddingAttrs
+    def Interleaved(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
+        if o != 0:
+            return bool(self._tab.Get(flatbuffers.number_types.BoolFlags, o + self._tab.Pos))
+        return False
+
+    # RotaryEmbeddingAttrs
+    def NumHeads(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(6))
+        if o != 0:
+            return self._tab.Get(flatbuffers.number_types.Uint32Flags, o + self._tab.Pos)
+        return 0
+
+    # RotaryEmbeddingAttrs
+    def RotaryEmbeddingDim(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(8))
+        if o != 0:
+            return self._tab.Get(flatbuffers.number_types.Uint32Flags, o + self._tab.Pos)
+        return 0
+
+def RotaryEmbeddingAttrsStart(builder):
+    builder.StartObject(3)
+
+def RotaryEmbeddingAttrsAddInterleaved(builder, interleaved):
+    builder.PrependBoolSlot(0, interleaved, 0)
+
+def RotaryEmbeddingAttrsAddNumHeads(builder, numHeads):
+    builder.PrependUint32Slot(1, numHeads, 0)
+
+def RotaryEmbeddingAttrsAddRotaryEmbeddingDim(builder, rotaryEmbeddingDim):
+    builder.PrependUint32Slot(2, rotaryEmbeddingDim, 0)
+
+def RotaryEmbeddingAttrsEnd(builder):
+    return builder.EndObject()
+
+
+
+class RotaryEmbeddingAttrsT(object):
+
+    # RotaryEmbeddingAttrsT
+    def __init__(
+        self,
+        interleaved = False,
+        numHeads = 0,
+        rotaryEmbeddingDim = 0,
+    ):
+        self.interleaved = interleaved  # type: bool
+        self.numHeads = numHeads  # type: int
+        self.rotaryEmbeddingDim = rotaryEmbeddingDim  # type: int
+
+    @classmethod
+    def InitFromBuf(cls, buf, pos):
+        rotaryEmbeddingAttrs = RotaryEmbeddingAttrs()
+        rotaryEmbeddingAttrs.Init(buf, pos)
+        return cls.InitFromObj(rotaryEmbeddingAttrs)
+
+    @classmethod
+    def InitFromPackedBuf(cls, buf, pos=0):
+        n = flatbuffers.encode.Get(flatbuffers.packer.uoffset, buf, pos)
+        return cls.InitFromBuf(buf, pos+n)
+
+    @classmethod
+    def InitFromObj(cls, rotaryEmbeddingAttrs):
+        x = RotaryEmbeddingAttrsT()
+        x._UnPack(rotaryEmbeddingAttrs)
+        return x
+
+    # RotaryEmbeddingAttrsT
+    def _UnPack(self, rotaryEmbeddingAttrs):
+        if rotaryEmbeddingAttrs is None:
+            return
+        self.interleaved = rotaryEmbeddingAttrs.Interleaved()
+        self.numHeads = rotaryEmbeddingAttrs.NumHeads()
+        self.rotaryEmbeddingDim = rotaryEmbeddingAttrs.RotaryEmbeddingDim()
+
+    # RotaryEmbeddingAttrsT
+    def Pack(self, builder):
+        RotaryEmbeddingAttrsStart(builder)
+        RotaryEmbeddingAttrsAddInterleaved(builder, self.interleaved)
+        RotaryEmbeddingAttrsAddNumHeads(builder, self.numHeads)
+        RotaryEmbeddingAttrsAddRotaryEmbeddingDim(builder, self.rotaryEmbeddingDim)
+        rotaryEmbeddingAttrs = RotaryEmbeddingAttrsEnd(builder)
+        return rotaryEmbeddingAttrs
+
+
 class SequenceEmptyAttrs(object):
     __slots__ = ['_tab']
 
@@ -6787,7 +6984,7 @@ class OperatorNodeT(object):
     ):
         self.type = type  # type: int
         self.attrsType = attrsType  # type: int
-        self.attrs = attrs  # type: Union[None, 'ArgMaxAttrsT', 'AveragePoolAttrsT', 'BatchNormalizationAttrsT', 'CastAttrsT', 'ConcatAttrsT', 'ConstantOfShapeAttrsT', 'ConvAttrsT', 'ConvTransposeAttrsT', 'FlattenAttrsT', 'GatherAttrsT', 'GemmAttrsT', 'GRUAttrsT', 'LeakyReluAttrsT', 'LSTMAttrsT', 'MaxPoolAttrsT', 'ReduceMeanAttrsT', 'ReshapeAttrsT', 'ResizeAttrsT', 'SplitAttrsT', 'SoftmaxAttrsT', 'TransposeAttrsT', 'ModAttrsT', 'ScatterElementsAttrsT', 'OneHotAttrsT', 'TopKAttrsT', 'HardSigmoidAttrsT', 'TriluAttrsT', 'ScatterNDAttrsT', 'NonMaxSuppressionAttrsT', 'LayerNormalizationAttrsT', 'RandomUniformAttrsT', 'EluAttrsT', 'RandomUniformLikeAttrsT', 'RandomNormalAttrsT', 'RandomNormalLikeAttrsT', 'GatherNDAttrsT', 'GeluAttrsT', 'EinsumAttrsT', 'IfAttrsT', 'PadAttrsT', 'DequantizeLinearAttrsT', 'QuantizeLinearAttrsT', 'DepthToSpaceAttrsT', 'CastLikeAttrsT', 'ShapeAttrsT', 'DropoutAttrsT', 'EyeLikeAttrsT', 'IsInfAttrsT', 'LoopAttrsT', 'SequenceEmptyAttrsT', 'ConcatFromSequenceAttrsT', 'SplitToSequenceAttrsT', 'GridSampleAttrsT', 'STFTAttrsT', 'MultinomialAttrsT', 'ReverseSequenceAttrsT', 'DFTAttrsT']
+        self.attrs = attrs  # type: Union[None, 'ArgMaxAttrsT', 'AveragePoolAttrsT', 'BatchNormalizationAttrsT', 'CastAttrsT', 'ConcatAttrsT', 'ConstantOfShapeAttrsT', 'ConvAttrsT', 'ConvTransposeAttrsT', 'FlattenAttrsT', 'GatherAttrsT', 'GemmAttrsT', 'GRUAttrsT', 'LeakyReluAttrsT', 'LSTMAttrsT', 'MaxPoolAttrsT', 'ReduceMeanAttrsT', 'ReshapeAttrsT', 'ResizeAttrsT', 'SplitAttrsT', 'SoftmaxAttrsT', 'TransposeAttrsT', 'ModAttrsT', 'ScatterElementsAttrsT', 'OneHotAttrsT', 'TopKAttrsT', 'HardSigmoidAttrsT', 'TriluAttrsT', 'ScatterNDAttrsT', 'NonMaxSuppressionAttrsT', 'LayerNormalizationAttrsT', 'RandomUniformAttrsT', 'EluAttrsT', 'RandomUniformLikeAttrsT', 'RandomNormalAttrsT', 'RandomNormalLikeAttrsT', 'GatherNDAttrsT', 'GeluAttrsT', 'EinsumAttrsT', 'IfAttrsT', 'PadAttrsT', 'DequantizeLinearAttrsT', 'QuantizeLinearAttrsT', 'DepthToSpaceAttrsT', 'CastLikeAttrsT', 'ShapeAttrsT', 'DropoutAttrsT', 'EyeLikeAttrsT', 'IsInfAttrsT', 'LoopAttrsT', 'SequenceEmptyAttrsT', 'ConcatFromSequenceAttrsT', 'SplitToSequenceAttrsT', 'GridSampleAttrsT', 'STFTAttrsT', 'MultinomialAttrsT', 'ReverseSequenceAttrsT', 'DFTAttrsT', 'UpsampleAttrsT', 'RotaryEmbeddingAttrsT']
         self.inputs = inputs  # type: Optional[List[int]]
         self.outputs = outputs  # type: Optional[List[int]]
 

--- a/rten-model-file/src/schema.fbs
+++ b/rten-model-file/src/schema.fbs
@@ -151,6 +151,9 @@ enum OperatorType: ubyte {
   Multinomial,
   ReverseSequence,
   DFT,
+  Scatter,
+  Upsample,
+  RotaryEmbedding,
 }
 
 enum RNNDirection: ubyte {
@@ -225,7 +228,7 @@ union OperatorAttrs {
   // New operator attrs. These are appended here to preserve binary compatibility
   // of existing model files.
   ModAttrs,
-  ScatterElementsAttrs,
+  ScatterElementsAttrs, // Also used for Scatter
   OneHotAttrs,
   TopKAttrs,
   HardSigmoidAttrs,
@@ -260,6 +263,8 @@ union OperatorAttrs {
   MultinomialAttrs,
   ReverseSequenceAttrs,
   DFTAttrs,
+  UpsampleAttrs,
+  RotaryEmbeddingAttrs,
 }
 
 table ArgMaxAttrs {
@@ -549,6 +554,16 @@ table ScatterElementsAttrs {
 
 table ScatterNDAttrs {
   reduction:ScatterReduction;
+}
+
+table UpsampleAttrs {
+  mode:ResizeMode;
+}
+
+table RotaryEmbeddingAttrs {
+  interleaved:bool;
+  num_heads:uint;
+  rotary_embedding_dim:uint;
 }
 
 table SequenceEmptyAttrs {

--- a/rten-model-file/src/schema_generated.rs
+++ b/rten-model-file/src/schema_generated.rs
@@ -11,13 +11,13 @@ pub const ENUM_MIN_OPERATOR_TYPE: u8 = 0;
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
-pub const ENUM_MAX_OPERATOR_TYPE: u8 = 137;
+pub const ENUM_MAX_OPERATOR_TYPE: u8 = 140;
 #[deprecated(
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 138] = [
+pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 141] = [
     OperatorType::Add,
     OperatorType::ArgMin,
     OperatorType::ArgMax,
@@ -156,6 +156,9 @@ pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 138] = [
     OperatorType::Multinomial,
     OperatorType::ReverseSequence,
     OperatorType::DFT,
+    OperatorType::Scatter,
+    OperatorType::Upsample,
+    OperatorType::RotaryEmbedding,
 ];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -301,9 +304,12 @@ impl OperatorType {
     pub const Multinomial: Self = Self(135);
     pub const ReverseSequence: Self = Self(136);
     pub const DFT: Self = Self(137);
+    pub const Scatter: Self = Self(138);
+    pub const Upsample: Self = Self(139);
+    pub const RotaryEmbedding: Self = Self(140);
 
     pub const ENUM_MIN: u8 = 0;
-    pub const ENUM_MAX: u8 = 137;
+    pub const ENUM_MAX: u8 = 140;
     pub const ENUM_VALUES: &'static [Self] = &[
         Self::Add,
         Self::ArgMin,
@@ -443,6 +449,9 @@ impl OperatorType {
         Self::Multinomial,
         Self::ReverseSequence,
         Self::DFT,
+        Self::Scatter,
+        Self::Upsample,
+        Self::RotaryEmbedding,
     ];
     /// Returns the variant's name or "" if unknown.
     pub fn variant_name(self) -> Option<&'static str> {
@@ -585,6 +594,9 @@ impl OperatorType {
             Self::Multinomial => Some("Multinomial"),
             Self::ReverseSequence => Some("ReverseSequence"),
             Self::DFT => Some("DFT"),
+            Self::Scatter => Some("Scatter"),
+            Self::Upsample => Some("Upsample"),
+            Self::RotaryEmbedding => Some("RotaryEmbedding"),
             _ => None,
         }
     }
@@ -1220,13 +1232,13 @@ pub const ENUM_MIN_OPERATOR_ATTRS: u8 = 0;
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
-pub const ENUM_MAX_OPERATOR_ATTRS: u8 = 57;
+pub const ENUM_MAX_OPERATOR_ATTRS: u8 = 59;
 #[deprecated(
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_OPERATOR_ATTRS: [OperatorAttrs; 58] = [
+pub const ENUM_VALUES_OPERATOR_ATTRS: [OperatorAttrs; 60] = [
     OperatorAttrs::NONE,
     OperatorAttrs::ArgMaxAttrs,
     OperatorAttrs::AveragePoolAttrs,
@@ -1285,6 +1297,8 @@ pub const ENUM_VALUES_OPERATOR_ATTRS: [OperatorAttrs; 58] = [
     OperatorAttrs::MultinomialAttrs,
     OperatorAttrs::ReverseSequenceAttrs,
     OperatorAttrs::DFTAttrs,
+    OperatorAttrs::UpsampleAttrs,
+    OperatorAttrs::RotaryEmbeddingAttrs,
 ];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -1350,9 +1364,11 @@ impl OperatorAttrs {
     pub const MultinomialAttrs: Self = Self(55);
     pub const ReverseSequenceAttrs: Self = Self(56);
     pub const DFTAttrs: Self = Self(57);
+    pub const UpsampleAttrs: Self = Self(58);
+    pub const RotaryEmbeddingAttrs: Self = Self(59);
 
     pub const ENUM_MIN: u8 = 0;
-    pub const ENUM_MAX: u8 = 57;
+    pub const ENUM_MAX: u8 = 59;
     pub const ENUM_VALUES: &'static [Self] = &[
         Self::NONE,
         Self::ArgMaxAttrs,
@@ -1412,6 +1428,8 @@ impl OperatorAttrs {
         Self::MultinomialAttrs,
         Self::ReverseSequenceAttrs,
         Self::DFTAttrs,
+        Self::UpsampleAttrs,
+        Self::RotaryEmbeddingAttrs,
     ];
     /// Returns the variant's name or "" if unknown.
     pub fn variant_name(self) -> Option<&'static str> {
@@ -1474,6 +1492,8 @@ impl OperatorAttrs {
             Self::MultinomialAttrs => Some("MultinomialAttrs"),
             Self::ReverseSequenceAttrs => Some("ReverseSequenceAttrs"),
             Self::DFTAttrs => Some("DFTAttrs"),
+            Self::UpsampleAttrs => Some("UpsampleAttrs"),
+            Self::RotaryEmbeddingAttrs => Some("RotaryEmbeddingAttrs"),
             _ => None,
         }
     }
@@ -8886,6 +8906,273 @@ impl ::core::fmt::Debug for ScatterNDAttrs<'_> {
         ds.finish()
     }
 }
+pub enum UpsampleAttrsOffset {}
+#[derive(Copy, Clone, PartialEq)]
+
+pub struct UpsampleAttrs<'a> {
+    pub _tab: ::flatbuffers::Table<'a>,
+}
+
+impl<'a> ::flatbuffers::Follow<'a> for UpsampleAttrs<'a> {
+    type Inner = UpsampleAttrs<'a>;
+    #[inline]
+    unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self {
+            _tab: unsafe { ::flatbuffers::Table::new(buf, loc) },
+        }
+    }
+}
+
+impl<'a> UpsampleAttrs<'a> {
+    pub const VT_MODE: ::flatbuffers::VOffsetT = 4;
+
+    #[inline]
+    pub unsafe fn init_from_table(table: ::flatbuffers::Table<'a>) -> Self {
+        UpsampleAttrs { _tab: table }
+    }
+    #[allow(unused_mut)]
+    pub fn create<
+        'bldr: 'args,
+        'args: 'mut_bldr,
+        'mut_bldr,
+        A: ::flatbuffers::Allocator + 'bldr,
+    >(
+        _fbb: &'mut_bldr mut ::flatbuffers::FlatBufferBuilder<'bldr, A>,
+        args: &'args UpsampleAttrsArgs,
+    ) -> ::flatbuffers::WIPOffset<UpsampleAttrs<'bldr>> {
+        let mut builder = UpsampleAttrsBuilder::new(_fbb);
+        builder.add_mode(args.mode);
+        builder.finish()
+    }
+
+    #[inline]
+    pub fn mode(&self) -> ResizeMode {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab
+                .get::<ResizeMode>(UpsampleAttrs::VT_MODE, Some(ResizeMode::Nearest))
+                .unwrap()
+        }
+    }
+}
+
+impl ::flatbuffers::Verifiable for UpsampleAttrs<'_> {
+    #[inline]
+    fn run_verifier(
+        v: &mut ::flatbuffers::Verifier,
+        pos: usize,
+    ) -> Result<(), ::flatbuffers::InvalidFlatbuffer> {
+        v.visit_table(pos)?
+            .visit_field::<ResizeMode>("mode", Self::VT_MODE, false)?
+            .finish();
+        Ok(())
+    }
+}
+pub struct UpsampleAttrsArgs {
+    pub mode: ResizeMode,
+}
+impl<'a> Default for UpsampleAttrsArgs {
+    #[inline]
+    fn default() -> Self {
+        UpsampleAttrsArgs {
+            mode: ResizeMode::Nearest,
+        }
+    }
+}
+
+pub struct UpsampleAttrsBuilder<'a: 'b, 'b, A: ::flatbuffers::Allocator + 'a> {
+    fbb_: &'b mut ::flatbuffers::FlatBufferBuilder<'a, A>,
+    start_: ::flatbuffers::WIPOffset<::flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b, A: ::flatbuffers::Allocator + 'a> UpsampleAttrsBuilder<'a, 'b, A> {
+    #[inline]
+    pub fn add_mode(&mut self, mode: ResizeMode) {
+        self.fbb_
+            .push_slot::<ResizeMode>(UpsampleAttrs::VT_MODE, mode, ResizeMode::Nearest);
+    }
+    #[inline]
+    pub fn new(
+        _fbb: &'b mut ::flatbuffers::FlatBufferBuilder<'a, A>,
+    ) -> UpsampleAttrsBuilder<'a, 'b, A> {
+        let start = _fbb.start_table();
+        UpsampleAttrsBuilder {
+            fbb_: _fbb,
+            start_: start,
+        }
+    }
+    #[inline]
+    pub fn finish(self) -> ::flatbuffers::WIPOffset<UpsampleAttrs<'a>> {
+        let o = self.fbb_.end_table(self.start_);
+        ::flatbuffers::WIPOffset::new(o.value())
+    }
+}
+
+impl ::core::fmt::Debug for UpsampleAttrs<'_> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+        let mut ds = f.debug_struct("UpsampleAttrs");
+        ds.field("mode", &self.mode());
+        ds.finish()
+    }
+}
+pub enum RotaryEmbeddingAttrsOffset {}
+#[derive(Copy, Clone, PartialEq)]
+
+pub struct RotaryEmbeddingAttrs<'a> {
+    pub _tab: ::flatbuffers::Table<'a>,
+}
+
+impl<'a> ::flatbuffers::Follow<'a> for RotaryEmbeddingAttrs<'a> {
+    type Inner = RotaryEmbeddingAttrs<'a>;
+    #[inline]
+    unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self {
+            _tab: unsafe { ::flatbuffers::Table::new(buf, loc) },
+        }
+    }
+}
+
+impl<'a> RotaryEmbeddingAttrs<'a> {
+    pub const VT_INTERLEAVED: ::flatbuffers::VOffsetT = 4;
+    pub const VT_NUM_HEADS: ::flatbuffers::VOffsetT = 6;
+    pub const VT_ROTARY_EMBEDDING_DIM: ::flatbuffers::VOffsetT = 8;
+
+    #[inline]
+    pub unsafe fn init_from_table(table: ::flatbuffers::Table<'a>) -> Self {
+        RotaryEmbeddingAttrs { _tab: table }
+    }
+    #[allow(unused_mut)]
+    pub fn create<
+        'bldr: 'args,
+        'args: 'mut_bldr,
+        'mut_bldr,
+        A: ::flatbuffers::Allocator + 'bldr,
+    >(
+        _fbb: &'mut_bldr mut ::flatbuffers::FlatBufferBuilder<'bldr, A>,
+        args: &'args RotaryEmbeddingAttrsArgs,
+    ) -> ::flatbuffers::WIPOffset<RotaryEmbeddingAttrs<'bldr>> {
+        let mut builder = RotaryEmbeddingAttrsBuilder::new(_fbb);
+        builder.add_rotary_embedding_dim(args.rotary_embedding_dim);
+        builder.add_num_heads(args.num_heads);
+        builder.add_interleaved(args.interleaved);
+        builder.finish()
+    }
+
+    #[inline]
+    pub fn interleaved(&self) -> bool {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab
+                .get::<bool>(RotaryEmbeddingAttrs::VT_INTERLEAVED, Some(false))
+                .unwrap()
+        }
+    }
+    #[inline]
+    pub fn num_heads(&self) -> u32 {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab
+                .get::<u32>(RotaryEmbeddingAttrs::VT_NUM_HEADS, Some(0))
+                .unwrap()
+        }
+    }
+    #[inline]
+    pub fn rotary_embedding_dim(&self) -> u32 {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab
+                .get::<u32>(RotaryEmbeddingAttrs::VT_ROTARY_EMBEDDING_DIM, Some(0))
+                .unwrap()
+        }
+    }
+}
+
+impl ::flatbuffers::Verifiable for RotaryEmbeddingAttrs<'_> {
+    #[inline]
+    fn run_verifier(
+        v: &mut ::flatbuffers::Verifier,
+        pos: usize,
+    ) -> Result<(), ::flatbuffers::InvalidFlatbuffer> {
+        v.visit_table(pos)?
+            .visit_field::<bool>("interleaved", Self::VT_INTERLEAVED, false)?
+            .visit_field::<u32>("num_heads", Self::VT_NUM_HEADS, false)?
+            .visit_field::<u32>("rotary_embedding_dim", Self::VT_ROTARY_EMBEDDING_DIM, false)?
+            .finish();
+        Ok(())
+    }
+}
+pub struct RotaryEmbeddingAttrsArgs {
+    pub interleaved: bool,
+    pub num_heads: u32,
+    pub rotary_embedding_dim: u32,
+}
+impl<'a> Default for RotaryEmbeddingAttrsArgs {
+    #[inline]
+    fn default() -> Self {
+        RotaryEmbeddingAttrsArgs {
+            interleaved: false,
+            num_heads: 0,
+            rotary_embedding_dim: 0,
+        }
+    }
+}
+
+pub struct RotaryEmbeddingAttrsBuilder<'a: 'b, 'b, A: ::flatbuffers::Allocator + 'a> {
+    fbb_: &'b mut ::flatbuffers::FlatBufferBuilder<'a, A>,
+    start_: ::flatbuffers::WIPOffset<::flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b, A: ::flatbuffers::Allocator + 'a> RotaryEmbeddingAttrsBuilder<'a, 'b, A> {
+    #[inline]
+    pub fn add_interleaved(&mut self, interleaved: bool) {
+        self.fbb_
+            .push_slot::<bool>(RotaryEmbeddingAttrs::VT_INTERLEAVED, interleaved, false);
+    }
+    #[inline]
+    pub fn add_num_heads(&mut self, num_heads: u32) {
+        self.fbb_
+            .push_slot::<u32>(RotaryEmbeddingAttrs::VT_NUM_HEADS, num_heads, 0);
+    }
+    #[inline]
+    pub fn add_rotary_embedding_dim(&mut self, rotary_embedding_dim: u32) {
+        self.fbb_.push_slot::<u32>(
+            RotaryEmbeddingAttrs::VT_ROTARY_EMBEDDING_DIM,
+            rotary_embedding_dim,
+            0,
+        );
+    }
+    #[inline]
+    pub fn new(
+        _fbb: &'b mut ::flatbuffers::FlatBufferBuilder<'a, A>,
+    ) -> RotaryEmbeddingAttrsBuilder<'a, 'b, A> {
+        let start = _fbb.start_table();
+        RotaryEmbeddingAttrsBuilder {
+            fbb_: _fbb,
+            start_: start,
+        }
+    }
+    #[inline]
+    pub fn finish(self) -> ::flatbuffers::WIPOffset<RotaryEmbeddingAttrs<'a>> {
+        let o = self.fbb_.end_table(self.start_);
+        ::flatbuffers::WIPOffset::new(o.value())
+    }
+}
+
+impl ::core::fmt::Debug for RotaryEmbeddingAttrs<'_> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+        let mut ds = f.debug_struct("RotaryEmbeddingAttrs");
+        ds.field("interleaved", &self.interleaved());
+        ds.field("num_heads", &self.num_heads());
+        ds.field("rotary_embedding_dim", &self.rotary_embedding_dim());
+        ds.finish()
+    }
+}
 pub enum SequenceEmptyAttrsOffset {}
 #[derive(Copy, Clone, PartialEq)]
 
@@ -11199,6 +11486,36 @@ impl<'a> OperatorNode<'a> {
             None
         }
     }
+
+    #[inline]
+    #[allow(non_snake_case)]
+    pub fn attrs_as_upsample_attrs(&self) -> Option<UpsampleAttrs<'a>> {
+        if self.attrs_type() == OperatorAttrs::UpsampleAttrs {
+            self.attrs().map(|t| {
+                // Safety:
+                // Created from a valid Table for this object
+                // Which contains a valid union in this slot
+                unsafe { UpsampleAttrs::init_from_table(t) }
+            })
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    #[allow(non_snake_case)]
+    pub fn attrs_as_rotary_embedding_attrs(&self) -> Option<RotaryEmbeddingAttrs<'a>> {
+        if self.attrs_type() == OperatorAttrs::RotaryEmbeddingAttrs {
+            self.attrs().map(|t| {
+                // Safety:
+                // Created from a valid Table for this object
+                // Which contains a valid union in this slot
+                unsafe { RotaryEmbeddingAttrs::init_from_table(t) }
+            })
+        } else {
+            None
+        }
+    }
 }
 
 impl ::flatbuffers::Verifiable for OperatorNode<'_> {
@@ -11268,6 +11585,8 @@ impl ::flatbuffers::Verifiable for OperatorNode<'_> {
           OperatorAttrs::MultinomialAttrs => v.verify_union_variant::<::flatbuffers::ForwardsUOffset<MultinomialAttrs>>("OperatorAttrs::MultinomialAttrs", pos),
           OperatorAttrs::ReverseSequenceAttrs => v.verify_union_variant::<::flatbuffers::ForwardsUOffset<ReverseSequenceAttrs>>("OperatorAttrs::ReverseSequenceAttrs", pos),
           OperatorAttrs::DFTAttrs => v.verify_union_variant::<::flatbuffers::ForwardsUOffset<DFTAttrs>>("OperatorAttrs::DFTAttrs", pos),
+          OperatorAttrs::UpsampleAttrs => v.verify_union_variant::<::flatbuffers::ForwardsUOffset<UpsampleAttrs>>("OperatorAttrs::UpsampleAttrs", pos),
+          OperatorAttrs::RotaryEmbeddingAttrs => v.verify_union_variant::<::flatbuffers::ForwardsUOffset<RotaryEmbeddingAttrs>>("OperatorAttrs::RotaryEmbeddingAttrs", pos),
           _ => Ok(()),
         }
      })?
@@ -11918,6 +12237,26 @@ impl ::core::fmt::Debug for OperatorNode<'_> {
             }
             OperatorAttrs::DFTAttrs => {
                 if let Some(x) = self.attrs_as_dftattrs() {
+                    ds.field("attrs", &x)
+                } else {
+                    ds.field(
+                        "attrs",
+                        &"InvalidFlatbuffer: Union discriminant does not match value.",
+                    )
+                }
+            }
+            OperatorAttrs::UpsampleAttrs => {
+                if let Some(x) = self.attrs_as_upsample_attrs() {
+                    ds.field("attrs", &x)
+                } else {
+                    ds.field(
+                        "attrs",
+                        &"InvalidFlatbuffer: Union discriminant does not match value.",
+                    )
+                }
+            }
+            OperatorAttrs::RotaryEmbeddingAttrs => {
+                if let Some(x) = self.attrs_as_rotary_embedding_attrs() {
                     ds.field("attrs", &x)
                 } else {
                     ds.field(

--- a/src/model.rs
+++ b/src/model.rs
@@ -1762,6 +1762,11 @@ mod tests {
 
         add_operator!(Round, [input_node]);
 
+        let upsample_scales = graph_builder.add_constant(Tensor::from([1., 1., 2., 2.]).view());
+        add_operator!(Upsample, [input_node, upsample_scales], {
+            mode: ResizeMode::Nearest
+        });
+
         add_operator!(Shape, [input_node], {
             start: Some(1),
             end: Some(-1),
@@ -1780,6 +1785,25 @@ mod tests {
             ScatterElements,
             [input_node, scatter_elem_indices, scatter_elem_updates],
             { axis: 0, reduction: None }
+        );
+        add_operator!(
+            Scatter,
+            [input_node, scatter_elem_indices, scatter_elem_updates],
+            { axis: 0 }
+        );
+
+        // The standard 4D input has shape [batch=1, num_heads=1, seq=3,
+        // head_size=3]. `rotary_embedding_dim` must be even and `<= head_size`,
+        // so rotate the first 2 of the 3 head elements. The cos/sin caches have
+        // shape [max_pos, rotary_embedding_dim / 2] and are gathered by
+        // `position_ids`.
+        let rotary_cos = graph_builder.add_constant(Tensor::<f32>::zeros(&[3, 1]).view());
+        let rotary_sin = graph_builder.add_constant(Tensor::<f32>::zeros(&[3, 1]).view());
+        let rotary_pos = graph_builder.add_constant(Tensor::from([[0i32, 1, 2]]).view());
+        add_operator!(
+            RotaryEmbedding,
+            [input_node, rotary_cos, rotary_sin, rotary_pos],
+            { interleaved: false, num_heads: 1, rotary_embedding_dim: 2 }
         );
 
         let const_0 = graph_builder.add_constant(Tensor::from([0]).view());

--- a/src/model/rten_builder.rs
+++ b/src/model/rten_builder.rs
@@ -13,8 +13,8 @@ use crate::ops::{
     GatherND, Gelu, Gemm, HardSigmoid, InstanceNormalization, LayerNormalization, LeakyRelu,
     LogSoftmax, MaxPool, Mod, NearestMode, NonMaxSuppression, OneHot, Padding, QuantizeLinear,
     ReduceL1, ReduceL2, ReduceMax, ReduceMean, ReduceMin, ReduceProd, ReduceSum, ReduceSumSquare,
-    Reshape, Resize, ResizeMode, ScatterElements, ScatterReduction, SequenceEmpty, Shape, Softmax,
-    Split, TopK, Transpose, Trilu,
+    Reshape, Resize, ResizeMode, RotaryEmbedding, Scatter, ScatterElements, ScatterReduction,
+    SequenceEmpty, Shape, Softmax, Split, TopK, Transpose, Trilu, Upsample,
 };
 use crate::value::{DataType, Scalar};
 
@@ -139,8 +139,10 @@ pub enum OpType<'a> {
     Relu,
     Reshape(Reshape),
     Resize(Resize),
+    RotaryEmbedding(RotaryEmbedding),
     Round,
     QuantizeLinear(QuantizeLinear),
+    Scatter(Scatter),
     ScatterElements(ScatterElements),
     #[allow(dead_code)]
     SequenceAt,
@@ -169,6 +171,7 @@ pub enum OpType<'a> {
     Transpose(Transpose),
     Trilu(Trilu),
     Unsqueeze,
+    Upsample(Upsample),
     Where,
     Xor,
 }
@@ -898,6 +901,15 @@ impl<'mb, 'a> GraphBuilder<'mb, 'a> {
                     nearest_mode,
                 }
             }),
+            OpType::RotaryEmbedding(args) => op_with_attrs!(
+                RotaryEmbedding,
+                RotaryEmbeddingAttrs,
+                sg::RotaryEmbeddingAttrsArgs {
+                    interleaved: args.interleaved,
+                    num_heads: args.num_heads as u32,
+                    rotary_embedding_dim: args.rotary_embedding_dim as u32,
+                }
+            ),
             OpType::Round => op!(Round),
             OpType::SequenceAt => op!(SequenceAt),
             OpType::SequenceEmpty(args) => op_with_attrs!(
@@ -908,6 +920,14 @@ impl<'mb, 'a> GraphBuilder<'mb, 'a> {
                 }
             ),
             OpType::SequenceInsert => op!(SequenceInsert),
+            OpType::Scatter(args) => op_with_attrs!(
+                Scatter,
+                ScatterElementsAttrs,
+                sg::ScatterElementsAttrsArgs {
+                    axis: args.axis as i32,
+                    reduction: sg::ScatterReduction::None,
+                }
+            ),
             OpType::ScatterElements(args) => {
                 op_with_attrs!(ScatterElements, ScatterElementsAttrs, {
                     let reduction = match args.reduction {
@@ -971,6 +991,13 @@ impl<'mb, 'a> GraphBuilder<'mb, 'a> {
                 sg::TriluAttrsArgs { upper: args.upper }
             }),
             OpType::Unsqueeze => op!(Unsqueeze),
+            OpType::Upsample(args) => op_with_attrs!(Upsample, UpsampleAttrs, {
+                let mode = match args.mode {
+                    ResizeMode::Nearest => sg::ResizeMode::Nearest,
+                    ResizeMode::Linear => sg::ResizeMode::Linear,
+                };
+                sg::UpsampleAttrsArgs { mode }
+            }),
             OpType::Where => op!(Where),
             OpType::Xor => op!(Xor),
         };

--- a/src/op_registry.rs
+++ b/src/op_registry.rs
@@ -310,7 +310,9 @@ pub mod op_types {
     declare_op!(Reshape);
     declare_op!(Resize);
     declare_op!(ReverseSequence);
+    declare_op!(RotaryEmbedding);
     declare_op!(Round);
+    declare_op!(Scatter);
     declare_op!(ScatterElements);
     declare_op!(ScatterND);
     declare_op!(SequenceAt);
@@ -341,6 +343,7 @@ pub mod op_types {
     declare_op!(Transpose);
     declare_op!(Trilu);
     declare_op!(Unsqueeze);
+    declare_op!(Upsample);
     declare_op!(Where);
     declare_op!(Xor);
 }

--- a/src/op_registry/rten_registry.rs
+++ b/src/op_registry/rten_registry.rs
@@ -197,7 +197,9 @@ impl RtenOpRegistry {
         register_op!(Reshape);
         register_op!(Resize);
         register_op!(ReverseSequence);
+        register_op!(RotaryEmbedding);
         register_op!(Round);
+        register_op!(Scatter);
         register_op!(ScatterElements);
         register_op!(ScatterND);
         register_op!(SequenceAt);
@@ -229,6 +231,7 @@ impl RtenOpRegistry {
         register_op!(Transpose);
         register_op!(Trilu);
         register_op!(Unsqueeze);
+        register_op!(Upsample);
         register_op!(Where);
         register_op!(Xor);
 
@@ -971,7 +974,27 @@ impl_read_op!(
         })
     }
 );
+impl_read_op!(
+    RotaryEmbedding,
+    attrs_as_rotary_embedding_attrs,
+    |attrs: sg::RotaryEmbeddingAttrs| {
+        Ok(ops::RotaryEmbedding {
+            interleaved: attrs.interleaved(),
+            num_heads: attrs.num_heads().as_usize(),
+            rotary_embedding_dim: attrs.rotary_embedding_dim().as_usize(),
+        })
+    }
+);
 impl_read_op!(Round);
+impl_read_op!(
+    Scatter,
+    attrs_as_scatter_elements_attrs,
+    |attrs: sg::ScatterElementsAttrs| {
+        Ok(ops::Scatter {
+            axis: attrs.axis() as isize,
+        })
+    }
+);
 impl_read_op!(
     ScatterElements,
     attrs_as_scatter_elements_attrs,
@@ -1096,6 +1119,18 @@ impl_read_op!(Trilu, attrs_as_trilu_attrs, |attrs: sg::TriluAttrs| {
     })
 });
 impl_read_op!(Unsqueeze);
+impl_read_op!(
+    Upsample,
+    attrs_as_upsample_attrs,
+    |attrs: sg::UpsampleAttrs| {
+        let mode = match attrs.mode() {
+            sg::ResizeMode::Nearest => ResizeMode::Nearest,
+            sg::ResizeMode::Linear => ResizeMode::Linear,
+            _ => ResizeMode::Nearest,
+        };
+        Ok(ops::Upsample { mode })
+    }
+);
 impl_read_op!(Where);
 impl_read_op!(Xor);
 


### PR DESCRIPTION
Add these operators to the FlatBuffers schema, the .rten read/write paths and the ONNX converter so they round-trip through .rten files.

Part of #1293.