### PR TITLE
Replace npyz dependency in rten-serialize with a custom `.npy` parser + direct use of the `zip` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,17 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "aes"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
-dependencies = [
- "cfg-if",
- "cipher",
- "cpufeatures",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -64,12 +53,6 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
-name = "base64ct"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bit-set"
@@ -132,58 +115,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
-name = "bzip2"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
-dependencies = [
- "bzip2-sys",
- "libc",
-]
-
-[[package]]
-name = "bzip2-sys"
-version = "0.1.13+1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
-dependencies = [
- "cc",
- "pkg-config",
-]
-
-[[package]]
-name = "cc"
-version = "1.2.64"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
-dependencies = [
- "find-msvc-tools",
- "jobserver",
- "libc",
- "shlex",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
-
-[[package]]
-name = "cipher"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
-dependencies = [
- "crypto-common",
- "inout",
-]
-
-[[package]]
-name = "constant_time_eq"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "cpufeatures"
@@ -239,12 +174,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "deranged"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-
-[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -252,7 +181,6 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
- "subtle",
 ]
 
 [[package]]
@@ -260,6 +188,12 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "fancy-regex"
@@ -297,12 +231,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "find-msvc-tools"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
-
-[[package]]
 name = "flatbuffers"
 version = "24.12.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -333,31 +261,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "getrandom"
-version = "0.3.4"
+name = "hashbrown"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi",
- "wasip2",
-]
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest",
-]
 
 [[package]]
 name = "hound"
@@ -392,12 +305,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "inout"
-version = "0.1.4"
+name = "indexmap"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
- "generic-array",
+ "equivalent",
+ "hashbrown",
 ]
 
 [[package]]
@@ -405,16 +319,6 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
-
-[[package]]
-name = "jobserver"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
-dependencies = [
- "getrandom",
- "libc",
-]
 
 [[package]]
 name = "libc"
@@ -472,7 +376,6 @@ dependencies = [
  "byteorder",
  "num-bigint",
  "py_literal",
- "zip",
 ]
 
 [[package]]
@@ -493,12 +396,6 @@ checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
  "num-traits",
 ]
-
-[[package]]
-name = "num-conv"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -533,29 +430,6 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
-
-[[package]]
-name = "password-hash"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
-dependencies = [
- "base64ct",
- "rand_core",
- "subtle",
-]
-
-[[package]]
-name = "pbkdf2"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
-dependencies = [
- "digest",
- "hmac",
- "password-hash",
- "sha2",
-]
 
 [[package]]
 name = "pest"
@@ -601,12 +475,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pkg-config"
-version = "0.3.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
-
-[[package]]
 name = "png"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -618,12 +486,6 @@ dependencies = [
  "flate2",
  "miniz_oxide",
 ]
-
-[[package]]
-name = "powerfmt"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "primal-check"
@@ -679,18 +541,6 @@ checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rayon"
@@ -880,6 +730,7 @@ version = "0.1.0"
 dependencies = [
  "npyz",
  "rten-tensor",
+ "zip",
 ]
 
 [[package]]
@@ -1040,17 +891,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1060,12 +900,6 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
-
-[[package]]
-name = "shlex"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "simd-adler32"
@@ -1086,12 +920,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
-name = "subtle"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
 name = "syn"
 version = "2.0.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1101,25 +929,6 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
-
-[[package]]
-name = "time"
-version = "0.3.49"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
-dependencies = [
- "deranged",
- "num-conv",
- "powerfmt",
- "serde_core",
- "time-core",
-]
-
-[[package]]
-name = "time-core"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "tinyvec"
@@ -1145,6 +954,12 @@ dependencies = [
  "num-integer",
  "strength_reduce",
 ]
