### PR TITLE
Avoid copying inputs on each iteration in rten-cli's run loop

### DIFF
--- a/rten-cli/src/main.rs
+++ b/rten-cli/src/main.rs
@@ -256,9 +256,19 @@ fn run_model(
     // Run duration in milliseconds.
     let mut durations: Vec<f32> = Vec::new();
 
+    // Take views of owned inputs to avoid copying potentially large input
+    // values in the loop, which might distort timings.
+    let input_views: Vec<(NodeId, ValueOrView)> = inputs
+        .iter()
+        .map(|(id, value)| (*id, value.as_view().into()))
+        .collect();
     for iter_num in 1..=n_iters {
         let start = Instant::now();
-        let outputs = model.run(inputs.clone(), model.output_ids(), Some(run_opts.clone()))?;
+        let outputs = model.run(
+            input_views.clone(),
+            model.output_ids(),
+            Some(run_opts.clone()),
+        )?;
         let elapsed_ms = (start.elapsed().as_secs_f64() * 1000.0) as f32;
 
         if !quiet {


### PR DESCRIPTION
The timed loop cloned the inputs on every run. If the inputs are synthetically generated they are owned values, so each iteration copied the full tensors. For large inputs this could distort timings. Build a list of views outside the loop and make a cheap copy of that on each iteration instead.

This issue was noticed by Claude while benchmarking the `Attention` operator implementation with various inputs.