### PR TITLE
Disable contrib operators when `onnx_format` feature is disabled

### DIFF
--- a/src/model/load_error.rs
+++ b/src/model/load_error.rs
@@ -123,6 +123,7 @@ pub(crate) enum LoadErrorImpl {
     UnknownFileType,
 
     /// An error occurred reading tensor data stored externally.
+    #[cfg(feature = "onnx_format")]
     ExternalDataError(Box<dyn Error + Send + Sync>),
 
     /// The model file type is supported by RTen, but the necessary crate
@@ -147,6 +148,7 @@ impl LoadErrorImpl {
                 OptimizeError::InferShapesError(_) => Kind::ShapeInferenceFailed,
             },
             Self::UnknownFileType => Kind::UnknownFileType,
+            #[cfg(feature = "onnx_format")]
             Self::ExternalDataError(_) => Kind::ExternalDataError,
             Self::FormatNotEnabled => Kind::FormatNotEnabled,
         }
@@ -162,6 +164,7 @@ impl LoadErrorImpl {
             Self::GraphError(err) => Some(err.as_ref()),
             Self::OptimizeError(err) => Some(err),
             Self::UnknownFileType => None,
+            #[cfg(feature = "onnx_format")]
             Self::ExternalDataError(err) => Some(err.as_ref()),
             Self::FormatNotEnabled => None,
         }
@@ -182,6 +185,7 @@ impl Display for LoadErrorImpl {
                 e => write!(f, "graph optimization error: {e}"),
             },
             Self::UnknownFileType => write!(f, "unknown model file type"),
+            #[cfg(feature = "onnx_format")]
             Self::ExternalDataError(e) => write!(f, "external data error: {e}"),
             Self::FormatNotEnabled => {
                 write!(f, "rten was built without support for this model format")

--- a/src/ops/attention.rs
+++ b/src/ops/attention.rs
@@ -2,25 +2,19 @@
 
 use rayon::prelude::*;
 use rten_gemm::{GemmExecutor, GemmInputA, GemmInputB, GemmUninitOptions};
-use rten_shape_inference::ops as shape_ops;
 use rten_simd::SimdOp;
 use rten_tensor::prelude::*;
-use rten_tensor::{CowNdTensor, NdTensor, NdTensorView, Tensor, TensorView};
+use rten_tensor::{NdTensorView, Tensor, TensorView};
 use rten_vecmath::Softmax;
 
 use crate::buffer_pool::{AutoReturn, BufferPool};
-use crate::infer_shapes::{InferShapes, impl_infer_shapes};
+use crate::infer_shapes::InferShapes;
 use crate::operator::{
     IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType, OutputTypeList,
     OutputTypesContext,
 };
 use crate::ops::{
-    binary_elementwise::{add, add_in_place, broadcast_shapes},
-    concat::concat,
-    layout::expand_to,
-    matmul::matmul,
-    norm::NanHandling,
-    resolve_axis,
+    binary_elementwise::broadcast_shapes, layout::expand_to, norm::NanHandling, resolve_axis,
 };
 use crate::value::Value;
 
@@ -316,406 +310,459 @@ impl Operator for GroupedQueryAttentionMatMul {
     }
 }
 
-/// Reshape (batch, seq, hidden) to (batch, num_heads, seq, head).
-fn split_attention_heads<'a>(
-    pool: &BufferPool,
-    input: CowNdTensor<'a, f32, 3>,
-    num_heads: usize,
-    head_size: usize,
-) -> Result<CowNdTensor<'a, f32, 4>, OpError> {
-    let [batch_size, seq_len, hidden] = input.shape();
-    if hidden != num_heads * head_size {
-        return Err(OpError::IncompatibleInputShapes(
-            "Hidden size does not match number of attention heads",
-        ));
-    }
+#[cfg(feature = "onnx_format")]
+pub use contrib::MultiHeadAttention;
 
