### PR TITLE
Add documentation page on safety and resource usage

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,42 @@
+# Security and resource usage
+
+This page describes the guarantees that RTen does and does not make when
+loading and running machine learning models, particularly models that come
+from untrusted sources.
+
+## Threat model
+
+Conceptually a model is like a program that RTen runs inside a sandbox.
+The sandbox constrains what the model can *observe* and *affect*, but it does
+not constrain the resources (memory, CPU usage) the model can consume.
+
+## Safety guarantees
+
+Loading or running a model is always *safe*, in the sense that a model, even a
+maliciously crafted one, cannot:
+
+- Cause undefined behavior, such as out-of-bounds reads or writes.
+- Read data other than the model's own weights and the inputs you provide.
+- Write data anywhere other than the model's outputs.
+
+If you find an exception, please [file an issue](https://github.com/robertknight/rten/issues).
+
+## Non-guarantees: resource usage
+
+RTen does **not** make any guarantees about the resources a model may use. In
+particular it does not limit:
+
+- How long inference will take, or whether it will terminate at all.
+- How much memory will be allocated.
+
+## Loading untrusted models
+
+In typical usage the model is chosen by the application embedding RTen, and
+resource usage is driven by the size of the inputs (for example, the number of
+tokens in a prompt). In that case you can bound resource usage by limiting the
+size of the inputs you pass to [`Model::run`](crate::Model::run).
+
+If your application needs to load *arbitrary*, untrusted models and enforce
+limits on how much CPU time or memory they can use, you must impose those limits
+at the process level - for example by running inference in a container or other
+sandbox.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,6 +140,12 @@
 //! guide](https://github.com/robertknight/rten/blob/main/docs/performance.md) for
 //! information on profiling and improving model execution performance.
 //!
+//! # Security and untrusted models
+//!
+//! Loading and running a model in RTen should always be memory-safe, but RTen
+//! does not limit the CPU time or memory an inference may use. See the
+//! [security guide][security] for more details.
+//!
 //! # Crate features
 //!
 //!  - **all-ops** - Enables all operators which are not enabled by default
@@ -152,6 +158,7 @@
 //!
 //! At least one of the **onnx_format** or **rten_format** features must be enabled.
 //!
+//! [security]: crate::docs::security
 //! [model_formats]: https://github.com/robertknight/rten/blob/main/docs/model-formats.md
 //! [onnx_operators]: https://onnx.ai/onnx/operators/
 //! [rten_examples]: https://github.com/robertknight/rten/tree/main/rten-examples
@@ -199,3 +206,9 @@ pub use value::{DataType, Sequence, TryFromValueError, Value, ValueOrView, Value
 
 #[deprecated = "renamed to `LoadError`"]
 pub type ModelLoadError = LoadError;
+
+/// Additional documentation on various topics.
+pub mod docs {
+    #[doc = include_str!("../docs/security.md")]
+    pub mod security {}
+}


### PR DESCRIPTION
Add a documentation page that explains the security guarantees that RTen does and does not provide when loading and running an untrusted model.

rustdoc doesn't have support for standalone pages that I know of, so add a `docs` module as a workaround.

Fixes #1219