+
+[[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "typeid"
@@ -1192,15 +1007,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
-name = "wasip2"
-version = "1.0.4+wasi-0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
 name = "wasm-bindgen"
 version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1246,58 +1052,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
 name = "zip"
-version = "0.6.6"
+version = "8.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
 dependencies = [
- "aes",
- "byteorder",
- "bzip2",
- "constant_time_eq",
  "crc32fast",
- "crossbeam-utils",
- "flate2",
- "hmac",
- "pbkdf2",
- "sha1",
- "time",
- "zstd",
-]
-
-[[package]]
-name = "zstd"
-version = "0.11.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "5.0.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
-dependencies = [
- "libc",
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.16+zstd.1.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
-dependencies = [
- "cc",
- "pkg-config",
+ "indexmap",
+ "memchr",
+ "typed-path",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,15 +82,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -103,12 +94,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "byteorder-lite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -119,15 +104,6 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
-
-[[package]]
-name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "crc32fast"
@@ -162,26 +138,6 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
-name = "crypto-common"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
-name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer",
- "crypto-common",
-]
 
 [[package]]
 name = "either"
@@ -248,16 +204,6 @@ checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
 ]
 
 [[package]]
@@ -368,27 +314,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "npyz"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a01a88a1d2f89d362475ad16f34de3994f7c86b12259236f5d33537b040bcd4"
-dependencies = [
- "byteorder",
- "num-bigint",
- "py_literal",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
-dependencies = [
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -432,49 +357,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
-name = "pest"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
-dependencies = [
- "memchr",
- "ucd-trie",
-]
-
-[[package]]
-name = "pest_derive"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
-dependencies = [
- "pest",
- "pest_generator",
-]
-
-[[package]]
-name = "pest_generator"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
-dependencies = [
- "pest",
- "pest_meta",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "pest_meta"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
-dependencies = [
- "pest",
- "sha2",
-]
-
-[[package]]
 name = "png"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -512,19 +394,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3cbdf373972bf78df4d3b518d07003938e2c7d1fb5891e55f9cb6df57009d84"
 dependencies = [
  "num-traits",
-]
-
-[[package]]
-name = "py_literal"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "102df7a3d46db9d3891f178dcc826dc270a6746277a9ae6436f8d29fd490a8e1"
-dependencies = [
- "num-bigint",
- "num-complex",
- "num-traits",
- "pest",
- "pest_derive",
 ]
 
 [[package]]
@@ -728,7 +597,6 @@ dependencies = [
 name = "rten-serialize"
 version = "0.1.0"
 dependencies = [
- "npyz",
  "rten-tensor",
  "zip",
 ]
@@ -891,17 +759,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
 name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -968,18 +825,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
-name = "typenum"
-version = "1.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -999,12 +844,6 @@ name = "unicode_categories"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasm-bindgen"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,6 +203,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
 dependencies = [
  "crc32fast",
+ "libz-rs-sys",
  "miniz_oxide",
 ]
 
@@ -277,6 +278,21 @@ name = "libm"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+
+[[package]]
+name = "libz-rs-sys"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15413ef615ad868d4d65dce091cb233b229419c7c0c4bcaa746c0901c49ff39c"
+dependencies = [
+ "zlib-rs",
+]
+
+[[package]]
+name = "log"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "memchr"
@@ -897,9 +913,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
 dependencies = [
  "crc32fast",
+ "flate2",
  "indexmap",
  "memchr",
  "typed-path",
+ "zopfli",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51f936044d677be1a1168fae1d03b583a285a5dd9d8cbf7b24c23aa1fc775235"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ miri:
 # nightly Rust.
 .PHONY: test
 test:
-	cargo test --no-fail-fast --workspace --features all-ops,mmap,text-decoder,serde
+	cargo test --no-fail-fast --workspace --features rten/all-ops,rten/mmap,rten-generate/text-decoder,rten-tensor/serde,rten-serialize/npy,rten-serialize/npz
 
 # Default to running tests for the main crate unless otherwise specified.
 PACKAGE ?= rten

--- a/rten-serialize/Cargo.toml
+++ b/rten-serialize/Cargo.toml
@@ -9,6 +9,10 @@ license = "MIT OR Apache-2.0"
 default = []
 npy = []
 npz = ["npy", "dep:zip"]
+# Enable reading compressed (deflate) NPZ archives, e.g. those produced by
+# `numpy.savez_compressed`. Without this, only uncompressed archives are
+# supported.
+npz-compression = ["npz", "zip/deflate"]
 
 [dependencies]
 rten-tensor = { path = "../rten-tensor", version = "0.24.0" }

--- a/rten-serialize/Cargo.toml
+++ b/rten-serialize/Cargo.toml
@@ -8,11 +8,12 @@ license = "MIT OR Apache-2.0"
 [features]
 default = []
 npy = ["dep:npyz"]
-npz = ["npy", "npyz/npz"]
+npz = ["npy", "dep:zip"]
 
 [dependencies]
 npyz = { version = "0.9.1", optional = true }
 rten-tensor = { path = "../rten-tensor", version = "0.24.0" }
+zip = { version = "8.6.0", default-features = false, optional = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/rten-serialize/Cargo.toml
+++ b/rten-serialize/Cargo.toml
@@ -7,11 +7,10 @@ license = "MIT OR Apache-2.0"
 
 [features]
 default = []
-npy = ["dep:npyz"]
+npy = []
 npz = ["npy", "dep:zip"]
 
 [dependencies]
-npyz = { version = "0.9.1", optional = true }
 rten-tensor = { path = "../rten-tensor", version = "0.24.0" }
 zip = { version = "8.6.0", default-features = false, optional = true }
 

--- a/rten-serialize/src/lib.rs
+++ b/rten-serialize/src/lib.rs
@@ -7,6 +7,8 @@
 //!
 //!  - **npy** - Enable the .npy format
 //!  - **npz** - Enable the .npz format
+//!  - **npz-compression** - Enable reading compressed (deflate) .npz archives,
+//!    such as those produced by `numpy.savez_compressed`
 //!
 //! # Supported formats
 //!
@@ -14,7 +16,9 @@
 //! is a simple format for reading and writing single tensors.
 //!
 //! [NumPy's .npz format](https://numpy.org/doc/stable/reference/generated/numpy.savez.html)
-//! is an archive format for reading and writing multiple tensors.
+//! is an archive format for reading and writing multiple tensors. Archives are
+//! always written uncompressed (matching `numpy.savez`). Reading compressed
+//! archives requires the **npz-compression** feature.
 #![cfg_attr(
     feature = "npz",
     doc = r#"

--- a/rten-serialize/src/npy.rs
+++ b/rten-serialize/src/npy.rs
@@ -1,67 +1,110 @@
-use npyz::{AutoSerialize, Deserialize, NpyFile, Order, WriterBuilder};
 use rten_tensor::{AsView, Layout, Storage, Tensor, TensorBase};
 use std::fs::File;
-use std::io;
+use std::io::{self, Read, Write};
 use std::path::Path;
 
+mod dtype;
+pub use dtype::Element;
+use dtype::ElementKind;
+
+/// Magic bytes at the start of every `.npy` file.
+const MAGIC: &[u8; 6] = b"\x93NUMPY";
+
+/// Alignment of the header in bytes. The magic string, version, header length
+/// and header dictionary are padded to a multiple of this.
+const HEADER_ALIGN: usize = 64;
+
+fn invalid_data(msg: impl Into<String>) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, msg.into())
+}
+
 /// Serialize a tensor to a writer.
-pub fn write<T: AutoSerialize, S: Storage<Elem = T>, L: Layout + Clone>(
+pub fn write<T: Element, S: Storage<Elem = T>, L: Layout + Clone>(
     writer: impl io::Write,
     array: &TensorBase<S, L>,
 ) -> io::Result<()> {
-    let shape = array
-        .shape()
-        .as_ref()
-        .iter()
-        .map(|x| *x as u64)
-        .collect::<Vec<_>>();
+    let mut writer = io::BufWriter::new(writer);
 
-    let mut writer = npyz::WriteOptions::new()
-        .default_dtype()
-        .shape(&shape)
-        .writer(writer)
-        .begin_nd()?;
-    writer.extend(array.iter())?;
-    writer.finish()
+    let header = build_header::<T>(array.shape().as_ref())?;
+    writer.write_all(&header)?;
+
+    for x in array.iter() {
+        writer.write_all(x.to_le_bytes().as_ref())?;
+    }
+    writer.flush()
 }
 
 /// Serialize a tensor to a file.
-pub fn write_to_file<T: AutoSerialize, S: Storage<Elem = T>, L: Layout + Clone>(
+pub fn write_to_file<T: Element, S: Storage<Elem = T>, L: Layout + Clone>(
     path: impl AsRef<Path>,
     array: &TensorBase<S, L>,
 ) -> io::Result<()> {
-    let file = io::BufWriter::new(File::create(path)?);
-    write(file, array)
+    write(File::create(path)?, array)
 }
 
 /// Read a tensor from a reader.
-pub fn read<T: Clone + Deserialize>(reader: impl io::Read) -> io::Result<Tensor<T>> {
-    let reader = NpyFile::new(reader)?;
-    tensor_from_npy_file(reader)
-}
+pub fn read<T: Element>(mut reader: impl io::Read) -> io::Result<Tensor<T>> {
+    let header = read_header(&mut reader)?;
 
-pub(crate) fn tensor_from_npy_file<T: Clone + Deserialize, R: io::Read>(
-    reader: NpyFile<R>,
-) -> io::Result<Tensor<T>> {
-    let shape = reader
-        .shape()
+    if header.dtype.kind != T::KIND || header.dtype.item_size != T::ITEM_SIZE {
+        return Err(invalid_data(format!(
+            "array dtype `{}{}` does not match requested element type",
+            header.dtype.kind.as_char(),
+            header.dtype.item_size
+        )));
+    }
+
+    let n_elements = header
+        .shape
         .iter()
-        .map(|x| *x as usize)
-        .collect::<Vec<_>>();
-    let order = reader.order();
-    let data = reader
-        .data()
-        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
+        .try_fold(1usize, |acc, &dim| acc.checked_mul(dim))
+        .ok_or_else(|| invalid_data("array element count overflows"))?;
+    let n_bytes = n_elements
+        .checked_mul(T::ITEM_SIZE)
+        .ok_or_else(|| invalid_data("array size in bytes overflows"))?;
 
-    let values: io::Result<Vec<T>> = data.collect();
-    let values = values?;
-    let values = match order {
-        Order::C => values,
-        Order::Fortran => fortran_order_to_row_major(values, &shape),
+    // Reject implausibly large arrays so a corrupt or malicious header cannot
+    // request a huge allocation.
+    if n_bytes > u32::MAX as usize {
+        return Err(invalid_data("array is too large"));
+    }
+    let mut data = Vec::with_capacity(n_bytes);
+    reader
+        .by_ref()
+        .take(n_bytes as u64)
+        .read_to_end(&mut data)?;
+    if data.len() != n_bytes {
+        return Err(invalid_data("array data is truncated"));
+    }
+
+    // FIXME: This copies every element even when the data is already in the
+    // requested little-endian, C-contiguous layout and could be used directly.
+    let swap_bytes = header.dtype.big_endian && T::ITEM_SIZE > 1;
+    let values: Vec<T> = data
+        .chunks_exact(T::ITEM_SIZE)
+        .map(|chunk| {
+            let mut bytes = T::Bytes::try_from(chunk)
+                .unwrap_or_else(|_| unreachable!("chunk is T::ITEM_SIZE bytes"));
+            if swap_bytes {
+                bytes.as_mut().reverse();
+            }
+            T::from_le_bytes(bytes)
+        })
+        .collect();
+
+    let values = if header.fortran_order {
+        fortran_order_to_row_major(values, &header.shape)
+    } else {
+        values
     };
 
-    let result = Tensor::from_vec(values).into_shape(shape.as_slice());
-    Ok(result)
+    Ok(Tensor::from_data(&header.shape, values))
+}
+
+/// Read a tensor from a file.
+pub fn read_from_file<T: Element>(path: impl AsRef<Path>) -> io::Result<Tensor<T>> {
+    let file = io::BufReader::new(File::open(path)?);
+    read(file)
 }
 
 fn fortran_order_to_row_major<T: Clone>(values: Vec<T>, shape: &[usize]) -> Vec<T> {
@@ -78,10 +121,281 @@ fn fortran_order_to_row_major<T: Clone>(values: Vec<T>, shape: &[usize]) -> Vec<
         .to_vec()
 }
 
-/// Read a tensor from a file.
-pub fn read_from_file<T: Clone + Deserialize>(path: impl AsRef<Path>) -> io::Result<Tensor<T>> {
-    let file = io::BufReader::new(File::open(path)?);
-    read(file)
+/// Parsed `descr` field of a `.npy` header.
+struct DType {
+    /// Whether multi-byte elements are stored big-endian.
+    big_endian: bool,
+    kind: ElementKind,
+    item_size: usize,
+}
+
+/// Parsed `.npy` header.
+struct Header {
+    dtype: DType,
+    fortran_order: bool,
+    shape: Vec<usize>,
+}
+
+/// Read and parse the header of a `.npy` file, leaving `reader` positioned at
+/// the start of the array data.
+fn read_header(mut reader: impl io::Read) -> io::Result<Header> {
+    let mut magic = [0u8; 6];
+    reader.read_exact(&mut magic)?;
+    if &magic != MAGIC {
+        return Err(invalid_data("not an npy file"));
+    }
+
+    let mut version = [0u8; 2];
+    reader.read_exact(&mut version)?;
+
+    // The header length is a u16 in format version 1 and a u32 in versions 2
+    // and 3. Versions differ only in the header encoding, which does not affect
+    // the fields this crate reads.
+    let header_len = match version[0] {
+        1 => {
+            let mut buf = [0u8; 2];
+            reader.read_exact(&mut buf)?;
+            u16::from_le_bytes(buf) as usize
+        }
+        2 | 3 => {
+            let mut buf = [0u8; 4];
+            reader.read_exact(&mut buf)?;
+            u32::from_le_bytes(buf) as usize
+        }
+        major => {
+            return Err(invalid_data(format!("unsupported npy version {major}")));
+        }
+    };
+
+    let mut header = vec![0u8; header_len];
+    reader.read_exact(&mut header)?;
+    let header =
+        std::str::from_utf8(&header).map_err(|_| invalid_data("npy header is not valid UTF-8"))?;
+
+    parse_header(header)
+}
+
+/// Parse the Python dictionary literal that makes up a `.npy` header.
+///
+/// This supports only the small subset of Python syntax that NumPy emits: a
+/// dictionary mapping single-quoted string keys to a single-quoted string
+/// (`descr`), a boolean (`fortran_order`) or a tuple of integers (`shape`).
+fn parse_header(header: &str) -> io::Result<Header> {
+    let mut parser = HeaderParser::new(header);
+    let mut descr = None;
+    let mut fortran_order = None;
+    let mut shape = None;
+
+    // NumPy tolerates leading whitespace before the dictionary when loading, so
+    // accept it here too.
+    parser.skip_whitespace();
+    parser.expect(b'{')?;
+    loop {
+        parser.skip_whitespace();
+        if parser.consume(b'}') {
+            break;
+        }
+
+        let key = parser.parse_string()?;
+        parser.skip_whitespace();
+        parser.expect(b':')?;
+        parser.skip_whitespace();
+
+        match key.as_str() {
+            "descr" => descr = Some(parse_descr(&parser.parse_string()?)?),
+            "fortran_order" => fortran_order = Some(parser.parse_bool()?),
+            "shape" => shape = Some(parser.parse_shape()?),
+            _ => return Err(invalid_data(format!("unexpected npy header key `{key}`"))),
+        }
+
+        parser.skip_whitespace();
+        // A comma separates entries and NumPy also writes a trailing comma
+        // before the closing brace.
+        parser.consume(b',');
+    }
+
+    Ok(Header {
+        dtype: descr.ok_or_else(|| invalid_data("npy header is missing `descr`"))?,
+        fortran_order: fortran_order
+            .ok_or_else(|| invalid_data("npy header is missing `fortran_order`"))?,
+        shape: shape.ok_or_else(|| invalid_data("npy header is missing `shape`"))?,
+    })
+}
+
+/// Parse a NumPy dtype string such as `<i4` or `|u1`.
+fn parse_descr(descr: &str) -> io::Result<DType> {
+    let invalid = || invalid_data(format!("invalid npy dtype `{descr}`"));
+
+    let mut chars = descr.chars();
+    let big_endian = match chars.next() {
+        Some('>') => true,
+        // `=` is native byte order.
+        Some('=') => cfg!(target_endian = "big"),
+        // `|` ("not applicable") is used for single-byte types.
+        Some('<' | '|') => false,
+        _ => return Err(invalid()),
+    };
+    let kind = chars
+        .next()
+        .and_then(ElementKind::from_char)
+        .ok_or_else(invalid)?;
+    // The order and kind characters are both ASCII, so byte index 2 is a
+    // character boundary and the remainder is the item size in bytes.
+    let item_size = descr[2..].parse::<usize>().map_err(|_| invalid())?;
+
+    Ok(DType {
+        big_endian,
+        kind,
+        item_size,
+    })
+}
+
+/// Parser for the contents of a `.npy` header.
+struct HeaderParser<'a> {
+    bytes: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> HeaderParser<'a> {
+    fn new(s: &'a str) -> Self {
+        HeaderParser {
+            bytes: s.as_bytes(),
+            pos: 0,
+        }
+    }
+
+    fn peek(&self) -> Option<u8> {
+        self.bytes.get(self.pos).copied()
+    }
+
+    fn skip_whitespace(&mut self) {
+        while matches!(self.peek(), Some(b) if b.is_ascii_whitespace()) {
+            self.pos += 1;
+        }
+    }
+
+    /// Consume the next byte if it equals `byte`, returning whether it did.
+    fn consume(&mut self, byte: u8) -> bool {
+        if self.peek() == Some(byte) {
+            self.pos += 1;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Consume the next byte, requiring it to equal `byte`.
+    fn expect(&mut self, byte: u8) -> io::Result<()> {
+        if self.consume(byte) {
+            Ok(())
+        } else {
+            Err(invalid_data(format!(
+                "expected `{}` in npy header",
+                byte as char
+            )))
+        }
+    }
+
+    /// Parse a single-quoted string.
+    fn parse_string(&mut self) -> io::Result<String> {
+        self.expect(b'\'')?;
+        let start = self.pos;
+        while let Some(byte) = self.peek() {
+            if byte == b'\'' {
+                let value = std::str::from_utf8(&self.bytes[start..self.pos])
+                    .map_err(|_| invalid_data("npy header string is not valid UTF-8"))?
+                    .to_string();
+                self.pos += 1;
+                return Ok(value);
+            }
+            self.pos += 1;
+        }
+        Err(invalid_data("unterminated string in npy header"))
+    }
+
+    /// Parse a `True` or `False` literal.
+    fn parse_bool(&mut self) -> io::Result<bool> {
+        if self.bytes[self.pos..].starts_with(b"True") {
+            self.pos += 4;
+            Ok(true)
+        } else if self.bytes[self.pos..].starts_with(b"False") {
+            self.pos += 5;
+            Ok(false)
+        } else {
+            Err(invalid_data("expected `True` or `False` in npy header"))
+        }
+    }
+
+    /// Parse a tuple of non-negative integers, e.g. `(2, 3)`, `(5,)` or `()`.
+    fn parse_shape(&mut self) -> io::Result<Vec<usize>> {
+        self.expect(b'(')?;
+        let mut shape = Vec::new();
+        loop {
+            self.skip_whitespace();
+            if self.consume(b')') {
+                break;
+            }
+            shape.push(self.parse_usize()?);
+            self.skip_whitespace();
+            self.consume(b',');
+        }
+        Ok(shape)
+    }
+
+    fn parse_usize(&mut self) -> io::Result<usize> {
+        let start = self.pos;
+        while matches!(self.peek(), Some(b) if b.is_ascii_digit()) {
+            self.pos += 1;
+        }
+        if self.pos == start {
+            return Err(invalid_data("expected integer in npy header"));
+        }
+        std::str::from_utf8(&self.bytes[start..self.pos])
+            .unwrap()
+            .parse::<usize>()
+            .map_err(|_| invalid_data("integer in npy header is out of range"))
+    }
+}
+
+/// Build the magic string, version, length and header dictionary for a tensor
+/// with the given element type and shape.
+fn build_header<T: Element>(shape: &[usize]) -> io::Result<Vec<u8>> {
+    let mut dims = shape
+        .iter()
+        .map(usize::to_string)
+        .collect::<Vec<_>>()
+        .join(", ");
+    // A 1-tuple requires a trailing comma to distinguish it from a parenthesized
+    // expression.
+    if shape.len() == 1 {
+        dims.push(',');
+    }
+    let mut dict = format!(
+        "{{'descr': '{}', 'fortran_order': False, 'shape': ({dims}), }}",
+        T::DESCR
+    );
+
+    // Pad with spaces and a trailing newline so the total header length is a
+    // multiple of `HEADER_ALIGN`. Version 1 uses a 2-byte length field.
+    let prefix_len = MAGIC.len() + 2 + 2;
+    let unpadded_len = prefix_len + dict.len() + 1;
+    let padding = unpadded_len.next_multiple_of(HEADER_ALIGN) - unpadded_len;
+    dict.reserve(padding + 1);
+    dict.extend(std::iter::repeat_n(' ', padding));
+    dict.push('\n');
+
+    // The version 1 length field is a `u16`. NumPy switches to version 2 for
+    // larger headers, but a header this size requires a tensor with thousands
+    // of dimensions, so reject it rather than emit a truncated length.
+    let dict_len =
+        u16::try_from(dict.len()).map_err(|_| invalid_data("npy header is too large to encode"))?;
+
+    let mut header = Vec::with_capacity(prefix_len + dict.len());
+    header.extend_from_slice(MAGIC);
+    header.extend_from_slice(&[1, 0]); // Format version 1.0.
+    header.extend_from_slice(&dict_len.to_le_bytes());
+    header.extend_from_slice(dict.as_bytes());
+    Ok(header)
 }
 
 #[cfg(test)]
@@ -109,6 +423,33 @@ mod tests {
         assert_eq!(&read, &tensor);
     }
 
+    /// Round-trip every supported element type through the in-memory writer
+    /// and reader.
+    #[test]
+    fn test_round_trip_npy_dtypes() {
+        macro_rules! check {
+            ($ty:ty, $tensor:expr) => {{
+                let tensor: Tensor<$ty> = $tensor;
+                let mut buffer = Vec::new();
+                write(&mut buffer, &tensor).unwrap();
+                let read = read::<$ty>(&buffer[..]).unwrap();
+                assert_eq!(&read, &tensor);
+            }};
+        }
+
+        check!(i8, [1i8, -2, 3].into());
+        check!(i16, [1i16, -2, 3].into());
+        check!(i32, [1i32, -2, 3].into());
+        check!(i64, [1i64, -2, 3].into());
+        check!(u8, [1u8, 2, 3].into());
+        check!(u16, [1u16, 2, 3].into());
+        check!(u32, [1u32, 2, 3].into());
+        check!(u64, [1u64, 2, 3].into());
+        check!(f32, [1.5f32, -2.5, 3.5].into());
+        check!(f64, [1.5f64, -2.5, 3.5].into());
+        check!(bool, [true, false, true].into());
+    }
+
     /// Exercises the file convenience helpers by writing and then reading a
     /// tensor from a real file path.
     #[test]
@@ -123,6 +464,19 @@ mod tests {
         assert_eq!(&read, &tensor);
     }
 
+    /// Round-trips a scalar tensor, whose header has an empty shape
+    /// tuple `()`.
+    #[test]
+    fn test_round_trip_npy_scalar() {
+        let tensor = Tensor::from_scalar(42i32);
+        let mut buffer = Vec::new();
+
+        write(&mut buffer, &tensor).unwrap();
+        let read = read::<i32>(&buffer[..]).unwrap();
+
+        assert_eq!(&read, &tensor);
+    }
+
     /// Confirms malformed input is surfaced as an I/O error instead of being
     /// accepted as an empty or partially decoded tensor.
     #[test]
@@ -130,6 +484,79 @@ mod tests {
         let err = read::<i32>(&b"not an npy file"[..]).unwrap_err();
 
         assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn test_read_npy_rejects_dtype_mismatch() {
+        let tensor: Tensor<i32> = [1, 2, 3].into();
+        let mut buffer = Vec::new();
+        write(&mut buffer, &tensor).unwrap();
+
+        let err = read::<f32>(&buffer[..]).unwrap_err();
+
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    /// Builds a minimal version 1.0 `.npy` file with the given header
+    /// dictionary and data.
+    fn npy_with_header(dict: &str, data: &[u8]) -> Vec<u8> {
+        let mut header = dict.as_bytes().to_vec();
+        header.push(b'\n');
+        let mut out = Vec::new();
+        out.extend_from_slice(MAGIC);
+        out.extend_from_slice(&[1, 0]);
+        out.extend_from_slice(&(header.len() as u16).to_le_bytes());
+        out.extend_from_slice(&header);
+        out.extend_from_slice(data);
+        out
+    }
+
+    #[test]
+    fn test_read_npy_rejects_malformed_headers() {
+        let cases = [
+            // Missing required keys.
+            "{'descr': '<i4'}",
+            "{'fortran_order': False, 'shape': (1,)}",
+            // Malformed dtype strings.
+            "{'descr': 'i4', 'fortran_order': False, 'shape': (1,)}",
+            "{'descr': '<', 'fortran_order': False, 'shape': (1,)}",
+            "{'descr': '<i', 'fortran_order': False, 'shape': (1,)}",
+            // Structurally broken dictionaries.
+            "{'descr': '<i4', 'fortran_order': False, 'shape': (1,",
+            "not a dict",
+            "{'descr': '<i4', 'fortran_order': Maybe, 'shape': (1,)}",
+        ];
+
+        for case in cases {
+            let bytes = npy_with_header(case, &[0, 0, 0, 0]);
+            let err = read::<i32>(&bytes[..]).unwrap_err();
+            assert_eq!(err.kind(), io::ErrorKind::InvalidData, "case: {case}");
+        }
+    }
+
+    #[test]
+    fn test_read_npy_accepts_leading_header_whitespace() {
+        let bytes = npy_with_header(
+            "  \n{'descr': '<i4', 'fortran_order': False, 'shape': (2,)}",
+            &[1, 0, 0, 0, 2, 0, 0, 0],
+        );
+
+        let read = read::<i32>(&bytes[..]).unwrap();
+
+        assert_eq!(read, Tensor::from([1, 2]));
+    }
+
+    #[test]
+    fn test_read_npy_big_endian() {
+        let bytes = npy_with_header(
+            "{'descr': '>i4', 'fortran_order': False, 'shape': (2,)}",
+            // 1 and 2 encoded as big-endian i32.
+            &[0, 0, 0, 1, 0, 0, 0, 2],
+        );
+
+        let read = read::<i32>(&bytes[..]).unwrap();
+
+        assert_eq!(read, Tensor::from([1, 2]));
     }
 
     /// Covers the rank-2 boundary in Fortran-to-row-major conversion. The

--- a/rten-serialize/src/npy/dtype.rs
+++ b/rten-serialize/src/npy/dtype.rs
@@ -1,0 +1,123 @@
+//! Mapping between Rust scalar types and NumPy array element types.
+
+mod sealed {
+    pub trait Sealed {}
+}
+
+/// NumPy array-protocol type kind: bool, signed integer, unsigned integer or
+/// float.
+#[doc(hidden)]
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum ElementKind {
+    Bool,
+    Int,
+    Uint,
+    Float,
+}
+
+impl ElementKind {
+    /// Parse the single-character type code used in a NumPy dtype string, e.g.
+    /// `i` for a signed integer.
+    pub(crate) fn from_char(c: char) -> Option<ElementKind> {
+        match c {
+            'b' => Some(ElementKind::Bool),
+            'i' => Some(ElementKind::Int),
+            'u' => Some(ElementKind::Uint),
+            'f' => Some(ElementKind::Float),
+            _ => None,
+        }
+    }
+
+    /// Return the single-character type code used in a NumPy dtype string.
+    pub(crate) fn as_char(self) -> char {
+        match self {
+            ElementKind::Bool => 'b',
+            ElementKind::Int => 'i',
+            ElementKind::Uint => 'u',
+            ElementKind::Float => 'f',
+        }
+    }
+}
+
+/// A scalar type that can be used as the element type of a NumPy array.
+///
+/// This is implemented for Rust's primitive integer and floating point types
+/// and `bool`.
+pub trait Element: sealed::Sealed + Copy {
+    /// NumPy array-protocol type kind.
+    #[doc(hidden)]
+    const KIND: ElementKind;
+
+    /// Size of the element in bytes.
+    #[doc(hidden)]
+    const ITEM_SIZE: usize;
+
+    /// dtype string written to `.npy` headers, using little-endian byte order.
+    #[doc(hidden)]
+    const DESCR: &'static str;
+
+    /// The little-endian byte representation of an element, `[u8; ITEM_SIZE]`.
+    #[doc(hidden)]
+    type Bytes: AsRef<[u8]> + AsMut<[u8]> + for<'a> TryFrom<&'a [u8]>;
+
+    /// Decode an element from its little-endian representation.
+    #[doc(hidden)]
+    fn from_le_bytes(bytes: Self::Bytes) -> Self;
+
+    /// Encode an element as its little-endian representation.
+    #[doc(hidden)]
+    fn to_le_bytes(self) -> Self::Bytes;
+}
+
+macro_rules! impl_element {
+    ($ty:ty, $kind:expr, $descr:literal) => {
+        impl sealed::Sealed for $ty {}
+
+        impl Element for $ty {
+            const KIND: ElementKind = $kind;
+            const ITEM_SIZE: usize = size_of::<$ty>();
+            const DESCR: &'static str = $descr;
+
+            type Bytes = [u8; size_of::<$ty>()];
+
+            fn from_le_bytes(bytes: Self::Bytes) -> Self {
+                <$ty>::from_le_bytes(bytes)
+            }
+
+            fn to_le_bytes(self) -> Self::Bytes {
+                <$ty>::to_le_bytes(self)
+            }
+        }
+    };
+}
+
+// Single-byte types use the `|` ("not applicable") byte-order marker, matching
+// the output of `numpy.dtype.str`.
+impl_element!(i8, ElementKind::Int, "|i1");
+impl_element!(i16, ElementKind::Int, "<i2");
+impl_element!(i32, ElementKind::Int, "<i4");
+impl_element!(i64, ElementKind::Int, "<i8");
+impl_element!(u8, ElementKind::Uint, "|u1");
+impl_element!(u16, ElementKind::Uint, "<u2");
+impl_element!(u32, ElementKind::Uint, "<u4");
+impl_element!(u64, ElementKind::Uint, "<u8");
+impl_element!(f32, ElementKind::Float, "<f4");
+impl_element!(f64, ElementKind::Float, "<f8");
+
+impl sealed::Sealed for bool {}
+
+impl Element for bool {
+    const KIND: ElementKind = ElementKind::Bool;
+    const ITEM_SIZE: usize = 1;
+    const DESCR: &'static str = "|b1";
+
+    type Bytes = [u8; 1];
+
+    fn from_le_bytes(bytes: Self::Bytes) -> Self {
+        bytes[0] != 0
+    }
+
+    fn to_le_bytes(self) -> Self::Bytes {
+        [self as u8]
+    }
+}

--- a/rten-serialize/src/npz.rs
+++ b/rten-serialize/src/npz.rs
@@ -3,15 +3,16 @@ use std::fs::File;
 use std::io;
 use std::path::Path;
 
-use npyz::npz::{NpzArchive, NpzWriter};
-use npyz::{AutoSerialize, Deserialize, WriterBuilder};
-use rten_tensor::{AsView, Layout, Storage, Tensor, TensorBase};
-
-use crate::npy::tensor_from_npy_file;
+use npyz::{AutoSerialize, Deserialize};
+use rten_tensor::{Layout, Storage, Tensor, TensorBase};
+use zip::write::SimpleFileOptions;
+use zip::{CompressionMethod, ZipArchive, ZipWriter};
 
 /// Serialize named tensors to an NPZ archive.
 ///
 /// Tensor names may be passed with or without the `.npy` suffix.
+///
+/// Arrays are stored uncompressed, matching the output of `numpy.savez`.
 pub fn write<'a, T, S, L, I, N, W>(writer: W, arrays: I) -> io::Result<()>
 where
     T: AutoSerialize + 'a,
@@ -21,27 +22,15 @@ where
     N: AsRef<str>,
     W: io::Write + io::Seek,
 {
-    let mut archive = NpzWriter::new(writer);
+    let mut archive = ZipWriter::new(writer);
+    let options = SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
 
     for (name, array) in arrays {
-        let name = npz_array_name(name.as_ref())?;
-        let shape = array
-            .shape()
-            .as_ref()
-            .iter()
-            .map(|x| *x as u64)
-            .collect::<Vec<_>>();
-
-        let mut writer = archive
-            .array(&name, Default::default())?
-            .default_dtype()
-            .shape(&shape)
-            .begin_nd()?;
-        writer.extend(array.iter())?;
-        writer.finish()?;
+        archive.start_file(npz_file_name(name.as_ref())?, options)?;
+        crate::npy::write(&mut archive, &array)?;
     }
 
-    archive.zip_writer().finish()?;
+    archive.finish()?;
     Ok(())
 }
 
@@ -64,21 +53,18 @@ where
 pub fn read<T: Clone + Deserialize>(
     reader: impl io::Read + io::Seek,
 ) -> io::Result<HashMap<String, Tensor<T>>> {
-    let mut archive = NpzArchive::new(reader)?;
+    let mut archive = ZipArchive::new(reader)?;
     let names = archive
-        .array_names()
+        .file_names()
+        .filter(|name| name.ends_with(".npy"))
         .map(str::to_string)
         .collect::<Vec<_>>();
     let mut arrays = HashMap::new();
 
     for name in names {
-        let file = archive.by_name(&name)?.ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!("missing NPZ array `{name}`"),
-            )
-        })?;
-        let array = tensor_from_npy_file(file)?;
+        let file = archive.by_name(&name)?;
+        let array = crate::npy::read(file)?;
+        let name = name.strip_suffix(".npy").unwrap().to_string();
         arrays.insert(name, array);
     }
 
@@ -100,15 +86,9 @@ pub fn read_array<T: Clone + Deserialize>(
     reader: impl io::Read + io::Seek,
     name: &str,
 ) -> io::Result<Tensor<T>> {
-    let mut archive = NpzArchive::new(reader)?;
-    let name = npz_array_name(name)?;
-    let file = archive.by_name(&name)?.ok_or_else(|| {
-        io::Error::new(
-            io::ErrorKind::NotFound,
-            format!("missing NPZ array `{name}`"),
-        )
-    })?;
-    tensor_from_npy_file(file)
+    let mut archive = ZipArchive::new(reader)?;
+    let file = archive.by_name(&npz_file_name(name)?)?;
+    crate::npy::read(file)
 }
 
 /// Read a single named tensor from an NPZ archive file.
@@ -120,19 +100,17 @@ pub fn read_array_from_file<T: Clone + Deserialize>(
     read_array(file, name)
 }
 
-fn npz_array_name(name: &str) -> io::Result<String> {
-    if name.is_empty() {
+/// Map a user-supplied array name, with or without the `.npy` suffix, to the
+/// archive entry filename, which always has exactly one `.npy` suffix.
+fn npz_file_name(name: &str) -> io::Result<String> {
+    let base = name.strip_suffix(".npy").unwrap_or(name);
+    if base.is_empty() {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
             "NPZ array name must not be empty",
         ));
     }
-
-    if name.ends_with(".npy") {
-        Ok(name.strip_suffix(".npy").unwrap().to_string())
-    } else {
-        Ok(name.to_string())
-    }
+    Ok(format!("{base}.npy"))
 }
 
 #[cfg(test)]
@@ -222,23 +200,16 @@ mod tests {
         let a: Tensor<i32> = [1, 2, 3].into();
         let mut buffer = Cursor::new(Vec::new());
         {
-            let mut archive = NpzWriter::new(&mut buffer);
-            let mut writer = archive
-                .array::<i32>("a", Default::default())
-                .unwrap()
-                .default_dtype()
-                .shape(&[3])
-                .begin_nd()
-                .unwrap();
-            writer.extend(a.iter().cloned()).unwrap();
-            writer.finish().unwrap();
+            let options =
+                SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
+            let mut archive = ZipWriter::new(&mut buffer);
 
-            archive
-                .zip_writer()
-                .start_file("metadata.txt", Default::default())
-                .unwrap();
-            archive.zip_writer().write_all(b"not an array").unwrap();
-            archive.zip_writer().finish().unwrap();
+            archive.start_file("a.npy", options).unwrap();
+            crate::npy::write(&mut archive, &a).unwrap();
+
+            archive.start_file("metadata.txt", options).unwrap();
+            archive.write_all(b"not an array").unwrap();
+            archive.finish().unwrap();
         }
 
         buffer.set_position(0);
@@ -253,7 +224,7 @@ mod tests {
     #[test]
     fn test_rejects_empty_npz_array_name() {
         assert_eq!(
-            npz_array_name("").unwrap_err().kind(),
+            npz_file_name("").unwrap_err().kind(),
             io::ErrorKind::InvalidInput
         );
     }

--- a/rten-serialize/src/npz.rs
+++ b/rten-serialize/src/npz.rs
@@ -3,10 +3,11 @@ use std::fs::File;
 use std::io;
 use std::path::Path;
 
-use npyz::{AutoSerialize, Deserialize};
 use rten_tensor::{Layout, Storage, Tensor, TensorBase};
 use zip::write::SimpleFileOptions;
 use zip::{CompressionMethod, ZipArchive, ZipWriter};
+
+use crate::npy::Element;
 
 /// Serialize named tensors to an NPZ archive.
 ///
@@ -15,7 +16,7 @@ use zip::{CompressionMethod, ZipArchive, ZipWriter};
 /// Arrays are stored uncompressed, matching the output of `numpy.savez`.
 pub fn write<'a, T, S, L, I, N, W>(writer: W, arrays: I) -> io::Result<()>
 where
-    T: AutoSerialize + 'a,
+    T: Element + 'a,
     S: Storage<Elem = T>,
     L: Layout + Clone,
     I: IntoIterator<Item = (N, TensorBase<S, L>)>,
@@ -37,7 +38,7 @@ where
 /// Serialize named tensors to an NPZ archive file - this will create the file.
 pub fn write_to_file<'a, T, S, L, I, N>(path: impl AsRef<Path>, arrays: I) -> io::Result<()>
 where
-    T: AutoSerialize + 'a,
+    T: Element + 'a,
     S: Storage<Elem = T>,
     L: Layout + Clone,
     I: IntoIterator<Item = (N, TensorBase<S, L>)>,
@@ -50,7 +51,11 @@ where
 /// Read all `.npy` entries from an NPZ archive.
 ///
 /// Returned names have the `.npy` suffix removed.
-pub fn read<T: Clone + Deserialize>(
+///
+/// Only uncompressed archives, as produced by `numpy.savez`, are supported.
+/// Reading a compressed entry (e.g. from `numpy.savez_compressed`) fails with
+/// an [`io::ErrorKind::Unsupported`] error.
+pub fn read<T: Element>(
     reader: impl io::Read + io::Seek,
 ) -> io::Result<HashMap<String, Tensor<T>>> {
     let mut archive = ZipArchive::new(reader)?;
@@ -72,7 +77,7 @@ pub fn read<T: Clone + Deserialize>(
 }
 
 /// Read all `.npy` entries from an NPZ archive file.
-pub fn read_from_file<T: Clone + Deserialize>(
+pub fn read_from_file<T: Element>(
     path: impl AsRef<Path>,
 ) -> io::Result<HashMap<String, Tensor<T>>> {
     let file = io::BufReader::new(File::open(path)?);
@@ -82,7 +87,11 @@ pub fn read_from_file<T: Clone + Deserialize>(
 /// Read a single named tensor from an NPZ archive.
 ///
 /// `name` may be passed with or without the `.npy` suffix.
-pub fn read_array<T: Clone + Deserialize>(
+///
+/// Only uncompressed archives, as produced by `numpy.savez`, are supported.
+/// Reading a compressed entry (e.g. from `numpy.savez_compressed`) fails with
+/// an [`io::ErrorKind::Unsupported`] error.
+pub fn read_array<T: Element>(
     reader: impl io::Read + io::Seek,
     name: &str,
 ) -> io::Result<Tensor<T>> {
@@ -92,7 +101,7 @@ pub fn read_array<T: Clone + Deserialize>(
 }
 
 /// Read a single named tensor from an NPZ archive file.
-pub fn read_array_from_file<T: Clone + Deserialize>(
+pub fn read_array_from_file<T: Element>(
     path: impl AsRef<Path>,
     name: &str,
 ) -> io::Result<Tensor<T>> {

--- a/rten-serialize/src/npz.rs
+++ b/rten-serialize/src/npz.rs
@@ -52,9 +52,8 @@ where
 ///
 /// Returned names have the `.npy` suffix removed.
 ///
-/// Only uncompressed archives, as produced by `numpy.savez`, are supported.
-/// Reading a compressed entry (e.g. from `numpy.savez_compressed`) fails with
-/// an [`io::ErrorKind::Unsupported`] error.
+/// Without the `npz-compression` feature, only uncompressed archives (as
+/// produced by `numpy.savez`) are supported.
 pub fn read<T: Element>(
     reader: impl io::Read + io::Seek,
 ) -> io::Result<HashMap<String, Tensor<T>>> {
@@ -88,9 +87,8 @@ pub fn read_from_file<T: Element>(
 ///
 /// `name` may be passed with or without the `.npy` suffix.
 ///
-/// Only uncompressed archives, as produced by `numpy.savez`, are supported.
-/// Reading a compressed entry (e.g. from `numpy.savez_compressed`) fails with
-/// an [`io::ErrorKind::Unsupported`] error.
+/// See [`read`] for behavior when reading compressed archives without the
+/// `npz-compression` feature.
 pub fn read_array<T: Element>(
     reader: impl io::Read + io::Seek,
     name: &str,
@@ -218,6 +216,27 @@ mod tests {
 
             archive.start_file("metadata.txt", options).unwrap();
             archive.write_all(b"not an array").unwrap();
+            archive.finish().unwrap();
+        }
+
+        buffer.set_position(0);
+        let arrays = read::<i32>(&mut buffer).unwrap();
+
+        assert_eq!(arrays.len(), 1);
+        assert_eq!(arrays.get("a").unwrap(), &a);
+    }
+
+    #[cfg(feature = "npz-compression")]
+    #[test]
+    fn test_read_compressed_npz() {
+        let a: Tensor<i32> = [[1, 2, 3], [4, 5, 6]].into();
+        let mut buffer = Cursor::new(Vec::new());
+        {
+            let options =
+                SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
+            let mut archive = ZipWriter::new(&mut buffer);
+            archive.start_file("a.npy", options).unwrap();
+            crate::npy::write(&mut archive, &a).unwrap();
             archive.finish().unwrap();
         }
 


### PR DESCRIPTION
The npyz crate added a large number of transitive dependencies when the `npz` format was enabled, as it used an old version of the `zip` crate with all default features enabled. `npz` files are usually created as simple, uncompressed and unencrypted archives with `numpy.savez`.

This PR replaces npyz with a custom parser for `.npy` files and direct use of the `zip` crate with all features disabled for `.npz`. There is a new `npz-compression` feature which enables loading compressed `.npz` archives like those created by `numpy.savez_compressed`.

On my system this reduces the time for a clean release build of `rten-serialize` from ~10.8s to ~3s, or ~3.8s with compression enabled. A maintenance bonus is that the `zip` crate can more easily be updated as needed.