### PR TITLE
Add Safetensors support to rten-serialize

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -538,9 +538,9 @@ dependencies = [
  "fastrand",
  "rten",
  "rten-base",
+ "rten-serialize",
  "rten-tensor",
  "rten-testing",
- "safetensors",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "argh"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -208,6 +214,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -258,7 +283,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -281,9 +306,9 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libz-rs-sys"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15413ef615ad868d4d65dce091cb233b229419c7c0c4bcaa746c0901c49ff39c"
+checksum = "c10501e7805cee23da17c7790e59df2870c0d4043ec6d03f67d31e2b53e77415"
 dependencies = [
  "zlib-rs",
 ]
@@ -613,7 +638,9 @@ dependencies = [
 name = "rten-serialize"
 version = "0.1.0"
 dependencies = [
+ "rten-base",
  "rten-tensor",
+ "safetensors",
  "zip",
 ]
 
@@ -717,10 +744,12 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "safetensors"
-version = "0.6.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "172dd94c5a87b5c79f945c863da53b2ebc7ccef4eca24ac63cca66a41aab2178"
+checksum = "79b079b829cb27a1c3c374341345ed2e8b2c0c839034522cee576c140bd7f846"
 dependencies = [
+ "hashbrown 0.16.1",
+ "libc",
  "serde",
  "serde_json",
 ]
@@ -922,9 +951,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51f936044d677be1a1168fae1d03b583a285a5dd9d8cbf7b24c23aa1fc775235"
+checksum = "40990edd51aae2c2b6907af74ffb635029d5788228222c4bb811e9351c0caad3"
 
 [[package]]
 name = "zopfli"

--- a/rten-cli/Cargo.toml
+++ b/rten-cli/Cargo.toml
@@ -14,7 +14,7 @@ argh = { workspace = true }
 fastrand = { workspace = true }
 rten = { path = "../", version = "0.24.0", features=["all-ops", "mmap"] }
 rten-base = { path = "../rten-base", version = "0.24.0" }
-safetensors = "0.6.2"
+rten-serialize = { path = "../rten-serialize", version = "0.1.0", features = ["safetensors"] }
 
 [dependencies.rten-tensor]
 path = "../rten-tensor"

--- a/rten-cli/src/main.rs
+++ b/rten-cli/src/main.rs
@@ -12,7 +12,6 @@ use rten::{
 use rten_base::num::AsUsize;
 use rten_tensor::prelude::*;
 use rten_tensor::{Tensor, TensorView};
-use safetensors::SafeTensors;
 
 mod dim_size;
 use dim_size::DimSize;
@@ -507,39 +506,31 @@ impl RandomInputGenerator {
     }
 }
 
-/// Convert a tensor from a Safetensors file into an rten Tensor.
-fn read_tensor<T, const ELEM_BYTES: usize>(
-    view: safetensors::tensor::TensorView,
-    convert: impl Fn([u8; ELEM_BYTES]) -> T,
-) -> Tensor<T> {
-    // We assume that safetensors has validated the length of the data.
-    let (chunks, remainder) = view.data().as_chunks::<ELEM_BYTES>();
-    assert!(remainder.is_empty());
-    let data: Vec<T> = chunks.iter().copied().map(convert).collect();
-    Tensor::from_data(view.shape(), data)
+/// Convert a tensor read from a Safetensors file into an rten [`Value`].
+fn rten_value(value: rten_serialize::Value) -> Result<Value, Box<dyn Error>> {
+    use rten_serialize::Value as SV;
+
+    let value = match value {
+        SV::Float32(tensor) => Value::from(tensor),
+        SV::Int32(tensor) => Value::from(tensor),
+        SV::Int8(tensor) => Value::from(tensor),
+        SV::UInt8(tensor) => Value::from(tensor),
+        other => {
+            return Err(format!("Unsupported tensor dtype {:?}", other.dtype()).into());
+        }
+    };
+    Ok(value)
 }
 
 /// Read tensor values from a Safetensors file.
 ///
 /// Returns a map of input name to value.
 fn read_safetensors(path: &Path) -> Result<HashMap<String, Value>, Box<dyn Error>> {
-    use safetensors::tensor::Dtype;
-
-    let data = std::fs::read(path)?;
-    let tensors = SafeTensors::deserialize(&data)?;
-
-    let mut result = HashMap::new();
-    for (name, view) in tensors.iter() {
-        let value: Value = match view.dtype() {
-            Dtype::F32 => read_tensor::<f32, _>(view, f32::from_le_bytes).into(),
-            Dtype::I32 => read_tensor::<i32, _>(view, i32::from_le_bytes).into(),
-            _ => {
-                return Err(format!("Unsupported tensor dtype {:?}", view.dtype()).into());
-            }
-        };
-        result.insert(name.to_string(), value);
-    }
-    Ok(result)
+    let tensors = rten_serialize::safetensors::read_from_file(path)?;
+    tensors
+        .into_iter()
+        .map(|(name, value)| Ok((name, rten_value(value)?)))
+        .collect()
 }
 
 /// Tool for inspecting converted ONNX models and running them with randomly

--- a/rten-serialize/Cargo.toml
+++ b/rten-serialize/Cargo.toml
@@ -13,9 +13,15 @@ npz = ["npy", "dep:zip"]
 # `numpy.savez_compressed`. Without this, only uncompressed archives are
 # supported.
 npz-compression = ["npz", "zip/deflate"]
+safetensors = ["dep:safetensors"]
 
 [dependencies]
+rten-base = { path = "../rten-base", version = "0.24.0" }
 rten-tensor = { path = "../rten-tensor", version = "0.24.0" }
+
+# We disable default features in these crates to reduce dependencies and build
+# times.
+safetensors = { version = "0.8.0", default-features = false, optional = true }
 zip = { version = "8.6.0", default-features = false, optional = true }
 
 [package.metadata.docs.rs]

--- a/rten-serialize/src/lib.rs
+++ b/rten-serialize/src/lib.rs
@@ -9,6 +9,7 @@
 //!  - **npz** - Enable the .npz format
 //!  - **npz-compression** - Enable reading compressed (deflate) .npz archives,
 //!    such as those produced by `numpy.savez_compressed`
+//!  - **safetensors** - Enable the .safetensors format
 //!
 //! # Data types
 //!
@@ -27,6 +28,10 @@
 //! is an archive format for reading and writing multiple tensors. Archives are
 //! always written uncompressed (matching `numpy.savez`). Reading compressed
 //! archives requires the **npz-compression** feature.
+//!
+//! [Safetensors](https://github.com/huggingface/safetensors) is an archive
+//! format for reading and writing multiple tensors, commonly used for model
+//! weights.
 #![cfg_attr(
     feature = "npz",
     doc = r#"
@@ -80,3 +85,7 @@ pub mod npy;
 /// Read and write tensors in NumPy's `.npz` format.
 #[cfg(feature = "npz")]
 pub mod npz;
+
+/// Read and write tensors in the `.safetensors` format.
+#[cfg(feature = "safetensors")]
+pub mod safetensors;

--- a/rten-serialize/src/safetensors.rs
+++ b/rten-serialize/src/safetensors.rs
@@ -1,0 +1,367 @@
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::fs::File;
+use std::io;
+use std::path::Path;
+
+use rten_base::byte_cast;
+use rten_tensor::{AsView, Layout, Tensor, TensorView};
+use safetensors::tensor::TensorView as SafeTensorView;
+use safetensors::{Dtype, SafeTensorError, SafeTensors, serialize};
+
+use crate::value::{DataType, Value, View, dispatch_data_type, match_view};
+
+/// A Rust element type that can be (de)serialized in the safetensors format.
+trait SafeElement: Sized {
+    /// The corresponding safetensors data type.
+    const DTYPE: Dtype;
+
+    /// Decode a little-endian byte buffer into a vector of elements.
+    fn from_le_bytes(bytes: &[u8]) -> Vec<Self>;
+
+    /// Encode a tensor's elements as a little-endian byte buffer.
+    ///
+    /// This borrows the data if the view is contiguous or copies it otherwise.
+    fn to_le_bytes(view: TensorView<'_, Self>) -> Cow<'_, [u8]>;
+}
+
+macro_rules! impl_safe_element {
+    ($ty:ty, $dtype:expr) => {
+        impl SafeElement for $ty {
+            const DTYPE: Dtype = $dtype;
+
+            fn from_le_bytes(bytes: &[u8]) -> Vec<Self> {
+                bytes
+                    .chunks_exact(size_of::<$ty>())
+                    .map(|chunk| <$ty>::from_le_bytes(chunk.try_into().unwrap()))
+                    .collect()
+            }
+
+            fn to_le_bytes(view: TensorView<'_, Self>) -> Cow<'_, [u8]> {
+                match view.data() {
+                    Some(data) if cfg!(target_endian = "little") => {
+                        Cow::Borrowed(byte_cast::cast_slice(data).unwrap())
+                    }
+                    _ => {
+                        let buf = view.iter().flat_map(|x| x.to_le_bytes()).collect();
+                        Cow::Owned(buf)
+                    }
+                }
+            }
+        }
+    };
+}
+
+impl_safe_element!(i8, Dtype::I8);
+impl_safe_element!(i16, Dtype::I16);
+impl_safe_element!(i32, Dtype::I32);
+impl_safe_element!(i64, Dtype::I64);
+impl_safe_element!(u8, Dtype::U8);
+impl_safe_element!(u16, Dtype::U16);
+impl_safe_element!(u32, Dtype::U32);
+impl_safe_element!(u64, Dtype::U64);
+impl_safe_element!(f32, Dtype::F32);
+impl_safe_element!(f64, Dtype::F64);
+
+impl SafeElement for bool {
+    const DTYPE: Dtype = Dtype::BOOL;
+
+    fn from_le_bytes(bytes: &[u8]) -> Vec<Self> {
+        bytes.iter().map(|&b| b != 0).collect()
+    }
+
+    fn to_le_bytes(view: TensorView<'_, Self>) -> Cow<'_, [u8]> {
+        match view.data() {
+            // nb. `cast_slice` to `[u8]` always succeeds.
+            Some(data) => Cow::Borrowed(byte_cast::cast_slice(data).unwrap()),
+            None => {
+                let bool_vec = view.to_vec();
+                Cow::Owned(byte_cast::cast_vec(bool_vec).unwrap())
+            }
+        }
+    }
+}
+
+/// Map a safetensors data type to the corresponding [`DataType`], or `None` if
+/// it has no corresponding Rust primitive type.
+fn data_type_from_safetensors(dtype: Dtype) -> Option<DataType> {
+    let data_type = match dtype {
+        Dtype::BOOL => DataType::Bool,
+        Dtype::I8 => DataType::Int8,
+        Dtype::I16 => DataType::Int16,
+        Dtype::I32 => DataType::Int32,
+        Dtype::I64 => DataType::Int64,
+        Dtype::U8 => DataType::UInt8,
+        Dtype::U16 => DataType::UInt16,
+        Dtype::U32 => DataType::UInt32,
+        Dtype::U64 => DataType::UInt64,
+        Dtype::F32 => DataType::Float32,
+        Dtype::F64 => DataType::Float64,
+        _ => return None,
+    };
+    Some(data_type)
+}
+
+fn to_io_error(err: SafeTensorError) -> io::Error {
+    // nb. `err` has an `IoError(io::Error)` variant which we could just return
+    // directly, but this is not available because we compile safetensors
+    // without the std feature to reduce dependencies.
+    io::Error::new(io::ErrorKind::InvalidData, err)
+}
+
+fn value_from_view(view: &SafeTensorView) -> io::Result<Value> {
+    let data_type = data_type_from_safetensors(view.dtype()).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("unsupported safetensors dtype {:?}", view.dtype()),
+        )
+    })?;
+    let shape = view.shape();
+    let bytes = view.data();
+    let value = dispatch_data_type!(data_type, T => {
+        let data = <T as SafeElement>::from_le_bytes(bytes);
+        Value::from(Tensor::<T>::from_data(shape, data))
+    });
+    Ok(value)
+}
+
+/// A maybe-owned tensor encoded as raw little-endian bytes.
+///
+/// This implements [`safetensors::View`].
+struct TensorBytes<'a> {
+    dtype: Dtype,
+    shape: Vec<usize>,
+    data: Cow<'a, [u8]>,
+}
+
+impl<'a> TensorBytes<'a> {
+    /// Convert an RTen tensor view into this type.
+    ///
+    /// This borrows the data if the view is contiguous or copies it otherwise.
+    fn from_rten_tensor<T: SafeElement>(view: TensorView<'a, T>) -> Self {
+        TensorBytes {
+            dtype: T::DTYPE,
+            shape: view.shape().to_vec(),
+            data: T::to_le_bytes(view),
+        }
+    }
+}
+
+impl safetensors::View for TensorBytes<'_> {
+    fn dtype(&self) -> Dtype {
+        self.dtype
+    }
+
+    fn shape(&self) -> &[usize] {
+        &self.shape
+    }
+
+    fn data(&self) -> Cow<'_, [u8]> {
+        Cow::Borrowed(self.data.as_ref())
+    }
+
+    fn data_len(&self) -> usize {
+        self.data.len()
+    }
+}
+
+/// Convert an iterator of named RTen tensor views into an iterator of named
+/// views that can be passed to [`safetensors::serialize`].
+fn tensor_bytes_iter<'a, I, N, V>(tensors: I) -> impl Iterator<Item = (N, TensorBytes<'a>)>
+where
+    I: IntoIterator<Item = (N, V)>,
+    N: AsRef<str>,
+    V: Into<View<'a>>,
+{
+    tensors.into_iter().map(|(name, tensor)| {
+        let bytes = match_view!(tensor.into(), tensor => TensorBytes::from_rten_tensor(tensor));
+        (name, bytes)
+    })
+}
+
+/// Serialize named tensors to a safetensors writer.
+pub fn write<'a, I, N, V>(mut writer: impl io::Write, tensors: I) -> io::Result<()>
+where
+    I: IntoIterator<Item = (N, V)>,
+    N: AsRef<str> + Ord + std::fmt::Display,
+    V: Into<View<'a>>,
+{
+    let bytes = serialize(tensor_bytes_iter(tensors), None).map_err(to_io_error)?;
+    writer.write_all(&bytes)
+}
+
+/// Serialize named tensors to a safetensors file - this will create the file.
+pub fn write_to_file<'a, I, N, V>(path: impl AsRef<Path>, tensors: I) -> io::Result<()>
+where
+    I: IntoIterator<Item = (N, V)>,
+    N: AsRef<str> + Ord + std::fmt::Display,
+    V: Into<View<'a>>,
+{
+    let file = io::BufWriter::new(File::create(path)?);
+    write(file, tensors)
+}
+
+/// Read all tensors from a Safetensors buffer.
+fn read_map(data: &[u8]) -> io::Result<HashMap<String, Value>> {
+    let tensors = SafeTensors::deserialize(data).map_err(to_io_error)?;
+    tensors
+        .iter()
+        .map(|(name, view)| Ok((name.to_string(), value_from_view(&view)?)))
+        .collect()
+}
+
+/// Read all tensors from a Safetensors archive.
+pub fn read(mut reader: impl io::Read) -> io::Result<HashMap<String, Value>> {
+    let mut data = Vec::new();
+    reader.read_to_end(&mut data)?;
+    read_map(&data)
+}
+
+/// Read all tensors from a Safetensors file.
+pub fn read_from_file(path: impl AsRef<Path>) -> io::Result<HashMap<String, Value>> {
+    let data = std::fs::read(path)?;
+    read_map(&data)
+}
+
+/// Read a single named tensor from a Safetensors buffer.
+fn read_one(data: &[u8], name: &str) -> io::Result<Value> {
+    let tensors = SafeTensors::deserialize(data).map_err(to_io_error)?;
+    let view = tensors.tensor(name).map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::NotFound,
+            format!("missing safetensors array `{name}`"),
+        )
+    })?;
+    value_from_view(&view)
+}
+
+/// Read a single named tensor from a Safetensors archive.
+pub fn read_array(mut reader: impl io::Read, name: &str) -> io::Result<Value> {
+    let mut data = Vec::new();
+    reader.read_to_end(&mut data)?;
+    read_one(&data, name)
+}
+
+/// Read a single named tensor from a Safetensors file.
+pub fn read_array_from_file(path: impl AsRef<Path>, name: &str) -> io::Result<Value> {
+    let data = std::fs::read(path)?;
+    read_one(&data, name)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use rten_tensor::Tensor;
+    use rten_tensor::prelude::*;
+
+    use super::{
+        View, read, read_array, read_array_from_file, read_from_file, write, write_to_file,
+    };
+
+    static NEXT_TEST_FILE: AtomicUsize = AtomicUsize::new(0);
+
+    fn temp_file(name: &str) -> std::path::PathBuf {
+        let id = NEXT_TEST_FILE.fetch_add(1, Ordering::Relaxed);
+        std::env::temp_dir().join(format!(
+            "rten-safetensors-{}-{id}-{name}",
+            std::process::id()
+        ))
+    }
+
+    #[test]
+    fn test_round_trip_safetensors_in_memory() {
+        let a: Tensor<f32> = [[1., 2., 3.], [4., 5., 6.]].into();
+        let b: Tensor<i32> = [7, 8, 9].into();
+
+        let mut buffer = Vec::new();
+        // `View::from` on the first entry fixes the element type, so the rest
+        // can use `.into()`.
+        write(
+            &mut buffer,
+            [("a", View::from(a.view())), ("b", b.view().into())],
+        )
+        .unwrap();
+
+        let arrays = read(&buffer[..]).unwrap();
+
+        assert_eq!(arrays.len(), 2);
+        assert_eq!(arrays.get("a").unwrap().as_type::<f32>().unwrap(), a);
+        assert_eq!(arrays.get("b").unwrap().as_type::<i32>().unwrap(), b);
+    }
+
+    #[test]
+    fn test_round_trip_safetensors_all_dtypes() {
+        let mut buffer = Vec::new();
+        write(
+            &mut buffer,
+            [
+                ("bool", View::from(Tensor::from([true, false, true]).view())),
+                ("i8", Tensor::from([-1i8, 2, -3]).view().into()),
+                ("i16", Tensor::from([-1i16, 2, -3]).view().into()),
+                ("i32", Tensor::from([-1i32, 2, -3]).view().into()),
+                ("i64", Tensor::from([-1i64, 2, -3]).view().into()),
+                ("u8", Tensor::from([1u8, 2, 3]).view().into()),
+                ("u16", Tensor::from([1u16, 2, 3]).view().into()),
+                ("u32", Tensor::from([1u32, 2, 3]).view().into()),
+                ("u64", Tensor::from([1u64, 2, 3]).view().into()),
+                ("f32", Tensor::from([1.5f32, -2.5]).view().into()),
+                ("f64", Tensor::from([1.5f64, -2.5]).view().into()),
+            ],
+        )
+        .unwrap();
+
+        let arrays = read(&buffer[..]).unwrap();
+
+        assert_eq!(arrays.len(), 11);
+        assert_eq!(
+            arrays.get("bool").unwrap().as_type::<bool>().unwrap(),
+            Tensor::from([true, false, true])
+        );
+        assert_eq!(
+            arrays.get("i64").unwrap().as_type::<i64>().unwrap(),
+            Tensor::from([-1i64, 2, -3])
+        );
+        assert_eq!(
+            arrays.get("u32").unwrap().as_type::<u32>().unwrap(),
+            Tensor::from([1u32, 2, 3])
+        );
+        assert_eq!(
+            arrays.get("f64").unwrap().as_type::<f64>().unwrap(),
+            Tensor::from([1.5f64, -2.5])
+        );
+    }
+
+    #[test]
+    fn test_round_trip_safetensors_to_file() {
+        let path = temp_file("round-trip.safetensors");
+        let a: Tensor<f32> = [[1., 2.], [3., 4.]].into();
+
+        write_to_file(&path, [("a", a.view())]).unwrap();
+        let arrays = read_from_file(&path).unwrap();
+        let a_read = read_array_from_file(&path, "a").unwrap();
+        std::fs::remove_file(&path).unwrap();
+
+        assert_eq!(arrays.get("a").unwrap().as_type::<f32>().unwrap(), a);
+        assert_eq!(a_read.into_type::<f32>().unwrap(), a);
+    }
+
+    #[test]
+    fn test_read_safetensors_array_reports_missing_name() {
+        let a: Tensor<i32> = [1, 2, 3].into();
+        let mut buffer = Vec::new();
+        write(&mut buffer, [("a", a.view())]).unwrap();
+
+        let err = read_array(&buffer[..], "missing").unwrap_err();
+
+        assert_eq!(err.kind(), io::ErrorKind::NotFound);
+    }
+
+    #[test]
+    fn test_read_safetensors_rejects_invalid_data() {
+        let err = read(&b"not a safetensors file"[..]).unwrap_err();
+
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+}

--- a/rten-serialize/src/value.rs
+++ b/rten-serialize/src/value.rs
@@ -229,7 +229,7 @@ define_value_types! {
 
 /// Evaluate `$body` with `$T` bound to the Rust element type corresponding to a
 /// runtime [`DataType`].
-#[cfg(any(feature = "npy", feature = "npz"))]
+#[cfg(any(feature = "npy", feature = "npz", feature = "safetensors"))]
 macro_rules! dispatch_data_type {
     ($dtype:expr, $T:ident => $body:expr) => {
         match $dtype {
@@ -280,12 +280,12 @@ macro_rules! dispatch_data_type {
         }
     };
 }
-#[cfg(any(feature = "npy", feature = "npz"))]
+#[cfg(any(feature = "npy", feature = "npz", feature = "safetensors"))]
 pub(crate) use dispatch_data_type;
 
 /// Evaluate `$body` with `$v` bound to the typed [`TensorView`] held by a
 /// [`View`].
-#[cfg(any(feature = "npy", feature = "npz"))]
+#[cfg(any(feature = "npy", feature = "npz", feature = "safetensors"))]
 macro_rules! match_view {
     ($view:expr, $v:ident => $body:expr) => {
         match $view {
@@ -303,7 +303,7 @@ macro_rules! match_view {
         }
     };
 }
-#[cfg(any(feature = "npy", feature = "npz"))]
+#[cfg(any(feature = "npy", feature = "npz", feature = "safetensors"))]
 pub(crate) use match_view;
 
 impl Value {


### PR DESCRIPTION
Add support for the Safetensors format to the rten-serialize crate and change rten-cli to use it. This enables support for additional data types with the CLI's `--input` and `--check-outputs` options, currently just i8 and u8.

Fixes https://github.com/robertknight/rten/issues/1310.