### PR TITLE
Refactor `Pod` trait used for byte-casting

### DIFF
--- a/rten-base/src/byte_cast.rs
+++ b/rten-base/src/byte_cast.rs
@@ -3,19 +3,13 @@
 use std::alloc::Layout;
 use std::mem::{ManuallyDrop, MaybeUninit};
 
-/// Marker trait for "plain old data".
-///
-/// POD types which are simple value types that impl `Copy`, have no padding,
-/// and for which any bit pattern is valid.
-///
-/// This means an arbitrary byte sequence can be converted to this type, as
-/// long as the byte sequence length is a multiple of the type's size.
+/// Types which can be transmuted to a byte array.
 ///
 /// # Safety
 ///
-/// This type must only be implemented for types which are initialized and for
-/// which any bit pattern is valid.
-pub unsafe trait Pod: Copy {
+/// This type must only be implemented for `Copy` types which contain no
+/// padding.
+pub unsafe trait ToByteArray: Copy {
     /// View of this type as an array of bytes.
     type Bytes: AsRef<[u8]>;
 
@@ -23,7 +17,48 @@ pub unsafe trait Pod: Copy {
     ///
     /// This is the same as `to_ne_bytes` for primitive types.
     fn to_bytes(self) -> Self::Bytes;
+}
 
+macro_rules! impl_to_byte_array {
+    ($type:ty) => {
+        unsafe impl ToByteArray for $type {
+            type Bytes = [u8; size_of::<$type>()];
+
+            fn to_bytes(self) -> Self::Bytes {
+                self.to_ne_bytes()
+            }
+        }
+    };
+}
+
+impl_to_byte_array!(i8);
+impl_to_byte_array!(u8);
+impl_to_byte_array!(i16);
+impl_to_byte_array!(u16);
+impl_to_byte_array!(i32);
+impl_to_byte_array!(u32);
+impl_to_byte_array!(i64);
+impl_to_byte_array!(u64);
+impl_to_byte_array!(f32);
+impl_to_byte_array!(f64);
+
+unsafe impl ToByteArray for bool {
+    type Bytes = [u8; 1];
+
+    fn to_bytes(self) -> [u8; 1] {
+        [self as u8]
+    }
+}
+
+/// Types which can be transmuted from a byte array.
+///
+/// These are types for which any bit pattern is valid.
+///
+/// # Safety
+///
+/// This type must only be implemented for types for which any bit pattern is
+/// valid.
+pub unsafe trait FromByteArray: ToByteArray {
     /// Convert an array of bytes, in native order, into this type.
     ///
     /// This is the same as `from_ne_bytes` for primitive types.
@@ -34,33 +69,32 @@ pub unsafe trait Pod: Copy {
     /// This should compile to a zero-cost transmute.
     fn cast_bytes<Dst>(self) -> Dst
     where
-        Dst: Pod<Bytes = Self::Bytes>,
+        Dst: FromByteArray<Bytes = Self::Bytes>,
     {
         Dst::from_bytes(self.to_bytes())
     }
 }
 
-macro_rules! impl_pod {
+macro_rules! impl_from_byte_array {
     ($type:ty) => {
-        unsafe impl Pod for $type {
-            type Bytes = [u8; size_of::<$type>()];
-
-            fn to_bytes(self) -> Self::Bytes {
-                self.to_ne_bytes()
-            }
-
+        unsafe impl FromByteArray for $type {
             fn from_bytes(val: Self::Bytes) -> Self {
                 Self::from_ne_bytes(val)
             }
         }
     };
 }
-impl_pod!(i8);
-impl_pod!(u8);
-impl_pod!(f32);
-impl_pod!(i32);
-impl_pod!(u32);
-impl_pod!(u64);
+
+impl_from_byte_array!(i8);
+impl_from_byte_array!(u8);
+impl_from_byte_array!(i16);
+impl_from_byte_array!(u16);
+impl_from_byte_array!(i32);
+impl_from_byte_array!(u32);
+impl_from_byte_array!(i64);
+impl_from_byte_array!(u64);
+impl_from_byte_array!(f32);
+impl_from_byte_array!(f64);
 
 /// Return the length of a slice transmuted from `Src` to `Dst`, or `None` if
 /// the transmute is not possible.
@@ -77,13 +111,14 @@ fn transmuted_slice_len<Src, Dst>(src: &[Src]) -> Option<usize> {
     Some(src_byte_len / size_of::<Dst>())
 }
 
-/// Transmute a slice of elements from one [`Pod`] type to another.
+/// Transmute a slice of elements from one type to another.
 ///
-/// This cast is safe because all bit patterns are valid for `Pod` elements.
+/// This cast is safe because all bytes of the source elements are initialized
+/// and all bit patterns are valid for the destination elements.
 ///
 /// Returns `None` if the source pointer is not correctly aligned for the
 /// destination type.
-pub fn cast_pod_slice<Src: Pod, Dst: Pod>(src: &[Src]) -> Option<&[Dst]> {
+pub fn cast_slice<Src: ToByteArray, Dst: FromByteArray>(src: &[Src]) -> Option<&[Dst]> {
     let new_len = transmuted_slice_len::<_, Dst>(src)?;
 
     // Safety:
@@ -92,14 +127,15 @@ pub fn cast_pod_slice<Src: Pod, Dst: Pod>(src: &[Src]) -> Option<&[Dst]> {
     Some(unsafe { std::slice::from_raw_parts(src.as_ptr() as *const Dst, new_len) })
 }
 
-/// Transmute a mutable slice of elements from one [`Pod`] type to another.
+/// Transmute a mutable slice of elements from one type to another.
 ///
-/// This cast is safe because all bit patterns are valid for `Pod` elements.
+/// This cast is safe because all bytes of the source elements are initialized
+/// and all bit patterns are valid for the destination elements.
 ///
 /// Returns `None` if the source pointer is not correctly aligned for the
 /// destination type.
 #[allow(unused)]
-pub fn cast_pod_mut_slice<Src: Pod, Dst: Pod>(src: &mut [Src]) -> Option<&mut [Dst]> {
+pub fn cast_mut_slice<Src: ToByteArray, Dst: FromByteArray>(src: &mut [Src]) -> Option<&mut [Dst]> {
     let new_len = transmuted_slice_len::<_, Dst>(src)?;
 
     // Safety:
@@ -108,11 +144,11 @@ pub fn cast_pod_mut_slice<Src: Pod, Dst: Pod>(src: &mut [Src]) -> Option<&mut [D
     Some(unsafe { std::slice::from_raw_parts_mut(src.as_mut_ptr() as *mut Dst, new_len) })
 }
 
-/// Transmute a mutable slice of elements from one uninitialized [`Pod`] type to another.
+/// Transmute a mutable slice of elements from one uninitialized type to another.
 ///
 /// Returns `None` if the source pointer is not correctly aligned for the
 /// destination type.
-pub fn cast_uninit_pod_mut_slice<Src: Pod, Dst: Pod>(
+pub fn cast_uninit_mut_slice<Src: ToByteArray, Dst: FromByteArray>(
     src: &mut [MaybeUninit<Src>],
 ) -> Option<&mut [MaybeUninit<Dst>]> {
     let new_len = transmuted_slice_len::<_, Dst>(src)?;
@@ -125,11 +161,11 @@ pub fn cast_uninit_pod_mut_slice<Src: Pod, Dst: Pod>(
     })
 }
 
-/// Transmute a vector of elements from one [`Pod`] type to another.
+/// Transmute a vector of elements from one type to another.
 ///
 /// The source and destination types must have the same size and alignment.
 /// The length and capacity of the vector will be the same afterwards.
-pub fn cast_pod_vec<Src: Pod, Dst: Pod>(src: Vec<Src>) -> Option<Vec<Dst>> {
+pub fn cast_vec<Src: ToByteArray, Dst: FromByteArray>(src: Vec<Src>) -> Option<Vec<Dst>> {
     // From `Vec::into_raw_parts`.
     let mut src = ManuallyDrop::new(src);
     let (src_ptr, src_len, src_cap) = (src.as_mut_ptr(), src.len(), src.capacity());
@@ -139,8 +175,8 @@ pub fn cast_pod_vec<Src: Pod, Dst: Pod>(src: Vec<Src>) -> Option<Vec<Dst>> {
     }
 
     // Safety: `Src` and `Dest` types have the same layout for an array of
-    // `src_cap` elements, so the allocation is compatible, and are `Pod` types
-    // so we can transmute any value of `Src` to a value of `Dst`.
+    // `src_cap` elements, so the allocation is compatible, all bytes of `Src`
+    // are initialized and any bit pattern is valid as a value of `Dst`.
     Some(unsafe { Vec::from_raw_parts(src_ptr as *mut Dst, src_len, src_cap) })
 }
 
@@ -192,77 +228,77 @@ mod tests {
     use std::mem::MaybeUninit;
 
     use super::{
-        AsBytes, FromBytes, Pod, cast_pod_mut_slice, cast_pod_slice, cast_pod_vec,
-        cast_uninit_pod_mut_slice,
+        AsBytes, FromByteArray, FromBytes, cast_mut_slice, cast_slice, cast_uninit_mut_slice,
+        cast_vec,
     };
 
     #[test]
-    fn test_cast_pod() {
+    fn test_cast_bytes() {
         let float_val = 1.2f32;
         let int_val: i32 = float_val.cast_bytes();
         assert_eq!(int_val, i32::from_ne_bytes(float_val.to_ne_bytes()));
     }
 
     #[test]
-    fn test_cast_pod_slice() {
+    fn test_cast_slice() {
         // Convert to narrower type
         let i32s = [1, 2, 3];
-        let i8s = cast_pod_slice::<i32, i8>(&i32s).unwrap();
+        let i8s = cast_slice::<i32, i8>(&i32s).unwrap();
         assert_eq!(i8s.as_ptr(), i32s.as_ptr() as *const i8);
         assert_eq!(i8s.len(), i32s.len() * 4);
 
         // Convert back to wider type
-        let i32s_v2 = cast_pod_slice::<i8, i32>(&i8s).unwrap();
+        let i32s_v2 = cast_slice::<i8, i32>(&i8s).unwrap();
         assert_eq!(i32s_v2, i32s);
     }
 
     #[test]
-    fn test_cast_pod_vec() {
+    fn test_cast_vec() {
         // Compatible types
         let i32s = Vec::from([1, 2, 3]);
         let (ptr, len, cap) = (i32s.as_ptr(), i32s.len(), i32s.capacity());
-        let f32s = cast_pod_vec::<i32, f32>(i32s).unwrap();
+        let f32s = cast_vec::<i32, f32>(i32s).unwrap();
         assert_eq!(f32s.as_ptr(), ptr as *const f32);
         assert_eq!(f32s.len(), len);
         assert_eq!(f32s.capacity(), cap);
 
         // Incompatible types
         let i32s = Vec::from([1, 2, 3]);
-        let i8s = cast_pod_vec::<i32, i8>(i32s);
+        let i8s = cast_vec::<i32, i8>(i32s);
         assert!(i8s.is_none());
     }
 
     #[test]
-    fn test_cast_pod_slice_fails_if_unaligned() {
+    fn test_cast_slice_fails_if_unaligned() {
         let i8s = [1, 2, 3, 4, 5];
-        let i32s_a = cast_pod_slice::<i8, i32>(&i8s);
-        let i32s_b = cast_pod_slice::<i8, i32>(&i8s[1..]);
+        let i32s_a = cast_slice::<i8, i32>(&i8s);
+        let i32s_b = cast_slice::<i8, i32>(&i8s[1..]);
 
         // At least one of `i32s_a` or `i32s_b`` will be incorrectly aligned for i32.
         assert!(i32s_a.is_none() || i32s_b.is_none());
     }
 
     #[test]
-    fn test_cast_pod_slice_fails_if_size_not_multiple_of_dst_size() {
+    fn test_cast_slice_fails_if_size_not_multiple_of_dst_size() {
         let i8s = [1, 2, 3, 4, 5];
-        let i32s = cast_pod_slice::<i8, i32>(&i8s);
+        let i32s = cast_slice::<i8, i32>(&i8s);
         assert!(i32s.is_none());
     }
 
     #[test]
-    fn test_cast_pod_mut_slice() {
+    fn test_cast_mut_slice() {
         let mut i32s = [1, 2, 3];
         let i32s_ptr = i32s.as_ptr();
-        let i8s = cast_pod_mut_slice::<i32, i8>(&mut i32s).unwrap();
+        let i8s = cast_mut_slice::<i32, i8>(&mut i32s).unwrap();
         assert_eq!(i8s.as_ptr(), i32s_ptr as *const i8);
         assert_eq!(i8s.len(), i32s.len() * 4);
     }
 
     #[test]
-    fn test_cast_uninit_pod_mut_slice() {
+    fn test_cast_uninit_mut_slice() {
         let mut i32s = [1, 2, 3].map(MaybeUninit::new);
         let i32s_ptr = i32s.as_ptr();
-        let i8s = cast_uninit_pod_mut_slice::<i32, i8>(&mut i32s).unwrap();
+        let i8s = cast_uninit_mut_slice::<i32, i8>(&mut i32s).unwrap();
         assert_eq!(i8s.as_ptr(), i32s_ptr as *const MaybeUninit<i8>);
         assert_eq!(i8s.len(), i32s.len() * 4);
     }

--- a/rten-gemm/src/im2col.rs
+++ b/rten-gemm/src/im2col.rs
@@ -1,7 +1,7 @@
 use std::mem::MaybeUninit;
 use std::ops::Range;
 
-use rten_base::byte_cast::{AsBytes, cast_uninit_pod_mut_slice};
+use rten_base::byte_cast::{AsBytes, cast_uninit_mut_slice};
 use rten_simd::ops::{MaskOps, NumOps};
 use rten_simd::{Isa, Mask, Simd};
 use rten_tensor::{NdTensorView, Storage};
@@ -256,7 +256,7 @@ impl Im2Col<'_, i8> {
         cols: Range<usize>,
         zero_point: i8,
     ) {
-        let out = cast_uninit_pod_mut_slice(out).unwrap();
+        let out = cast_uninit_mut_slice(out).unwrap();
         self.pack_block_int8::<_, NR, NR_REGS, K_TILE, true>(isa, out, rows, cols, zero_point);
     }
 

--- a/rten-gemm/src/kernels/aarch64.rs
+++ b/rten-gemm/src/kernels/aarch64.rs
@@ -2,7 +2,7 @@ use std::arch::aarch64::{int8x16_t, int32x4_t};
 use std::mem::MaybeUninit;
 use std::ops::Range;
 
-use rten_base::byte_cast::{cast_pod_slice, cast_uninit_pod_mut_slice};
+use rten_base::byte_cast::{cast_slice, cast_uninit_mut_slice};
 use rten_simd::isa::ArmNeonIsa;
 use rten_tensor::{Matrix, MatrixLayout};
 
@@ -74,7 +74,7 @@ unsafe impl Kernel<f32, f32, f32> for ArmNeonKernel {
         cols: Range<usize>,
         _quant: Option<QuantParams<f32>>,
     ) {
-        let out = cast_uninit_pod_mut_slice(out).expect("incorrect alignment for packing buffer");
+        let out = cast_uninit_mut_slice(out).expect("incorrect alignment for packing buffer");
         pack_a_block::<f32, { Self::MR }>(out, a, rows, cols);
     }
 
@@ -95,7 +95,7 @@ unsafe impl Kernel<f32, f32, f32> for ArmNeonKernel {
         cols: Range<usize>,
         _quant: Option<QuantParams<f32>>,
     ) {
-        let out = cast_uninit_pod_mut_slice(out).expect("incorrect alignment for packing buffer");
+        let out = cast_uninit_mut_slice(out).expect("incorrect alignment for packing buffer");
         pack_b_block::<f32, { Self::NR }>(out, b, rows, cols);
     }
 
@@ -110,7 +110,7 @@ unsafe impl Kernel<f32, f32, f32> for ArmNeonKernel {
         const NR_REGS: usize = ArmNeonKernel::NR / X32_LANES;
 
         // Safety: Arm Neon instructions are supported
-        let out = cast_uninit_pod_mut_slice(out).unwrap();
+        let out = cast_uninit_mut_slice(out).unwrap();
         image.pack_block::<_, NR_REGS>(self.isa, out, Self::NR, rows, cols);
     }
 
@@ -141,7 +141,7 @@ unsafe impl Kernel<f32, f32, f32> for ArmNeonKernel {
         const NR: usize = ArmNeonKernel::NR;
         const NR_REGS: usize = NR / X32_LANES;
 
-        let b = cast_pod_slice(b).unwrap();
+        let b = cast_slice(b).unwrap();
 
         let mut tmp_tile = TempTile::<f32, MR, NR>::new();
         let (dest_ptr, dest_row_stride, dest_beta) = if used_cols == NR {
@@ -229,7 +229,7 @@ macro_rules! impl_arm_int8_common {
             cols: Range<usize>,
             quant: Option<QuantParams<u8>>,
         ) {
-            let out = cast_uninit_pod_mut_slice(out).unwrap();
+            let out = cast_uninit_mut_slice(out).unwrap();
             packing::int8::pack_a::<{ Self::MR }, I8DOT_K_TILE>(
                 out,
                 a.slice((rows.clone(), cols)),
@@ -424,7 +424,7 @@ unsafe impl Kernel<u8, i8, i32> for ArmInt8MlalKernel {
         cols: Range<usize>,
         quant: Option<QuantParams<u8>>,
     ) {
-        let out = cast_uninit_pod_mut_slice(out).unwrap();
+        let out = cast_uninit_mut_slice(out).unwrap();
         packing::int8::pack_a::<{ Self::MR }, { Self::K_TILE }>(
             out,
             a.slice((rows.clone(), cols)),
@@ -824,7 +824,7 @@ unsafe impl Kernel<u8, i8, i32> for ArmInt8MMKernel {
         cols: Range<usize>,
         quant: Option<QuantParams<u8>>,
     ) {
-        let out = cast_uninit_pod_mut_slice(out).unwrap();
+        let out = cast_uninit_mut_slice(out).unwrap();
         packing::int8::pack_a::<{ Self::MR }, I8MM_K_TILE>(
             out,
             a.slice((rows.clone(), cols)),

--- a/rten-gemm/src/kernels/generic.rs
+++ b/rten-gemm/src/kernels/generic.rs
@@ -1,7 +1,7 @@
 use std::mem::MaybeUninit;
 use std::ops::Range;
 
-use rten_base::byte_cast::{cast_pod_slice, cast_uninit_pod_mut_slice};
+use rten_base::byte_cast::{cast_slice, cast_uninit_mut_slice};
 use rten_simd::{Isa, isa::GenericIsa};
 use rten_tensor::{Matrix, MatrixLayout};
 
@@ -70,7 +70,7 @@ unsafe impl Kernel<f32, f32, f32> for GenericKernel {
         cols: Range<usize>,
         _quant: Option<QuantParams<f32>>,
     ) {
-        let out = cast_uninit_pod_mut_slice(out).unwrap();
+        let out = cast_uninit_mut_slice(out).unwrap();
         pack_a_block::<f32, { Self::MR }>(out, a, rows, cols);
     }
 
@@ -91,7 +91,7 @@ unsafe impl Kernel<f32, f32, f32> for GenericKernel {
         cols: Range<usize>,
         _quant: Option<QuantParams<f32>>,
     ) {
-        let out = cast_uninit_pod_mut_slice(out).unwrap();
+        let out = cast_uninit_mut_slice(out).unwrap();
         pack_b_block::<f32, { Self::NR }>(out, b, rows, cols);
     }
 
@@ -106,7 +106,7 @@ unsafe impl Kernel<f32, f32, f32> for GenericKernel {
         const NR_REGS: usize = GenericKernel::NR / X32_LANES;
 
         // Safety: Scalar "SIMD" types are always supported
-        let out = cast_uninit_pod_mut_slice(out).unwrap();
+        let out = cast_uninit_mut_slice(out).unwrap();
         image.pack_block::<_, NR_REGS>(self.isa, out, Self::NR, rows, cols);
     }
 
@@ -137,7 +137,7 @@ unsafe impl Kernel<f32, f32, f32> for GenericKernel {
         const NR: usize = GenericKernel::NR;
         const NR_REGS: usize = NR / 4;
 
-        let b = cast_pod_slice(b).unwrap();
+        let b = cast_slice(b).unwrap();
         let mut tmp_tile = TempTile::<f32, MR, NR>::new();
         let (dest_ptr, dest_row_stride, dest_beta) = if used_cols == NR {
             (tile_ptr, tile_row_stride, beta)
@@ -231,7 +231,7 @@ unsafe impl Kernel<u8, i8, i32> for GenericKernel {
         cols: Range<usize>,
         _quant: Option<QuantParams<u8>>,
     ) {
-        let out = cast_uninit_pod_mut_slice(out).unwrap();
+        let out = cast_uninit_mut_slice(out).unwrap();
         pack_a_block::<u8, { Self::MR }>(out, a, rows, cols);
     }
 
@@ -252,7 +252,7 @@ unsafe impl Kernel<u8, i8, i32> for GenericKernel {
         cols: Range<usize>,
         _quant: Option<QuantParams<i8>>,
     ) {
-        let out = cast_uninit_pod_mut_slice(out).unwrap();
+        let out = cast_uninit_mut_slice(out).unwrap();
         pack_b_block::<i8, { Self::NR }>(out, b, rows, cols);
     }
 
@@ -267,7 +267,7 @@ unsafe impl Kernel<u8, i8, i32> for GenericKernel {
         const NR_REGS: usize = GenericKernel::NR / 4;
 
         // Safety: Scalar "SIMD" types are always supported
-        let out = cast_uninit_pod_mut_slice(out).unwrap();
+        let out = cast_uninit_mut_slice(out).unwrap();
         image.pack_block::<_, NR_REGS>(self.isa, out, Self::NR, rows, cols);
     }
 
@@ -314,7 +314,7 @@ unsafe impl Kernel<u8, i8, i32> for GenericKernel {
             }
         }
 
-        let b: &[i8] = cast_pod_slice(b).unwrap();
+        let b: &[i8] = cast_slice(b).unwrap();
         let use_tmp_tile = used_cols < NR || used_rows < MR;
 
         let mut tmp_tile = TempTile::<i32, MR, NR>::new();

--- a/rten-gemm/src/kernels/wasm.rs
+++ b/rten-gemm/src/kernels/wasm.rs
@@ -1,7 +1,7 @@
 use std::mem::MaybeUninit;
 use std::ops::Range;
 
-use rten_base::byte_cast::{cast_pod_slice, cast_uninit_pod_mut_slice};
+use rten_base::byte_cast::{cast_slice, cast_uninit_mut_slice};
 use rten_simd::{Isa, isa::Wasm32Isa};
 use rten_tensor::{Matrix, MatrixLayout};
 
@@ -68,7 +68,7 @@ unsafe impl Kernel<f32, f32, f32> for WasmKernel {
         cols: Range<usize>,
         _quant: Option<QuantParams<f32>>,
     ) {
-        let out = cast_uninit_pod_mut_slice(out).unwrap();
+        let out = cast_uninit_mut_slice(out).unwrap();
         pack_a_block::<f32, { Self::MR }>(out, a, rows, cols);
     }
 
@@ -89,7 +89,7 @@ unsafe impl Kernel<f32, f32, f32> for WasmKernel {
         cols: Range<usize>,
         _quant: Option<QuantParams<f32>>,
     ) {
-        let out = cast_uninit_pod_mut_slice(out).unwrap();
+        let out = cast_uninit_mut_slice(out).unwrap();
         pack_b_block::<f32, { Self::NR }>(out, b, rows, cols);
     }
 
@@ -104,7 +104,7 @@ unsafe impl Kernel<f32, f32, f32> for WasmKernel {
         const NR_REGS: usize = WasmKernel::NR / X32_LANES;
 
         // Safety: WASM SIMD types are supported
-        let out = cast_uninit_pod_mut_slice(out).unwrap();
+        let out = cast_uninit_mut_slice(out).unwrap();
         image.pack_block::<_, NR_REGS>(self.isa, out, Self::NR, rows, cols);
     }
 
@@ -135,7 +135,7 @@ unsafe impl Kernel<f32, f32, f32> for WasmKernel {
         const NR: usize = WasmKernel::NR;
         const NR_REGS: usize = NR / X32_LANES;
 
-        let b = cast_pod_slice(b).unwrap();
+        let b = cast_slice(b).unwrap();
         let mut tmp_tile = TempTile::<f32, MR, NR>::new();
         let (dest_ptr, dest_row_stride, dest_beta) = if used_cols == NR {
             (tile_ptr, tile_row_stride, beta)
@@ -243,7 +243,7 @@ unsafe impl Kernel<u8, i8, i32> for WasmInt8Kernel {
         cols: Range<usize>,
         quant: Option<QuantParams<u8>>,
     ) {
-        let out = cast_uninit_pod_mut_slice(out).unwrap();
+        let out = cast_uninit_mut_slice(out).unwrap();
         packing::int8::pack_a::<{ Self::MR }, K_TILE>(
             out,
             a.slice((rows.clone(), cols)),

--- a/rten-gemm/src/kernels/x86_64.rs
+++ b/rten-gemm/src/kernels/x86_64.rs
@@ -1,7 +1,7 @@
 use std::mem::MaybeUninit;
 use std::ops::Range;
 
-use rten_base::byte_cast::{cast_pod_slice, cast_uninit_pod_mut_slice};
+use rten_base::byte_cast::{cast_slice, cast_uninit_mut_slice};
 use rten_simd::{Isa, isa::Avx2Isa};
 use rten_tensor::{Matrix, MatrixLayout};
 
@@ -97,7 +97,7 @@ unsafe impl Kernel<f32, f32, f32> for FmaKernel {
         cols: Range<usize>,
         _quant: Option<QuantParams<f32>>,
     ) {
-        let out = cast_uninit_pod_mut_slice(out).expect("incorrect alignment for packing buffer");
+        let out = cast_uninit_mut_slice(out).expect("incorrect alignment for packing buffer");
 
         // Safety: Kernel can only be constructed if AVX is supported.
         unsafe {
@@ -122,7 +122,7 @@ unsafe impl Kernel<f32, f32, f32> for FmaKernel {
         cols: Range<usize>,
         _quant: Option<QuantParams<f32>>,
     ) {
-        let out = cast_uninit_pod_mut_slice(out).unwrap();
+        let out = cast_uninit_mut_slice(out).unwrap();
 
         // Safety: Kernel can only be constructed if AVX is supported.
         unsafe {
@@ -153,7 +153,7 @@ unsafe impl Kernel<f32, f32, f32> for FmaKernel {
         }
 
         // Safety: Kernel can only be constructed if AVX is supported
-        let out = cast_uninit_pod_mut_slice(out).unwrap();
+        let out = cast_uninit_mut_slice(out).unwrap();
         unsafe {
             pack_im2col_avx::<NR_REGS, { Self::NR }>(self.isa, out, image, rows, cols);
         }
@@ -188,7 +188,7 @@ unsafe impl Kernel<f32, f32, f32> for FmaKernel {
         const NR: usize = FmaKernel::NR;
         const NR_REGS: usize = NR / AVX2_X32_LANES;
 
-        let b = cast_pod_slice(b).unwrap();
+        let b = cast_slice(b).unwrap();
 
         // TODO - Replace temporary tile with masked loads and stores.
         let mut tmp_tile = TempTile::<f32, MR, NR>::new();
@@ -312,7 +312,7 @@ unsafe impl Kernel<f32, f32, f32> for Avx512Kernel {
         cols: Range<usize>,
         _quant: Option<QuantParams<f32>>,
     ) {
-        let out = cast_uninit_pod_mut_slice(out).expect("incorrect alignment for packing buffer");
+        let out = cast_uninit_mut_slice(out).expect("incorrect alignment for packing buffer");
 
         // Safety: AVX-512 implies availability of AVX 2.
         unsafe {
@@ -337,7 +337,7 @@ unsafe impl Kernel<f32, f32, f32> for Avx512Kernel {
         cols: Range<usize>,
         _quant: Option<QuantParams<f32>>,
     ) {
-        let out = cast_uninit_pod_mut_slice(out).expect("incorrect alignment for packing buffer");
+        let out = cast_uninit_mut_slice(out).expect("incorrect alignment for packing buffer");
 
         // Safety: We assume AVX-512 implies availability of AVX 2.
         unsafe {
@@ -368,7 +368,7 @@ unsafe impl Kernel<f32, f32, f32> for Avx512Kernel {
         const NR_REGS: usize = Avx512Kernel::NR / AVX512_X32_LANES;
 
         // Safety: Kernel can only be constructed if AVX-512 is supported.
-        let out = cast_uninit_pod_mut_slice(out).unwrap();
+        let out = cast_uninit_mut_slice(out).unwrap();
         unsafe {
             pack_im2col_avx512::<NR_REGS, { Self::NR }>(self.isa, out, image, rows, cols);
         }
@@ -403,7 +403,7 @@ unsafe impl Kernel<f32, f32, f32> for Avx512Kernel {
         const NR: usize = Avx512Kernel::NR;
         const NR_REGS: usize = NR / AVX512_X32_LANES;
 
-        let b = cast_pod_slice(b).unwrap();
+        let b = cast_slice(b).unwrap();
 
         // TODO - Replace temporary tile with masked loads and stores.
         let mut tmp_tile = TempTile::<f32, MR, NR>::new();
@@ -529,7 +529,7 @@ unsafe impl Kernel<u8, i8, i32> for Avx2Int8Kernel {
         cols: Range<usize>,
         quant: Option<QuantParams<u8>>,
     ) {
-        let out = cast_uninit_pod_mut_slice(out).unwrap();
+        let out = cast_uninit_mut_slice(out).unwrap();
         packing::int8::pack_a::<{ Self::MR }, K_TILE>(
             out,
             a.slice((rows.clone(), cols)),
@@ -554,7 +554,7 @@ unsafe impl Kernel<u8, i8, i32> for Avx2Int8Kernel {
         cols: Range<usize>,
         quant: Option<QuantParams<i8>>,
     ) {
-        let out = cast_uninit_pod_mut_slice(out).unwrap();
+        let out = cast_uninit_mut_slice(out).unwrap();
         packing::int8::pack_b::<{ Self::NR }, K_TILE>(
             out,
             b.slice((rows, cols.clone())),
@@ -582,7 +582,7 @@ unsafe impl Kernel<u8, i8, i32> for Avx2Int8Kernel {
             const NR: usize = Avx2Int8Kernel::NR;
             const NR_REGS: usize = NR / AVX2_X32_LANES;
 
-            let out = cast_uninit_pod_mut_slice(out).unwrap();
+            let out = cast_uninit_mut_slice(out).unwrap();
             image.pack_block_i8_dot::<_, NR, NR_REGS, K_TILE>(
                 isa,
                 out,
@@ -753,7 +753,7 @@ unsafe impl Kernel<u8, i8, i32> for Avx512Int8Kernel {
         cols: Range<usize>,
         quant: Option<QuantParams<u8>>,
     ) {
-        let out = cast_uninit_pod_mut_slice(out).unwrap();
+        let out = cast_uninit_mut_slice(out).unwrap();
         packing::int8::pack_a::<{ Self::MR }, K_TILE>(
             out,
             a.slice((rows.clone(), cols)),
@@ -778,7 +778,7 @@ unsafe impl Kernel<u8, i8, i32> for Avx512Int8Kernel {
         cols: Range<usize>,
         quant: Option<QuantParams<i8>>,
     ) {
-        let out = cast_uninit_pod_mut_slice(out).unwrap();
+        let out = cast_uninit_mut_slice(out).unwrap();
         packing::int8::pack_b::<{ Self::NR }, K_TILE>(
             out,
             b.slice((rows, cols.clone())),
@@ -807,7 +807,7 @@ unsafe impl Kernel<u8, i8, i32> for Avx512Int8Kernel {
             const NR: usize = Avx512Int8Kernel::NR;
             const NR_REGS: usize = NR / AVX512_X32_LANES;
 
-            let out = cast_uninit_pod_mut_slice(out).unwrap();
+            let out = cast_uninit_mut_slice(out).unwrap();
             image.pack_block_i8_dot::<_, NR, NR_REGS, K_TILE>(
                 isa,
                 out,

--- a/rten-gemm/src/lib.rs
+++ b/rten-gemm/src/lib.rs
@@ -7,7 +7,7 @@ use std::mem::MaybeUninit;
 use std::ops::{Add, Mul, Range};
 
 use rayon::prelude::*;
-use rten_base::byte_cast::Pod;
+use rten_base::byte_cast::FromByteArray;
 use rten_base::iter::range_chunks;
 use rten_base::num::Identities;
 use rten_parallel::par_iter::MaybeParIter;
@@ -66,7 +66,7 @@ impl<T> GemmInputA<'_, T> {
 }
 
 /// Trait implemented by GEMM input types.
-pub trait GemmInT: Copy + Default + Send + Sync + Identities + Pod {}
+pub trait GemmInT: Copy + Default + Send + Sync + Identities + FromByteArray {}
 impl GemmInT for i8 {}
 impl GemmInT for u8 {}
 impl GemmInT for f32 {}
@@ -81,7 +81,7 @@ pub trait GemmOutT:
     + Mul<Self, Output = Self>
     + Add<Self, Output = Self>
     + Identities
-    + Pod
+    + FromByteArray
 {
 }
 impl GemmOutT for i32 {}

--- a/rten-gemm/src/packing.rs
+++ b/rten-gemm/src/packing.rs
@@ -1,7 +1,7 @@
 use std::mem::MaybeUninit;
 use std::ops::Range;
 
-use rten_base::byte_cast::{cast_pod_slice, cast_uninit_pod_mut_slice};
+use rten_base::byte_cast::{cast_slice, cast_uninit_mut_slice};
 use rten_base::iter::range_chunks;
 use rten_tensor::storage::Alloc;
 use rten_tensor::{AssumeInit, Matrix, MatrixLayout, Storage};
@@ -326,7 +326,7 @@ impl<'a, const NR: usize> BlockQuantizedMatrixPacker<'a, f32, NR> {
 
 impl<'a, const NR: usize> Packer<'a> for BlockQuantizedMatrixPacker<'a, f32, NR> {
     fn pack(&self, out: &mut [MaybeUninit<u8>], rows: Range<usize>, cols: Range<usize>) {
-        let out = cast_uninit_pod_mut_slice(out).unwrap();
+        let out = cast_uninit_mut_slice(out).unwrap();
         self.pack(out, rows, cols);
     }
 }
@@ -373,7 +373,7 @@ impl PackingBuffer {
         self.used_len = 0;
 
         let uninit_data = &mut self.buf.spare_capacity_mut()[..buf_len];
-        cast_uninit_pod_mut_slice(uninit_data).unwrap()
+        cast_uninit_mut_slice(uninit_data).unwrap()
     }
 
     /// Clear the buffer and allocate a new one using `alloc`.
@@ -394,7 +394,7 @@ impl PackingBuffer {
         self.used_len = 0;
 
         let uninit_data = &mut self.buf.spare_capacity_mut()[..buf_len];
-        cast_uninit_pod_mut_slice(uninit_data).unwrap()
+        cast_uninit_mut_slice(uninit_data).unwrap()
     }
 
     /// Set the number of bytes in the buffer which have been initialized.
@@ -410,7 +410,7 @@ impl PackingBuffer {
 
     /// Return the contents of the buffer as a slice of bytes.
     pub fn as_bytes(&self) -> &[u8] {
-        &cast_pod_slice(&self.buf).unwrap()[..self.used_len]
+        &cast_slice(&self.buf).unwrap()[..self.used_len]
     }
 
     /// Extract the buffer from self.

--- a/rten-gemm/src/packing/int8.rs
+++ b/rten-gemm/src/packing/int8.rs
@@ -508,7 +508,7 @@ pub fn extract_packed_b<const NR: usize>(b: &[u8]) -> (&[u8], &PackedBMeta<NR>) 
 
 #[cfg(test)]
 mod tests {
-    use rten_base::byte_cast::{AsBytes, cast_pod_slice};
+    use rten_base::byte_cast::{AsBytes, cast_slice};
     use rten_tensor::prelude::*;
     use rten_tensor::rng::XorShiftRng;
     use rten_tensor::{Matrix, MatrixLayout, NdTensor};
@@ -615,7 +615,7 @@ mod tests {
                 col_sums,
                 zero_points: [0; NR],
             };
-            buf.extend_from_slice(cast_pod_slice(meta.as_bytes()).unwrap());
+            buf.extend_from_slice(cast_slice(meta.as_bytes()).unwrap());
         }
 
         assert_eq!(buf.len(), layout.size());
@@ -729,7 +729,7 @@ mod tests {
         let mat = NdTensor::<i8, 2>::from([[1, 2], [3, 4]]);
         let packed = pack_b_matrix::<NR, K_TILE_I8DOT>(mat.view());
 
-        let (packed_elems, meta) = extract_packed_b(cast_pod_slice(&packed).unwrap());
+        let (packed_elems, meta) = extract_packed_b(cast_slice(&packed).unwrap());
 
         assert!(packed_elems.len() >= mat.rows() * mat.cols());
         assert_eq!(meta.col_sums, [4, 6, 0, 0, 0, 0, 0, 0]);

--- a/src/constant_storage.rs
+++ b/src/constant_storage.rs
@@ -4,7 +4,7 @@ use std::marker::PhantomData;
 use std::ops::Range;
 use std::sync::Arc;
 
-use rten_base::byte_cast::Pod;
+use rten_base::byte_cast::FromByteArray;
 use rten_tensor::{DynLayout, Storage, TensorBase};
 
 #[cfg(feature = "mmap")]
@@ -126,7 +126,7 @@ impl<T> ArcSlice<T> {
     /// `T` respectively.
     pub fn from_bytes(buf: Vec<u8>) -> Option<ArcSlice<T>>
     where
-        T: Pod,
+        T: FromByteArray,
     {
         // Vecs with zero capacity have a non-null dangling pointer which can
         // have a smaller alignment that the minimum used by the global
@@ -186,7 +186,7 @@ pub type ArcTensorView<T> = TensorBase<ArcSlice<T>, DynLayout>;
 mod tests {
     use std::sync::Arc;
 
-    use rten_base::byte_cast::cast_pod_slice;
+    use rten_base::byte_cast::cast_slice;
     use rten_tensor::prelude::*;
 
     use super::{ArcSlice, ArcTensorView, ConstantStorage};
@@ -205,10 +205,10 @@ mod tests {
         let storage = Arc::new(ConstantStorage::Buffer(bytes));
 
         // Create two slices referencing memory from the storage.
-        let slice_one = cast_pod_slice::<u8, i32>(&storage.data()[0..32]).unwrap();
+        let slice_one = cast_slice::<u8, i32>(&storage.data()[0..32]).unwrap();
         assert_eq!(slice_one, [0, 1, 2, 3, 4, 5, 6, 7]);
 
-        let slice_two = cast_pod_slice::<u8, i32>(&storage.data()[32..64]).unwrap();
+        let slice_two = cast_slice::<u8, i32>(&storage.data()[32..64]).unwrap();
         assert_eq!(slice_two, [8, 9, 10, 11, 12, 13, 14, 15]);
 
         let arc_slice_one = ArcSlice::new(storage.clone(), slice_one).unwrap();

--- a/src/model/onnx_loader.rs
+++ b/src/model/onnx_loader.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::path::Path;
 
-use rten_base::byte_cast::{Pod, cast_pod_slice};
+use rten_base::byte_cast::{FromByteArray, cast_slice};
 use rten_base::half::f16_to_f32;
 use rten_onnx::onnx;
 use rten_tensor::{ArcTensor, Storage, Tensor};
@@ -610,7 +610,7 @@ fn external_data_location(
 ///
 /// The tensor will use `raw_data` without copying if provided, otherwise the
 /// data in `typed_data` will be copied and converted.
-fn make_constant<T: Pod, U: Pod>(
+fn make_constant<T: FromByteArray, U: FromByteArray>(
     name: Option<&str>,
     shape: &[usize],
     raw_data: Option<Vec<u8>>,
@@ -770,7 +770,7 @@ fn tensor_from_elements<T>(
 }
 
 /// Create a tensor by reinterpreting the little-endian bytes in `data` as type T.
-fn tensor_from_bytes<T: Pod>(
+fn tensor_from_bytes<T: FromByteArray>(
     shape: &[usize],
     data: Vec<u8>,
     name: Option<&str>,
@@ -806,12 +806,12 @@ fn tensor_from_bytes<T: Pod>(
 
 /// Create a tensor by reinterpreting bytes that have been loaded or
 /// memory-mapped from an external file.
-fn tensor_from_external_data<T: Pod>(
+fn tensor_from_external_data<T: FromByteArray>(
     shape: &[usize],
     data: &DataSlice,
     name: Option<&str>,
 ) -> Result<ArcTensorView<T>, LoadError> {
-    let data: ArcSlice<T> = if let Some(elements) = cast_pod_slice(data.data()) {
+    let data: ArcSlice<T> = if let Some(elements) = cast_slice(data.data()) {
         ArcSlice::new(data.storage.clone(), elements).unwrap()
     } else if data.data().is_empty() {
         // If `data.storage`'s backing storage is a zero-length `Vec<u8>` it

--- a/src/model/rten_loader.rs
+++ b/src/model/rten_loader.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use rten_base::byte_cast::{Pod, cast_pod_slice};
+use rten_base::byte_cast::{FromByteArray, cast_slice};
 use rten_base::num::{AsUsize, LeBytes};
 use rten_model_file::header::{Header, HeaderError};
 use rten_model_file::schema as sg;
@@ -385,7 +385,7 @@ fn add_graph_constant(
 ///
 /// If the data is correctly aligned and the system is little-endian, this will
 /// return a view, otherwise it will copy the data into an owned tensor.
-fn constant_data_from_flatbuffers_vec<'a, T: Pod + flatbuffers::Follow<'a, Inner = T>>(
+fn constant_data_from_flatbuffers_vec<'a, T: FromByteArray + flatbuffers::Follow<'a, Inner = T>>(
     storage: &Arc<ConstantStorage>,
     fb_vec: flatbuffers::Vector<'a, T>,
     shape: &[usize],
@@ -402,18 +402,18 @@ fn constant_data_from_flatbuffers_vec<'a, T: Pod + flatbuffers::Follow<'a, Inner
 
 /// Transmute a `[u8]` to `[T]` provided it is correctly aligned and we're on
 /// a little-endian system.
-fn cast_le_bytes<T: Pod>(bytes: &[u8]) -> Option<&[T]> {
+fn cast_le_bytes<T: FromByteArray>(bytes: &[u8]) -> Option<&[T]> {
     if std::mem::size_of::<T>() != 1 && !cfg!(target_endian = "little") {
         return None;
     }
-    cast_pod_slice(bytes)
+    cast_slice(bytes)
 }
 
 /// Convert a range of bytes in storage into data for a graph constant.
 ///
 /// If the data is correctly aligned and the system is little-endian, this will
 /// return a view, otherwise it will copy the data into an owned tensor.
-fn constant_data_from_storage_offset<T: LeBytes + Pod>(
+fn constant_data_from_storage_offset<T: LeBytes + FromByteArray>(
     storage: &Arc<ConstantStorage>,
     shape: &[usize],
     offset: usize,

--- a/src/ops/convert.rs
+++ b/src/ops/convert.rs
@@ -1,4 +1,4 @@
-use rten_base::byte_cast::{Pod, cast_pod_vec};
+use rten_base::byte_cast::{FromByteArray, cast_vec};
 use rten_base::num;
 
 use rten_tensor::Tensor;
@@ -63,15 +63,15 @@ fn cast(pool: &BufferPool, input: ValueView, dtype: DataType) -> Result<Value, O
 /// Both T and U must have the same size.
 fn cast_tensor<T, U>(mut data: Tensor<T>) -> Tensor<U>
 where
-    T: Pod + num::Cast<U>,
-    U: Pod<Bytes = T::Bytes>,
+    T: FromByteArray + num::Cast<U>,
+    U: FromByteArray<Bytes = T::Bytes>,
 {
     // Cast elements from type T to U in place.
     data.apply(|x| num::Cast::<U>::cast(*x).cast_bytes());
 
     // Extract the converted data and transmute from T to U.
     let shape = data.shape().to_vec();
-    let data = cast_pod_vec::<T, U>(data.into_data()).unwrap();
+    let data = cast_vec::<T, U>(data.into_data()).unwrap();
     Tensor::from_data(&shape, data)
 }
 

--- a/src/ops/matmul.rs
+++ b/src/ops/matmul.rs
@@ -1,7 +1,7 @@
 use std::any::TypeId;
 
 use rayon::prelude::*;
-use rten_base::byte_cast::{Pod, cast_pod_vec};
+use rten_base::byte_cast::{FromByteArray, cast_vec};
 use rten_gemm::{
     BiasVector, GemmExecutor, GemmInT, GemmInputA, GemmInputB, GemmOptions, GemmOutT,
     GemmUninitOptions, PackedBMatrix, QuantParams,
@@ -749,7 +749,7 @@ fn cast_scale(
 
     // Transmute tensor from i32 to f32.
     let shape = data.shape().to_vec();
-    let data = cast_pod_vec::<i32, f32>(data.into_data()).unwrap();
+    let data = cast_vec::<i32, f32>(data.into_data()).unwrap();
     Ok(Tensor::from_data(&shape, data))
 }
 

--- a/src/optimize/tests.rs
+++ b/src/optimize/tests.rs
@@ -1,7 +1,7 @@
 use std::error::Error;
 use std::sync::Arc;
 
-use rten_base::byte_cast::cast_pod_slice;
+use rten_base::byte_cast::cast_slice;
 use rten_shape_inference::{SymExpr, Symbol};
 use rten_tensor::{NdTensor, Tensor};
 use rten_testing::TestCases;
@@ -47,7 +47,7 @@ fn arc_tensor_view(val: f32) -> ArcTensorView<f32> {
     let const_storage = Arc::new(ConstantStorage::Buffer(const_data));
     let slice = ArcSlice::new(
         const_storage.clone(),
-        cast_pod_slice(const_storage.data()).unwrap(),
+        cast_slice(const_storage.data()).unwrap(),
     )
     .unwrap();
     ArcTensorView::from_data(&[], slice)


### PR DESCRIPTION
Split the single trait that covers the "can be transmuted to a byte array" and "can be transmuted from a byte array" characteristics of types. This allows for types like `bool` which can be transmuted to, but not from a byte array.

Implement these traits for all primitive numeric types and `bool`.