### PR TITLE
Support reading/writing dynamic / mixed-dtype tensors in rten-serialize

### DIFF
--- a/rten-serialize/src/lib.rs
+++ b/rten-serialize/src/lib.rs
@@ -10,6 +10,14 @@
 //!  - **npz-compression** - Enable reading compressed (deflate) .npz archives,
 //!    such as those produced by `numpy.savez_compressed`
 //!
+//! # Data types
+//!
+//! Readers return tensors as a [`Value`], and writers accept them as a
+//! [`View`]. These are enums that hold a tensor of any supported
+//! [element type](Element), since a single file may contain tensors with
+//! different element types. Use [`Value::into_type`] / [`Value::as_type`] to
+//! extract a typed tensor.
+//!
 //! # Supported formats
 //!
 //! [NumPy's .npy format](https://numpy.org/doc/stable/reference/generated/numpy.lib.format.html)
@@ -26,35 +34,44 @@
 
 ```
 # fn main() -> Result<(), Box<dyn std::error::Error>> {
-use rten_serialize::npy;
-use rten_serialize::npz;
+use rten_serialize::{npy, npz};
 use rten_tensor::prelude::*;
 use rten_tensor::NdTensor;
 
-// Write a single tensor.
 let matrix = NdTensor::from([[1i32, 2], [3, 4]]);
-npy::write_to_file("tensor.npy", &matrix)?;
 
-// Read a single tensor.
-let matrix_2 = npy::read_from_file("tensor.npy")?.into_rank::<2>()?;
+// Write and read back a single tensor.
+npy::write_to_file("tensor.npy", matrix.view())?;
+let matrix_2 = npy::read_from_file("tensor.npy")?.into_type::<i32>()?.into_rank::<2>()?;
 assert_eq!(matrix, matrix_2);
 
-// Write multiple tensors.
+// Write and read back a map of named tensors.
 npz::write_to_file("tensors.npz", [("some_matrix", matrix.view())])?;
+let mut tensors = npz::read_from_file("tensors.npz")?;
 
-// Read a map of name to tensor
-let tensors = npz::read_from_file("tensors.npz")?;
+// Borrow a tensor from the map as a typed view.
 let matrix_3 = tensors
     .get("some_matrix")
     .ok_or("tensor not found")?
-    .view()
+    .as_type::<i32>()?
     .into_rank::<2>()?;
 assert_eq!(matrix, matrix_3);
+
+// Or remove an entry to extract its tensor as an owned value.
+let matrix_4 = tensors
+    .remove("some_matrix")
+    .ok_or("tensor not found")?
+    .into_type::<i32>()?
+    .into_rank::<2>()?;
+assert_eq!(matrix, matrix_4);
 
 # Ok(()) }
 ```
 "#
 )]
+
+mod value;
+pub use value::{DataType, Element, TypeError, Value, View};
 
 /// Read and write tensors in NumPy's `.npy` format.
 #[cfg(feature = "npy")]

--- a/rten-serialize/src/npy.rs
+++ b/rten-serialize/src/npy.rs
@@ -1,11 +1,12 @@
-use rten_tensor::{AsView, Layout, Storage, Tensor, TensorBase};
+use rten_tensor::{AsView, Layout, Tensor, TensorView};
 use std::fs::File;
 use std::io::{self, Read, Write};
 use std::path::Path;
 
 mod dtype;
-pub use dtype::Element;
-use dtype::ElementKind;
+use dtype::{Element, ElementKind};
+
+use crate::value::{DataType, Value, View, dispatch_data_type, match_view};
 
 /// Magic bytes at the start of every `.npy` file.
 const MAGIC: &[u8; 6] = b"\x93NUMPY";
@@ -19,13 +20,20 @@ fn invalid_data(msg: impl Into<String>) -> io::Error {
 }
 
 /// Serialize a tensor to a writer.
