### PR TITLE
Increase the maximum number of operator outputs from 32 to 64

### DIFF
--- a/rten-base/src/bit_set.rs
+++ b/rten-base/src/bit_set.rs
@@ -1,23 +1,26 @@
+/// Wraps an integer type `B` to treat it as a set of bit flags.
 #[derive(Copy, Clone, Default, PartialEq)]
-pub struct BitSet(u32);
+pub struct BitSet<B: BitOps = u32>(B);
 
-impl BitSet {
-    pub const BITS: usize = u32::BITS as usize;
-
+impl<B: BitOps> BitSet<B> {
     /// Return a bit set with all positions cleared.
     pub fn new() -> Self {
-        Self(0)
+        Self(B::ZERO)
     }
 
     /// Return a bit set with the first `n` positions set.
     pub fn ones(n: u32) -> Self {
-        let bits = if n >= 32 { u32::MAX } else { (1 << n) - 1 };
+        let bits = if n >= B::BITS {
+            B::MAX
+        } else {
+            B::nth(n) - B::ONE
+        };
         Self(bits)
     }
 
     /// Return a bit set with given indices set.
     pub fn from_indices<I: IntoIterator<Item = u32>>(indices: I) -> Self {
-        let mut bits = Self(0);
+        let mut bits = Self(B::ZERO);
         for pos in indices {
             bits.set(pos);
         }
@@ -26,17 +29,17 @@ impl BitSet {
 
     /// Unset the bit at position `pos`.
     pub fn delete(&mut self, pos: u32) {
-        self.0 &= !(1 << pos)
+        self.0 &= !B::nth(pos)
     }
 
     /// Set the bit at position `pos`.
     pub fn set(&mut self, pos: u32) {
-        self.0 |= 1 << pos;
+        self.0 |= B::nth(pos);
     }
 
     /// Return true if position `pos` is set.
     pub fn get(&self, pos: u32) -> bool {
-        self.0 & (1 << pos) != 0
+        self.0 & B::nth(pos) != B::ZERO
     }
 
     /// Return the number of bits set.
@@ -46,20 +49,75 @@ impl BitSet {
 
     /// Return true if no bits are set.
     pub fn is_empty(&self) -> bool {
-        self.0 == 0
+        self.0 == B::ZERO
     }
 
     /// Return an iterator over the indices of set positions.
-    pub fn iter(&self) -> impl Iterator<Item = usize> {
-        (0..u32::BITS as usize).filter(|pos| self.get(*pos as u32))
+    pub fn iter(&self) -> impl Iterator<Item = u32> {
+        (0..B::BITS).filter(|pos| self.get(*pos))
     }
 }
 
-impl std::fmt::Debug for BitSet {
+impl<B: BitOps> std::fmt::Debug for BitSet<B> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:b}", self.0)
     }
 }
+
+/// Operations needed for types that can be used as a [`BitSet`].
+pub trait BitOps:
+    Copy
+    + Default
+    + Eq
+    + std::fmt::Binary
+    + std::ops::BitAnd<Self, Output = Self>
+    + std::ops::BitAndAssign
+    + std::ops::BitOr<Self, Output = Self>
+    + std::ops::BitOrAssign
+    + std::ops::Not<Output = Self>
+    + std::ops::Sub<Self, Output = Self>
+{
+    /// Number of bits in this type.
+    const BITS: u32;
+
+    /// Maximum value of this type.
+    const MAX: Self;
+
+    const ZERO: Self;
+    const ONE: Self;
+
+    /// Return the number of bits set to one.
+    fn count_ones(self) -> u32;
+
+    /// Return `Self` with bit `idx` set to one.
+    fn nth(idx: u32) -> Self;
+}
+
+macro_rules! impl_bitops {
+    ($ty:ty) => {
+        impl BitOps for $ty {
+            const BITS: u32 = <$ty>::BITS;
+            const MAX: $ty = <$ty>::MAX;
+            const ZERO: $ty = 0;
+            const ONE: $ty = 1;
+
+            fn count_ones(self) -> u32 {
+                <$ty>::count_ones(self)
+            }
+
+            fn nth(idx: u32) -> Self {
+                (1 << idx) as Self
+            }
+        }
+    };
+}
+
+impl_bitops!(u8);
+impl_bitops!(u16);
+impl_bitops!(u32);
+impl_bitops!(u64);
+impl_bitops!(u128);
+impl_bitops!(usize);
 
 #[cfg(test)]
 mod tests {
@@ -67,7 +125,7 @@ mod tests {
 
     #[test]
     fn test_bit_set() {
-        let mut set = BitSet::ones(5);
+        let mut set = BitSet::<u32>::ones(5);
         assert_eq!(set.count_true(), 5);
         assert!(!set.is_empty());
         for i in 0..5 {
@@ -78,34 +136,34 @@ mod tests {
         assert_eq!(set.count_true(), 0);
         assert!(set.is_empty());
 
-        let all_zeros = BitSet::default();
+        let all_zeros = BitSet::<u32>::default();
         assert_eq!(all_zeros.count_true(), 0);
-        assert_eq!(BitSet::new(), all_zeros);
+        assert_eq!(BitSet::<u32>::new(), all_zeros);
     }
 
     #[test]
     fn test_bit_set_ones() {
         for i in 0..=32 {
-            let all_ones = BitSet::ones(i);
+            let all_ones = BitSet::<u32>::ones(i);
             assert_eq!(all_ones.count_true(), i);
         }
     }
 
     #[test]
     fn test_bit_set_iter() {
-        let mut set = BitSet::ones(6);
+        let mut set = BitSet::<u32>::ones(6);
         set.delete(0);
         set.delete(5);
 
-        let positions: Vec<usize> = set.iter().collect();
+        let positions: Vec<_> = set.iter().collect();
         assert_eq!(positions, [1, 2, 3, 4]);
     }
 
     #[test]
     fn test_bit_set_from_indices() {
-        let set = BitSet::from_indices([0, 3]);
-        for i in 0..BitSet::BITS {
-            assert_eq!(set.get(i as u32), i == 0 || i == 3);
+        let set = BitSet::<u32>::from_indices([0, 3]);
+        for i in 0..u32::BITS {
+            assert_eq!(set.get(i), i == 0 || i == 3);
         }
     }
 }

--- a/rten-shape-inference/src/sym_expr.rs
+++ b/rten-shape-inference/src/sym_expr.rs
@@ -691,14 +691,13 @@ fn remove_common_factors(lhs: SymExpr, rhs: SymExpr) -> (SymExpr, SymExpr) {
             _ => None,
         })
     };
-    if let (Some((li, lc)), Some((ri, rc))) = (const_term(&lhs_terms), const_term(&rhs_terms)) {
-        if let Some(g) = gcd(lc, rc)
-            && g > 1
-            && rc != 0
-        {
-            lhs_terms[li] = SymExpr::Value(lc / g);
-            rhs_terms[ri] = SymExpr::Value(rc / g);
-        }
+    if let (Some((li, lc)), Some((ri, rc))) = (const_term(&lhs_terms), const_term(&rhs_terms))
+        && let Some(g) = gcd(lc, rc)
+        && g > 1
+        && rc != 0
+    {
+        lhs_terms[li] = SymExpr::Value(lc / g);
+        rhs_terms[ri] = SymExpr::Value(rc / g);
     }
 
     // Construct simplified LHS and RHS

--- a/src/graph/node.rs
+++ b/src/graph/node.rs
@@ -132,7 +132,7 @@ pub struct OperatorNode {
     outputs: Box<[Option<NodeId>]>,
 
     // Cached mask indicating which positions in `outputs` are set.
-    output_mask: BitSet<u32>,
+    output_mask: BitSet<u64>,
 
     operator: Arc<dyn Operator + Send + Sync>,
 
@@ -158,7 +158,7 @@ impl OperatorNode {
         let output_ids = trim_none_suffix(output_ids);
 
         // Pre-compute mask of used outputs.
-        let mut output_mask = BitSet::<u32>::ones(output_ids.len() as u32);
+        let mut output_mask = BitSet::<u64>::ones(output_ids.len() as u32);
         for (i, id) in output_ids.iter().enumerate() {
             if id.is_none() {
                 output_mask.delete(i as u32);
@@ -188,7 +188,7 @@ impl OperatorNode {
     }
 
     /// Return a bit mask indicating which outputs are used.
-    pub fn output_mask(&self) -> BitSet<u32> {
+    pub fn output_mask(&self) -> BitSet<u64> {
         self.output_mask
     }
 

--- a/src/graph/node.rs
+++ b/src/graph/node.rs
@@ -132,7 +132,7 @@ pub struct OperatorNode {
     outputs: Box<[Option<NodeId>]>,
 
     // Cached mask indicating which positions in `outputs` are set.
-    output_mask: BitSet,
+    output_mask: BitSet<u32>,
 
     operator: Arc<dyn Operator + Send + Sync>,
 
@@ -158,7 +158,7 @@ impl OperatorNode {
         let output_ids = trim_none_suffix(output_ids);
 
         // Pre-compute mask of used outputs.
-        let mut output_mask = BitSet::ones(output_ids.len() as u32);
+        let mut output_mask = BitSet::<u32>::ones(output_ids.len() as u32);
         for (i, id) in output_ids.iter().enumerate() {
             if id.is_none() {
                 output_mask.delete(i as u32);
@@ -188,7 +188,7 @@ impl OperatorNode {
     }
 
     /// Return a bit mask indicating which outputs are used.
-    pub fn output_mask(&self) -> BitSet {
+    pub fn output_mask(&self) -> BitSet<u32> {
         self.output_mask
     }
 

--- a/src/model/onnx_loader.rs
+++ b/src/model/onnx_loader.rs
@@ -951,7 +951,12 @@ fn add_operator(
     if !unused_attrs.is_empty() {
         let names: Vec<_> = unused_attrs
             .iter()
-            .map(|i| onnx_op.attribute[i].name.as_deref().unwrap_or_default())
+            .map(|i| {
+                onnx_op.attribute[i as usize]
+                    .name
+                    .as_deref()
+                    .unwrap_or_default()
+            })
             .collect();
 
         return Err(load_error!(

--- a/src/model/onnx_loader.rs
+++ b/src/model/onnx_loader.rs
@@ -1004,9 +1004,9 @@ fn add_operator(
         ));
     }
 
-    // We set a limit of 32 outputs per operator so we can represent the used
-    // positions conveniently in a u32 mask.
-    const MAX_OUTPUTS: usize = u32::BITS as usize;
+    // We set a limit of 64 outputs per operator so we can represent the used
+    // positions conveniently in a u64 mask.
+    const MAX_OUTPUTS: usize = u64::BITS as usize;
 
     let max_outputs = op.max_outputs().unwrap_or(MAX_OUTPUTS).min(MAX_OUTPUTS);
 
@@ -1486,7 +1486,7 @@ mod tests {
         // Test RTen's implementation limit that applies to all op types.
         let mut node = create_node("Split").with_input("x").with_name("split_op");
 
-        for i in 0..33 {
+        for i in 0..65 {
             let name = format!("y_{}", i);
             node = node.with_output(&name);
         }
@@ -1496,7 +1496,7 @@ mod tests {
         let err = load_model(graph.into_model(), None).err().unwrap();
         assert_eq!(
             err.to_string(),
-            "in node \"split_op\": operator error: operator has 33 outputs but maximum is 32"
+            "in node \"split_op\": operator error: operator has 65 outputs but maximum is 64"
         );
     }
 

--- a/src/op_registry/onnx_registry.rs
+++ b/src/op_registry/onnx_registry.rs
@@ -7,7 +7,7 @@ use std::fmt;
 use std::sync::Arc;
 
 use rten_base::bit_set::BitSet;
-use rten_base::num::LeBytes;
+use rten_base::num::{AsUsize, LeBytes};
 use rten_onnx::onnx;
 use rustc_hash::FxHashMap;
 use smallvec::SmallVec;
@@ -331,7 +331,7 @@ pub struct ParsedOp<Op: Operator + Send + Sync> {
     const_inputs: Vec<(u32, ConstInput)>,
 
     /// Indices of unused attributes in the [`onnx::NodeProto::attribute`] field.
-    unused_attrs: BitSet,
+    unused_attrs: BitSet<u32>,
 }
 
 impl<Op: Operator + Send + Sync> From<Op> for ParsedOp<Op> {
@@ -354,7 +354,7 @@ impl<Op: Operator + Send + Sync> ParsedOp<Op> {
         self
     }
 
-    fn with_unused_attrs(mut self, attrs: BitSet) -> Self {
+    fn with_unused_attrs(mut self, attrs: BitSet<u32>) -> Self {
         self.unused_attrs = attrs;
         self
     }
@@ -364,7 +364,7 @@ impl<Op: Operator + Send + Sync> ParsedOp<Op> {
 pub struct DynParsedOp {
     pub op: Arc<dyn Operator + Send + Sync>,
     pub const_inputs: Vec<(u32, ConstInput)>,
-    pub unused_attrs: BitSet,
+    pub unused_attrs: BitSet<u32>,
 }
 
 impl<Op: Operator + Send + Sync> From<ParsedOp<Op>> for DynParsedOp {
@@ -409,7 +409,7 @@ pub trait ReadOp: Operator + Sized + Send + Sync {
 /// detecting unsupported attributes.
 struct Attrs<'a> {
     attrs: &'a [onnx::AttributeProto],
-    unused_attrs: Cell<BitSet>,
+    unused_attrs: Cell<BitSet<u32>>,
 
     /// Opset version the operator uses.
     #[allow(dead_code)] // May be unused depending on enabled features.
@@ -420,8 +420,8 @@ impl<'a> Attrs<'a> {
     fn new(attrs: &'a [onnx::AttributeProto], opset_version: Option<u16>) -> Self {
         // Assume there will be at most 32 attributes. If there are more, we'll
         // just ignore them.
-        let n_attrs: u32 = attrs.len().min(BitSet::BITS).try_into().unwrap();
-        let unused_attrs = Cell::new(BitSet::ones(n_attrs));
+        let n_attrs: u32 = attrs.len().min(u32::BITS.as_usize()).try_into().unwrap();
+        let unused_attrs = Cell::new(BitSet::<u32>::ones(n_attrs));
 
         Self {
             attrs,
@@ -446,7 +446,7 @@ impl<'a> Attrs<'a> {
             .find(|(_pos, att)| att.name.as_deref() == Some(name))?;
 
         let mut unused_attrs = self.unused_attrs.take();
-        if pos < BitSet::BITS {
+        if pos < u32::BITS.as_usize() {
             unused_attrs.delete(pos.try_into().unwrap());
             self.unused_attrs.set(unused_attrs);
         }
@@ -477,7 +477,7 @@ impl<'a> Attrs<'a> {
     }
 
     /// Return the indices of unused attributes
-    fn unused_attrs(&self) -> BitSet {
+    fn unused_attrs(&self) -> BitSet<u32> {
         self.unused_attrs.get()
     }
 
@@ -2070,7 +2070,12 @@ mod tests {
         let unused_attrs: Vec<_> = op
             .unused_attrs
             .iter()
-            .map(|i| node.attribute[i].name.as_deref().unwrap_or_default())
+            .map(|i| {
+                node.attribute[i as usize]
+                    .name
+                    .as_deref()
+                    .unwrap_or_default()
+            })
             .collect();
         assert_eq!(unused_attrs, &["unused_a", "unused_b"]);
     }

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -263,7 +263,7 @@ pub(crate) use check_eq;
 pub struct OpRunContext<'a, 'i> {
     pool: &'a BufferPool,
     inputs: &'a InputList<'i>,
-    outputs: BitSet<u32>,
+    outputs: BitSet<u64>,
     name: Option<&'a str>,
 }
 
@@ -272,7 +272,7 @@ impl<'a, 'i> OpRunContext<'a, 'i> {
     ///
     /// `outputs` is a mask indicating which of the operator's outputs are
     /// requested.
-    pub fn new(pool: &'a BufferPool, inputs: &'a InputList<'i>, outputs: BitSet<u32>) -> Self {
+    pub fn new(pool: &'a BufferPool, inputs: &'a InputList<'i>, outputs: BitSet<u64>) -> Self {
         OpRunContext {
             pool,
             inputs,
@@ -309,7 +309,7 @@ impl<'a, 'i> OpRunContext<'a, 'i> {
     /// This can be used to skip generating outputs that are unused, or in
     /// the rare cases that the output count cannot be determined from the
     /// operator's inputs and attributes alone.
-    pub fn outputs(&self) -> BitSet<u32> {
+    pub fn outputs(&self) -> BitSet<u64> {
         self.outputs
     }
 

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -263,7 +263,7 @@ pub(crate) use check_eq;
 pub struct OpRunContext<'a, 'i> {
     pool: &'a BufferPool,
     inputs: &'a InputList<'i>,
-    outputs: BitSet,
+    outputs: BitSet<u32>,
     name: Option<&'a str>,
 }
 
@@ -272,7 +272,7 @@ impl<'a, 'i> OpRunContext<'a, 'i> {
     ///
     /// `outputs` is a mask indicating which of the operator's outputs are
     /// requested.
-    pub fn new(pool: &'a BufferPool, inputs: &'a InputList<'i>, outputs: BitSet) -> Self {
+    pub fn new(pool: &'a BufferPool, inputs: &'a InputList<'i>, outputs: BitSet<u32>) -> Self {
         OpRunContext {
             pool,
             inputs,
@@ -309,7 +309,7 @@ impl<'a, 'i> OpRunContext<'a, 'i> {
     /// This can be used to skip generating outputs that are unused, or in
     /// the rare cases that the output count cannot be determined from the
     /// operator's inputs and attributes alone.
-    pub fn outputs(&self) -> BitSet {
+    pub fn outputs(&self) -> BitSet<u32> {
         self.outputs
     }
 


### PR DESCRIPTION
Increase the maximum number of supported outputs for an operator node from 32 to 64. I found a [real model](https://huggingface.co/smank/mel-band-roformer-vocals-onnx) which has a `Split` instance with 60 outputs. This could be easily raised to 128 in future if really needed.

The model card suggests the model was LLM-generated and inference does take a long time to run. I haven't checked if the model structure is in any way sensible.