-    Ok(input
-        .into_shape_in(pool, [batch_size, seq_len, num_heads, head_size])
-        .into_permuted([0, 2, 1, 3]))
-}
+#[cfg(feature = "onnx_format")]
+mod contrib {
+    use rayon::prelude::*;
+    use rten_gemm::{GemmExecutor, GemmInputA, GemmInputB, GemmUninitOptions};
+    use rten_shape_inference::ops as shape_ops;
+    use rten_simd::SimdOp;
+    use rten_tensor::prelude::*;
+    use rten_tensor::{CowNdTensor, NdTensor, NdTensorView, TensorView};
+    use rten_vecmath::Softmax;
 
-/// `query` input for MultiHeadAttention which can be either the query tensor
-/// or packed QKV tensors.
-enum MhaQuery<'a> {
-    /// Tensor of shape (batch, kv_seq, num_heads, 3, head_dim)
-    Packed(NdTensorView<'a, f32, 5>),
-    /// Tensor of shape (batch, seq, hidden) where hidden = num_heads * head_dim
-    Unpacked(NdTensorView<'a, f32, 3>),
-}
+    use crate::buffer_pool::{AutoReturn, BufferPool};
+    use crate::infer_shapes::{InferShapes, impl_infer_shapes};
+    use crate::operator::{
+        OpError, OpRunContext, Operator, OutputList, OutputType, OutputTypeList, OutputTypesContext,
+    };
+    use crate::ops::{
+        binary_elementwise::{add, add_in_place},
+        concat::concat,
+        matmul::matmul,
+    };
 
-impl<'a> MhaQuery<'a> {
-    fn new(query: TensorView<'a, f32>) -> Result<Self, OpError> {
-        match query.ndim() {
-            5 => Ok(Self::Packed(query.nd_view())),
-            3 => Ok(Self::Unpacked(query.nd_view())),
-            _ => Err(OpError::InvalidValue("query must have 3 or 5 dims")),
-        }
-    }
-}
+    use super::BROADCAST_ERROR;
 
-/// Fused multi-head attention contrib operator.
-///
-/// See
-/// <https://github.com/microsoft/onnxruntime/blob/main/docs/ContribOperators.md#commicrosoftmultiheadattention>.
-#[derive(Debug)]
-pub struct MultiHeadAttention {
-    pub mask_filter_value: f32,
-    pub num_heads: u32,
-    pub scale: Option<f32>,
-    pub unidirectional: bool,
-}
-
-impl Operator for MultiHeadAttention {
-    fn name(&self) -> &str {
-        "MultiHeadAttention"
-    }
-
-    fn max_inputs(&self) -> Option<usize> {
-        Some(10)
-    }
-
-    fn max_outputs(&self) -> Option<usize> {
-        // Spec defines 4 outputs: output, present_key, present_value, qk.
-        // The `qk` output is not yet implemented.
-        Some(3)
-    }
-
-    fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
-        // (batch, seq, hidden) or (batch, kv_seq, num_heads, 3, head_size)
-        let query: TensorView<f32> = ctx.inputs().require_as(0)?;
-        let query = MhaQuery::new(query)?;
-
-        // (batch, kv_seq, hidden). Spec says it can be 4D or 5D as well, but
-        // this is not supported.
-        let key: Option<NdTensorView<f32, 3>> = ctx.inputs().get_as(1)?;
-
-        // (batch, kv_seq, hidden). Spec says it can be 4D as well, but this is
-        // not supported.
-        let value: Option<NdTensorView<f32, 3>> = ctx.inputs().get_as(2)?;
-        let bias: Option<NdTensorView<f32, 1>> = ctx.inputs().get_as(3)?;
-
-        // (batch, kv_seq). Spec says it can be 1D or 3D, but this is not supported.
-        let key_padding_mask: Option<NdTensorView<i32, 2>> = ctx.inputs().get_as(4)?;
-
-        // (batch or 1, num_heads or 1, seq, total_seq)
-        let attention_bias: Option<NdTensorView<f32, 4>> = ctx.inputs().get_as(5)?;
-
-        // (batch, num_heads, past_seq, head_size)
-        let past_key: Option<NdTensorView<f32, 4>> = ctx.inputs().get_as(6)?;
-        // (batch, num_heads, past_seq, head_size)
-        let past_value: Option<NdTensorView<f32, 4>> = ctx.inputs().get_as(7)?;
-
-        let past_seq_len: Option<NdTensorView<i32, 0>> = ctx.inputs().get_as(8)?;
-        if past_seq_len.is_some() {
-            return Err(OpError::UnsupportedValue("past_seq_len is not supported"));
-        }
-
-        let cache_indirection: Option<NdTensorView<i32, 3>> = ctx.inputs().get_as(9)?;
-        if cache_indirection.is_some() {
-            return Err(OpError::UnsupportedValue(
-                "cache_indirection is not supported",
+    /// Reshape (batch, seq, hidden) to (batch, num_heads, seq, head).
+    fn split_attention_heads<'a>(
+        pool: &BufferPool,
+        input: CowNdTensor<'a, f32, 3>,
+        num_heads: usize,
+        head_size: usize,
+    ) -> Result<CowNdTensor<'a, f32, 4>, OpError> {
+        let [batch_size, seq_len, hidden] = input.shape();
+        if hidden != num_heads * head_size {
+            return Err(OpError::IncompatibleInputShapes(
+                "Hidden size does not match number of attention heads",
             ));
         }
 
-        let num_heads = self.num_heads as usize;
-        if num_heads == 0 {
-            return Err(OpError::InvalidValue("num_heads must be positive"));
+        Ok(input
+            .into_shape_in(pool, [batch_size, seq_len, num_heads, head_size])
+            .into_permuted([0, 2, 1, 3]))
+    }
+
+    /// `query` input for MultiHeadAttention which can be either the query tensor
+    /// or packed QKV tensors.
+    enum MhaQuery<'a> {
+        /// Tensor of shape (batch, kv_seq, num_heads, 3, head_dim)
+        Packed(NdTensorView<'a, f32, 5>),
+        /// Tensor of shape (batch, seq, hidden) where hidden = num_heads * head_dim
+        Unpacked(NdTensorView<'a, f32, 3>),
+    }
+
+    impl<'a> MhaQuery<'a> {
+        fn new(query: TensorView<'a, f32>) -> Result<Self, OpError> {
+            match query.ndim() {
+                5 => Ok(Self::Packed(query.nd_view())),
+                3 => Ok(Self::Unpacked(query.nd_view())),
+                _ => Err(OpError::InvalidValue("query must have 3 or 5 dims")),
+            }
+        }
+    }
+
+    /// Fused multi-head attention contrib operator.
+    ///
+    /// See
+    /// <https://github.com/microsoft/onnxruntime/blob/main/docs/ContribOperators.md#commicrosoftmultiheadattention>.
+    #[derive(Debug)]
+    pub struct MultiHeadAttention {
+        pub mask_filter_value: f32,
+        pub num_heads: u32,
+        pub scale: Option<f32>,
+        pub unidirectional: bool,
+    }
+
+    impl Operator for MultiHeadAttention {
+        fn name(&self) -> &str {
+            "MultiHeadAttention"
         }
 
-        let (query, key, value, batch_size, seq_len, head_size, v_head_size, v_hidden) = match query
-        {
-            MhaQuery::Packed(query) => {
-                let [batch_size, kv_seq_len, q_num_heads, three, head_size] = query.shape();
+        fn max_inputs(&self) -> Option<usize> {
+            Some(10)
+        }
 
-                if key.is_some() {
-                    return Err(OpError::InvalidValue(
-                        "key must be None when query is packed",
-                    ));
-                }
-                if value.is_some() {
-                    return Err(OpError::InvalidValue(
-                        "value must be None when query is packed",
-                    ));
-                }
-                if bias.is_some() {
-                    return Err(OpError::InvalidValue(
-                        "bias is not supported with packed QKV format",
-                    ));
-                }
-                if three != 3 {
-                    return Err(OpError::InvalidValue(
-                        "4th dimension of packed qkv input must be 3",
-                    ));
-                }
-                if q_num_heads != num_heads {
-                    return Err(OpError::InvalidValue(
-                        "2nd dimension of packed qkv input must be equal to number of attention heads",
-                    ));
-                }
-                let q = query.slice((.., .., .., 0, ..));
-                let k = query.slice((.., .., .., 1, ..));
-                let v = query.slice((.., .., .., 2, ..));
+        fn max_outputs(&self) -> Option<usize> {
+            // Spec defines 4 outputs: output, present_key, present_value, qk.
+            // The `qk` output is not yet implemented.
+            Some(3)
+        }
 
-                (
-                    // (batch, kv_seq, num_heads, head) => (batch, num_heads, kv_seq, head)
-                    q.permuted([0, 2, 1, 3]).as_cow(),
-                    k.permuted([0, 2, 1, 3]).as_cow(),
-                    v.permuted([0, 2, 1, 3]).as_cow(),
-                    batch_size,
-                    kv_seq_len,
-                    head_size,
-                    head_size,
-                    num_heads * head_size,
-                )
+        fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+            // (batch, seq, hidden) or (batch, kv_seq, num_heads, 3, head_size)
+            let query: TensorView<f32> = ctx.inputs().require_as(0)?;
+            let query = MhaQuery::new(query)?;
+
+            // (batch, kv_seq, hidden). Spec says it can be 4D or 5D as well, but
+            // this is not supported.
+            let key: Option<NdTensorView<f32, 3>> = ctx.inputs().get_as(1)?;
+
+            // (batch, kv_seq, hidden). Spec says it can be 4D as well, but this is
+            // not supported.
+            let value: Option<NdTensorView<f32, 3>> = ctx.inputs().get_as(2)?;
+            let bias: Option<NdTensorView<f32, 1>> = ctx.inputs().get_as(3)?;
+
+            // (batch, kv_seq). Spec says it can be 1D or 3D, but this is not supported.
+            let key_padding_mask: Option<NdTensorView<i32, 2>> = ctx.inputs().get_as(4)?;
+
+            // (batch or 1, num_heads or 1, seq, total_seq)
+            let attention_bias: Option<NdTensorView<f32, 4>> = ctx.inputs().get_as(5)?;
+
+            // (batch, num_heads, past_seq, head_size)
+            let past_key: Option<NdTensorView<f32, 4>> = ctx.inputs().get_as(6)?;
+            // (batch, num_heads, past_seq, head_size)
+            let past_value: Option<NdTensorView<f32, 4>> = ctx.inputs().get_as(7)?;
+
+            let past_seq_len: Option<NdTensorView<i32, 0>> = ctx.inputs().get_as(8)?;
+            if past_seq_len.is_some() {
+                return Err(OpError::UnsupportedValue("past_seq_len is not supported"));
             }
-            MhaQuery::Unpacked(query) => {
-                let [batch_size, seq_len, hidden] = query.shape();
-                if hidden % num_heads != 0 {
-                    return Err(OpError::IncompatibleInputShapes(
-                        "Hidden size must be divisible by number of attention heads",
-                    ));
-                }
-                let head_size = hidden / num_heads;
 
-                let (key, value) = match (key, value) {
-                    (None, _) => (query, query), // Reference impl ignores if value is some
-                    (Some(key), Some(value)) => (key, value),
-                    (Some(_), None) => {
-                        return Err(OpError::InvalidValue(
-                            "value input must be set if key input is present",
-                        ));
+            let cache_indirection: Option<NdTensorView<i32, 3>> = ctx.inputs().get_as(9)?;
+            if cache_indirection.is_some() {
+                return Err(OpError::UnsupportedValue(
+                    "cache_indirection is not supported",
+                ));
+            }
+
+            let num_heads = self.num_heads as usize;
+            if num_heads == 0 {
+                return Err(OpError::InvalidValue("num_heads must be positive"));
+            }
+
+            let (query, key, value, batch_size, seq_len, head_size, v_head_size, v_hidden) =
+                match query {
+                    MhaQuery::Packed(query) => {
+                        let [batch_size, kv_seq_len, q_num_heads, three, head_size] = query.shape();
+
+                        if key.is_some() {
+                            return Err(OpError::InvalidValue(
+                                "key must be None when query is packed",
+                            ));
+                        }
+                        if value.is_some() {
+                            return Err(OpError::InvalidValue(
+                                "value must be None when query is packed",
+                            ));
+                        }
+                        if bias.is_some() {
+                            return Err(OpError::InvalidValue(
+                                "bias is not supported with packed QKV format",
+                            ));
+                        }
+                        if three != 3 {
+                            return Err(OpError::InvalidValue(
+                                "4th dimension of packed qkv input must be 3",
+                            ));
+                        }
+                        if q_num_heads != num_heads {
+                            return Err(OpError::InvalidValue(
+                                "2nd dimension of packed qkv input must be equal to number of attention heads",
+                            ));
+                        }
+                        let q = query.slice((.., .., .., 0, ..));
+                        let k = query.slice((.., .., .., 1, ..));
+                        let v = query.slice((.., .., .., 2, ..));
+
+                        (
+                            // (batch, kv_seq, num_heads, head) => (batch, num_heads, kv_seq, head)
+                            q.permuted([0, 2, 1, 3]).as_cow(),
+                            k.permuted([0, 2, 1, 3]).as_cow(),
+                            v.permuted([0, 2, 1, 3]).as_cow(),
+                            batch_size,
+                            kv_seq_len,
+                            head_size,
+                            head_size,
+                            num_heads * head_size,
+                        )
                     }
-                };
+                    MhaQuery::Unpacked(query) => {
+                        let [batch_size, seq_len, hidden] = query.shape();
+                        if hidden % num_heads != 0 {
+                            return Err(OpError::IncompatibleInputShapes(
+                                "Hidden size must be divisible by number of attention heads",
+                            ));
+                        }
+                        let head_size = hidden / num_heads;
 
-                let [key_batch, key_seq_len, key_hidden] = key.shape();
-                let [value_batch, value_seq_len, v_hidden] = value.shape();
-                if key_batch != batch_size
-                    || value_batch != batch_size
-                    || value_seq_len != key_seq_len
-                {
-                    return Err(OpError::IncompatibleInputShapes(
-                        "Key and value batch or sequence lengths do not match",
-                    ));
-                }
-                if key_hidden != hidden {
-                    return Err(OpError::IncompatibleInputShapes(
-                        "Key hidden size does not match query hidden size",
-                    ));
-                }
-                if v_hidden % num_heads != 0 {
-                    return Err(OpError::IncompatibleInputShapes(
-                        "Value hidden size must be divisible by number of attention heads",
-                    ));
-                }
-                let v_head_size = v_hidden / num_heads;
+                        let (key, value) = match (key, value) {
+                            (None, _) => (query, query), // Reference impl ignores if value is some
+                            (Some(key), Some(value)) => (key, value),
+                            (Some(_), None) => {
+                                return Err(OpError::InvalidValue(
+                                    "value input must be set if key input is present",
+                                ));
+                            }
+                        };
 
-                let (query, key, value) = if let Some(bias) = bias {
-                    if bias.shape() != [hidden * 2 + v_hidden] {
-                        return Err(OpError::IncompatibleInputShapes(
-                            "Bias shape does not match QKV hidden sizes",
-                        ));
-                    }
-                    let q_bias = bias.slice(..hidden);
-                    let k_bias = bias.slice(hidden..(hidden * 2));
-                    let v_bias = bias.slice((hidden * 2)..);
+                        let [key_batch, key_seq_len, key_hidden] = key.shape();
+                        let [value_batch, value_seq_len, v_hidden] = value.shape();
+                        if key_batch != batch_size
+                            || value_batch != batch_size
+                            || value_seq_len != key_seq_len
+                        {
+                            return Err(OpError::IncompatibleInputShapes(
+                                "Key and value batch or sequence lengths do not match",
+                            ));
+                        }
+                        if key_hidden != hidden {
+                            return Err(OpError::IncompatibleInputShapes(
+                                "Key hidden size does not match query hidden size",
+                            ));
+                        }
+                        if v_hidden % num_heads != 0 {
+                            return Err(OpError::IncompatibleInputShapes(
+                                "Value hidden size must be divisible by number of attention heads",
+                            ));
+                        }
+                        let v_head_size = v_hidden / num_heads;
 
-                    let query = add(ctx.pool(), query.as_dyn(), q_bias.as_dyn())?
-                        .into_rank::<3>()
-                        .unwrap();
-                    let key = add(ctx.pool(), key.as_dyn(), k_bias.as_dyn())?
-                        .into_rank::<3>()
-                        .unwrap();
-                    let value = add(ctx.pool(), value.as_dyn(), v_bias.as_dyn())?
-                        .into_rank::<3>()
-                        .unwrap();
-                    (
-                        split_attention_heads(ctx.pool(), query.into_cow(), num_heads, head_size)?,
-                        split_attention_heads(ctx.pool(), key.into_cow(), num_heads, head_size)?,
-                        split_attention_heads(
-                            ctx.pool(),
-                            value.into_cow(),
-                            num_heads,
+                        let (query, key, value) = if let Some(bias) = bias {
+                            if bias.shape() != [hidden * 2 + v_hidden] {
+                                return Err(OpError::IncompatibleInputShapes(
+                                    "Bias shape does not match QKV hidden sizes",
+                                ));
+                            }
+                            let q_bias = bias.slice(..hidden);
+                            let k_bias = bias.slice(hidden..(hidden * 2));
+                            let v_bias = bias.slice((hidden * 2)..);
+
+                            let query = add(ctx.pool(), query.as_dyn(), q_bias.as_dyn())?
+                                .into_rank::<3>()
+                                .unwrap();
+                            let key = add(ctx.pool(), key.as_dyn(), k_bias.as_dyn())?
+                                .into_rank::<3>()
+                                .unwrap();
+                            let value = add(ctx.pool(), value.as_dyn(), v_bias.as_dyn())?
+                                .into_rank::<3>()
+                                .unwrap();
+                            (
+                                split_attention_heads(
+                                    ctx.pool(),
+                                    query.into_cow(),
+                                    num_heads,
+                                    head_size,
+                                )?,
+                                split_attention_heads(
+                                    ctx.pool(),
+                                    key.into_cow(),
+                                    num_heads,
+                                    head_size,
+                                )?,
+                                split_attention_heads(
+                                    ctx.pool(),
+                                    value.into_cow(),
+                                    num_heads,
+                                    v_head_size,
+                                )?,
+                            )
+                        } else {
+                            (
+                                split_attention_heads(
+                                    ctx.pool(),
+                                    query.as_cow(),
+                                    num_heads,
+                                    head_size,
+                                )?,
+                                split_attention_heads(
+                                    ctx.pool(),
+                                    key.as_cow(),
+                                    num_heads,
+                                    head_size,
+                                )?,
+                                split_attention_heads(
+                                    ctx.pool(),
+                                    value.as_cow(),
+                                    num_heads,
+                                    v_head_size,
+                                )?,
+                            )
+                        };
+
+                        (
+                            query,
+                            key,
+                            value,
+                            batch_size,
+                            seq_len,
+                            head_size,
                             v_head_size,
-                        )?,
-                    )
-                } else {
-                    (
-                        split_attention_heads(ctx.pool(), query.as_cow(), num_heads, head_size)?,
-                        split_attention_heads(ctx.pool(), key.as_cow(), num_heads, head_size)?,
-                        split_attention_heads(ctx.pool(), value.as_cow(), num_heads, v_head_size)?,
-                    )
+                            v_hidden,
+                        )
+                    }
                 };
 
-                (
-                    query,
-                    key,
-                    value,
-                    batch_size,
-                    seq_len,
-                    head_size,
-                    v_head_size,
-                    v_hidden,
-                )
-            }
-        };
+            let query = query.auto_return(ctx.pool());
+            let mut key = key.auto_return(ctx.pool());
+            let mut value = value.auto_return(ctx.pool());
 
-        let query = query.auto_return(ctx.pool());
-        let mut key = key.auto_return(ctx.pool());
-        let mut value = value.auto_return(ctx.pool());
-
-        // Concatenate present and past KV
-        match (past_key, past_value) {
-            (Some(past_key), Some(past_value)) => {
-                let [past_batch, past_heads, _past_seq, past_head_size] = past_key.shape();
-                if past_batch != batch_size
-                    || past_heads != num_heads
-                    || past_head_size != head_size
-                {
-                    return Err(OpError::IncompatibleInputShapes(
-                        "past_key shape does not match query/key shape",
+            // Concatenate present and past KV
+            match (past_key, past_value) {
+                (Some(past_key), Some(past_value)) => {
+                    let [past_batch, past_heads, _past_seq, past_head_size] = past_key.shape();
+                    if past_batch != batch_size
+                        || past_heads != num_heads
+                        || past_head_size != head_size
+                    {
+                        return Err(OpError::IncompatibleInputShapes(
+                            "past_key shape does not match query/key shape",
+                        ));
+                    }
+                    let [past_batch, past_heads, _past_seq, past_v_head_size] = past_value.shape();
+                    if past_batch != batch_size
+                        || past_heads != num_heads
+                        || past_v_head_size != v_head_size
+                    {
+                        return Err(OpError::IncompatibleInputShapes(
+                            "past_value shape does not match query/value shape",
+                        ));
+                    }
+                    key = concat(ctx.pool(), &[past_key.as_dyn(), key.as_dyn()], 2)?
+                        .into_rank::<4>()
+                        .unwrap()
+                        .into_cow()
+                        .auto_return(ctx.pool());
+                    value = concat(ctx.pool(), &[past_value.as_dyn(), value.as_dyn()], 2)?
+                        .into_rank::<4>()
+                        .unwrap()
+                        .into_cow()
+                        .auto_return(ctx.pool());
+                }
+                (Some(_), None) | (None, Some(_)) => {
+                    return Err(OpError::InvalidValue(
+                        "past_key and past_value must either both be present or both be absent",
                     ));
                 }
-                let [past_batch, past_heads, _past_seq, past_v_head_size] = past_value.shape();
-                if past_batch != batch_size
-                    || past_heads != num_heads
-                    || past_v_head_size != v_head_size
-                {
+                (None, None) => {}
+            }
+
+            // Compute attention scores - (Q ^ K^T) * scale + bias
+            let total_seq_len = key.size(2);
+            let scale = self
+                .scale
+                .unwrap_or_else(|| 1.0 / (head_size as f32).sqrt());
+            let key_t = key.permuted([0, 1, 3, 2]);
+
+            let mut scores = NdTensor::uninit_in(
+                ctx.pool(),
+                [batch_size, num_heads, query.size(2), key_t.size(3)],
+            );
+            let gemm = GemmExecutor::new();
+            scores
+                .inner_iter_mut::<2>()
+                .into_par_iter()
+                .zip(
+                    query
+                        .inner_iter::<2>()
+                        .into_par_iter()
+                        .zip(key_t.inner_iter::<2>().into_par_iter()),
+                )
+                .for_each(|(mut out, (query, key))| {
+                    gemm.gemm_uninit(
+                        out.data_mut().unwrap(),
+                        GemmInputA::Unpacked(query),
+                        GemmInputB::Unpacked(key),
+                        GemmUninitOptions {
+                            alpha: scale,
+                            ..Default::default()
+                        },
+                    )
+                    .unwrap();
+                });
+
+            // Safety: Score matrices initialized.
+            let mut scores = unsafe { scores.assume_init() };
+
+            if let Some(attention_bias) = attention_bias {
+                let attention_bias = attention_bias
+                    .try_broadcast(scores.shape())
+                    .map_err(|_| BROADCAST_ERROR)?;
+                add_in_place(scores.as_dyn_mut(), attention_bias.into());
+            }
+
+            // Apply masks to attention scores
+            if self.unidirectional {
+                let past_len = total_seq_len - seq_len;
+                for q_idx in 0..scores.size(2) {
+                    scores
+                        .slice_mut((.., .., q_idx, past_len + q_idx + 1..))
+                        .fill(self.mask_filter_value);
+                }
+            }
+
+            if let Some(key_padding_mask) = key_padding_mask {
+                if key_padding_mask.shape() != [batch_size, total_seq_len] {
                     return Err(OpError::IncompatibleInputShapes(
-                        "past_value shape does not match query/value shape",
+                        "key_padding_mask shape does not match key sequence length",
                     ));
                 }
-                key = concat(ctx.pool(), &[past_key.as_dyn(), key.as_dyn()], 2)?
-                    .into_rank::<4>()
-                    .unwrap()
-                    .into_cow()
-                    .auto_return(ctx.pool());
-                value = concat(ctx.pool(), &[past_value.as_dyn(), value.as_dyn()], 2)?
-                    .into_rank::<4>()
-                    .unwrap()
-                    .into_cow()
-                    .auto_return(ctx.pool());
-            }
-            (Some(_), None) | (None, Some(_)) => {
-                return Err(OpError::InvalidValue(
-                    "past_key and past_value must either both be present or both be absent",
-                ));
-            }
-            (None, None) => {}
-        }
-
-        // Compute attention scores - (Q ^ K^T) * scale + bias
-        let total_seq_len = key.size(2);
-        let scale = self
-            .scale
-            .unwrap_or_else(|| 1.0 / (head_size as f32).sqrt());
-        let key_t = key.permuted([0, 1, 3, 2]);
-
-        let mut scores = NdTensor::uninit_in(
-            ctx.pool(),
-            [batch_size, num_heads, query.size(2), key_t.size(3)],
-        );
-        let gemm = GemmExecutor::new();
-        scores
-            .inner_iter_mut::<2>()
-            .into_par_iter()
-            .zip(
-                query
-                    .inner_iter::<2>()
-                    .into_par_iter()
-                    .zip(key_t.inner_iter::<2>().into_par_iter()),
-            )
-            .for_each(|(mut out, (query, key))| {
-                gemm.gemm_uninit(
-                    out.data_mut().unwrap(),
-                    GemmInputA::Unpacked(query),
-                    GemmInputB::Unpacked(key),
-                    GemmUninitOptions {
-                        alpha: scale,
-                        ..Default::default()
-                    },
-                )
-                .unwrap();
-            });
-
-        // Safety: Score matrices initialized.
-        let mut scores = unsafe { scores.assume_init() };
-
-        if let Some(attention_bias) = attention_bias {
-            let attention_bias = attention_bias
-                .try_broadcast(scores.shape())
-                .map_err(|_| BROADCAST_ERROR)?;
-            add_in_place(scores.as_dyn_mut(), attention_bias.into());
-        }
-
-        // Apply masks to attention scores
-        if self.unidirectional {
-            let past_len = total_seq_len - seq_len;
-            for q_idx in 0..scores.size(2) {
-                scores
-                    .slice_mut((.., .., q_idx, past_len + q_idx + 1..))
-                    .fill(self.mask_filter_value);
-            }
-        }
-
-        if let Some(key_padding_mask) = key_padding_mask {
-            if key_padding_mask.shape() != [batch_size, total_seq_len] {
-                return Err(OpError::IncompatibleInputShapes(
-                    "key_padding_mask shape does not match key sequence length",
-                ));
-            }
-            for batch in 0..scores.size(0) {
-                for head in 0..scores.size(1) {
-                    for key_idx in 0..scores.size(2) {
-                        if key_padding_mask[[batch, key_idx]] == 0 {
-                            for query_idx in 0..seq_len {
-                                scores[[batch, head, query_idx, key_idx]] = self.mask_filter_value;
+                for batch in 0..scores.size(0) {
+                    for head in 0..scores.size(1) {
+                        for key_idx in 0..scores.size(2) {
+                            if key_padding_mask[[batch, key_idx]] == 0 {
+                                for query_idx in 0..seq_len {
+                                    scores[[batch, head, query_idx, key_idx]] =
+                                        self.mask_filter_value;
+                                }
                             }
                         }
                     }
                 }
             }
+
+            // Normalize scores to probabilities.
+            scores.lanes_mut(3).into_par_iter().for_each(|mut lane| {
+                Softmax::new_mut(lane.as_slice_mut().unwrap()).dispatch();
+            });
+
+            // Compute attention outputs.
+            let context = matmul(ctx.pool(), scores.as_dyn(), value.as_dyn(), None)?
+                .into_rank::<4>()
+                .unwrap()
+                .auto_return(ctx.pool());
+            let output = context
+                .permuted([0, 2, 1, 3])
+                .to_tensor_in(ctx.pool())
+                .into_shape([batch_size, seq_len, v_hidden]);
+
+            let mut outputs: OutputList = [output.into()].into();
+            if ctx.outputs().get(1) || ctx.outputs().get(2) {
+                outputs.push(key.take().into_owned().into());
+                outputs.push(value.take().into_owned().into());
+            }
+            Ok(outputs)
         }
 
-        // Normalize scores to probabilities.
-        scores.lanes_mut(3).into_par_iter().for_each(|mut lane| {
-            Softmax::new_mut(lane.as_slice_mut().unwrap()).dispatch();
-        });
-
-        // Compute attention outputs.
-        let context = matmul(ctx.pool(), scores.as_dyn(), value.as_dyn(), None)?
-            .into_rank::<4>()
-            .unwrap()
-            .auto_return(ctx.pool());
-        let output = context
-            .permuted([0, 2, 1, 3])
-            .to_tensor_in(ctx.pool())
-            .into_shape([batch_size, seq_len, v_hidden]);
-
-        let mut outputs: OutputList = [output.into()].into();
-        if ctx.outputs().get(1) || ctx.outputs().get(2) {
-            outputs.push(key.take().into_owned().into());
-            outputs.push(value.take().into_owned().into());
+        fn output_types(&self, _ctx: &OutputTypesContext) -> Option<OutputTypeList> {
+            Some([OutputType::CopyFromInput(0)].into())
         }
-        Ok(outputs)
+
+        fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+            Some(self)
+        }
     }
 
-    fn output_types(&self, _ctx: &OutputTypesContext) -> Option<OutputTypeList> {
-        Some([OutputType::CopyFromInput(0)].into())
-    }
-
-    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
-        Some(self)
-    }
+    impl_infer_shapes!(
+        MultiHeadAttention,
+        op,
+        shape_ops::MultiHeadAttention {
+            num_heads: op.num_heads,
+        }
+    );
 }
-
-impl_infer_shapes!(
-    MultiHeadAttention,
-    op,
-    shape_ops::MultiHeadAttention {
-        num_heads: op.num_heads,
-    }
-);
 
 #[cfg(test)]
 mod tests {

--- a/src/ops/embedding.rs
+++ b/src/ops/embedding.rs
@@ -1,6 +1,6 @@
 use rayon::prelude::*;
 use rten_tensor::prelude::*;
-use rten_tensor::{NdTensor, NdTensorView, Tensor, TensorView};
+use rten_tensor::{NdTensorView, Tensor, TensorView};
 
 use crate::{
     buffer_pool::{AutoReturn, BufferPool},
@@ -243,124 +243,143 @@ impl Operator for RotaryEmbedding {
     }
 }
 
-#[derive(Debug)]
-pub struct RotaryEmbeddingMicrosoft {
-    pub interleaved: bool,
-    pub num_heads: Option<usize>,
-    pub rotary_embedding_dim: usize,
-}
+#[cfg(feature = "onnx_format")]
+pub use contrib::RotaryEmbeddingMicrosoft;
 
-impl Operator for RotaryEmbeddingMicrosoft {
-    fn name(&self) -> &str {
-        "com.microsoft.RotaryEmbedding"
+#[cfg(feature = "onnx_format")]
+mod contrib {
+    use rten_tensor::prelude::*;
+    use rten_tensor::{NdTensor, TensorView};
+
+    use crate::{
+        infer_shapes::{InferShapes, UnaryOp},
+        operator::{
+            IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType, OutputTypeList,
+            OutputTypesContext,
+        },
+    };
+
+    use super::rotary_embedding;
+
+    #[derive(Debug)]
+    pub struct RotaryEmbeddingMicrosoft {
+        pub interleaved: bool,
+        pub num_heads: Option<usize>,
+        pub rotary_embedding_dim: usize,
     }
 
-    fn max_inputs(&self) -> Option<usize> {
-        Some(4)
-    }
+    impl Operator for RotaryEmbeddingMicrosoft {
+        fn name(&self) -> &str {
+            "com.microsoft.RotaryEmbedding"
+        }
 
-    fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
-        let inputs = ctx.inputs();
+        fn max_inputs(&self) -> Option<usize> {
+            Some(4)
+        }
 
-        let input: TensorView<f32> = inputs.require_as(0)?;
-        let position_ids: TensorView<i32> = inputs.require_as(1)?;
-        let cos: TensorView<f32> = inputs.require_as(2)?;
-        let sin = inputs.require_as(3)?;
+        fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+            let inputs = ctx.inputs();
 
-        // The sequence length is needed to expand the offset form of
-        // `position_ids` below. The shared implementation re-validates the full
-        // input shape.
-        let (batch, seq_len) = match *input.shape() {
-            [batch, seq_len, _] => (batch, seq_len),
-            [batch, _, seq_len, _] => (batch, seq_len),
-            _ => {
-                return Err(OpError::IncompatibleInputShapes(
-                    "Input processed needs 3-4 dimensions",
-                ));
-            }
-        };
+            let input: TensorView<f32> = inputs.require_as(0)?;
+            let position_ids: TensorView<i32> = inputs.require_as(1)?;
+            let cos: TensorView<f32> = inputs.require_as(2)?;
+            let sin = inputs.require_as(3)?;
 
-        // `position_ids` has two forms, matching ONNX Runtime's contrib op:
-        //
-        //  - Format 1, shape `(batch, seq_len)`: the explicit position of each
-        //    token.
-        //  - Format 0, a scalar or 1-element tensor holding an offset `k`:
-        //    token `i` uses position `k + i`. This is used during generation,
-        //    where only the position of the sequence's first token is passed.
-        let offset_positions;
-        let position_ids = match (position_ids.ndim(), position_ids.item().copied()) {
-            (0 | 1, Some(offset)) => {
-                offset_positions =
-                    NdTensor::from_fn([batch, seq_len], |[_, pos]| offset + pos as i32);
-                offset_positions.view()
-            }
-            (2, _) => position_ids.nd_view(),
-            _ => {
-                return Err(OpError::InvalidValue(
-                    "position_ids must be a scalar, a 1-element vector or have 2 dims",
-                ));
-            }
-        };
-
-        let num_heads = match input.shape() {
-            &[_, _, hidden_size] => match self.num_heads {
-                // The ONNX spec requires `num_heads` for rank-3 input. The
-                // Microsoft contrib op gives this attribute a default of 0, so
-                // infer it from the cos cache before calling the shared
-                // implementation. The cache's last dimension is
-                // `rotary_embedding_dim / 2`, which only equals `head_size / 2`
-                // for full rotation. With partial rotary embeddings the head
-                // size cannot be recovered from the cache, so `num_heads` must
-                // be provided explicitly.
-                Some(0) | None => {
-                    if self.rotary_embedding_dim != 0 {
-                        return Err(OpError::InvalidValue(
-                            "num_heads must be specified when rotary_embedding_dim is set",
-                        ));
-                    }
-                    let head_size_half = cos
-                        .shape()
-                        .last()
-                        .copied()
-                        .ok_or(OpError::InvalidValue("cos cache must not be scalar"))?;
-                    if head_size_half == 0 {
-                        return Err(OpError::InvalidValue(
-                            "Last dimension of cos cache must not be 0",
-                        ));
-                    }
-                    let head_size = head_size_half * 2;
-                    if hidden_size % head_size != 0 {
-                        return Err(OpError::InvalidValue(
-                            "hidden_size must be divisible by head size",
-                        ));
-                    }
-                    hidden_size / head_size
+            // The sequence length is needed to expand the offset form of
+            // `position_ids` below. The shared implementation re-validates the full
+            // input shape.
+            let (batch, seq_len) = match *input.shape() {
+                [batch, seq_len, _] => (batch, seq_len),
+                [batch, _, seq_len, _] => (batch, seq_len),
+                _ => {
+                    return Err(OpError::IncompatibleInputShapes(
+                        "Input processed needs 3-4 dimensions",
+                    ));
                 }
-                Some(num_heads) => num_heads,
-            },
-            _ => self.num_heads.unwrap_or_default(),
-        };
+            };
 
-        let output = rotary_embedding(
-            ctx.pool(),
-            input,
-            cos,
-            sin,
-            Some(position_ids),
-            self.interleaved,
-            num_heads,
-            self.rotary_embedding_dim,
-        )?;
+            // `position_ids` has two forms, matching ONNX Runtime's contrib op:
+            //
+            //  - Format 1, shape `(batch, seq_len)`: the explicit position of each
+            //    token.
+            //  - Format 0, a scalar or 1-element tensor holding an offset `k`:
+            //    token `i` uses position `k + i`. This is used during generation,
+            //    where only the position of the sequence's first token is passed.
+            let offset_positions;
+            let position_ids = match (position_ids.ndim(), position_ids.item().copied()) {
+                (0 | 1, Some(offset)) => {
+                    offset_positions =
+                        NdTensor::from_fn([batch, seq_len], |[_, pos]| offset + pos as i32);
+                    offset_positions.view()
+                }
+                (2, _) => position_ids.nd_view(),
+                _ => {
+                    return Err(OpError::InvalidValue(
+                        "position_ids must be a scalar, a 1-element vector or have 2 dims",
+                    ));
+                }
+            };
 
-        output.into_op_result()
-    }
+            let num_heads = match input.shape() {
+                &[_, _, hidden_size] => match self.num_heads {
+                    // The ONNX spec requires `num_heads` for rank-3 input. The
+                    // Microsoft contrib op gives this attribute a default of 0, so
+                    // infer it from the cos cache before calling the shared
+                    // implementation. The cache's last dimension is
+                    // `rotary_embedding_dim / 2`, which only equals `head_size / 2`
+                    // for full rotation. With partial rotary embeddings the head
+                    // size cannot be recovered from the cache, so `num_heads` must
+                    // be provided explicitly.
+                    Some(0) | None => {
+                        if self.rotary_embedding_dim != 0 {
+                            return Err(OpError::InvalidValue(
+                                "num_heads must be specified when rotary_embedding_dim is set",
+                            ));
+                        }
+                        let head_size_half = cos
+                            .shape()
+                            .last()
+                            .copied()
+                            .ok_or(OpError::InvalidValue("cos cache must not be scalar"))?;
+                        if head_size_half == 0 {
+                            return Err(OpError::InvalidValue(
+                                "Last dimension of cos cache must not be 0",
+                            ));
+                        }
+                        let head_size = head_size_half * 2;
+                        if hidden_size % head_size != 0 {
+                            return Err(OpError::InvalidValue(
+                                "hidden_size must be divisible by head size",
+                            ));
+                        }
+                        hidden_size / head_size
+                    }
+                    Some(num_heads) => num_heads,
+                },
+                _ => self.num_heads.unwrap_or_default(),
+            };
 
-    fn output_types(&self, _ctx: &OutputTypesContext) -> Option<OutputTypeList> {
-        Some([OutputType::CopyFromInput(0)].into())
-    }
+            let output = rotary_embedding(
+                ctx.pool(),
+                input,
+                cos,
+                sin,
+                Some(position_ids),
+                self.interleaved,
+                num_heads,
+                self.rotary_embedding_dim,
+            )?;
 
-    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
-        Some(&UnaryOp)
+            output.into_op_result()
+        }
+
+        fn output_types(&self, _ctx: &OutputTypesContext) -> Option<OutputTypeList> {
+            Some([OutputType::CopyFromInput(0)].into())
+        }
+
+        fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+            Some(&UnaryOp)
+        }
     }
 }
 

--- a/src/ops/matmul.rs
+++ b/src/ops/matmul.rs
@@ -3,13 +3,12 @@ use std::any::TypeId;
 use rayon::prelude::*;
 use rten_base::byte_cast::{Pod, cast_pod_vec};
 use rten_gemm::{
-    BiasVector, BlockQuantizedError, BlockQuantizedGemm, BlockQuantizedMatrix, ComputeMode,
-    GemmExecutor, GemmInT, GemmInputA, GemmInputB, GemmOptions, GemmOutT, GemmUninitOptions,
-    PackedBMatrix, QuantParams,
+    BiasVector, GemmExecutor, GemmInT, GemmInputA, GemmInputB, GemmOptions, GemmOutT,
+    GemmUninitOptions, PackedBMatrix, QuantParams,
 };
 use rten_shape_inference::ops as shape_ops;
 use rten_tensor::prelude::*;
-use rten_tensor::{CowNdTensor, CowTensor, Matrix, NdTensorView, Tensor, TensorView};
+use rten_tensor::{CowTensor, Matrix, NdTensorView, Tensor, TensorView};
 use rten_vecmath::ExtendInit;
 use smallvec::SmallVec;
 
@@ -798,179 +797,203 @@ impl Operator for MatMulIntegerToFloat {
     }
 }
 
-fn matmul_nbits(
-    pool: &BufferPool,
-    lhs: TensorView<f32>,
-    rhs: NdTensorView<u8, 3>,
-    scales: NdTensorView<f32, 2>,
-    bits: u8,
-    accuracy: AccuracyLevel,
-) -> Result<Tensor<f32>, OpError> {
-    if lhs.ndim() < 2 {
-        return Err(OpError::InvalidValue("A input must have at least 2 dims"));
-    }
+#[cfg(feature = "onnx_format")]
+pub use contrib::{AccuracyLevel, MatMulNBits};
 
-    let batch_dims = &lhs.shape()[..lhs.ndim() - 2];
-    let rows = lhs.size(lhs.ndim() - 2);
-    let lhs_cols = lhs.size(lhs.ndim() - 1);
+#[cfg(feature = "onnx_format")]
+mod contrib {
+    use rten_gemm::{
+        BlockQuantizedError, BlockQuantizedGemm, BlockQuantizedMatrix, ComputeMode, GemmExecutor,
+        GemmInputA, GemmInputB, GemmUninitOptions,
+    };
+    use rten_shape_inference::ops as shape_ops;
+    use rten_tensor::prelude::*;
+    use rten_tensor::{CowNdTensor, NdTensorView, Tensor, TensorView};
+    use rten_vecmath::ExtendInit;
+    use smallvec::SmallVec;
 
-    let rhs = rhs.to_contiguous_in(pool);
-    let scales = scales.to_contiguous_in(pool);
+    use crate::buffer_pool::{AutoReturn, BufferPool};
+    use crate::infer_shapes::InferShapes;
+    use crate::operator::{
+        IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType, OutputTypeList,
+        OutputTypesContext,
+    };
+    use crate::value::{DataType, ValueType};
 
-    let b_mat = BlockQuantizedMatrix::new(rhs.view(), scales.view(), bits).map_err(|err| {
-        OpError::UnsupportedValue(match err {
-            BlockQuantizedError::UnsupportedBlockSize => "Unsupported K block size",
-            BlockQuantizedError::UnsupportedElementSize => "Unsupported bits-per-element",
-        })
-    })?;
+    fn matmul_nbits(
+        pool: &BufferPool,
+        lhs: TensorView<f32>,
+        rhs: NdTensorView<u8, 3>,
+        scales: NdTensorView<f32, 2>,
+        bits: u8,
+        accuracy: AccuracyLevel,
+    ) -> Result<Tensor<f32>, OpError> {
+        if lhs.ndim() < 2 {
+            return Err(OpError::InvalidValue("A input must have at least 2 dims"));
+        }
 
-    let batch_len = batch_dims.iter().product();
-    let out_shape: SmallVec<[usize; 4]> = batch_dims
-        .iter()
-        .copied()
-        .chain([rows, b_mat.cols()])
-        .collect();
-    let out_len = out_shape.iter().product();
-    let mut out_data = pool.alloc(out_len);
+        let batch_dims = &lhs.shape()[..lhs.ndim() - 2];
+        let rows = lhs.size(lhs.ndim() - 2);
+        let lhs_cols = lhs.size(lhs.ndim() - 1);
 
-    if lhs_cols != b_mat.rows() {
-        return Err(OpError::IncompatibleInputShapes(
-            "Columns of first matrix does not match rows of second matrix",
-        ));
-    }
+        let rhs = rhs.to_contiguous_in(pool);
+        let scales = scales.to_contiguous_in(pool);
 
-    // For vector-matrix products use an optimized implementation. Otherwise use
-    // the standard GEMM implementation which handles block-quantized inputs via
-    // a custom packing function, but otherwise uses the same logic as for
-    // regular matmuls.
-    if rows == 1 {
-        let compute = match accuracy {
-            AccuracyLevel::Int8 => ComputeMode::Int8,
-            AccuracyLevel::Float => ComputeMode::Float,
-        };
-        let gemm = if BlockQuantizedGemm::is_compute_optimized(compute) {
-            BlockQuantizedGemm::new().with_compute(compute)
-        } else {
-            BlockQuantizedGemm::new()
-        };
+        let b_mat = BlockQuantizedMatrix::new(rhs.view(), scales.view(), bits).map_err(|err| {
+            OpError::UnsupportedValue(match err {
+                BlockQuantizedError::UnsupportedBlockSize => "Unsupported K block size",
+                BlockQuantizedError::UnsupportedElementSize => "Unsupported bits-per-element",
+            })
+        })?;
 
-        let lhs = lhs
-            .reshaped_in(pool, [batch_len, rows, lhs_cols])
-            .auto_return(pool);
-        out_data.extend_init(|uninit_out_data| {
-            gemm.batched_gemm_uninit(&mut uninit_out_data[..out_len], lhs.view(), b_mat)
-                .unwrap()
-        });
-    } else {
-        let lhs = lhs
-            .reshaped_in(pool, [batch_len * rows, lhs_cols])
-            .auto_return(pool);
+        let batch_len = batch_dims.iter().product();
+        let out_shape: SmallVec<[usize; 4]> = batch_dims
+            .iter()
+            .copied()
+            .chain([rows, b_mat.cols()])
+            .collect();
+        let out_len = out_shape.iter().product();
+        let mut out_data = pool.alloc(out_len);
 
-        let gemm = GemmExecutor::default();
-        out_data.extend_init(|uninit_out_data| {
-            gemm.gemm_uninit(
-                &mut uninit_out_data[..out_len],
-                GemmInputA::Unpacked(lhs.view()),
-                GemmInputB::BlockQuantized(b_mat),
-                GemmUninitOptions::default(),
-            )
-            .unwrap()
-        });
-    }
-
-    Ok(Tensor::from_data(out_shape.as_slice(), out_data))
-}
-
-/// Specifies whether the LHS input may be quantized.
-///
-/// Using [`Int8`](Self::Int8) quantization can significantly improve
-/// performance but may reduce accuracy. The accuracy level that is used may
-/// be higher than requested if an optimized implementation of the requested
-/// level is not available on the current platform.
-#[derive(Copy, Clone, Debug, PartialEq)]
-pub enum AccuracyLevel {
-    /// Do not quantize the LHS input.
-    Float,
-    /// Quantize the LHS to 8-bit integers using blockwise quantization with
-    /// the same quantization as the RHS.
-    Int8,
-}
-
-/// Matrix multiplication of un-quantized LHS by block-quantized RHS.
-///
-/// See https://github.com/microsoft/onnxruntime/blob/main/docs/ContribOperators.md#com.microsoft.MatMulNBits.
-#[derive(Debug)]
-pub struct MatMulNBits {
-    pub bits: u8,
-    pub block_size: usize,
-    pub accuracy_level: AccuracyLevel,
-}
-
-impl Operator for MatMulNBits {
-    fn name(&self) -> &str {
-        "MatMulNBits"
-    }
-
-    fn max_inputs(&self) -> Option<usize> {
-        Some(3)
-    }
-
-    fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
-        let lhs: TensorView<f32> = ctx.inputs().require_as(0)?;
-        let rhs: NdTensorView<u8, 3> = ctx.inputs().require_as(1)?;
-
-        // Current spec requires scales to be 2D, but earlier versions used 1D
-        // scales. See https://github.com/microsoft/onnxruntime/pull/24828.
-        let scales: TensorView<f32> = ctx.inputs().require_as(2)?;
-
-        let scales: CowNdTensor<f32, 2> = match scales.ndim() {
-            2 => scales
-                .to_contiguous_in(ctx.pool())
-                .into_inner()
-                .try_into()
-                .unwrap(),
-            1 => {
-                let k = lhs.ndim().checked_sub(1).map(|d| lhs.size(d)).unwrap_or(1);
-                let k_blocks = k.checked_div(self.block_size).unwrap_or(0);
-                let rhs_cols = rhs.size(0);
-
-                if scales.len() != rhs_cols * k_blocks {
-                    return Err(OpError::InvalidValue(
-                        "Expected 1D `scales` size to match columns * block_size",
-                    ));
-                }
-                scales.reshaped([rhs_cols, k_blocks])
-            }
-            _ => {
-                return Err(OpError::InvalidValue(
-                    "Expected `scales` to have one or two dims",
-                ));
-            }
-        };
-
-        if ctx.inputs().len() > 3 {
-            return Err(OpError::UnsupportedValue(
-                "zero_points, g_idx and bias inputs are unsupported",
+        if lhs_cols != b_mat.rows() {
+            return Err(OpError::IncompatibleInputShapes(
+                "Columns of first matrix does not match rows of second matrix",
             ));
         }
 
-        matmul_nbits(
-            ctx.pool(),
-            lhs,
-            rhs,
-            scales.view(),
-            self.bits,
-            self.accuracy_level,
-        )
-        .into_op_result()
+        // For vector-matrix products use an optimized implementation. Otherwise use
+        // the standard GEMM implementation which handles block-quantized inputs via
+        // a custom packing function, but otherwise uses the same logic as for
+        // regular matmuls.
+        if rows == 1 {
+            let compute = match accuracy {
+                AccuracyLevel::Int8 => ComputeMode::Int8,
+                AccuracyLevel::Float => ComputeMode::Float,
+            };
+            let gemm = if BlockQuantizedGemm::is_compute_optimized(compute) {
+                BlockQuantizedGemm::new().with_compute(compute)
+            } else {
+                BlockQuantizedGemm::new()
+            };
+
+            let lhs = lhs
+                .reshaped_in(pool, [batch_len, rows, lhs_cols])
+                .auto_return(pool);
+            out_data.extend_init(|uninit_out_data| {
+                gemm.batched_gemm_uninit(&mut uninit_out_data[..out_len], lhs.view(), b_mat)
+                    .unwrap()
+            });
+        } else {
+            let lhs = lhs
+                .reshaped_in(pool, [batch_len * rows, lhs_cols])
+                .auto_return(pool);
+
+            let gemm = GemmExecutor::default();
+            out_data.extend_init(|uninit_out_data| {
+                gemm.gemm_uninit(
+                    &mut uninit_out_data[..out_len],
+                    GemmInputA::Unpacked(lhs.view()),
+                    GemmInputB::BlockQuantized(b_mat),
+                    GemmUninitOptions::default(),
+                )
+                .unwrap()
+            });
+        }
+
+        Ok(Tensor::from_data(out_shape.as_slice(), out_data))
     }
 
-    fn output_types(&self, _ctx: &OutputTypesContext) -> Option<OutputTypeList> {
-        Some([OutputType::Fixed(ValueType::Tensor(DataType::Float))].into())
+    /// Specifies whether the LHS input may be quantized.
+    ///
+    /// Using [`Int8`](Self::Int8) quantization can significantly improve
+    /// performance but may reduce accuracy. The accuracy level that is used may
+    /// be higher than requested if an optimized implementation of the requested
+    /// level is not available on the current platform.
+    #[derive(Copy, Clone, Debug, PartialEq)]
+    pub enum AccuracyLevel {
+        /// Do not quantize the LHS input.
+        Float,
+        /// Quantize the LHS to 8-bit integers using blockwise quantization with
+        /// the same quantization as the RHS.
+        Int8,
     }
 
-    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
-        Some(&shape_ops::MatMulNBits)
+    /// Matrix multiplication of un-quantized LHS by block-quantized RHS.
+    ///
+    /// See https://github.com/microsoft/onnxruntime/blob/main/docs/ContribOperators.md#com.microsoft.MatMulNBits.
+    #[derive(Debug)]
+    pub struct MatMulNBits {
+        pub bits: u8,
+        pub block_size: usize,
+        pub accuracy_level: AccuracyLevel,
+    }
+
+    impl Operator for MatMulNBits {
+        fn name(&self) -> &str {
+            "MatMulNBits"
+        }
+
+        fn max_inputs(&self) -> Option<usize> {
+            Some(3)
+        }
+
+        fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+            let lhs: TensorView<f32> = ctx.inputs().require_as(0)?;
+            let rhs: NdTensorView<u8, 3> = ctx.inputs().require_as(1)?;
+
+            // Current spec requires scales to be 2D, but earlier versions used 1D
+            // scales. See https://github.com/microsoft/onnxruntime/pull/24828.
+            let scales: TensorView<f32> = ctx.inputs().require_as(2)?;
+
+            let scales: CowNdTensor<f32, 2> = match scales.ndim() {
+                2 => scales
+                    .to_contiguous_in(ctx.pool())
+                    .into_inner()
+                    .try_into()
+                    .unwrap(),
+                1 => {
+                    let k = lhs.ndim().checked_sub(1).map(|d| lhs.size(d)).unwrap_or(1);
+                    let k_blocks = k.checked_div(self.block_size).unwrap_or(0);
+                    let rhs_cols = rhs.size(0);
+
+                    if scales.len() != rhs_cols * k_blocks {
+                        return Err(OpError::InvalidValue(
+                            "Expected 1D `scales` size to match columns * block_size",
+                        ));
+                    }
+                    scales.reshaped([rhs_cols, k_blocks])
+                }
+                _ => {
+                    return Err(OpError::InvalidValue(
+                        "Expected `scales` to have one or two dims",
+                    ));
+                }
+            };
+
+            if ctx.inputs().len() > 3 {
+                return Err(OpError::UnsupportedValue(
+                    "zero_points, g_idx and bias inputs are unsupported",
+                ));
+            }
+
+            matmul_nbits(
+                ctx.pool(),
+                lhs,
+                rhs,
+                scales.view(),
+                self.bits,
+                self.accuracy_level,
+            )
+            .into_op_result()
+        }
+
+        fn output_types(&self, _ctx: &OutputTypesContext) -> Option<OutputTypeList> {
+            Some([OutputType::Fixed(ValueType::Tensor(DataType::Float))].into())
+        }
+
+        fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+            Some(&shape_ops::MatMulNBits)
+        }
     }
 }
 

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -119,6 +119,10 @@ pub(crate) use {
     variadic_elementwise::{Max, Mean, Min, Sum},
 };
 
+// Non-standard "contrib" operators in the `com.microsoft` namespace which
+// are supported.
+//
+// See https://onnxruntime.ai/docs/reference/operators/ContribOperators.html.
 #[cfg(feature = "onnx_format")]
 pub(crate) use {
     attention::MultiHeadAttention,

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -68,7 +68,7 @@ pub(crate) use random::{
     Dropout, Multinomial, RandomNormal, RandomNormalLike, RandomUniform, RandomUniformLike,
 };
 pub(crate) use {
-    attention::{AddSoftmax, GroupedQueryAttentionMatMul, MultiHeadAttention, RepeatInterleave},
+    attention::{AddSoftmax, GroupedQueryAttentionMatMul, RepeatInterleave},
     binary_elementwise::{
         Add, And, Div, Equal, Greater, GreaterOrEqual, Less, LessOrEqual, Mod, Mul, Or, Pow, Sub,
         Where, Xor,
@@ -80,7 +80,7 @@ pub(crate) use {
     conv_transpose::ConvTranspose,
     convert::{Cast, CastLike},
     einsum::Einsum,
-    embedding::{RotaryEmbedding, RotaryEmbeddingMicrosoft},
+    embedding::RotaryEmbedding,
     gather::{
         Gather, GatherElements, GatherND, ReverseSequence, Scatter, ScatterElements, ScatterND,
         ScatterReduction,
@@ -89,13 +89,11 @@ pub(crate) use {
     grid_sample::GridSample,
     identity::Identity,
     layout::{DepthToSpace, Expand, Flatten, Reshape, Shape, Size, Squeeze, Transpose, Unsqueeze},
-    matmul::{
-        AccuracyLevel, FusedMatMul, Gemm, MatMul, MatMulInteger, MatMulIntegerToFloat, MatMulNBits,
-    },
+    matmul::{FusedMatMul, Gemm, MatMul, MatMulInteger, MatMulIntegerToFloat},
     non_max_suppression::NonMaxSuppression,
     norm::{
         BatchNormalization, InstanceNormalization, LayerNormalization, LogSoftmax,
-        RMSNormalization, SimplifiedLayerNormalization, SkipSimplifiedLayerNormalization, Softmax,
+        RMSNormalization, Softmax,
     },
     pad::Pad,
     pooling::{AveragePool, GlobalAveragePool, GlobalMaxPool, MaxPool},
@@ -119,6 +117,14 @@ pub(crate) use {
         Relu, Round, Sigmoid, Sign, Silu, Sin, Sinh, Softplus, Sqrt, Swish, Tan, Tanh,
     },
     variadic_elementwise::{Max, Mean, Min, Sum},
+};
+
+#[cfg(feature = "onnx_format")]
+pub(crate) use {
+    attention::MultiHeadAttention,
+    embedding::RotaryEmbeddingMicrosoft,
+    matmul::{AccuracyLevel, MatMulNBits},
+    norm::{SimplifiedLayerNormalization, SkipSimplifiedLayerNormalization},
 };
 
 // Operators as functions. These are exported for use by pre/post-processing

--- a/src/ops/norm.rs
+++ b/src/ops/norm.rs
@@ -2,7 +2,6 @@ use std::mem::MaybeUninit;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use rayon::prelude::*;
-use rten_shape_inference::ops as shape_ops;
 use rten_simd::SimdOp;
 use rten_tensor::prelude::*;
 use rten_tensor::{NdTensorView, Tensor, TensorView};
@@ -14,7 +13,7 @@ use crate::operator::{
     IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType, OutputTypeList,
     OutputTypesContext, check_eq,
 };
-use crate::ops::{add, resolve_axis};
+use crate::ops::resolve_axis;
 use crate::slice_reductions::slice_max;
 use crate::value::Value;
 
@@ -547,127 +546,6 @@ impl Operator for LayerNormalization {
     }
 }
 
-/// Simplified Layer Normalization
-///
-/// This is a experimental ONNX operator for layer normalization which is equivalent to the later
-/// stabilised RMSNormalization. See [onnx/onnx#6582](https://github.com/onnx/onnx/issues/6582) for
-/// more details.
-#[derive(Debug)]
-pub struct SimplifiedLayerNormalization {
-    pub axis: isize,
-    pub epsilon: Option<f32>,
-}
-
-impl Operator for SimplifiedLayerNormalization {
-    fn name(&self) -> &str {
-        "SimplifiedLayerNormalization"
-    }
-
-    fn max_inputs(&self) -> Option<usize> {
-        Some(2)
-    }
-
-    fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
-        let inputs = ctx.inputs();
-        let input = inputs.require_as(0)?;
-        let scale = inputs.require_as(1)?;
-
-        rms_normalization(ctx.pool(), input, scale, self.axis, self.epsilon).into_op_result()
-    }
-
-    fn output_types(&self, _ctx: &OutputTypesContext) -> Option<OutputTypeList> {
-        Some([OutputType::CopyFromInput(0)].into())
-    }
-
-    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
-        Some(&UnaryOp)
-    }
-}
-
-/// Skip Simplified Layer Normalization
-///
-/// This is a fusion of `Add` and `RMSNormalization` (also known as
-/// SimplifiedLayerNormalization in Microsoft's contrib ops).
-///
-/// See https://github.com/microsoft/onnxruntime/blob/main/docs/ContribOperators.md#com.microsoft.SkipSimplifiedLayerNormalization
-#[derive(Debug)]
-pub struct SkipSimplifiedLayerNormalization {
-    pub epsilon: f32,
-}
-
-impl Operator for SkipSimplifiedLayerNormalization {
-    fn name(&self) -> &str {
-        "SkipSimplifiedLayerNormalisation"
-    }
-
-    fn max_inputs(&self) -> Option<usize> {
-        Some(4)
-    }
-
-    fn max_outputs(&self) -> Option<usize> {
-        Some(4)
-    }
-
-    fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
-        let inputs = ctx.inputs();
-        let input: TensorView<_> = inputs.require_as(0)?;
-        let skip: TensorView<_> = inputs.require_as(1)?;
-
-        // Scale factor, called gamma (γ) in the RMS normalization paper.
-        let gamma: TensorView<_> = inputs.require_as(2)?;
-
-        let bias: Option<TensorView<_>> = inputs.get_as(3)?;
-
-        if input.shape() != skip.shape() {
-            return Err(OpError::IncompatibleInputShapes(
-                "input and skip tensor shapes must match",
-            ));
-        }
-
-        if !matches!(input.ndim(), 2 | 3) {
-            return Err(OpError::InvalidValue("input must be 2 or 3 dimensioned"));
-        }
-
-        let mut x_plus_skip = add(ctx.pool(), input, skip)?;
-        if let Some(bias) = bias {
-            x_plus_skip = add(ctx.pool(), x_plus_skip.view(), bias)?;
-        }
-
-        let output = layer_normalization_impl(
-            ctx.pool(),
-            x_plus_skip.view(),
-            gamma,
-            None,
-            -1,
-            Some(self.epsilon),
-            MeanNormalize::DynamicRootMeanSquare,
-        )?;
-
-        let mut outputs: OutputList = [output.into()].into();
-        if ctx.outputs().get(3) {
-            outputs.push(Tensor::<f32>::zeros(&[0]).into()); // mean dummy
-            outputs.push(Tensor::<f32>::zeros(&[0]).into()); // inv_std_var dummy
-            outputs.push(x_plus_skip.into());
-        }
-
-        Ok(outputs)
-    }
-
-    fn output_types(&self, ctx: &OutputTypesContext) -> Option<OutputTypeList> {
-        let mut types = OutputTypeList::from([OutputType::CopyFromInput(0)]);
-        if ctx.num_outputs > 1 {
-            types.push(OutputType::CopyFromInput(0));
-            types.push(OutputType::CopyFromInput(0));
-            types.push(OutputType::CopyFromInput(0));
-        }
-        Some(types)
-    }
-
-    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
-        Some(&shape_ops::SkipSimplifiedLayerNormalization)
-    }
-}
-
 /// Root Mean Square normalization.
 ///
 /// This is a simplified version of [`LayerNormalization`] which does not center
@@ -923,6 +801,146 @@ impl Operator for Softmax {
 
     fn output_types(&self, _ctx: &OutputTypesContext) -> Option<OutputTypeList> {
         Some([OutputType::CopyFromInput(0)].into())
+    }
+}
+
+#[cfg(feature = "onnx_format")]
+pub use contrib::{SimplifiedLayerNormalization, SkipSimplifiedLayerNormalization};
+
+#[cfg(feature = "onnx_format")]
+mod contrib {
+    use rten_shape_inference::ops as shape_ops;
+    use rten_tensor::prelude::*;
+    use rten_tensor::{Tensor, TensorView};
+
+    use crate::infer_shapes::{InferShapes, UnaryOp};
+    use crate::operator::{
+        IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType, OutputTypeList,
+        OutputTypesContext,
+    };
+    use crate::ops::add;
+
+    use super::{MeanNormalize, layer_normalization_impl, rms_normalization};
+
+    /// Simplified Layer Normalization
+    ///
+    /// This is a experimental ONNX operator for layer normalization which is equivalent to the later
+    /// stabilised RMSNormalization. See [onnx/onnx#6582](https://github.com/onnx/onnx/issues/6582) for
+    /// more details.
+    #[derive(Debug)]
+    pub struct SimplifiedLayerNormalization {
+        pub axis: isize,
+        pub epsilon: Option<f32>,
+    }
+
+    impl Operator for SimplifiedLayerNormalization {
+        fn name(&self) -> &str {
+            "SimplifiedLayerNormalization"
+        }
+
+        fn max_inputs(&self) -> Option<usize> {
+            Some(2)
+        }
+
+        fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+            let inputs = ctx.inputs();
+            let input = inputs.require_as(0)?;
+            let scale = inputs.require_as(1)?;
+
+            rms_normalization(ctx.pool(), input, scale, self.axis, self.epsilon).into_op_result()
+        }
+
+        fn output_types(&self, _ctx: &OutputTypesContext) -> Option<OutputTypeList> {
+            Some([OutputType::CopyFromInput(0)].into())
+        }
+
+        fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+            Some(&UnaryOp)
+        }
+    }
+
+    /// Skip Simplified Layer Normalization
+    ///
+    /// This is a fusion of `Add` and `RMSNormalization` (also known as
+    /// SimplifiedLayerNormalization in Microsoft's contrib ops).
+    ///
+    /// See https://github.com/microsoft/onnxruntime/blob/main/docs/ContribOperators.md#com.microsoft.SkipSimplifiedLayerNormalization
+    #[derive(Debug)]
+    pub struct SkipSimplifiedLayerNormalization {
+        pub epsilon: f32,
+    }
+
+    impl Operator for SkipSimplifiedLayerNormalization {
+        fn name(&self) -> &str {
+            "SkipSimplifiedLayerNormalisation"
+        }
+
+        fn max_inputs(&self) -> Option<usize> {
+            Some(4)
+        }
+
+        fn max_outputs(&self) -> Option<usize> {
+            Some(4)
+        }
+
+        fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+            let inputs = ctx.inputs();
+            let input: TensorView<_> = inputs.require_as(0)?;
+            let skip: TensorView<_> = inputs.require_as(1)?;
+
+            // Scale factor, called gamma (γ) in the RMS normalization paper.
+            let gamma: TensorView<_> = inputs.require_as(2)?;
+
+            let bias: Option<TensorView<_>> = inputs.get_as(3)?;
+
+            if input.shape() != skip.shape() {
+                return Err(OpError::IncompatibleInputShapes(
+                    "input and skip tensor shapes must match",
+                ));
+            }
+
+            if !matches!(input.ndim(), 2 | 3) {
+                return Err(OpError::InvalidValue("input must be 2 or 3 dimensioned"));
+            }
+
+            let mut x_plus_skip = add(ctx.pool(), input, skip)?;
+            if let Some(bias) = bias {
+                x_plus_skip = add(ctx.pool(), x_plus_skip.view(), bias)?;
+            }
+
+            let output = layer_normalization_impl(
+                ctx.pool(),
+                x_plus_skip.view(),
+                gamma,
+                None,
+                -1,
+                Some(self.epsilon),
+                MeanNormalize::DynamicRootMeanSquare,
+            )?;
+
+            let mut outputs: OutputList = [output.into()].into();
+            if ctx.outputs().get(3) {
+                outputs.push(Tensor::<f32>::zeros(&[0]).into()); // mean dummy
+                outputs.push(Tensor::<f32>::zeros(&[0]).into()); // inv_std_var dummy
+                outputs.push(x_plus_skip.into());
+            }
+
+            Ok(outputs)
+        }
+
+        fn output_types(&self, ctx: &OutputTypesContext) -> Option<OutputTypeList> {
+            let mut types = OutputTypeList::from([OutputType::CopyFromInput(0)]);
+            if ctx.num_outputs > 1 {
+                types.push(OutputType::CopyFromInput(0));
+                types.push(OutputType::CopyFromInput(0));
+                types.push(OutputType::CopyFromInput(0));
+            }
+            Some(types)
+        }
+
+        fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+            Some(&shape_ops::SkipSimplifiedLayerNormalization)
+        }
     }
 }
 


### PR DESCRIPTION
Disable the `com.microsoft.*` ONNX operators unless the ONNX format is enabled. This is done by putting these operators in `contrib` submodules which are excluded from the build unless the `onnx_format` feature is enabled.

Fixes https://github.com/robertknight/rten/issues/1293