-pub fn write<T: Element, S: Storage<Elem = T>, L: Layout + Clone>(
-    writer: impl io::Write,
-    array: &TensorBase<S, L>,
-) -> io::Result<()> {
+pub fn write<'a, V: Into<View<'a>>>(writer: impl io::Write, array: V) -> io::Result<()> {
+    let view = array.into();
+    match_view!(view, array => write_typed(writer, array))
+}
+
+/// Serialize a tensor to a file.
+pub fn write_to_file<'a, V: Into<View<'a>>>(path: impl AsRef<Path>, array: V) -> io::Result<()> {
+    write(File::create(path)?, array)
+}
+
+fn write_typed<T: Element>(writer: impl io::Write, array: TensorView<T>) -> io::Result<()> {
     let mut writer = io::BufWriter::new(writer);
 
-    let header = build_header::<T>(array.shape().as_ref())?;
+    let header = build_header::<T>(array.shape())?;
     writer.write_all(&header)?;
 
     for x in array.iter() {
@@ -34,26 +42,27 @@ pub fn write<T: Element, S: Storage<Elem = T>, L: Layout + Clone>(
     writer.flush()
 }
 
-/// Serialize a tensor to a file.
-pub fn write_to_file<T: Element, S: Storage<Elem = T>, L: Layout + Clone>(
-    path: impl AsRef<Path>,
-    array: &TensorBase<S, L>,
-) -> io::Result<()> {
-    write(File::create(path)?, array)
-}
-
 /// Read a tensor from a reader.
-pub fn read<T: Element>(mut reader: impl io::Read) -> io::Result<Tensor<T>> {
+///
+/// The returned [`Value`] holds a tensor whose element type matches the dtype
+/// stored in the file. Use [`Value::into_type`] / [`Value::as_type`] to extract
+/// a typed tensor.
+pub fn read(mut reader: impl io::Read) -> io::Result<Value> {
     let header = read_header(&mut reader)?;
-
-    if header.dtype.kind != T::KIND || header.dtype.item_size != T::ITEM_SIZE {
-        return Err(invalid_data(format!(
-            "array dtype `{}{}` does not match requested element type",
+    let data_type = data_type_from_dtype(&header.dtype).ok_or_else(|| {
+        invalid_data(format!(
+            "unsupported npy dtype `{}{}`",
             header.dtype.kind.as_char(),
             header.dtype.item_size
-        )));
-    }
+        ))
+    })?;
+    let value = dispatch_data_type!(data_type, T => {
+        Value::from(read_typed::<T>(&header, reader)?)
+    });
+    Ok(value)
+}
 
+fn read_typed<T: Element>(header: &Header, mut reader: impl io::Read) -> io::Result<Tensor<T>> {
     let n_elements = header
         .shape
         .iter()
@@ -102,9 +111,29 @@ pub fn read<T: Element>(mut reader: impl io::Read) -> io::Result<Tensor<T>> {
 }
 
 /// Read a tensor from a file.
-pub fn read_from_file<T: Element>(path: impl AsRef<Path>) -> io::Result<Tensor<T>> {
+pub fn read_from_file(path: impl AsRef<Path>) -> io::Result<Value> {
     let file = io::BufReader::new(File::open(path)?);
     read(file)
+}
+
+/// Map a parsed npy dtype to the corresponding [`DataType`], or `None` if it is
+/// not a supported scalar type.
+fn data_type_from_dtype(dtype: &DType) -> Option<DataType> {
+    let data_type = match (dtype.kind, dtype.item_size) {
+        (ElementKind::Bool, 1) => DataType::Bool,
+        (ElementKind::Int, 1) => DataType::Int8,
+        (ElementKind::Int, 2) => DataType::Int16,
+        (ElementKind::Int, 4) => DataType::Int32,
+        (ElementKind::Int, 8) => DataType::Int64,
+        (ElementKind::Uint, 1) => DataType::UInt8,
+        (ElementKind::Uint, 2) => DataType::UInt16,
+        (ElementKind::Uint, 4) => DataType::UInt32,
+        (ElementKind::Uint, 8) => DataType::UInt64,
+        (ElementKind::Float, 4) => DataType::Float32,
+        (ElementKind::Float, 8) => DataType::Float64,
+        _ => return None,
+    };
+    Some(data_type)
 }
 
 fn fortran_order_to_row_major<T: Clone>(values: Vec<T>, shape: &[usize]) -> Vec<T> {
@@ -400,8 +429,9 @@ fn build_header<T: Element>(shape: &[usize]) -> io::Result<Vec<u8>> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::*;
 
     static NEXT_TEST_FILE: AtomicUsize = AtomicUsize::new(0);
 
@@ -417,10 +447,10 @@ mod tests {
         let tensor: Tensor<i32> = [[1, 2, 3], [4, 5, 6]].into();
         let mut buffer = Vec::new();
 
-        write(&mut buffer, &tensor).unwrap();
-        let read = read::<i32>(&buffer[..]).unwrap();
+        write(&mut buffer, tensor.view()).unwrap();
+        let read = read(&buffer[..]).unwrap().into_type::<i32>().unwrap();
 
-        assert_eq!(&read, &tensor);
+        assert_eq!(read, tensor);
     }
 
     /// Round-trip every supported element type through the in-memory writer
@@ -431,8 +461,8 @@ mod tests {
             ($ty:ty, $tensor:expr) => {{
                 let tensor: Tensor<$ty> = $tensor;
                 let mut buffer = Vec::new();
-                write(&mut buffer, &tensor).unwrap();
-                let read = read::<$ty>(&buffer[..]).unwrap();
+                write(&mut buffer, tensor.view()).unwrap();
+                let read = read(&buffer[..]).unwrap().into_type::<$ty>().unwrap();
                 assert_eq!(&read, &tensor);
             }};
         }
@@ -457,11 +487,11 @@ mod tests {
         let path = temp_file("round-trip.npy");
         let tensor: Tensor<f32> = [[1., 2.], [3., 4.]].into();
 
-        write_to_file(&path, &tensor).unwrap();
-        let read = read_from_file::<f32>(&path).unwrap();
+        write_to_file(&path, tensor.view()).unwrap();
+        let read = read_from_file(&path).unwrap();
         std::fs::remove_file(&path).unwrap();
 
-        assert_eq!(&read, &tensor);
+        assert_eq!(read.into_type::<f32>().unwrap(), tensor);
     }
 
     /// Round-trips a scalar tensor, whose header has an empty shape
@@ -471,8 +501,8 @@ mod tests {
         let tensor = Tensor::from_scalar(42i32);
         let mut buffer = Vec::new();
 
-        write(&mut buffer, &tensor).unwrap();
-        let read = read::<i32>(&buffer[..]).unwrap();
+        write(&mut buffer, tensor.view()).unwrap();
+        let read = read(&buffer[..]).unwrap().into_type::<i32>().unwrap();
 
         assert_eq!(&read, &tensor);
     }
@@ -481,20 +511,20 @@ mod tests {
     /// accepted as an empty or partially decoded tensor.
     #[test]
     fn test_read_npy_rejects_invalid_data() {
-        let err = read::<i32>(&b"not an npy file"[..]).unwrap_err();
+        let err = read(&b"not an npy file"[..]).unwrap_err();
 
         assert_eq!(err.kind(), io::ErrorKind::InvalidData);
     }
 
     #[test]
-    fn test_read_npy_rejects_dtype_mismatch() {
+    fn test_read_npy_reports_stored_dtype() {
         let tensor: Tensor<i32> = [1, 2, 3].into();
         let mut buffer = Vec::new();
-        write(&mut buffer, &tensor).unwrap();
+        write(&mut buffer, tensor.view()).unwrap();
 
-        let err = read::<f32>(&buffer[..]).unwrap_err();
+        let value = read(&buffer[..]).unwrap();
 
-        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        assert_eq!(value.dtype(), DataType::Int32);
     }
 
     /// Builds a minimal version 1.0 `.npy` file with the given header
@@ -529,7 +559,7 @@ mod tests {
 
         for case in cases {
             let bytes = npy_with_header(case, &[0, 0, 0, 0]);
-            let err = read::<i32>(&bytes[..]).unwrap_err();
+            let err = read(&bytes[..]).unwrap_err();
             assert_eq!(err.kind(), io::ErrorKind::InvalidData, "case: {case}");
         }
     }
@@ -541,7 +571,7 @@ mod tests {
             &[1, 0, 0, 0, 2, 0, 0, 0],
         );
 
-        let read = read::<i32>(&bytes[..]).unwrap();
+        let read = read(&bytes[..]).unwrap().into_type::<i32>().unwrap();
 
         assert_eq!(read, Tensor::from([1, 2]));
     }
@@ -554,7 +584,7 @@ mod tests {
             &[0, 0, 0, 1, 0, 0, 0, 2],
         );
 
-        let read = read::<i32>(&bytes[..]).unwrap();
+        let read = read(&bytes[..]).unwrap().into_type::<i32>().unwrap();
 
         assert_eq!(read, Tensor::from([1, 2]));
     }
@@ -575,15 +605,18 @@ mod tests {
         let c_order = include_bytes!("../tests/fixtures/order_c_i32.npy");
         let fortran_order = include_bytes!("../tests/fixtures/order_fortran_i32.npy");
 
-        let c_tensor = read::<i32>(&c_order[..]).unwrap();
-        let fortran_tensor = read::<i32>(&fortran_order[..]).unwrap();
+        let c_tensor = read(&c_order[..]).unwrap().into_type::<i32>().unwrap();
+        let fortran_tensor = read(&fortran_order[..])
+            .unwrap()
+            .into_type::<i32>()
+            .unwrap();
         let expected = Tensor::from([
             [[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]],
             [[12, 13, 14, 15], [16, 17, 18, 19], [20, 21, 22, 23]],
         ]);
 
-        assert_eq!(&c_tensor, &expected);
-        assert_eq!(&fortran_tensor, &expected);
-        assert_eq!(&fortran_tensor, &c_tensor);
+        assert_eq!(c_tensor, expected);
+        assert_eq!(fortran_tensor, expected);
+        assert_eq!(fortran_tensor, c_tensor);
     }
 }

--- a/rten-serialize/src/npy/dtype.rs
+++ b/rten-serialize/src/npy/dtype.rs
@@ -44,10 +44,6 @@ impl ElementKind {
 /// This is implemented for Rust's primitive integer and floating point types
 /// and `bool`.
 pub trait Element: sealed::Sealed + Copy {
-    /// NumPy array-protocol type kind.
-    #[doc(hidden)]
-    const KIND: ElementKind;
-
     /// Size of the element in bytes.
     #[doc(hidden)]
     const ITEM_SIZE: usize;
@@ -70,11 +66,10 @@ pub trait Element: sealed::Sealed + Copy {
 }
 
 macro_rules! impl_element {
-    ($ty:ty, $kind:expr, $descr:literal) => {
+    ($ty:ty, $descr:literal) => {
         impl sealed::Sealed for $ty {}
 
         impl Element for $ty {
-            const KIND: ElementKind = $kind;
             const ITEM_SIZE: usize = size_of::<$ty>();
             const DESCR: &'static str = $descr;
 
@@ -93,21 +88,20 @@ macro_rules! impl_element {
 
 // Single-byte types use the `|` ("not applicable") byte-order marker, matching
 // the output of `numpy.dtype.str`.
-impl_element!(i8, ElementKind::Int, "|i1");
-impl_element!(i16, ElementKind::Int, "<i2");
-impl_element!(i32, ElementKind::Int, "<i4");
-impl_element!(i64, ElementKind::Int, "<i8");
-impl_element!(u8, ElementKind::Uint, "|u1");
-impl_element!(u16, ElementKind::Uint, "<u2");
-impl_element!(u32, ElementKind::Uint, "<u4");
-impl_element!(u64, ElementKind::Uint, "<u8");
-impl_element!(f32, ElementKind::Float, "<f4");
-impl_element!(f64, ElementKind::Float, "<f8");
+impl_element!(i8, "|i1");
+impl_element!(i16, "<i2");
+impl_element!(i32, "<i4");
+impl_element!(i64, "<i8");
+impl_element!(u8, "|u1");
+impl_element!(u16, "<u2");
+impl_element!(u32, "<u4");
+impl_element!(u64, "<u8");
+impl_element!(f32, "<f4");
+impl_element!(f64, "<f8");
 
 impl sealed::Sealed for bool {}
 
 impl Element for bool {
-    const KIND: ElementKind = ElementKind::Bool;
     const ITEM_SIZE: usize = 1;
     const DESCR: &'static str = "|b1";
 

--- a/rten-serialize/src/npz.rs
+++ b/rten-serialize/src/npz.rs
@@ -3,24 +3,36 @@ use std::fs::File;
 use std::io;
 use std::path::Path;
 
-use rten_tensor::{Layout, Storage, Tensor, TensorBase};
 use zip::write::SimpleFileOptions;
 use zip::{CompressionMethod, ZipArchive, ZipWriter};
 
-use crate::npy::Element;
+use crate::value::{Value, View};
 
 /// Serialize named tensors to an NPZ archive.
 ///
+/// Arrays are stored uncompressed, matching the output of `numpy.savez`.
+///
 /// Tensor names may be passed with or without the `.npy` suffix.
 ///
-/// Arrays are stored uncompressed, matching the output of `numpy.savez`.
-pub fn write<'a, T, S, L, I, N, W>(writer: W, arrays: I) -> io::Result<()>
+/// A single archive may hold tensors of different element types. If all tensors
+/// have the same type, pass views directly:
+///
+/// ```text
+/// npz::write(writer, [("a", a.view()), ("b", b.view())])?;
+/// ```
+///
+/// If the tensors have mixed types, they must be converted to [`View`]s first.
+/// Using [`View::from`] on the first entry fixes the element type, so the rest
+/// can use `.into()`:
+///
+/// ```text
+/// npz::write(writer, [("a", View::from(a.view())), ("b", b.view().into())])?;
+/// ```
+pub fn write<'a, I, N, V, W>(writer: W, arrays: I) -> io::Result<()>
 where
-    T: Element + 'a,
-    S: Storage<Elem = T>,
-    L: Layout + Clone,
-    I: IntoIterator<Item = (N, TensorBase<S, L>)>,
+    I: IntoIterator<Item = (N, V)>,
     N: AsRef<str>,
+    V: Into<View<'a>>,
     W: io::Write + io::Seek,
 {
     let mut archive = ZipWriter::new(writer);
@@ -28,7 +40,7 @@ where
 
     for (name, array) in arrays {
         archive.start_file(npz_file_name(name.as_ref())?, options)?;
-        crate::npy::write(&mut archive, &array)?;
+        crate::npy::write(&mut archive, array)?;
     }
 
     archive.finish()?;
@@ -36,13 +48,11 @@ where
 }
 
 /// Serialize named tensors to an NPZ archive file - this will create the file.
-pub fn write_to_file<'a, T, S, L, I, N>(path: impl AsRef<Path>, arrays: I) -> io::Result<()>
+pub fn write_to_file<'a, I, N, V>(path: impl AsRef<Path>, arrays: I) -> io::Result<()>
 where
-    T: Element + 'a,
-    S: Storage<Elem = T>,
-    L: Layout + Clone,
-    I: IntoIterator<Item = (N, TensorBase<S, L>)>,
+    I: IntoIterator<Item = (N, V)>,
     N: AsRef<str>,
+    V: Into<View<'a>>,
 {
     let file = io::BufWriter::new(File::create(path)?);
     write(file, arrays)
@@ -50,13 +60,13 @@ where
 
 /// Read all `.npy` entries from an NPZ archive.
 ///
-/// Returned names have the `.npy` suffix removed.
+/// Returned names have the `.npy` suffix removed. Each entry's element type is
+/// preserved in the returned [`Value`]. Use [`Value::into_type`] /
+/// [`Value::as_type`] to extract a typed tensor.
 ///
 /// Without the `npz-compression` feature, only uncompressed archives (as
 /// produced by `numpy.savez`) are supported.
-pub fn read<T: Element>(
-    reader: impl io::Read + io::Seek,
-) -> io::Result<HashMap<String, Tensor<T>>> {
+pub fn read(reader: impl io::Read + io::Seek) -> io::Result<HashMap<String, Value>> {
     let mut archive = ZipArchive::new(reader)?;
     let names = archive
         .file_names()
@@ -67,18 +77,16 @@ pub fn read<T: Element>(
 
     for name in names {
         let file = archive.by_name(&name)?;
-        let array = crate::npy::read(file)?;
+        let value = crate::npy::read(file)?;
         let name = name.strip_suffix(".npy").unwrap().to_string();
-        arrays.insert(name, array);
+        arrays.insert(name, value);
     }
 
     Ok(arrays)
 }
 
 /// Read all `.npy` entries from an NPZ archive file.
-pub fn read_from_file<T: Element>(
-    path: impl AsRef<Path>,
-) -> io::Result<HashMap<String, Tensor<T>>> {
+pub fn read_from_file(path: impl AsRef<Path>) -> io::Result<HashMap<String, Value>> {
     let file = io::BufReader::new(File::open(path)?);
     read(file)
 }
@@ -89,20 +97,14 @@ pub fn read_from_file<T: Element>(
 ///
 /// See [`read`] for behavior when reading compressed archives without the
 /// `npz-compression` feature.
-pub fn read_array<T: Element>(
-    reader: impl io::Read + io::Seek,
-    name: &str,
-) -> io::Result<Tensor<T>> {
+pub fn read_array(reader: impl io::Read + io::Seek, name: &str) -> io::Result<Value> {
     let mut archive = ZipArchive::new(reader)?;
     let file = archive.by_name(&npz_file_name(name)?)?;
     crate::npy::read(file)
 }
 
 /// Read a single named tensor from an NPZ archive file.
-pub fn read_array_from_file<T: Element>(
-    path: impl AsRef<Path>,
-    name: &str,
-) -> io::Result<Tensor<T>> {
+pub fn read_array_from_file(path: impl AsRef<Path>, name: &str) -> io::Result<Value> {
     let file = io::BufReader::new(File::open(path)?);
     read_array(file, name)
 }
@@ -124,6 +126,7 @@ fn npz_file_name(name: &str) -> io::Result<String> {
 mod tests {
     use super::*;
     use rten_tensor::AsView;
+    use rten_tensor::Tensor;
     use std::io::{Cursor, Write};
     use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -145,11 +148,38 @@ mod tests {
         write(&mut buffer, [("a", a.view()), ("nested/b.npy", b.view())]).unwrap();
 
         buffer.set_position(0);
-        let arrays = read::<i32>(&mut buffer).unwrap();
+        let arrays = read(&mut buffer).unwrap();
 
         assert_eq!(arrays.len(), 2);
-        assert_eq!(arrays.get("a").unwrap(), &a);
-        assert_eq!(arrays.get("nested/b").unwrap(), &b);
+        assert_eq!(arrays.get("a").unwrap().as_type::<i32>().unwrap(), a);
+        assert_eq!(arrays.get("nested/b").unwrap().as_type::<i32>().unwrap(), b);
+    }
+
+    #[test]
+    fn test_round_trip_npz_mixed_dtypes() {
+        let floats: Tensor<f32> = [[1., 2.], [3., 4.]].into();
+        let ints: Tensor<i32> = [5, 6, 7].into();
+
+        let mut buffer = Cursor::new(Vec::new());
+        write(
+            &mut buffer,
+            [
+                // `View::from` on the first entry fixes the element type, so the
+                // rest can use `.into()`.
+                ("floats", View::from(floats.view())),
+                ("ints", ints.view().into()),
+            ],
+        )
+        .unwrap();
+
+        buffer.set_position(0);
+        let arrays = read(&mut buffer).unwrap();
+
+        assert_eq!(
+            arrays.get("floats").unwrap().as_type::<f32>().unwrap(),
+            floats
+        );
+        assert_eq!(arrays.get("ints").unwrap().as_type::<i32>().unwrap(), ints);
     }
 
     /// Exercises the single-array reader and confirms callers can use either
@@ -162,9 +192,9 @@ mod tests {
         write(&mut buffer, [("a.npy", a.view())]).unwrap();
 
         buffer.set_position(0);
-        let read = read_array::<f32>(&mut buffer, "a").unwrap();
+        let read = read_array(&mut buffer, "a").unwrap();
 
-        assert_eq!(&read, &a);
+        assert_eq!(read.into_type::<f32>().unwrap(), a);
     }
 
     /// Covers the NPZ file convenience helpers with a real file path and checks
@@ -176,14 +206,14 @@ mod tests {
         let b: Tensor<i32> = [5, 6, 7].into();
 
         write_to_file(&path, [("a", a.view()), ("b", b.view())]).unwrap();
-        let arrays = read_from_file::<i32>(&path).unwrap();
-        let b_read = read_array_from_file::<i32>(&path, "b.npy").unwrap();
+        let arrays = read_from_file(&path).unwrap();
+        let b_read = read_array_from_file(&path, "b.npy").unwrap();
         std::fs::remove_file(&path).unwrap();
 
         assert_eq!(arrays.len(), 2);
-        assert_eq!(arrays.get("a").unwrap(), &a);
-        assert_eq!(arrays.get("b").unwrap(), &b);
-        assert_eq!(&b_read, &b);
+        assert_eq!(arrays.get("a").unwrap().as_type::<i32>().unwrap(), a);
+        assert_eq!(arrays.get("b").unwrap().as_type::<i32>().unwrap(), b);
+        assert_eq!(b_read.into_type::<i32>().unwrap(), b);
     }
 
     /// Ensures lookup of a missing NPZ array returns a not-found error instead
@@ -195,7 +225,7 @@ mod tests {
         write(&mut buffer, [("a", a.view())]).unwrap();
 
         buffer.set_position(0);
-        let err = read_array::<i32>(&mut buffer, "missing").unwrap_err();
+        let err = read_array(&mut buffer, "missing").unwrap_err();
 
         assert_eq!(err.kind(), io::ErrorKind::NotFound);
     }
@@ -212,7 +242,7 @@ mod tests {
             let mut archive = ZipWriter::new(&mut buffer);
 
             archive.start_file("a.npy", options).unwrap();
-            crate::npy::write(&mut archive, &a).unwrap();
+            crate::npy::write(&mut archive, a.view()).unwrap();
 
             archive.start_file("metadata.txt", options).unwrap();
             archive.write_all(b"not an array").unwrap();
@@ -220,10 +250,10 @@ mod tests {
         }
 
         buffer.set_position(0);
-        let arrays = read::<i32>(&mut buffer).unwrap();
+        let arrays = read(&mut buffer).unwrap();
 
         assert_eq!(arrays.len(), 1);
-        assert_eq!(arrays.get("a").unwrap(), &a);
+        assert_eq!(arrays.get("a").unwrap().as_type::<i32>().unwrap(), a);
     }
 
     #[cfg(feature = "npz-compression")]
@@ -236,15 +266,15 @@ mod tests {
                 SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
             let mut archive = ZipWriter::new(&mut buffer);
             archive.start_file("a.npy", options).unwrap();
-            crate::npy::write(&mut archive, &a).unwrap();
+            crate::npy::write(&mut archive, a.view()).unwrap();
             archive.finish().unwrap();
         }
 
         buffer.set_position(0);
-        let arrays = read::<i32>(&mut buffer).unwrap();
+        let arrays = read(&mut buffer).unwrap();
 
         assert_eq!(arrays.len(), 1);
-        assert_eq!(arrays.get("a").unwrap(), &a);
+        assert_eq!(arrays.get("a").unwrap().as_type::<i32>().unwrap(), a);
     }
 
     /// Checks validation of empty array names so invalid NPZ member names are

--- a/rten-serialize/src/value.rs
+++ b/rten-serialize/src/value.rs
@@ -1,0 +1,386 @@
+//! Dynamically-typed tensor containers.
+//!
+//! Serialization formats can store tensors of various element types within a
+//! single file. [`Value`] and [`View`] are enums that hold a tensor of
+//! any [supported element type](Element), allowing readers to return tensors
+//! whose type is only known at runtime, and writers to accept a heterogeneous
+//! collection of tensors.
+
+use std::error::Error;
+use std::fmt;
+
+use rten_tensor::storage::ViewData;
+use rten_tensor::{AsView, DynLayout, Layout, Scalar, Tensor, TensorBase, TensorView};
+
+mod private {
+    /// Prevents [`Element`](super::Element) from being implemented outside this
+    /// crate.
+    pub trait Sealed {}
+}
+
+/// The element type of a tensor stored in a serialization format.
+///
+/// This enumerates the element types that have a corresponding Rust primitive
+/// and are supported by all of this crate's formats.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum DataType {
+    Bool,
+    Int8,
+    Int16,
+    Int32,
+    Int64,
+    UInt8,
+    UInt16,
+    UInt32,
+    UInt64,
+    Float32,
+    Float64,
+}
+
+/// Error returned when a [`Value`] or [`View`] is accessed as the wrong element
+/// type.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TypeError {
+    /// The element type that was requested.
+    pub expected: DataType,
+    /// The element type the value actually holds.
+    pub actual: DataType,
+}
+
+impl fmt::Display for TypeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "expected tensor with data type {:?}, but found {:?}",
+            self.expected, self.actual
+        )
+    }
+}
+
+impl Error for TypeError {}
+
+/// A Rust primitive type that can be stored in a [`Value`] or [`View`].
+///
+/// This trait is sealed and implemented for `bool`, the signed and unsigned
+/// integer types up to 64 bits, and `f32`/`f64`.
+pub trait Element: Scalar + private::Sealed + Sized {
+    /// Extract an owned tensor, or fail if `value` holds a different type.
+    ///
+    /// Prefer [`Value::into_type`], which calls this.
+    #[doc(hidden)]
+    fn tensor_from_value(value: Value) -> Result<Tensor<Self>, TypeError>;
+
+    /// Extract the typed view from `view`, or fail if it holds a different type.
+    ///
+    /// Prefer [`View::into_type`] / [`View::as_type`], which call this.
+    #[doc(hidden)]
+    fn view_from_view<'a>(view: View<'a>) -> Result<TensorView<'a, Self>, TypeError>;
+}
+
+/// Generate the [`Value`] and [`View`] enums plus the per-type [`Element`] impls
+/// and `From`/`TryFrom` conversions.
+///
+/// Each row maps an enum variant to its Rust element type and [`DataType`].
+macro_rules! define_value_types {
+    ($($variant:ident => $ty:ty, $dtype:ident;)*) => {
+        /// An owned tensor whose element type is determined at runtime.
+        ///
+        /// A typed [`Tensor`] can be converted into a `Value` using
+        /// [`From`]/[`Into`]:
+        ///
+        /// ```
+        /// use rten_serialize::Value;
+        /// use rten_tensor::Tensor;
+        ///
+        /// let tensor = Tensor::from([1i32, 2, 3]);
+        /// let value: Value = tensor.clone().into();
+        /// assert_eq!(value.into_type::<i32>().unwrap(), tensor);
+        /// ```
+        ///
+        /// To go the other way, use [`Value::into_type`] to extract an owned
+        /// tensor or [`Value::as_type`] to borrow a typed view, both of which
+        /// fail if the value holds a different element type.
+        #[derive(Clone, Debug)]
+        #[non_exhaustive]
+        pub enum Value {
+            $($variant(Tensor<$ty>),)*
+        }
+
+        /// A borrowed view of a tensor whose element type is determined at
+        /// runtime.
+        ///
+        /// A typed [`TensorView`] can be converted into a `View` using
+        /// [`From`]/[`Into`]:
+        ///
+        /// ```
+        /// use rten_serialize::View;
+        /// use rten_tensor::Tensor;
+        /// use rten_tensor::prelude::*;
+        ///
+        /// let tensor = Tensor::from([1i32, 2, 3]);
+        /// let view: View = tensor.view().into();
+        /// assert_eq!(view.into_type::<i32>().unwrap().to_vec(), [1, 2, 3]);
+        /// ```
+        ///
+        /// To go the other way, use [`View::into_type`] / [`View::as_type`] to
+        /// extract a typed view, both of which fail if the view holds a
+        /// different element type.
+        #[derive(Clone, Debug)]
+        #[non_exhaustive]
+        pub enum View<'a> {
+            $($variant(TensorView<'a, $ty>),)*
+        }
+
+        impl Value {
+            /// Return the element type of this tensor.
+            pub fn dtype(&self) -> DataType {
+                match self {
+                    $(Value::$variant(_) => DataType::$dtype,)*
+                }
+            }
+
+            /// Return a borrowed view of this tensor.
+            pub fn view(&self) -> View<'_> {
+                match self {
+                    $(Value::$variant(t) => View::$variant(t.view()),)*
+                }
+            }
+        }
+
+        impl<'a> View<'a> {
+            /// Return the element type of this tensor.
+            pub fn dtype(&self) -> DataType {
+                match self {
+                    $(View::$variant(_) => DataType::$dtype,)*
+                }
+            }
+        }
+
+        $(
+            impl private::Sealed for $ty {}
+
+            impl Element for $ty {
+                fn tensor_from_value(value: Value) -> Result<Tensor<Self>, TypeError> {
+                    match value {
+                        Value::$variant(t) => Ok(t),
+                        other => Err(TypeError {
+                            expected: DataType::$dtype,
+                            actual: other.dtype(),
+                        }),
+                    }
+                }
+
+                fn view_from_view<'a>(view: View<'a>) -> Result<TensorView<'a, Self>, TypeError> {
+                    match view {
+                        View::$variant(t) => Ok(t),
+                        other => Err(TypeError {
+                            expected: DataType::$dtype,
+                            actual: other.dtype(),
+                        }),
+                    }
+                }
+            }
+
+            impl From<Tensor<$ty>> for Value {
+                fn from(tensor: Tensor<$ty>) -> Value {
+                    Value::$variant(tensor)
+                }
+            }
+
+            impl<'a, L: Layout + Into<DynLayout>> From<TensorBase<ViewData<'a, $ty>, L>> for View<'a> {
+                fn from(view: TensorBase<ViewData<'a, $ty>, L>) -> View<'a> {
+                    View::$variant(view.into_dyn())
+                }
+            }
+
+            impl TryFrom<Value> for Tensor<$ty> {
+                type Error = TypeError;
+
+                fn try_from(value: Value) -> Result<Self, TypeError> {
+                    <$ty as Element>::tensor_from_value(value)
+                }
+            }
+
+            impl<'a> TryFrom<View<'a>> for TensorView<'a, $ty> {
+                type Error = TypeError;
+
+                fn try_from(view: View<'a>) -> Result<Self, TypeError> {
+                    <$ty as Element>::view_from_view(view)
+                }
+            }
+        )*
+    };
+}
+
+define_value_types! {
+    Bool => bool, Bool;
+    Int8 => i8, Int8;
+    Int16 => i16, Int16;
+    Int32 => i32, Int32;
+    Int64 => i64, Int64;
+    UInt8 => u8, UInt8;
+    UInt16 => u16, UInt16;
+    UInt32 => u32, UInt32;
+    UInt64 => u64, UInt64;
+    Float32 => f32, Float32;
+    Float64 => f64, Float64;
+}
+
+/// Evaluate `$body` with `$T` bound to the Rust element type corresponding to a
+/// runtime [`DataType`].
+#[cfg(any(feature = "npy", feature = "npz"))]
+macro_rules! dispatch_data_type {
+    ($dtype:expr, $T:ident => $body:expr) => {
+        match $dtype {
+            $crate::value::DataType::Bool => {
+                type $T = bool;
+                $body
+            }
+            $crate::value::DataType::Int8 => {
+                type $T = i8;
+                $body
+            }
+            $crate::value::DataType::Int16 => {
+                type $T = i16;
+                $body
+            }
+            $crate::value::DataType::Int32 => {
+                type $T = i32;
+                $body
+            }
+            $crate::value::DataType::Int64 => {
+                type $T = i64;
+                $body
+            }
+            $crate::value::DataType::UInt8 => {
+                type $T = u8;
+                $body
+            }
+            $crate::value::DataType::UInt16 => {
+                type $T = u16;
+                $body
+            }
+            $crate::value::DataType::UInt32 => {
+                type $T = u32;
+                $body
+            }
+            $crate::value::DataType::UInt64 => {
+                type $T = u64;
+                $body
+            }
+            $crate::value::DataType::Float32 => {
+                type $T = f32;
+                $body
+            }
+            $crate::value::DataType::Float64 => {
+                type $T = f64;
+                $body
+            }
+        }
+    };
+}
+#[cfg(any(feature = "npy", feature = "npz"))]
+pub(crate) use dispatch_data_type;
+
+/// Evaluate `$body` with `$v` bound to the typed [`TensorView`] held by a
+/// [`View`].
+#[cfg(any(feature = "npy", feature = "npz"))]
+macro_rules! match_view {
+    ($view:expr, $v:ident => $body:expr) => {
+        match $view {
+            $crate::value::View::Bool($v) => $body,
+            $crate::value::View::Int8($v) => $body,
+            $crate::value::View::Int16($v) => $body,
+            $crate::value::View::Int32($v) => $body,
+            $crate::value::View::Int64($v) => $body,
+            $crate::value::View::UInt8($v) => $body,
+            $crate::value::View::UInt16($v) => $body,
+            $crate::value::View::UInt32($v) => $body,
+            $crate::value::View::UInt64($v) => $body,
+            $crate::value::View::Float32($v) => $body,
+            $crate::value::View::Float64($v) => $body,
+        }
+    };
+}
+#[cfg(any(feature = "npy", feature = "npz"))]
+pub(crate) use match_view;
+
+impl Value {
+    /// Convert this value into a tensor of type `T`, or fail if it holds a
+    /// different type.
+    pub fn into_type<T: Element>(self) -> Result<Tensor<T>, TypeError> {
+        T::tensor_from_value(self)
+    }
+
+    /// Borrow this value as a tensor view of type `T`, or fail if it holds a
+    /// different type.
+    pub fn as_type<T: Element>(&self) -> Result<TensorView<'_, T>, TypeError> {
+        T::view_from_view(self.view())
+    }
+}
+
+impl<'a> View<'a> {
+    /// Convert this view into a tensor view of type `T`, or fail if it holds a
+    /// different type.
+    pub fn into_type<T: Element>(self) -> Result<TensorView<'a, T>, TypeError> {
+        T::view_from_view(self)
+    }
+
+    /// Borrow this view as a tensor view of type `T`, or fail if it holds a
+    /// different type.
+    pub fn as_type<T: Element>(&self) -> Result<TensorView<'_, T>, TypeError> {
+        T::view_from_view(self.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DataType, Value, View};
+    use rten_tensor::Tensor;
+    use rten_tensor::prelude::*;
+
+    #[test]
+    fn test_value_from_into_type() {
+        let tensor: Tensor<i32> = [[1, 2], [3, 4]].into();
+        let value: Value = tensor.clone().into();
+
+        assert_eq!(value.dtype(), DataType::Int32);
+        assert_eq!(value.into_type::<i32>().unwrap(), tensor);
+    }
+
+    #[test]
+    fn test_value_into_type_wrong_type_errors() {
+        let value: Value = Tensor::<f32>::zeros(&[2, 2]).into();
+
+        let err = value.into_type::<i32>().unwrap_err();
+
+        assert_eq!(err.expected, DataType::Int32);
+        assert_eq!(err.actual, DataType::Float32);
+    }
+
+    #[test]
+    fn test_value_as_type_borrows() {
+        let value: Value = Tensor::from([1i64, 2, 3]).into();
+
+        let view = value.as_type::<i64>().unwrap();
+
+        assert_eq!(view.to_vec(), [1, 2, 3]);
+    }
+
+    #[test]
+    fn test_value_as_type_wrong_type_errors() {
+        let value: Value = Tensor::from([1i64, 2, 3]).into();
+
+        assert!(value.as_type::<u8>().is_err());
+    }
+
+    #[test]
+    fn test_view_into_type() {
+        let tensor: Tensor<f32> = [1., 2., 3.].into();
+        let view: View = tensor.view().into();
+
+        assert_eq!(view.dtype(), DataType::Float32);
+        assert_eq!(view.into_type::<f32>().unwrap().to_vec(), [1., 2., 3.]);
+    }
+}


### PR DESCRIPTION
Change the npy/npz (de-)serialization functions to use enums for tensor values with variants for each supported type. This allows for reading/writing npz archives with a mix of tensor types. When reading npy files this allows for the case where the dtype is not known at compile time.

This will be needed in future for porting rten-cli's tensor (de-)serialization to use rten-serialize. rten-cli reads model inputs / expected outputs in Safetensors format, and inputs/outputs may have a mix of tensor types.

See the updated usage example in the front page of the rten-serialization docs for an overview of the updated APIs.