### PR TITLE
Distinguish missing from unknown-rank inputs in shape inference

### DIFF
--- a/rten-shape-inference/src/infer_shapes.rs
+++ b/rten-shape-inference/src/infer_shapes.rs
@@ -1,5 +1,6 @@
 //! Traits for shape inference and common implementations.
 
+use std::borrow::Cow;
 use std::error::Error;
 use std::fmt;
 
@@ -46,6 +47,86 @@ impl fmt::Display for InferShapesError {
 
 impl Error for InferShapesError {}
 
+/// Inputs to an operator's shape inference.
+///
+/// This provides access to the shapes and (optionally) values of an operator's
+/// inputs.
+pub struct InferShapesContext<'a> {
+    /// Shapes or values of operator inputs. Can be `None` for optional inputs
+    /// that are not set.
+    inputs: Cow<'a, [Option<SymTensor>]>,
+}
+
+impl<'a> InferShapesContext<'a> {
+    /// Create a context which wraps a slice of optional inputs.
+    pub fn new(inputs: &'a [Option<SymTensor>]) -> Self {
+        Self {
+            inputs: Cow::Borrowed(inputs),
+        }
+    }
+
+    /// Return the number of inputs.
+    pub fn len(&self) -> usize {
+        self.inputs.len()
+    }
+
+    /// Return true if the operator was given no inputs.
+    pub fn is_empty(&self) -> bool {
+        self.inputs.is_empty()
+    }
+
+    /// Get an optional input by index.
+    ///
+    /// Returns `None` if the input was omitted or the index is out of range.
+    pub fn get(&self, idx: usize) -> Option<&SymTensor> {
+        self.inputs.get(idx).and_then(|t| t.as_ref())
+    }
+
+    /// Get a required input by index.
+    ///
+    /// Returns an error if the input was omitted or the index is out of range.
+    pub fn require(&self, idx: usize) -> Result<&SymTensor, InferShapesError> {
+        self.get(idx).ok_or(InferShapesError::IncorrectInputCount)
+    }
+
+    /// Iterate over all inputs, yielding `None` for omitted inputs.
+    pub fn iter(&self) -> impl ExactSizeIterator<Item = Option<&SymTensor>> {
+        self.inputs.iter().map(|t| t.as_ref())
+    }
+}
+
+impl From<Vec<SymTensor>> for InferShapesContext<'static> {
+    fn from(inputs: Vec<SymTensor>) -> Self {
+        Self {
+            inputs: Cow::Owned(inputs.into_iter().map(Some).collect()),
+        }
+    }
+}
+
+impl<const N: usize> From<[SymTensor; N]> for InferShapesContext<'static> {
+    fn from(inputs: [SymTensor; N]) -> Self {
+        Self {
+            inputs: Cow::Owned(inputs.into_iter().map(Some).collect()),
+        }
+    }
+}
+
+impl From<Vec<Option<SymTensor>>> for InferShapesContext<'static> {
+    fn from(inputs: Vec<Option<SymTensor>>) -> Self {
+        Self {
+            inputs: Cow::Owned(inputs),
+        }
+    }
+}
+
+impl<const N: usize> From<[Option<SymTensor>; N]> for InferShapesContext<'static> {
+    fn from(inputs: [Option<SymTensor>; N]) -> Self {
+        Self {
+            inputs: Cow::Owned(inputs.into()),
+        }
+    }
+}
+
 /// Infer the shapes of an operator's outputs given its inputs.
 pub trait InferShapes {
     /// Infer the shapes and optionally values of an operator's outputs given
@@ -56,7 +137,7 @@ pub trait InferShapes {
     /// generated using `sym_gen`.
     fn infer_shapes(
         &self,
-        inputs: &[SymTensor],
+        inputs: InferShapesContext,
         sym_gen: &mut SymbolGen,
     ) -> Result<Vec<SymTensor>, InferShapesError>;
 }
@@ -72,12 +153,10 @@ pub struct UnaryOp;
 impl InferShapes for UnaryOp {
     fn infer_shapes(
         &self,
-        inputs: &[SymTensor],
+        inputs: InferShapesContext,
         _sym_gen: &mut SymbolGen,
     ) -> Result<Vec<SymTensor>, InferShapesError> {
-        let Some(data) = inputs.first() else {
-            return Err(InferShapesError::IncorrectInputCount);
-        };
+        let data = inputs.require(0)?;
 
         let shape = if let Some(shape) = data.shape() {
             SymTensor::from_shape(shape.collect())
@@ -99,12 +178,11 @@ pub struct BinaryOp;
 impl InferShapes for BinaryOp {
     fn infer_shapes(
         &self,
-        inputs: &[SymTensor],
+        inputs: InferShapesContext,
         _sym_gen: &mut SymbolGen,
     ) -> Result<Vec<SymTensor>, InferShapesError> {
-        let [a, b] = inputs else {
-            return Err(InferShapesError::IncorrectInputCount);
-        };
+        let a = inputs.require(0)?;
+        let b = inputs.require(1)?;
 
         let (Some(a_dims), Some(b_dims)) = (a.shape(), b.shape()) else {
             return Ok([SymTensor::unknown("unknown input shape")].into());
@@ -168,27 +246,23 @@ pub struct VariadicOp;
 impl InferShapes for VariadicOp {
     fn infer_shapes(
         &self,
-        inputs: &[SymTensor],
+        inputs: InferShapesContext,
         sym_gen: &mut SymbolGen,
     ) -> Result<Vec<SymTensor>, InferShapesError> {
-        if inputs.is_empty() {
-            return Err(InferShapesError::IncorrectInputCount);
-        }
+        let first = inputs.require(0)?;
 
-        let first_shape = inputs[0]
+        let first_shape = first
             .shape()
             .map(|shape| SymTensor::from_shape(shape.collect()))
             .unwrap_or_else(|| SymTensor::unknown("unknown input shape"));
 
         let out_shape: Result<SymTensor, InferShapesError> =
-            inputs
-                .iter()
-                .skip(1)
-                .try_fold(first_shape, |out_shape, in_shape| {
-                    let mut shapes =
-                        BinaryOp.infer_shapes(&[out_shape, in_shape.clone()], sym_gen)?;
-                    Ok(shapes.remove(0))
-                });
+            (1..inputs.len()).try_fold(first_shape, |out_shape, i| {
+                let in_shape = inputs.require(i)?;
+                let mut shapes =
+                    BinaryOp.infer_shapes([out_shape, in_shape.clone()].into(), sym_gen)?;
+                Ok(shapes.remove(0))
+            });
 
         Ok([out_shape?].into())
     }
@@ -211,7 +285,7 @@ pub struct ReductionOp<'a> {
 impl InferShapes for ReductionOp<'_> {
     fn infer_shapes(
         &self,
-        inputs: &[SymTensor],
+        inputs: InferShapesContext,
         _sym_gen: &mut SymbolGen,
     ) -> Result<Vec<SymTensor>, InferShapesError> {
         match inputs.len() {
@@ -221,7 +295,7 @@ impl InferShapes for ReductionOp<'_> {
             }
         }
 
-        let data = &inputs[0];
+        let data = inputs.require(0)?;
 
         let Some(data_dims) = data.shape() else {
             return Ok([SymTensor::unknown("unknown input shape")].into());
@@ -303,8 +377,8 @@ mod tests {
     use rten_testing::TestCases;
 
     use super::{
-        BinaryOp, InferShapes, InferShapesError, ReductionOp, SymExpr, SymTensor, SymbolGen,
-        UnaryOp, VariadicOp,
+        BinaryOp, InferShapes, InferShapesContext, InferShapesError, ReductionOp, SymExpr,
+        SymTensor, SymbolGen, UnaryOp, VariadicOp,
     };
     use crate::sym_tensor::{sym_elems, sym_shape};
 
@@ -313,12 +387,15 @@ mod tests {
         let input = sym_shape!("batch", 16, "seq", 24);
         let mut sym_gen = SymbolGen::new();
         let shape = UnaryOp
-            .infer_shapes(&[input.clone()], &mut sym_gen)
+            .infer_shapes([input.clone()].into(), &mut sym_gen)
             .unwrap();
         assert_eq!(shape.len(), 1);
         assert_eq!(shape[0], input);
 
-        let err = UnaryOp.infer_shapes(&[], &mut sym_gen).err().unwrap();
+        let err = UnaryOp
+            .infer_shapes(InferShapesContext::new(&[]), &mut sym_gen)
+            .err()
+            .unwrap();
         assert_eq!(err, InferShapesError::IncorrectInputCount);
     }
 
@@ -367,7 +444,7 @@ mod tests {
         cases.test_each(|case| {
             let mut sym_gen = SymbolGen::new();
             let shape = BinaryOp
-                .infer_shapes(&[case.lhs.clone(), case.rhs.clone()], &mut sym_gen)
+                .infer_shapes([case.lhs.clone(), case.rhs.clone()].into(), &mut sym_gen)
                 .unwrap();
             assert_eq!(shape.len(), 1);
             assert_eq!(shape[0], case.expected.clone());
@@ -396,7 +473,10 @@ mod tests {
         cases.test_each_clone(|case| {
             let mut sym_gen = SymbolGen::new();
             let inputs: Vec<_> = case.inputs.into_iter().map(SymTensor::from_shape).collect();
-            let err = BinaryOp.infer_shapes(&inputs, &mut sym_gen).err().unwrap();
+            let err = BinaryOp
+                .infer_shapes(inputs.into(), &mut sym_gen)
+                .err()
+                .unwrap();
             assert_eq!(err, case.expected);
         });
     }
@@ -409,12 +489,14 @@ mod tests {
         let c = sym_shape!("batch", 1, 8, 16);
 
         // Single input
-        let result = VariadicOp.infer_shapes(&[a.clone()], &mut sym_gen).unwrap();
+        let result = VariadicOp
+            .infer_shapes([a.clone()].into(), &mut sym_gen)
+            .unwrap();
         assert_eq!(result[0], sym_shape!("batch", 4, 1, 1));
 
         // N inputs
         let result = VariadicOp
-            .infer_shapes(&[a.clone(), b, c], &mut sym_gen)
+            .infer_shapes([a.clone(), b, c].into(), &mut sym_gen)
             .unwrap();
         assert_eq!(result[0], sym_shape!("batch", 4, 8, 16));
     }
@@ -478,7 +560,10 @@ mod tests {
 
         cases.test_each(|case| {
             let mut sym_gen = SymbolGen::new();
-            let shapes = case.op.infer_shapes(&case.inputs, &mut sym_gen).unwrap();
+            let shapes = case
+                .op
+                .infer_shapes(case.inputs.clone().into(), &mut sym_gen)
+                .unwrap();
             assert_eq!(shapes.len(), 1);
             assert_eq!(shapes[0], SymTensor::from_shape(case.expected.clone()));
         });

--- a/rten-shape-inference/src/lib.rs
+++ b/rten-shape-inference/src/lib.rs
@@ -67,7 +67,9 @@ mod sym_expr;
 mod sym_gen;
 mod sym_tensor;
 
-pub use infer_shapes::{BinaryOp, InferShapes, InferShapesError, ReductionOp, UnaryOp, VariadicOp};
+pub use infer_shapes::{
+    BinaryOp, InferShapes, InferShapesContext, InferShapesError, ReductionOp, UnaryOp, VariadicOp,
+};
 pub use sym_expr::{EvalError, SymExpr, Symbol, SymbolMap};
 pub use sym_gen::SymbolGen;
 pub use sym_tensor::{Constant, SymTensor};

--- a/rten-shape-inference/src/ops.rs
+++ b/rten-shape-inference/src/ops.rs
@@ -3,7 +3,9 @@
 //! See the [ONNX operator reference](https://onnx.ai/onnx/operators/index.html)
 //! for operator details.
 
-use crate::infer_shapes::{BinaryOp, InferShapes, InferShapesError, resolve_axis, resolve_index};
+use crate::infer_shapes::{
+    BinaryOp, InferShapes, InferShapesContext, InferShapesError, resolve_axis, resolve_index,
+};
 use crate::sym_expr::SymExpr;
 use crate::sym_gen::SymbolGen;
 use crate::sym_tensor::{Constant, SymTensor};
@@ -54,12 +56,10 @@ pub struct ConstantOfShape {
 impl InferShapes for ConstantOfShape {
     fn infer_shapes(
         &self,
-        inputs: &[SymTensor],
+        inputs: InferShapesContext,
         sym_gen: &mut SymbolGen,
     ) -> Result<Vec<SymTensor>, InferShapesError> {
-        let [shape] = inputs else {
-            return Err(InferShapesError::IncorrectInputCount);
-        };
+        let shape = inputs.require(0)?;
 
         let out_shape = if let Some(values) = shape.values() {
             if let Some(val) = self.value
@@ -110,12 +110,10 @@ pub struct Dropout;
 impl InferShapes for Dropout {
     fn infer_shapes(
         &self,
-        inputs: &[SymTensor],
+        inputs: InferShapesContext,
         _sym_gen: &mut SymbolGen,
     ) -> Result<Vec<SymTensor>, InferShapesError> {
-        let Some(data) = inputs.first() else {
-            return Err(InferShapesError::IncorrectInputCount);
-        };
+        let data = inputs.require(0)?;
 
         let shape = if let Some(dims) = data.shape() {
             SymTensor::from_shape(dims.collect())
@@ -137,12 +135,10 @@ pub struct DynamicQuantizeLinear;
 impl InferShapes for DynamicQuantizeLinear {
     fn infer_shapes(
         &self,
-        inputs: &[SymTensor],
+        inputs: InferShapesContext,
         _sym_gen: &mut SymbolGen,
     ) -> Result<Vec<SymTensor>, InferShapesError> {
-        let Some(data) = inputs.first() else {
-            return Err(InferShapesError::IncorrectInputCount);
-        };
+        let data = inputs.require(0)?;
 
         let shape = if let Some(shape) = data.shape() {
             SymTensor::from_shape(shape.collect())
@@ -166,12 +162,11 @@ pub struct Gather {
 impl InferShapes for Gather {
     fn infer_shapes(
         &self,
-        inputs: &[SymTensor],
+        inputs: InferShapesContext,
         _sym_gen: &mut SymbolGen,
     ) -> Result<Vec<SymTensor>, InferShapesError> {
-        let [data, indices] = inputs else {
-            return Err(InferShapesError::IncorrectInputCount);
-        };
+        let data = inputs.require(0)?;
+        let indices = inputs.require(1)?;
 
         let Some(mut data_dims) = data.shape() else {
             return Ok([SymTensor::unknown("unknown data shape")].into());
@@ -225,12 +220,10 @@ pub struct GatherElements;
 impl InferShapes for GatherElements {
     fn infer_shapes(
         &self,
-        inputs: &[SymTensor],
+        inputs: InferShapesContext,
         _sym_gen: &mut SymbolGen,
     ) -> Result<Vec<SymTensor>, InferShapesError> {
-        let [_data, indices] = inputs else {
-            return Err(InferShapesError::IncorrectInputCount);
-        };
+        let indices = inputs.require(1)?;
 
         let shape = if let Some(dims) = indices.shape() {
             SymTensor::from_shape(dims.collect())
@@ -252,12 +245,11 @@ pub struct GatherND {
 impl InferShapes for GatherND {
     fn infer_shapes(
         &self,
-        inputs: &[SymTensor],
+        inputs: InferShapesContext,
         _sym_gen: &mut SymbolGen,
     ) -> Result<Vec<SymTensor>, InferShapesError> {
-        let [data, indices] = inputs else {
-            return Err(InferShapesError::IncorrectInputCount);
-        };
+        let data = inputs.require(0)?;
+        let indices = inputs.require(1)?;
 
         let Some(data_dims) = data.shape() else {
             return Ok([SymTensor::unknown("unknown data shape")].into());
@@ -308,12 +300,11 @@ pub struct GridSample;
 impl InferShapes for GridSample {
     fn infer_shapes(
         &self,
-        inputs: &[SymTensor],
+        inputs: InferShapesContext,
         _sym_gen: &mut SymbolGen,
     ) -> Result<Vec<SymTensor>, InferShapesError> {
-        let [data, grid] = inputs else {
-            return Err(InferShapesError::IncorrectInputCount);
-        };
+        let data = inputs.require(0)?;
+        let grid = inputs.require(1)?;
 
         let Some(data_dims) = data.shape() else {
             return Ok([SymTensor::unknown("unknown input shape")].into());
@@ -353,12 +344,10 @@ pub struct Identity;
 impl InferShapes for Identity {
     fn infer_shapes(
         &self,
-        inputs: &[SymTensor],
+        inputs: InferShapesContext,
         _sym_gen: &mut SymbolGen,
     ) -> Result<Vec<SymTensor>, InferShapesError> {
-        let [data] = inputs else {
-            return Err(InferShapesError::IncorrectInputCount);
-        };
+        let data = inputs.require(0)?;
         Ok([data.clone()].into())
     }
 }
@@ -371,12 +360,10 @@ pub struct NonZero;
 impl InferShapes for NonZero {
     fn infer_shapes(
         &self,
-        inputs: &[SymTensor],
+        inputs: InferShapesContext,
         sym_gen: &mut SymbolGen,
     ) -> Result<Vec<SymTensor>, InferShapesError> {
-        let [data] = inputs else {
-            return Err(InferShapesError::IncorrectInputCount);
-        };
+        let data = inputs.require(0)?;
 
         // Output is a 2D tensor of shape `(input.ndim(), num_nonzero)`.
         let first_dim = data
@@ -397,7 +384,7 @@ pub struct FixedShape<'a> {
 impl InferShapes for FixedShape<'_> {
     fn infer_shapes(
         &self,
-        _inputs: &[SymTensor],
+        _inputs: InferShapesContext,
         _sym_gen: &mut SymbolGen,
     ) -> Result<Vec<SymTensor>, InferShapesError> {
         Ok([SymTensor::from_fixed_shape(self.shape)].into())
@@ -415,12 +402,10 @@ pub struct Multinomial {
 impl InferShapes for Multinomial {
     fn infer_shapes(
         &self,
-        inputs: &[SymTensor],
+        inputs: InferShapesContext,
         sym_gen: &mut SymbolGen,
     ) -> Result<Vec<SymTensor>, InferShapesError> {
-        let [input] = inputs else {
-            return Err(InferShapesError::IncorrectInputCount);
-        };
+        let input = inputs.require(0)?;
 
         if input.ndim().is_some_and(|ndim| ndim != 2) {
             return Err(InferShapesError::IncorrectRank);
@@ -443,7 +428,7 @@ pub struct NonMaxSuppression;
 impl InferShapes for NonMaxSuppression {
     fn infer_shapes(
         &self,
-        _inputs: &[SymTensor],
+        _inputs: InferShapesContext,
         sym_gen: &mut SymbolGen,
     ) -> Result<Vec<SymTensor>, InferShapesError> {
         // Output is `(num_selected, 3)`. `num_selected` is data-dependent.
@@ -460,12 +445,12 @@ pub struct Range;
 impl InferShapes for Range {
     fn infer_shapes(
         &self,
-        inputs: &[SymTensor],
+        inputs: InferShapesContext,
         sym_gen: &mut SymbolGen,
     ) -> Result<Vec<SymTensor>, InferShapesError> {
-        let [start, limit, delta] = inputs else {
-            return Err(InferShapesError::IncorrectInputCount);
-        };
+        let start = inputs.require(0)?;
+        let limit = inputs.require(1)?;
+        let delta = inputs.require(2)?;
 
         let start = start.values().map(|v| v[0].clone());
         let limit = limit.values().map(|v| v[0].clone());
@@ -514,12 +499,10 @@ pub struct SkipSimplifiedLayerNormalization;
 impl InferShapes for SkipSimplifiedLayerNormalization {
     fn infer_shapes(
         &self,
-        inputs: &[SymTensor],
+        inputs: InferShapesContext,
         _sym_gen: &mut SymbolGen,
     ) -> Result<Vec<SymTensor>, InferShapesError> {
-        let Some(data) = inputs.first() else {
-            return Err(InferShapesError::IncorrectInputCount);
-        };
+        let data = inputs.require(0)?;
 
         let shape = if let Some(dims) = data.shape() {
             SymTensor::from_shape(dims.collect())
@@ -547,12 +530,11 @@ pub struct TopK {
 impl InferShapes for TopK {
     fn infer_shapes(
         &self,
-        inputs: &[SymTensor],
+        inputs: InferShapesContext,
         sym_gen: &mut SymbolGen,
     ) -> Result<Vec<SymTensor>, InferShapesError> {
-        let [data, k] = inputs else {
-            return Err(InferShapesError::IncorrectInputCount);
-        };
+        let data = inputs.require(0)?;
+        let k = inputs.require(1)?;
 
         let Some(data_dims) = data.shape() else {
             return Ok([
@@ -588,12 +570,12 @@ pub struct Where;
 impl InferShapes for Where {
     fn infer_shapes(
         &self,
-        inputs: &[SymTensor],
+        inputs: InferShapesContext,
         sym_gen: &mut SymbolGen,
     ) -> Result<Vec<SymTensor>, InferShapesError> {
-        let [cond, x, y] = inputs else {
-            return Err(InferShapesError::IncorrectInputCount);
-        };
+        let cond = inputs.require(0)?;
+        let x = inputs.require(1)?;
+        let y = inputs.require(2)?;
 
         if let Some(cond_vals) = cond.values()
             && let Some(x_vals) = x.values()
@@ -636,15 +618,15 @@ impl InferShapes for Where {
         // Broadcast the first two inputs together, then broadcast the result
         // against the last input.
         let cond_x = BinaryOp
-            .infer_shapes(&[cond.clone(), x.clone()], sym_gen)?
+            .infer_shapes([cond.clone(), x.clone()].into(), sym_gen)?
             .remove(0);
-        BinaryOp.infer_shapes(&[cond_x, y.clone()], sym_gen)
+        BinaryOp.infer_shapes([cond_x, y.clone()].into(), sym_gen)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::infer_shapes::{InferShapes, InferShapesError};
+    use crate::infer_shapes::{InferShapes, InferShapesContext, InferShapesError};
     use crate::sym_expr::SymExpr;
     use crate::sym_gen::SymbolGen;
     use crate::sym_tensor::{SymTensor, sym_shape, sym_vec};
@@ -662,25 +644,25 @@ mod tests {
         // Scalar shape, int value.
         let shape = sym_vec!();
         let op = ConstantOfShape { value: Some(1) };
-        let result = op.infer_shapes(&[shape], &mut sym_gen).unwrap();
+        let result = op.infer_shapes([shape].into(), &mut sym_gen).unwrap();
         assert_eq!(result[0], SymTensor::from_scalar(1.into()));
 
         // Vector shape, int value.
         let shape = sym_vec!(3);
         let op = ConstantOfShape { value: Some(1) };
-        let result = op.infer_shapes(&[shape], &mut sym_gen).unwrap();
+        let result = op.infer_shapes([shape].into(), &mut sym_gen).unwrap();
         assert_eq!(result[0], sym_vec!(1, 1, 1));
 
         // Vector shape, non-int value.
         let shape = sym_vec!(3);
         let op = ConstantOfShape { value: None };
-        let result = op.infer_shapes(&[shape], &mut sym_gen).unwrap();
+        let result = op.infer_shapes([shape].into(), &mut sym_gen).unwrap();
         assert_eq!(result[0], sym_shape!(3));
 
         // 2D+ shape
         let shape = sym_vec!(2, 2);
         let op = ConstantOfShape { value: Some(1) };
-        let result = op.infer_shapes(&[shape], &mut sym_gen).unwrap();
+        let result = op.infer_shapes([shape].into(), &mut sym_gen).unwrap();
         assert_eq!(result[0], sym_shape!(2, 2));
     }
 
@@ -688,14 +670,14 @@ mod tests {
     fn test_dropout() {
         let mut sym_gen = SymbolGen::new();
         let data = sym_shape!("batch", 16, 32);
-        let result = Dropout.infer_shapes(&[data], &mut sym_gen).unwrap();
+        let result = Dropout.infer_shapes([data].into(), &mut sym_gen).unwrap();
         assert_eq!(result.len(), 2);
         assert_eq!(result[0], sym_shape!("batch", 16, 32));
         assert_eq!(result[1], sym_shape!("batch", 16, 32));
 
         // Unknown input shape.
         let data = SymTensor::unknown("unknown");
-        let result = Dropout.infer_shapes(&[data], &mut sym_gen).unwrap();
+        let result = Dropout.infer_shapes([data].into(), &mut sym_gen).unwrap();
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].ndim(), None);
         assert_eq!(result[1].ndim(), None);
@@ -707,11 +689,14 @@ mod tests {
 
         let input = sym_vec!("batch", 16, "seq", 24);
         let result = Identity
-            .infer_shapes(&[input.clone()], &mut sym_gen)
+            .infer_shapes([input.clone()].into(), &mut sym_gen)
             .unwrap();
         assert_eq!(result, &[input]);
 
-        let err = Identity.infer_shapes(&[], &mut sym_gen).err().unwrap();
+        let err = Identity
+            .infer_shapes(InferShapesContext::new(&[]), &mut sym_gen)
+            .err()
+            .unwrap();
         assert_eq!(err, InferShapesError::IncorrectInputCount);
     }
 
@@ -722,14 +707,14 @@ mod tests {
         // Known batch size.
         let data = sym_shape!("batch", 32);
         let result = Multinomial { sample_size: 4 }
-            .infer_shapes(&[data], &mut sym_gen)
+            .infer_shapes([data].into(), &mut sym_gen)
             .unwrap();
         assert_eq!(result, &[sym_shape!("batch", 4)]);
 
         // Unknown input shape still yields a known sample size.
         let data = SymTensor::unknown("unknown");
         let result = Multinomial { sample_size: 4 }
-            .infer_shapes(&[data], &mut sym_gen)
+            .infer_shapes([data].into(), &mut sym_gen)
             .unwrap();
         assert_eq!(result[0].ndim(), Some(2));
         assert_eq!(result[0].size(1), Some(4.into()));
@@ -737,7 +722,7 @@ mod tests {
         // Input with a known rank other than 2 is an error.
         let data = sym_shape!("batch", 32, 8);
         let err = Multinomial { sample_size: 4 }
-            .infer_shapes(&[data], &mut sym_gen)
+            .infer_shapes([data].into(), &mut sym_gen)
             .err();
         assert_eq!(err, Some(InferShapesError::IncorrectRank));
     }
@@ -750,7 +735,7 @@ mod tests {
         // `mean` and `inv_std_var` are empty placeholders.
         let data = sym_shape!("batch", "seq", 32);
         let result = SkipSimplifiedLayerNormalization
-            .infer_shapes(&[data], &mut sym_gen)
+            .infer_shapes([data].into(), &mut sym_gen)
             .unwrap();
         assert_eq!(
             result,
@@ -765,7 +750,7 @@ mod tests {
         // Unknown input shape.
         let data = SymTensor::unknown("unknown");
         let result = SkipSimplifiedLayerNormalization
-            .infer_shapes(&[data], &mut sym_gen)
+            .infer_shapes([data].into(), &mut sym_gen)
             .unwrap();
         assert_eq!(result.len(), 4);
         assert_eq!(result[0].ndim(), None);
@@ -775,7 +760,7 @@ mod tests {
 
         // Missing input.
         let err = SkipSimplifiedLayerNormalization
-            .infer_shapes(&[], &mut sym_gen)
+            .infer_shapes(InferShapesContext::new(&[]), &mut sym_gen)
             .err();
         assert_eq!(err, Some(InferShapesError::IncorrectInputCount));
     }
@@ -785,7 +770,7 @@ mod tests {
         let mut sym_gen = SymbolGen::new();
         let data = sym_shape!(32, 32);
         let result = DynamicQuantizeLinear
-            .infer_shapes(&[data], &mut sym_gen)
+            .infer_shapes([data].into(), &mut sym_gen)
             .unwrap();
         assert_eq!(result, &[sym_shape!(32, 32), sym_shape!(), sym_shape!(),]);
     }
@@ -795,7 +780,7 @@ mod tests {
         let infer = |data, indices, axis| {
             let mut sym_gen = SymbolGen::new();
             let op = Gather { axis };
-            op.infer_shapes(&[data, indices], &mut sym_gen)
+            op.infer_shapes([data, indices].into(), &mut sym_gen)
         };
 
         // Gather scalar from symbolic vec.
@@ -837,7 +822,7 @@ mod tests {
         let data = sym_shape!(4, 3, 2);
         let indices = sym_shape!(2, 3, 2);
         let result = GatherElements
-            .infer_shapes(&[data, indices], &mut sym_gen)
+            .infer_shapes([data, indices].into(), &mut sym_gen)
             .unwrap();
         assert_eq!(result[0], sym_shape!(2, 3, 2));
 
@@ -845,7 +830,7 @@ mod tests {
         let data = sym_shape!(4, 3, 2);
         let indices = SymTensor::unknown("unknown");
         let result = GatherElements
-            .infer_shapes(&[data, indices], &mut sym_gen)
+            .infer_shapes([data, indices].into(), &mut sym_gen)
             .unwrap();
         assert_eq!(result[0].ndim(), None);
     }
@@ -858,49 +843,61 @@ mod tests {
         let data = sym_shape!(4, 3, 2);
         let indices = sym_shape!(2, 1);
         let op = GatherND { batch_dims: 0 };
-        let result = op.infer_shapes(&[data, indices], &mut sym_gen).unwrap();
+        let result = op
+            .infer_shapes([data, indices].into(), &mut sym_gen)
+            .unwrap();
         assert_eq!(result[0], sym_shape!(2, 3, 2));
 
         // Index tuple covers all input dims.
         let data = sym_shape!(4, 3, 2);
         let indices = sym_shape!(2, 3);
         let op = GatherND { batch_dims: 0 };
-        let result = op.infer_shapes(&[data, indices], &mut sym_gen).unwrap();
+        let result = op
+            .infer_shapes([data, indices].into(), &mut sym_gen)
+            .unwrap();
         assert_eq!(result[0], sym_shape!(2));
 
         // With batch_dims.
         let data = sym_shape!(2, 3, 4);
         let indices = sym_shape!(2, 1);
         let op = GatherND { batch_dims: 1 };
-        let result = op.infer_shapes(&[data, indices], &mut sym_gen).unwrap();
+        let result = op
+            .infer_shapes([data, indices].into(), &mut sym_gen)
+            .unwrap();
         assert_eq!(result[0], sym_shape!(2, 4));
 
         // Symbolic dims preserved.
         let data = sym_shape!("batch", "seq", 64);
         let indices = sym_shape!("batch", "k", 1);
         let op = GatherND { batch_dims: 1 };
-        let result = op.infer_shapes(&[data, indices], &mut sym_gen).unwrap();
+        let result = op
+            .infer_shapes([data, indices].into(), &mut sym_gen)
+            .unwrap();
         assert_eq!(result[0], sym_shape!("batch", "k", 64));
 
         // Unknown data shape.
         let data = SymTensor::unknown("unknown");
         let indices = sym_shape!(2, 1);
         let op = GatherND { batch_dims: 0 };
-        let result = op.infer_shapes(&[data, indices], &mut sym_gen).unwrap();
+        let result = op
+            .infer_shapes([data, indices].into(), &mut sym_gen)
+            .unwrap();
         assert_eq!(result[0].ndim(), None);
 
         // Symbolic index tuple size — output rank can't be determined.
         let data = sym_shape!(4, 3, 2);
         let indices = sym_shape!(2, "k");
         let op = GatherND { batch_dims: 0 };
-        let result = op.infer_shapes(&[data, indices], &mut sym_gen).unwrap();
+        let result = op
+            .infer_shapes([data, indices].into(), &mut sym_gen)
+            .unwrap();
         assert_eq!(result[0].ndim(), None);
 
         // Negative index tuple size — invalid value.
         let data = sym_shape!(4, 3, 2);
         let indices = sym_shape!(2, -1);
         let op = GatherND { batch_dims: 0 };
-        let result = op.infer_shapes(&[data, indices], &mut sym_gen);
+        let result = op.infer_shapes([data, indices].into(), &mut sym_gen);
         assert_eq!(result, Err(InferShapesError::InvalidValue));
     }
 
@@ -908,12 +905,16 @@ mod tests {
     fn test_fixed_shape() {
         let mut sym_gen = SymbolGen::new();
         let op = FixedShape { shape: &[2, 3, 4] };
-        let result = op.infer_shapes(&[], &mut sym_gen).unwrap();
+        let result = op
+            .infer_shapes(InferShapesContext::new(&[]), &mut sym_gen)
+            .unwrap();
         assert_eq!(result[0], sym_shape!(2, 3, 4));
 
         // Zero-dim shape produces a scalar tensor.
         let op = FixedShape { shape: &[] };
-        let result = op.infer_shapes(&[], &mut sym_gen).unwrap();
+        let result = op
+            .infer_shapes(InferShapesContext::new(&[]), &mut sym_gen)
+            .unwrap();
         assert_eq!(result[0], sym_shape!());
     }
 
@@ -925,7 +926,7 @@ mod tests {
         let data = sym_shape!("batch", 3, 224, 224);
         let grid = sym_shape!("batch", 32, 64, 2);
         let result = GridSample
-            .infer_shapes(&[data, grid], &mut sym_gen)
+            .infer_shapes([data, grid].into(), &mut sym_gen)
             .unwrap();
         assert_eq!(result[0], sym_shape!("batch", 3, 32, 64));
 
@@ -933,7 +934,7 @@ mod tests {
         let data = sym_shape!("batch", 3, 224);
         let grid = sym_shape!("batch", 32, 1);
         let result = GridSample
-            .infer_shapes(&[data, grid], &mut sym_gen)
+            .infer_shapes([data, grid].into(), &mut sym_gen)
             .unwrap();
         assert_eq!(result[0], sym_shape!("batch", 3, 32));
 
@@ -941,7 +942,7 @@ mod tests {
         let data = SymTensor::unknown("unknown");
         let grid = sym_shape!(1, 32, 64, 2);
         let result = GridSample
-            .infer_shapes(&[data, grid], &mut sym_gen)
+            .infer_shapes([data, grid].into(), &mut sym_gen)
             .unwrap();
         assert_eq!(result[0].ndim(), None);
 
@@ -949,7 +950,7 @@ mod tests {
         let data = sym_shape!(1, 3, 224);
         let grid = sym_shape!(1, 32, 64, 2);
         let err = GridSample
-            .infer_shapes(&[data, grid], &mut sym_gen)
+            .infer_shapes([data, grid].into(), &mut sym_gen)
             .unwrap_err();
         assert_eq!(err, InferShapesError::IncorrectRank);
     }
@@ -960,7 +961,7 @@ mod tests {
 
         // Known input shape, output is 2D with first dim = ndim.
         let data = sym_shape!("batch", 16, 32);
-        let result = NonZero.infer_shapes(&[data], &mut sym_gen).unwrap();
+        let result = NonZero.infer_shapes([data].into(), &mut sym_gen).unwrap();
         let shape: Vec<_> = result[0].shape().unwrap().collect();
         assert_eq!(shape.len(), 2);
         assert_eq!(shape[0], SymExpr::Value(3));
@@ -968,7 +969,7 @@ mod tests {
 
         // Unknown input shape, output is still 2D.
         let data = SymTensor::unknown("unknown");
-        let result = NonZero.infer_shapes(&[data], &mut sym_gen).unwrap();
+        let result = NonZero.infer_shapes([data].into(), &mut sym_gen).unwrap();
         let shape: Vec<_> = result[0].shape().unwrap().collect();
         assert_eq!(shape.len(), 2);
     }
@@ -981,7 +982,7 @@ mod tests {
         let boxes = sym_shape!(1, 100, 4);
         let scores = sym_shape!(1, 80, 100);
         let result = NonMaxSuppression
-            .infer_shapes(&[boxes, scores], &mut sym_gen)
+            .infer_shapes([boxes, scores].into(), &mut sym_gen)
             .unwrap();
         let shape: Vec<_> = result[0].shape().unwrap().collect();
         assert_eq!(shape.len(), 2);
@@ -998,7 +999,7 @@ mod tests {
         let limit = sym_vec!(5);
         let delta = sym_vec!(1);
         let result = Range
-            .infer_shapes(&[start, limit, delta], &mut sym_gen)
+            .infer_shapes([start, limit, delta].into(), &mut sym_gen)
             .unwrap();
         assert_eq!(result[0], sym_vec!(0, 1, 2, 3, 4));
 
@@ -1007,7 +1008,7 @@ mod tests {
         let limit = sym_vec!("limit");
         let delta = sym_vec!(1);
         let result = Range
-            .infer_shapes(&[start, limit, delta], &mut sym_gen)
+            .infer_shapes([start, limit, delta].into(), &mut sym_gen)
             .unwrap();
         assert_eq!(result[0], sym_shape!("limit"));
 
@@ -1016,7 +1017,7 @@ mod tests {
         let limit = sym_vec!(SymExpr::from("start") + SymExpr::from("limit"));
         let delta = sym_vec!(1);
         let result = Range
-            .infer_shapes(&[start, limit, delta], &mut sym_gen)
+            .infer_shapes([start, limit, delta].into(), &mut sym_gen)
             .unwrap();
         assert_eq!(result[0], sym_shape!("limit"));
 
@@ -1025,7 +1026,7 @@ mod tests {
         let limit = sym_vec!("limit");
         let delta = sym_vec!(1);
         let result = Range
-            .infer_shapes(&[start, limit, delta], &mut sym_gen)
+            .infer_shapes([start, limit, delta].into(), &mut sym_gen)
             .unwrap();
         assert_eq!(
             result[0],
@@ -1037,7 +1038,7 @@ mod tests {
         let limit = sym_vec!("end");
         let delta = sym_vec!("delta");
         let result = Range
-            .infer_shapes(&[start, limit, delta], &mut sym_gen)
+            .infer_shapes([start, limit, delta].into(), &mut sym_gen)
             .unwrap();
         assert_eq!(result[0], sym_shape!("unknown_1"));
     }
@@ -1050,7 +1051,7 @@ mod tests {
         let data = sym_shape!("batch", 16, 32);
         let k = sym_vec!(5);
         let op = TopK { axis: None };
-        let result = op.infer_shapes(&[data, k], &mut sym_gen).unwrap();
+        let result = op.infer_shapes([data, k].into(), &mut sym_gen).unwrap();
         assert_eq!(result.len(), 2);
         assert_eq!(result[0], sym_shape!("batch", 16, 5));
         assert_eq!(result[1], sym_shape!("batch", 16, 5));
@@ -1059,14 +1060,14 @@ mod tests {
         let data = sym_shape!("batch", 16, 32);
         let k = sym_vec!(5);
         let op = TopK { axis: Some(0) };
-        let result = op.infer_shapes(&[data, k], &mut sym_gen).unwrap();
+        let result = op.infer_shapes([data, k].into(), &mut sym_gen).unwrap();
         assert_eq!(result[0], sym_shape!(5, 16, 32));
 
         // Symbolic K value.
         let data = sym_shape!("batch", 32);
         let k = sym_vec!(SymExpr::from("k"));
         let op = TopK { axis: Some(-1) };
-        let result = op.infer_shapes(&[data, k], &mut sym_gen).unwrap();
+        let result = op.infer_shapes([data, k].into(), &mut sym_gen).unwrap();
         assert_eq!(result[0], sym_shape!("batch", "k"));
     }
 
@@ -1078,7 +1079,9 @@ mod tests {
         let cond = sym_vec!(0, 1, 0, 1);
         let x = sym_vec!(1, 2, 3, 4);
         let y = sym_vec!("foo", "bar", "baz", "meep");
-        let result = Where.infer_shapes(&[cond, x, y], &mut sym_gen).unwrap();
+        let result = Where
+            .infer_shapes([cond, x, y].into(), &mut sym_gen)
+            .unwrap();
         assert_eq!(result[0], sym_vec!("foo", 2, "baz", 4));
 
         // Where op with shapes.
@@ -1087,7 +1090,9 @@ mod tests {
         let cond = sym_shape!(1, 16, 1);
         let x = sym_shape!(8, 16, 1);
         let y = sym_shape!(1, 16, 24);
-        let result = Where.infer_shapes(&[cond, x, y], &mut sym_gen).unwrap();
+        let result = Where
+            .infer_shapes([cond, x, y].into(), &mut sym_gen)
+            .unwrap();
         assert_eq!(result[0], sym_shape!(8, 16, 24));
     }
 }

--- a/rten-shape-inference/src/ops/attention.rs
+++ b/rten-shape-inference/src/ops/attention.rs
@@ -1,4 +1,4 @@
-use crate::infer_shapes::{InferShapes, InferShapesError};
+use crate::infer_shapes::{InferShapes, InferShapesContext, InferShapesError};
 use crate::sym_expr::SymExpr;
 use crate::sym_gen::SymbolGen;
 use crate::sym_tensor::SymTensor;
@@ -31,7 +31,7 @@ pub struct MultiHeadAttention {
 impl InferShapes for MultiHeadAttention {
     fn infer_shapes(
         &self,
-        inputs: &[SymTensor],
+        inputs: InferShapesContext,
         _sym_gen: &mut SymbolGen,
     ) -> Result<Vec<SymTensor>, InferShapesError> {
         if self.num_heads == 0 || self.num_heads > i32::MAX as u32 {
@@ -41,9 +41,7 @@ impl InferShapes for MultiHeadAttention {
 
         // Inputs: query (0), key (1), value (2), bias (3), key_padding_mask (4),
         // attention_bias (5), past_key (6), past_value (7), ...
-        let query = inputs
-            .first()
-            .ok_or(InferShapesError::IncorrectInputCount)?;
+        let query = inputs.require(0)?;
         let key = inputs.get(1);
         let value = inputs.get(2);
         let past_key = inputs.get(6);
@@ -125,7 +123,7 @@ pub struct GroupQueryAttention {
 impl InferShapes for GroupQueryAttention {
     fn infer_shapes(
         &self,
-        inputs: &[SymTensor],
+        inputs: InferShapesContext,
         _sym_gen: &mut SymbolGen,
     ) -> Result<Vec<SymTensor>, InferShapesError> {
         if self.num_heads == 0
@@ -140,9 +138,7 @@ impl InferShapes for GroupQueryAttention {
 
         // Inputs: query (0), key (1), value (2), past_key (3), past_value (4),
         // seqlens_k (5), total_sequence_length (6), ...
-        let query = inputs
-            .first()
-            .ok_or(InferShapesError::IncorrectInputCount)?;
+        let query = inputs.require(0)?;
         let past_key = inputs.get(3);
 
         let Some(query_ndim) = query.ndim() else {
@@ -197,7 +193,7 @@ pub struct Attention {
 impl InferShapes for Attention {
     fn infer_shapes(
         &self,
-        inputs: &[SymTensor],
+        inputs: InferShapesContext,
         _sym_gen: &mut SymbolGen,
     ) -> Result<Vec<SymTensor>, InferShapesError> {
         // Validate the head-count attributes that are set.
@@ -209,9 +205,7 @@ impl InferShapes for Attention {
 
         // Inputs: query (0), key (1), value (2), attn_mask (3), past_key (4),
         // past_value (5), nonpad_kv_seqlen (6).
-        let query = inputs
-            .first()
-            .ok_or(InferShapesError::IncorrectInputCount)?;
+        let query = inputs.require(0)?;
         let (Some(key), Some(value)) = (inputs.get(1), inputs.get(2)) else {
             return Err(InferShapesError::IncorrectInputCount);
         };
@@ -306,7 +300,7 @@ mod tests {
     fn infer(num_heads: u32, inputs: &[SymTensor]) -> Vec<SymTensor> {
         let mut sym_gen = SymbolGen::new();
         let op = MultiHeadAttention { num_heads };
-        op.infer_shapes(inputs, &mut sym_gen)
+        op.infer_shapes(inputs.to_vec().into(), &mut sym_gen)
             .unwrap()
             .into_iter()
             .map(SymTensor::simplify)
@@ -391,7 +385,7 @@ mod tests {
         let mut sym_gen = SymbolGen::new();
         let op = MultiHeadAttention { num_heads: 0 };
         let err = op
-            .infer_shapes(&[sym_shape!("batch", "seq", 768)], &mut sym_gen)
+            .infer_shapes([sym_shape!("batch", "seq", 768)].into(), &mut sym_gen)
             .unwrap_err();
         assert_eq!(err, InferShapesError::InvalidValue);
     }
@@ -402,7 +396,7 @@ mod tests {
             num_heads,
             kv_num_heads,
         };
-        op.infer_shapes(inputs, &mut sym_gen)
+        op.infer_shapes(inputs.to_vec().into(), &mut sym_gen)
             .unwrap()
             .into_iter()
             .map(SymTensor::simplify)
@@ -455,7 +449,7 @@ mod tests {
             kv_num_heads: 0,
         };
         let err = op
-            .infer_shapes(&[sym_shape!("batch", "seq", 1024)], &mut sym_gen)
+            .infer_shapes([sym_shape!("batch", "seq", 1024)].into(), &mut sym_gen)
             .unwrap_err();
         assert_eq!(err, InferShapesError::InvalidValue);
     }
@@ -470,7 +464,7 @@ mod tests {
             q_num_heads,
             kv_num_heads,
         };
-        op.infer_shapes(inputs, &mut sym_gen)
+        op.infer_shapes(inputs.to_vec().into(), &mut sym_gen)
             .unwrap()
             .into_iter()
             .map(SymTensor::simplify)
@@ -588,7 +582,7 @@ mod tests {
             kv_num_heads: Some(12),
         };
         let err = op
-            .infer_shapes(&[sym_shape!("batch", "seq", 768)], &mut sym_gen)
+            .infer_shapes([sym_shape!("batch", "seq", 768)].into(), &mut sym_gen)
             .unwrap_err();
         assert_eq!(err, InferShapesError::InvalidValue);
     }

--- a/rten-shape-inference/src/ops/binary.rs
+++ b/rten-shape-inference/src/ops/binary.rs
@@ -1,4 +1,4 @@
-use crate::infer_shapes::{BinaryOp, InferShapes, InferShapesError};
+use crate::infer_shapes::{BinaryOp, InferShapes, InferShapesContext, InferShapesError};
 use crate::sym_expr::SymExpr;
 use crate::sym_gen::SymbolGen;
 use crate::sym_tensor::SymTensor;
@@ -44,13 +44,12 @@ fn symbolic_binary_op(
 /// This will attempt to evaluate the operation on values in the tensor,
 /// otherwise it will fall back to inferring just the shape.
 fn binary_op_infer_shapes(
-    inputs: &[SymTensor],
+    inputs: InferShapesContext,
     sym_gen: &mut SymbolGen,
     op: impl FnMut(&SymExpr, &SymExpr) -> Option<SymExpr>,
 ) -> Result<Vec<SymTensor>, InferShapesError> {
-    let [lhs, rhs] = inputs else {
-        return Err(InferShapesError::IncorrectInputCount);
-    };
+    let lhs = inputs.require(0)?;
+    let rhs = inputs.require(1)?;
 
     if let Some(result) = symbolic_binary_op(lhs, rhs, op) {
         return Ok([result].into());
@@ -67,7 +66,7 @@ pub struct Add;
 impl InferShapes for Add {
     fn infer_shapes(
         &self,
-        inputs: &[SymTensor],
+        inputs: InferShapesContext,
         sym_gen: &mut SymbolGen,
     ) -> Result<Vec<SymTensor>, InferShapesError> {
         let add = |x: &SymExpr, y: &SymExpr| {
@@ -88,7 +87,7 @@ pub struct Sub;
 impl InferShapes for Sub {
     fn infer_shapes(
         &self,
-        inputs: &[SymTensor],
+        inputs: InferShapesContext,
         sym_gen: &mut SymbolGen,
     ) -> Result<Vec<SymTensor>, InferShapesError> {
         let sub = |x: &SymExpr, y: &SymExpr| {
@@ -109,7 +108,7 @@ pub struct Div;
 impl InferShapes for Div {
     fn infer_shapes(
         &self,
-        inputs: &[SymTensor],
+        inputs: InferShapesContext,
         sym_gen: &mut SymbolGen,
     ) -> Result<Vec<SymTensor>, InferShapesError> {
         let div = |x: &SymExpr, y: &SymExpr| {
@@ -130,7 +129,7 @@ pub struct Equal;
 impl InferShapes for Equal {
     fn infer_shapes(
         &self,
-        inputs: &[SymTensor],
+        inputs: InferShapesContext,
         sym_gen: &mut SymbolGen,
     ) -> Result<Vec<SymTensor>, InferShapesError> {
         let eq = |x: &SymExpr, y: &SymExpr| {
@@ -162,7 +161,7 @@ pub struct Mul;
 impl InferShapes for Mul {
     fn infer_shapes(
         &self,
-        inputs: &[SymTensor],
+        inputs: InferShapesContext,
         sym_gen: &mut SymbolGen,
     ) -> Result<Vec<SymTensor>, InferShapesError> {
         let mul = |x: &SymExpr, y: &SymExpr| {
@@ -191,13 +190,13 @@ mod tests {
         // Symbolic scalar
         let a = SymTensor::from_scalar(6.into());
         let b = SymTensor::from_scalar(5.into());
-        let result = Add.infer_shapes(&[a, b], &mut sym_gen).unwrap();
+        let result = Add.infer_shapes([a, b].into(), &mut sym_gen).unwrap();
         assert_eq!(result[0], SymTensor::from_scalar(11.into()));
 
         // Symbolic vector
         let a = sym_vec!(5, "foo");
         let b = sym_vec!(6, "bar");
-        let result = Add.infer_shapes(&[a, b], &mut sym_gen).unwrap();
+        let result = Add.infer_shapes([a, b].into(), &mut sym_gen).unwrap();
         assert_eq!(
             result[0],
             sym_vec!(11, SymExpr::from("foo") + SymExpr::from("bar"))
@@ -206,7 +205,7 @@ mod tests {
         // Other shape
         let a = sym_shape!(5, "foo");
         let b = sym_shape!(1, "foo");
-        let result = Add.infer_shapes(&[a, b], &mut sym_gen).unwrap();
+        let result = Add.infer_shapes([a, b].into(), &mut sym_gen).unwrap();
         assert_eq!(result[0], sym_shape!(5, "foo"));
     }
 
@@ -217,13 +216,13 @@ mod tests {
         // Symbolic scalar
         let a = SymTensor::from_scalar(6.into());
         let b = SymTensor::from_scalar(5.into());
-        let result = Sub.infer_shapes(&[a, b], &mut sym_gen).unwrap();
+        let result = Sub.infer_shapes([a, b].into(), &mut sym_gen).unwrap();
         assert_eq!(result[0], SymTensor::from_scalar(1.into()));
 
         // Symbolic vector
         let a = sym_vec!(5, "foo");
         let b = sym_vec!(6, "bar");
-        let result = Sub.infer_shapes(&[a, b], &mut sym_gen).unwrap();
+        let result = Sub.infer_shapes([a, b].into(), &mut sym_gen).unwrap();
         assert_eq!(
             result[0],
             sym_vec!(-1, SymExpr::from("foo") - SymExpr::from("bar"))
@@ -232,7 +231,7 @@ mod tests {
         // Other shape
         let a = sym_shape!(5, "foo");
         let b = sym_shape!(1, "foo");
-        let result = Sub.infer_shapes(&[a, b], &mut sym_gen).unwrap();
+        let result = Sub.infer_shapes([a, b].into(), &mut sym_gen).unwrap();
         assert_eq!(result[0], sym_shape!(5, "foo"));
     }
 
@@ -243,13 +242,13 @@ mod tests {
         // Symbolic vector with fixed values.
         let a = sym_vec!(16);
         let b = sym_vec!(2);
-        let result = Div.infer_shapes(&[a, b], &mut sym_gen).unwrap();
+        let result = Div.infer_shapes([a, b].into(), &mut sym_gen).unwrap();
         assert_eq!(result[0], sym_vec!(8));
 
         // Symbolic vector with symbolic values.
         let a = sym_vec!(16);
         let b = sym_vec!("foo");
-        let result = Div.infer_shapes(&[a, b], &mut sym_gen).unwrap();
+        let result = Div.infer_shapes([a, b].into(), &mut sym_gen).unwrap();
         assert_eq!(
             result[0],
             sym_vec!(SymExpr::from(16) / SymExpr::from("foo"))
@@ -258,7 +257,7 @@ mod tests {
         // Other shape
         let a = sym_shape!(5, "foo");
         let b = sym_shape!(1, "foo");
-        let result = Div.infer_shapes(&[a, b], &mut sym_gen).unwrap();
+        let result = Div.infer_shapes([a, b].into(), &mut sym_gen).unwrap();
         assert_eq!(result[0], sym_shape!(5, "foo"));
     }
 
@@ -269,14 +268,14 @@ mod tests {
         // Comparison of fixed values.
         let a = sym_vec!(4, 8, 12);
         let b = sym_vec!(4, 2, 12);
-        let result = Equal.infer_shapes(&[a, b], &mut sym_gen).unwrap();
+        let result = Equal.infer_shapes([a, b].into(), &mut sym_gen).unwrap();
         assert_eq!(result[0], sym_vec!(1, 0, 1));
 
         // Comparison of negative values with symbols that are known to have
         // a value >= 0.
         let a = sym_vec!("foo", "bar");
         let b = sym_vec!(-1, -1);
-        let result = Equal.infer_shapes(&[a, b], &mut sym_gen).unwrap();
+        let result = Equal.infer_shapes([a, b].into(), &mut sym_gen).unwrap();
         assert_eq!(result[0], sym_vec!(0, 0));
 
         // Comparison of positive values with symbols.
@@ -285,7 +284,7 @@ mod tests {
         // fall back to regular shape inference.
         let a = sym_vec!("foo", "bar");
         let b = sym_vec!(2, 3);
-        let result = Equal.infer_shapes(&[a, b], &mut sym_gen).unwrap();
+        let result = Equal.infer_shapes([a, b].into(), &mut sym_gen).unwrap();
         assert_eq!(result[0], sym_shape!(2));
     }
 
@@ -296,13 +295,13 @@ mod tests {
         // Symbolic scalar
         let a = SymTensor::from_scalar(6.into());
         let b = SymTensor::from_scalar(5.into());
-        let result = Mul.infer_shapes(&[a, b], &mut sym_gen).unwrap();
+        let result = Mul.infer_shapes([a, b].into(), &mut sym_gen).unwrap();
         assert_eq!(result[0], SymTensor::from_scalar(30.into()));
 
         // Symbolic vector
         let a = sym_vec!(5, "foo");
         let b = sym_vec!(6, "bar");
-        let result = Mul.infer_shapes(&[a, b], &mut sym_gen).unwrap();
+        let result = Mul.infer_shapes([a, b].into(), &mut sym_gen).unwrap();
         assert_eq!(
             result[0],
             sym_vec!(30, SymExpr::from("foo") * SymExpr::from("bar"))
@@ -311,7 +310,7 @@ mod tests {
         // Other shape
         let a = sym_shape!(5, "foo");
         let b = sym_shape!(1, "foo");
-        let result = Mul.infer_shapes(&[a, b], &mut sym_gen).unwrap();
+        let result = Mul.infer_shapes([a, b].into(), &mut sym_gen).unwrap();
         assert_eq!(result[0], sym_shape!(5, "foo"));
     }
 }

--- a/rten-shape-inference/src/ops/concat.rs
+++ b/rten-shape-inference/src/ops/concat.rs
@@ -1,4 +1,4 @@
-use crate::infer_shapes::{InferShapes, InferShapesError, resolve_axis};
+use crate::infer_shapes::{InferShapes, InferShapesContext, InferShapesError, resolve_axis};
 use crate::sym_gen::SymbolGen;
 use crate::sym_tensor::SymTensor;
 
@@ -12,12 +12,10 @@ pub struct Concat {
 impl InferShapes for Concat {
     fn infer_shapes(
         &self,
-        inputs: &[SymTensor],
+        inputs: InferShapesContext,
         sym_gen: &mut SymbolGen,
     ) -> Result<Vec<SymTensor>, InferShapesError> {
-        let [first, rest @ ..] = inputs else {
-            return Err(InferShapesError::IncorrectInputCount);
-        };
+        let first = inputs.require(0)?;
 
         let Some(first_dims) = first.shape() else {
             return Ok([SymTensor::unknown("unknown input shape")].into());
@@ -28,10 +26,14 @@ impl InferShapes for Concat {
 
         // If input is a constant or symbolic vector, return a constant or
         // symbolic vector by concatenating each input.
-        if axis == 0 && inputs.iter().all(|inp| inp.values().is_some()) {
+        if axis == 0
+            && inputs
+                .iter()
+                .all(|inp| inp.is_some_and(|t| t.values().is_some()))
+        {
             let value = {
                 let mut values = Vec::new();
-                for inp in inputs {
+                for inp in inputs.iter().flatten() {
                     values.extend(inp.values().expect("should have values").to_vec());
                 }
                 SymTensor::from_vec(values)
@@ -41,7 +43,8 @@ impl InferShapes for Concat {
 
         let mut out_shape: Vec<_> = first_dims.collect();
 
-        for input in rest {
+        for i in 1..inputs.len() {
+            let input = inputs.require(i)?;
             if let Some(dim) = input.shape().and_then(|mut dims| dims.nth(axis)) {
                 out_shape[axis] += dim;
             } else {
@@ -61,12 +64,11 @@ pub struct Tile;
 impl InferShapes for Tile {
     fn infer_shapes(
         &self,
-        inputs: &[SymTensor],
+        inputs: InferShapesContext,
         sym_gen: &mut SymbolGen,
     ) -> Result<Vec<SymTensor>, InferShapesError> {
-        let [data, repeats] = inputs else {
-            return Err(InferShapesError::IncorrectInputCount);
-        };
+        let data = inputs.require(0)?;
+        let repeats = inputs.require(1)?;
 
         let Some(data_dims) = data.shape() else {
             return Ok([SymTensor::unknown("unknown input shape")].into());
@@ -115,7 +117,7 @@ mod tests {
 
         let mut sym_gen = SymbolGen::new();
         let op = Concat { axis: 1 };
-        let result = op.infer_shapes(&[a, b], &mut sym_gen).unwrap();
+        let result = op.infer_shapes([a, b].into(), &mut sym_gen).unwrap();
         let shape = extract_shape(result);
         assert_eq!(
             shape,
@@ -127,7 +129,7 @@ mod tests {
         let b = sym_shape!("batch", "bar", 64);
 
         let op = Concat { axis: 1 };
-        let result = op.infer_shapes(&[a, b], &mut sym_gen).unwrap();
+        let result = op.infer_shapes([a, b].into(), &mut sym_gen).unwrap();
         let shape = extract_shape(result);
         assert_eq!(
             shape,
@@ -138,7 +140,9 @@ mod tests {
         let bc_dims = sym_vec!("batch", "chans");
         let hw_dims = sym_vec!("height", "width");
         let op = Concat { axis: 0 };
-        let mut result = op.infer_shapes(&[bc_dims, hw_dims], &mut sym_gen).unwrap();
+        let mut result = op
+            .infer_shapes([bc_dims, hw_dims].into(), &mut sym_gen)
+            .unwrap();
         assert_eq!(
             result.remove(0).as_vector().unwrap(),
             sym_elems!("batch", "chans", "height", "width")
@@ -152,13 +156,17 @@ mod tests {
         // Fixed shape and known repeats.
         let data = sym_shape!(2, 3, 4);
         let repeats = sym_vec!(2, 1, 3);
-        let result = Tile.infer_shapes(&[data, repeats], &mut sym_gen).unwrap();
+        let result = Tile
+            .infer_shapes([data, repeats].into(), &mut sym_gen)
+            .unwrap();
         assert_eq!(result[0].clone().simplify(), sym_shape!(4, 3, 12));
 
         // Symbolic dim multiplied by a known repeat.
         let data = sym_shape!("batch", 16);
         let repeats = sym_vec!(2, 1);
-        let result = Tile.infer_shapes(&[data, repeats], &mut sym_gen).unwrap();
+        let result = Tile
+            .infer_shapes([data, repeats].into(), &mut sym_gen)
+            .unwrap();
         assert_eq!(
             result[0].clone().simplify(),
             sym_shape!(SymExpr::from("batch") * SymExpr::from(2), 16)
@@ -168,7 +176,9 @@ mod tests {
         // symbols.
         let data = sym_shape!(2, 3);
         let repeats = SymTensor::unknown("unknown");
-        let result = Tile.infer_shapes(&[data, repeats], &mut sym_gen).unwrap();
+        let result = Tile
+            .infer_shapes([data, repeats].into(), &mut sym_gen)
+            .unwrap();
         let shape: Vec<_> = result[0].shape().unwrap().collect();
         assert_eq!(shape.len(), 2);
         for dim in &shape {
@@ -179,7 +189,7 @@ mod tests {
         let data = sym_shape!(2, 3);
         let repeats = sym_vec!(2, 2, 2);
         let err = Tile
-            .infer_shapes(&[data, repeats], &mut sym_gen)
+            .infer_shapes([data, repeats].into(), &mut sym_gen)
             .unwrap_err();
         assert_eq!(err, InferShapesError::InvalidValue);
     }

--- a/rten-shape-inference/src/ops/conv_pool.rs
+++ b/rten-shape-inference/src/ops/conv_pool.rs
@@ -1,6 +1,6 @@
 use smallvec::SmallVec;
 
-use crate::infer_shapes::{InferShapes, InferShapesError};
+use crate::infer_shapes::{InferShapes, InferShapesContext, InferShapesError};
 use crate::sym_expr::SymExpr;
 use crate::sym_gen::SymbolGen;
 use crate::sym_tensor::SymTensor;
@@ -84,12 +84,11 @@ pub struct Conv<'a> {
 impl InferShapes for Conv<'_> {
     fn infer_shapes(
         &self,
-        inputs: &[SymTensor],
+        inputs: InferShapesContext,
         _sym_gen: &mut SymbolGen,
     ) -> Result<Vec<SymTensor>, InferShapesError> {
-        let [data, weights, ..] = inputs else {
-            return Err(InferShapesError::IncorrectInputCount);
-        };
+        let data = inputs.require(0)?;
+        let weights = inputs.require(1)?;
 
         let Some(data_dims) = data.shape() else {
             return Ok([SymTensor::unknown("unknown input shape")].into());
@@ -201,12 +200,11 @@ pub struct ConvTranspose<'a> {
 impl InferShapes for ConvTranspose<'_> {
     fn infer_shapes(
         &self,
-        inputs: &[SymTensor],
+        inputs: InferShapesContext,
         _sym_gen: &mut SymbolGen,
     ) -> Result<Vec<SymTensor>, InferShapesError> {
-        let [data, weights, ..] = inputs else {
-            return Err(InferShapesError::IncorrectInputCount);
-        };
+        let data = inputs.require(0)?;
+        let weights = inputs.require(1)?;
 
         let Some(data_dims) = data.shape() else {
             return Ok([SymTensor::unknown("unknown input shape")].into());
@@ -276,12 +274,10 @@ pub struct Pool<'a> {
 impl InferShapes for Pool<'_> {
     fn infer_shapes(
         &self,
-        inputs: &[SymTensor],
+        inputs: InferShapesContext,
         _sym_gen: &mut SymbolGen,
     ) -> Result<Vec<SymTensor>, InferShapesError> {
-        let [data, ..] = inputs else {
-            return Err(InferShapesError::IncorrectInputCount);
-        };
+        let data = inputs.require(0)?;
 
         let Some(data_dims) = data.shape() else {
             return Ok([SymTensor::unknown("unknown input shape")].into());
@@ -354,12 +350,10 @@ pub struct GlobalPool;
 impl InferShapes for GlobalPool {
     fn infer_shapes(
         &self,
-        inputs: &[SymTensor],
+        inputs: InferShapesContext,
         _sym_gen: &mut SymbolGen,
     ) -> Result<Vec<SymTensor>, InferShapesError> {
-        let [data, ..] = inputs else {
-            return Err(InferShapesError::IncorrectInputCount);
-        };
+        let data = inputs.require(0)?;
         let Some(dims) = data.shape() else {
             return Ok([SymTensor::unknown("unknown input shape")].into());
         };
@@ -396,7 +390,7 @@ mod tests {
             strides: &[16],
         };
         let result = op
-            .infer_shapes(&[data.clone(), weights.clone()], &mut sym_gen)
+            .infer_shapes([data.clone(), weights.clone()].into(), &mut sym_gen)
             .unwrap();
         assert_eq!(
             result[0],
@@ -417,7 +411,9 @@ mod tests {
             dilations: &[4],
             strides: &[16],
         };
-        let result = op.infer_shapes(&[data, weights], &mut sym_gen).unwrap();
+        let result = op
+            .infer_shapes([data, weights].into(), &mut sym_gen)
+            .unwrap();
         assert_eq!(
             result[0],
             sym_shape!(
@@ -435,7 +431,9 @@ mod tests {
             dilations: &[4, 5],
             strides: &[16, 32],
         };
-        let result = op.infer_shapes(&[data, weights], &mut sym_gen).unwrap();
+        let result = op
+            .infer_shapes([data, weights].into(), &mut sym_gen)
+            .unwrap();
         assert_eq!(
             result[0],
             sym_shape!(
@@ -467,7 +465,9 @@ mod tests {
             dilations: &[4],
             strides: &[16],
         };
-        let result = op.infer_shapes(&[data.clone()], &mut sym_gen).unwrap();
+        let result = op
+            .infer_shapes([data.clone()].into(), &mut sym_gen)
+            .unwrap();
         assert_eq!(
             result[0],
             sym_shape!(
@@ -488,7 +488,7 @@ mod tests {
             dilations: &[4],
             strides: &[16],
         };
-        let result = op.infer_shapes(&[data], &mut sym_gen).unwrap();
+        let result = op.infer_shapes([data].into(), &mut sym_gen).unwrap();
         assert_eq!(
             result[0],
             sym_shape!(
@@ -506,7 +506,7 @@ mod tests {
             dilations: &[4, 5],
             strides: &[16, 32],
         };
-        let result = op.infer_shapes(&[data], &mut sym_gen).unwrap();
+        let result = op.infer_shapes([data].into(), &mut sym_gen).unwrap();
         assert_eq!(
             result[0],
             sym_shape!(
@@ -542,7 +542,9 @@ mod tests {
             dilations: &[1, 1],
             output_padding: None,
         };
-        let result = op.infer_shapes(&[data, weights], &mut sym_gen).unwrap();
+        let result = op
+            .infer_shapes([data, weights].into(), &mut sym_gen)
+            .unwrap();
         assert_eq!(result[0].clone().simplify(), sym_shape!(1, 16, 6, 6));
 
         // 2D transposed conv with output padding.
@@ -557,7 +559,9 @@ mod tests {
             dilations: &[1, 1],
             output_padding: Some(&[1, 0]),
         };
-        let result = op.infer_shapes(&[data, weights], &mut sym_gen).unwrap();
+        let result = op
+            .infer_shapes([data, weights].into(), &mut sym_gen)
+            .unwrap();
         assert_eq!(result[0].clone().simplify(), sym_shape!(1, 16, 8, 7));
 
         // 2D transposed conv with Same padding. Expected: out = in * stride.
@@ -570,7 +574,9 @@ mod tests {
             dilations: &[1, 1],
             output_padding: None,
         };
-        let result = op.infer_shapes(&[data, weights], &mut sym_gen).unwrap();
+        let result = op
+            .infer_shapes([data, weights].into(), &mut sym_gen)
+            .unwrap();
         assert_eq!(
             result[0].clone().simplify(),
             sym_shape!(
@@ -591,7 +597,9 @@ mod tests {
             dilations: &[1, 1],
             output_padding: None,
         };
-        let result = op.infer_shapes(&[data, weights], &mut sym_gen).unwrap();
+        let result = op
+            .infer_shapes([data, weights].into(), &mut sym_gen)
+            .unwrap();
         assert_eq!(result[0].clone().simplify(), sym_shape!(1, 4, 7, 7));
 
         // 1D transposed conv. Expected:
@@ -606,7 +614,9 @@ mod tests {
             dilations: &[1],
             output_padding: None,
         };
-        let result = op.infer_shapes(&[data, weights], &mut sym_gen).unwrap();
+        let result = op
+            .infer_shapes([data, weights].into(), &mut sym_gen)
+            .unwrap();
         assert_eq!(result[0].clone().simplify(), sym_shape!(1, 8, 8));
 
         // Unknown input shape.
@@ -618,7 +628,7 @@ mod tests {
             output_padding: None,
         }
         .infer_shapes(
-            &[SymTensor::unknown("?"), sym_shape!("in_c", 16, 3, 3)],
+            [SymTensor::unknown("?"), sym_shape!("in_c", 16, 3, 3)].into(),
             &mut sym_gen,
         )
         .unwrap();
@@ -636,7 +646,9 @@ mod tests {
             dilations: &[2, 2],
             output_padding: None,
         };
-        let result = op.infer_shapes(&[data, weights], &mut sym_gen).unwrap();
+        let result = op
+            .infer_shapes([data, weights].into(), &mut sym_gen)
+            .unwrap();
         assert_eq!(result[0].clone().simplify(), sym_shape!(1, 16, 9, 9));
     }
 
@@ -646,12 +658,16 @@ mod tests {
 
         // 1D global pool
         let data = sym_shape!("batch", "in_c", "height", "width");
-        let result = GlobalPool.infer_shapes(&[data], &mut sym_gen).unwrap();
+        let result = GlobalPool
+            .infer_shapes([data].into(), &mut sym_gen)
+            .unwrap();
         assert_eq!(result[0], sym_shape!("batch", "in_c", 1, 1,));
 
         // 2D global pool
         let data = sym_shape!("batch", "in_c", "height", "width");
-        let result = GlobalPool.infer_shapes(&[data], &mut sym_gen).unwrap();
+        let result = GlobalPool
+            .infer_shapes([data].into(), &mut sym_gen)
+            .unwrap();
         assert_eq!(result[0], sym_shape!("batch", "in_c", 1, 1,));
     }
 }

--- a/rten-shape-inference/src/ops/einsum.rs
+++ b/rten-shape-inference/src/ops/einsum.rs
@@ -1,5 +1,5 @@
 use crate::einsum_parser::{EinsumExpr, ValidateError, expand_ellipsis};
-use crate::infer_shapes::{InferShapes, InferShapesError};
+use crate::infer_shapes::{InferShapes, InferShapesContext, InferShapesError};
 use crate::sym_expr::SymExpr;
 use crate::sym_gen::SymbolGen;
 use crate::sym_tensor::SymTensor;
@@ -14,7 +14,7 @@ pub struct Einsum<'a> {
 impl InferShapes for Einsum<'_> {
     fn infer_shapes(
         &self,
-        inputs: &[SymTensor],
+        inputs: InferShapesContext,
         sym_gen: &mut SymbolGen,
     ) -> Result<Vec<SymTensor>, InferShapesError> {
         let Ok(expr) = EinsumExpr::parse(self.equation) else {
@@ -23,22 +23,23 @@ impl InferShapes for Einsum<'_> {
 
         // Validate the inputs and determine the number of dimensions
         // represented by `...` across inputs which contain an ellipsis.
-        let broadcast_ndim = match expr.validate_inputs(inputs.iter().map(|input| input.ndim())) {
-            Ok(n) => n,
-            // We can't determine the rank of the output without knowing the
-            // rank of an ellipsis input.
-            Err(ValidateError::UnknownRank) => {
-                return Ok([SymTensor::unknown("unknown einsum input shape")].into());
-            }
-            Err(ValidateError::IncorrectInputCount) => {
-                return Err(InferShapesError::IncorrectInputCount);
-            }
-            Err(ValidateError::RankMismatch) => return Err(InferShapesError::IncorrectRank),
-            Err(ValidateError::TooManyDims) => return Err(InferShapesError::InvalidValue),
-            Err(ValidateError::BroadcastMismatch) => {
-                return Err(InferShapesError::IncompatibleShapes);
-            }
-        };
+        let broadcast_ndim =
+            match expr.validate_inputs(inputs.iter().map(|input| input.and_then(|t| t.ndim()))) {
+                Ok(n) => n,
+                // We can't determine the rank of the output without knowing the
+                // rank of an ellipsis input.
+                Err(ValidateError::UnknownRank) => {
+                    return Ok([SymTensor::unknown("unknown einsum input shape")].into());
+                }
+                Err(ValidateError::IncorrectInputCount) => {
+                    return Err(InferShapesError::IncorrectInputCount);
+                }
+                Err(ValidateError::RankMismatch) => return Err(InferShapesError::IncorrectRank),
+                Err(ValidateError::TooManyDims) => return Err(InferShapesError::InvalidValue),
+                Err(ValidateError::BroadcastMismatch) => {
+                    return Err(InferShapesError::IncompatibleShapes);
+                }
+            };
 
         // Expand "..." in each input and output term to digit placeholders.
         let expanded_inputs: Vec<String> = expr
@@ -52,8 +53,8 @@ impl InferShapes for Einsum<'_> {
             .chars()
             .map(|output_ch| {
                 let mut out_dim: Option<SymExpr> = None;
-                for (term, input) in expanded_inputs.iter().zip(inputs) {
-                    let Some(dims) = input.shape() else {
+                for (term, input) in expanded_inputs.iter().zip(inputs.iter()) {
+                    let Some(dims) = input.and_then(|t| t.shape()) else {
                         continue;
                     };
                     debug_assert_eq!(term.chars().count(), dims.len());
@@ -90,7 +91,7 @@ mod tests {
     fn infer(equation: &str, inputs: &[SymTensor]) -> SymTensor {
         let mut sym_gen = SymbolGen::new();
         Einsum { equation }
-            .infer_shapes(inputs, &mut sym_gen)
+            .infer_shapes(inputs.to_vec().into(), &mut sym_gen)
             .unwrap()
             .remove(0)
             // Simplify broadcasts in shape expression.

--- a/rten-shape-inference/src/ops/fft.rs
+++ b/rten-shape-inference/src/ops/fft.rs
@@ -1,4 +1,4 @@
-use crate::infer_shapes::{InferShapes, InferShapesError, resolve_axis};
+use crate::infer_shapes::{InferShapes, InferShapesContext, InferShapesError, resolve_axis};
 use crate::sym_expr::SymExpr;
 use crate::sym_gen::SymbolGen;
 use crate::sym_tensor::SymTensor;
@@ -13,14 +13,13 @@ pub struct STFT {
 impl InferShapes for STFT {
     fn infer_shapes(
         &self,
-        inputs: &[SymTensor],
+        inputs: InferShapesContext,
         sym_gen: &mut SymbolGen,
     ) -> Result<Vec<SymTensor>, InferShapesError> {
-        let [signal, frame_step, rest @ ..] = inputs else {
-            return Err(InferShapesError::IncorrectInputCount);
-        };
-        let window = rest.first();
-        let frame_length = rest.get(1);
+        let signal = inputs.require(0)?;
+        let frame_step = inputs.require(1)?;
+        let window = inputs.get(2);
+        let frame_length = inputs.get(3);
 
         // At least one of `window` or `frame_length` must be set so `n_fft`
         // can be determined.
@@ -82,12 +81,10 @@ pub struct DFT {
 impl InferShapes for DFT {
     fn infer_shapes(
         &self,
-        inputs: &[SymTensor],
+        inputs: InferShapesContext,
         _sym_gen: &mut SymbolGen,
     ) -> Result<Vec<SymTensor>, InferShapesError> {
-        let [input, ..] = inputs else {
-            return Err(InferShapesError::IncorrectInputCount);
-        };
+        let input = inputs.require(0)?;
         let dft_length = inputs.get(1);
 
         let irfft = self.inverse && self.onesided;
@@ -186,7 +183,7 @@ mod tests {
 
         let mut sym_gen = SymbolGen::new();
         let mut result = STFT { onesided }
-            .infer_shapes(&inputs, &mut sym_gen)
+            .infer_shapes(inputs.into(), &mut sym_gen)
             .unwrap();
         result.remove(0).simplify()
     }
@@ -297,8 +294,10 @@ mod tests {
     #[test]
     fn test_stft_missing_window_and_frame_length() {
         let mut sym_gen = SymbolGen::new();
-        let result = STFT { onesided: true }
-            .infer_shapes(&[sym_shape!("batch", 8), sym_scalar!(4)], &mut sym_gen);
+        let result = STFT { onesided: true }.infer_shapes(
+            [sym_shape!("batch", 8), sym_scalar!(4)].into(),
+            &mut sym_gen,
+        );
         assert_eq!(result, Err(InferShapesError::InvalidValue));
     }
 
@@ -318,7 +317,7 @@ mod tests {
         ];
         let mut sym_gen = SymbolGen::new();
         let mut result = DFT { inverse, onesided }
-            .infer_shapes(&inputs, &mut sym_gen)
+            .infer_shapes(inputs.into(), &mut sym_gen)
             .unwrap();
         result.remove(0).simplify()
     }

--- a/rten-shape-inference/src/ops/generate.rs
+++ b/rten-shape-inference/src/ops/generate.rs
@@ -1,4 +1,4 @@
-use crate::infer_shapes::{InferShapes, InferShapesError, resolve_axis};
+use crate::infer_shapes::{InferShapes, InferShapesContext, InferShapesError, resolve_axis};
 use crate::sym_expr::SymExpr;
 use crate::sym_gen::SymbolGen;
 use crate::sym_tensor::SymTensor;
@@ -13,12 +13,13 @@ pub struct OneHot {
 impl InferShapes for OneHot {
     fn infer_shapes(
         &self,
-        inputs: &[SymTensor],
+        inputs: InferShapesContext,
         sym_gen: &mut SymbolGen,
     ) -> Result<Vec<SymTensor>, InferShapesError> {
-        let [indices, depth, _values] = inputs else {
-            return Err(InferShapesError::IncorrectInputCount);
-        };
+        let indices = inputs.require(0)?;
+        let depth = inputs.require(1)?;
+        // `values` is required but unused for shape inference.
+        inputs.require(2)?;
 
         let Some(indices_dims) = indices.shape() else {
             return Ok([SymTensor::unknown("unknown indices shape")].into());
@@ -62,7 +63,7 @@ mod tests {
         let values = sym_vec!(0, 1);
         let op = OneHot { axis: -1 };
         let result = op
-            .infer_shapes(&[indices, depth, values], &mut sym_gen)
+            .infer_shapes([indices, depth, values].into(), &mut sym_gen)
             .unwrap();
         assert_eq!(result[0], sym_shape!("batch", 8, 10));
 
@@ -72,7 +73,7 @@ mod tests {
         let values = sym_vec!(0, 1);
         let op = OneHot { axis: 0 };
         let result = op
-            .infer_shapes(&[indices, depth, values], &mut sym_gen)
+            .infer_shapes([indices, depth, values].into(), &mut sym_gen)
             .unwrap();
         assert_eq!(result[0], sym_shape!(10, "batch", 8));
 
@@ -82,7 +83,7 @@ mod tests {
         let values = sym_vec!(0, 1);
         let op = OneHot { axis: -1 };
         let result = op
-            .infer_shapes(&[indices, depth, values], &mut sym_gen)
+            .infer_shapes([indices, depth, values].into(), &mut sym_gen)
             .unwrap();
         assert_eq!(result[0], sym_shape!(4, "d"));
 
@@ -92,7 +93,7 @@ mod tests {
         let values = sym_vec!(0, 1);
         let op = OneHot { axis: -1 };
         let result = op
-            .infer_shapes(&[indices, depth, values], &mut sym_gen)
+            .infer_shapes([indices, depth, values].into(), &mut sym_gen)
             .unwrap();
         assert_eq!(result[0], sym_shape!("batch", 8, 10));
 
@@ -102,7 +103,7 @@ mod tests {
         let values = sym_vec!(0, 1);
         let op = OneHot { axis: -1 };
         let result = op
-            .infer_shapes(&[indices, depth, values], &mut sym_gen)
+            .infer_shapes([indices, depth, values].into(), &mut sym_gen)
             .unwrap();
         assert_eq!(result[0].ndim(), None);
     }

--- a/rten-shape-inference/src/ops/layout.rs
+++ b/rten-shape-inference/src/ops/layout.rs
@@ -1,4 +1,6 @@
-use crate::infer_shapes::{BinaryOp, InferShapes, InferShapesError, resolve_axis};
+use crate::infer_shapes::{
+    BinaryOp, InferShapes, InferShapesContext, InferShapesError, resolve_axis,
+};
 use crate::sym_expr::SymExpr;
 use crate::sym_gen::SymbolGen;
 use crate::sym_tensor::{Constant, SymTensor};
@@ -11,16 +13,18 @@ pub struct Expand;
 impl InferShapes for Expand {
     fn infer_shapes(
         &self,
-        inputs: &[SymTensor],
+        inputs: InferShapesContext,
         sym_gen: &mut SymbolGen,
     ) -> Result<Vec<SymTensor>, InferShapesError> {
-        let [data, shape] = inputs else {
-            return Err(InferShapesError::IncorrectInputCount);
-        };
+        let data = inputs.require(0)?;
+        let shape = inputs.require(1)?;
 
         if let Some(sizes) = shape.values() {
             let rhs_shape: Vec<SymExpr> = sizes.to_vec();
-            BinaryOp.infer_shapes(&[data.clone(), SymTensor::from_shape(rhs_shape)], sym_gen)
+            BinaryOp.infer_shapes(
+                [data.clone(), SymTensor::from_shape(rhs_shape)].into(),
+                sym_gen,
+            )
         } else if let Some(data_dims) = data.shape()
             && let Some(shape_len) = shape.size(0).and_then(|d| match d {
                 SymExpr::Value(size) => Some(size),
@@ -72,12 +76,10 @@ pub struct Flatten {
 impl InferShapes for Flatten {
     fn infer_shapes(
         &self,
-        inputs: &[SymTensor],
+        inputs: InferShapesContext,
         _sym_gen: &mut SymbolGen,
     ) -> Result<Vec<SymTensor>, InferShapesError> {
-        let [input] = inputs else {
-            return Err(InferShapesError::IncorrectInputCount);
-        };
+        let input = inputs.require(0)?;
         let Some(mut dims) = input.shape() else {
             return Ok([SymTensor::unknown("unknown input shape")].into());
         };
@@ -120,12 +122,11 @@ pub struct Reshape {
 impl InferShapes for Reshape {
     fn infer_shapes(
         &self,
-        inputs: &[SymTensor],
+        inputs: InferShapesContext,
         sym_gen: &mut SymbolGen,
     ) -> Result<Vec<SymTensor>, InferShapesError> {
-        let [data, shape] = inputs else {
-            return Err(InferShapesError::IncorrectInputCount);
-        };
+        let data = inputs.require(0)?;
+        let shape = inputs.require(1)?;
 
         // Minimum fixed value in the `shape` argument which doesn't require
         // special handling.
@@ -278,12 +279,10 @@ impl Shape {
 impl InferShapes for Shape {
     fn infer_shapes(
         &self,
-        inputs: &[SymTensor],
+        inputs: InferShapesContext,
         _sym_gen: &mut SymbolGen,
     ) -> Result<Vec<SymTensor>, InferShapesError> {
-        let [input] = inputs else {
-            return Err(InferShapesError::IncorrectInputCount);
-        };
+        let input = inputs.require(0)?;
 
         let shape = input
             .shape()
@@ -306,12 +305,10 @@ pub struct Size;
 impl InferShapes for Size {
     fn infer_shapes(
         &self,
-        inputs: &[SymTensor],
+        inputs: InferShapesContext,
         _sym_gen: &mut SymbolGen,
     ) -> Result<Vec<SymTensor>, InferShapesError> {
-        let [input] = inputs else {
-            return Err(InferShapesError::IncorrectInputCount);
-        };
+        let input = inputs.require(0)?;
 
         // The value of the output is the product of the input's dimensions,
         // when they are known.
@@ -336,12 +333,10 @@ pub struct DepthToSpace {
 impl InferShapes for DepthToSpace {
     fn infer_shapes(
         &self,
-        inputs: &[SymTensor],
+        inputs: InferShapesContext,
         _sym_gen: &mut SymbolGen,
     ) -> Result<Vec<SymTensor>, InferShapesError> {
-        let [data] = inputs else {
-            return Err(InferShapesError::IncorrectInputCount);
-        };
+        let data = inputs.require(0)?;
 
         let Some(dims) = data.shape() else {
             return Ok([SymTensor::unknown("unknown input shape")].into());
@@ -382,18 +377,16 @@ pub struct Squeeze;
 impl InferShapes for Squeeze {
     fn infer_shapes(
         &self,
-        inputs: &[SymTensor],
+        inputs: InferShapesContext,
         _sym_gen: &mut SymbolGen,
     ) -> Result<Vec<SymTensor>, InferShapesError> {
-        let [data, rest @ ..] = inputs else {
-            return Err(InferShapesError::IncorrectInputCount);
-        };
+        let data = inputs.require(0)?;
 
         let Some(shape) = data.shape() else {
             return Ok([SymTensor::unknown("Unknown input shape")].into());
         };
 
-        let axes = rest.first();
+        let axes = inputs.get(1);
 
         // Check if the `axes` input is constant and if so, resolve negative
         // values.
@@ -453,12 +446,10 @@ pub struct Transpose<'a> {
 impl InferShapes for Transpose<'_> {
     fn infer_shapes(
         &self,
-        inputs: &[SymTensor],
+        inputs: InferShapesContext,
         sym_gen: &mut SymbolGen,
     ) -> Result<Vec<SymTensor>, InferShapesError> {
-        let [input] = inputs else {
-            return Err(InferShapesError::IncorrectInputCount);
-        };
+        let input = inputs.require(0)?;
 
         if let Some(dims) = input.shape() {
             let permuted_dims = if let Some(perm) = self.perm {
@@ -496,12 +487,11 @@ pub struct Unsqueeze;
 impl InferShapes for Unsqueeze {
     fn infer_shapes(
         &self,
-        inputs: &[SymTensor],
+        inputs: InferShapesContext,
         _sym_gen: &mut SymbolGen,
     ) -> Result<Vec<SymTensor>, InferShapesError> {
-        let [data, axes] = inputs else {
-            return Err(InferShapesError::IncorrectInputCount);
-        };
+        let data = inputs.require(0)?;
+        let axes = inputs.require(1)?;
 
         // If data is a constant or symbolic scalar and axes is 0, the output
         // will be a length-1 vector. We can't handle higher-rank symbolic
@@ -557,25 +547,33 @@ mod tests {
         // Broadcast with known shape.
         let data = sym_shape!("batch", 1, 16);
         let shape = sym_vec!("batch", 8, 16);
-        let result = Expand.infer_shapes(&[data, shape], &mut sym_gen).unwrap();
+        let result = Expand
+            .infer_shapes([data, shape].into(), &mut sym_gen)
+            .unwrap();
         assert_eq!(result[0], sym_shape!("batch", 8, 16));
 
         // Broadcast with known shape that is shorter than the input data.
         let data = sym_shape!("batch", 1, 16);
         let shape = sym_vec!(8, 16);
-        let result = Expand.infer_shapes(&[data, shape], &mut sym_gen).unwrap();
+        let result = Expand
+            .infer_shapes([data, shape].into(), &mut sym_gen)
+            .unwrap();
         assert_eq!(result[0], sym_shape!("batch", 8, 16));
 
         // Broadcast with known shape that is longer than the input data.
         let data = sym_shape!("batch", 1, 16);
         let shape = sym_vec!(4, "batch", 8, 16);
-        let result = Expand.infer_shapes(&[data, shape], &mut sym_gen).unwrap();
+        let result = Expand
+            .infer_shapes([data, shape].into(), &mut sym_gen)
+            .unwrap();
         assert_eq!(result[0], sym_shape!(4, "batch", 8, 16));
 
         // Broadcast with shape that has a known length but unknown values.
         let data = sym_shape!("batch", 1, 16);
         let shape = sym_shape!(3);
-        let result = Expand.infer_shapes(&[data, shape], &mut sym_gen).unwrap();
+        let result = Expand
+            .infer_shapes([data, shape].into(), &mut sym_gen)
+            .unwrap();
         assert_eq!(result[0], sym_shape!("unknown_1", "unknown_2", 16));
     }
 
@@ -586,7 +584,7 @@ mod tests {
         // Combine last two dims.
         let data = sym_shape!("batch", "rows", "cols");
         let op = Flatten { axis: 1 };
-        let result = op.infer_shapes(&[data], &mut sym_gen).unwrap();
+        let result = op.infer_shapes([data].into(), &mut sym_gen).unwrap();
         assert_eq!(
             result[0],
             sym_shape!("batch", SymExpr::from("rows") * SymExpr::from("cols"))
@@ -595,7 +593,7 @@ mod tests {
         // Combine first two dims.
         let data = sym_shape!("batch", "rows", "cols");
         let op = Flatten { axis: 2 };
-        let result = op.infer_shapes(&[data], &mut sym_gen).unwrap();
+        let result = op.infer_shapes([data].into(), &mut sym_gen).unwrap();
         assert_eq!(
             result[0],
             sym_shape!(SymExpr::from("batch") * SymExpr::from("rows"), "cols")
@@ -604,7 +602,7 @@ mod tests {
         // Combine all dims
         let data = sym_shape!("batch", "rows", "cols");
         let op = Flatten { axis: 3 };
-        let result = op.infer_shapes(&[data], &mut sym_gen).unwrap();
+        let result = op.infer_shapes([data].into(), &mut sym_gen).unwrap();
         assert_eq!(
             result[0],
             sym_shape!(
@@ -616,7 +614,7 @@ mod tests {
         // Empty shape
         let data = sym_shape!();
         let op = Flatten { axis: 0 };
-        let result = op.infer_shapes(&[data], &mut sym_gen).unwrap();
+        let result = op.infer_shapes([data].into(), &mut sym_gen).unwrap();
         assert_eq!(result[0], sym_shape!(1, 1));
     }
 
@@ -629,34 +627,34 @@ mod tests {
         // Simple reshape of fixed dims.
         let data = sym_shape!("batch", 8, 8);
         let shape = sym_vec!("batch", 64);
-        let result = op.infer_shapes(&[data, shape], &mut sym_gen).unwrap();
+        let result = op.infer_shapes([data, shape].into(), &mut sym_gen).unwrap();
         assert_eq!(result[0], sym_shape!("batch", 64));
 
         // Reshape of fixed dims with -1 in shape.
         let data = sym_shape!("batch", 8, 8);
         let shape = sym_vec!("batch", -1);
-        let result = op.infer_shapes(&[data, shape], &mut sym_gen).unwrap();
+        let result = op.infer_shapes([data, shape].into(), &mut sym_gen).unwrap();
         assert_eq!(result[0], sym_shape!("batch", 64));
 
         // Reshape where shape contains a zero and the corresponding input dim
         // is fixed.
         let data = sym_shape!(32, 8, 8);
         let shape = sym_vec!(0, -1);
-        let result = op.infer_shapes(&[data, shape], &mut sym_gen).unwrap();
+        let result = op.infer_shapes([data, shape].into(), &mut sym_gen).unwrap();
         assert_eq!(result[0], sym_shape!(32, 64));
 
         // Reshape where shape contains a zero and the corresponding input dim
         // is symbolic.
         let data = sym_shape!("batch", 8, 8);
         let shape = sym_vec!(0, -1);
-        let result = op.infer_shapes(&[data, shape], &mut sym_gen).unwrap();
+        let result = op.infer_shapes([data, shape].into(), &mut sym_gen).unwrap();
         assert_eq!(result[0], sym_shape!("batch", 64));
 
         // Reshape where shape contains a zero and `allow_zero` is true.
         let data = sym_shape!("batch", 8, 0);
         let shape = sym_vec!("batch", 0, 8);
         let result = allow_zero_op
-            .infer_shapes(&[data, shape], &mut sym_gen)
+            .infer_shapes([data, shape].into(), &mut sym_gen)
             .unwrap();
         assert_eq!(result[0], sym_shape!("batch", 0, 8));
 
@@ -665,7 +663,7 @@ mod tests {
         let data = SymTensor::from_scalar(5.into());
         let shape = sym_vec!();
         let result = op
-            .infer_shapes(&[data.clone(), shape], &mut sym_gen)
+            .infer_shapes([data.clone(), shape].into(), &mut sym_gen)
             .unwrap();
         assert_eq!(result[0], data);
 
@@ -674,7 +672,7 @@ mod tests {
         let data = sym_vec!("batch", 3, 8);
         let shape = sym_vec!(3);
         let result = op
-            .infer_shapes(&[data.clone(), shape], &mut sym_gen)
+            .infer_shapes([data.clone(), shape].into(), &mut sym_gen)
             .unwrap();
         assert_eq!(result[0], data);
 
@@ -682,7 +680,7 @@ mod tests {
         let data = SymTensor::unknown("unknown");
         let shape = sym_vec!(2, 4, 8);
         let result = allow_zero_op
-            .infer_shapes(&[data, shape.clone()], &mut sym_gen)
+            .infer_shapes([data, shape.clone()].into(), &mut sym_gen)
             .unwrap();
         assert_eq!(result[0], sym_shape!(2, 4, 8));
 
@@ -695,7 +693,7 @@ mod tests {
         let data = SymTensor::unknown("unknown");
         let shape = sym_vec!("batch", "seq");
         let result = op
-            .infer_shapes(&[data, shape.clone()], &mut sym_gen)
+            .infer_shapes([data, shape.clone()].into(), &mut sym_gen)
             .unwrap();
         assert_eq!(result[0], sym_shape!("unknown_1", "unknown_2"));
 
@@ -704,7 +702,7 @@ mod tests {
         let data = sym_shape!("batch", "seq");
         let shape = sym_shape!(3);
         let result = allow_zero_op
-            .infer_shapes(&[data, shape.clone()], &mut sym_gen)
+            .infer_shapes([data, shape.clone()].into(), &mut sym_gen)
             .unwrap();
         assert_eq!(result[0], sym_shape!("unknown_1", "unknown_2", "unknown_3"));
 
@@ -712,7 +710,7 @@ mod tests {
         let data = sym_shape!("batch", "seq", 12, 64);
         let shape = sym_vec!("batch", -1, 768);
         let result = allow_zero_op
-            .infer_shapes(&[data, shape.clone()], &mut sym_gen)
+            .infer_shapes([data, shape.clone()].into(), &mut sym_gen)
             .unwrap();
         assert_eq!(result[0], sym_shape!("batch", "seq", 768));
 
@@ -720,7 +718,7 @@ mod tests {
         let data = sym_shape!("batch", "seq");
         let shape = sym_vec!("batch", 2, -1);
         let result = allow_zero_op
-            .infer_shapes(&[data, shape.clone()], &mut sym_gen)
+            .infer_shapes([data, shape.clone()].into(), &mut sym_gen)
             .unwrap();
         assert_eq!(
             result[0],
@@ -737,7 +735,7 @@ mod tests {
             start: None,
             end: None,
         };
-        let result = op.infer_shapes(&[data], &mut sym_gen).unwrap();
+        let result = op.infer_shapes([data].into(), &mut sym_gen).unwrap();
         assert_eq!(result[0], sym_vec!("batch", "seq", 64));
 
         // Shape with start and end attribute
@@ -747,7 +745,7 @@ mod tests {
             start: Some(1),
             end: Some(2),
         };
-        let result = op.infer_shapes(&[data], &mut sym_gen).unwrap();
+        let result = op.infer_shapes([data].into(), &mut sym_gen).unwrap();
         assert_eq!(result[0], sym_vec!("seq"));
     }
 
@@ -757,12 +755,12 @@ mod tests {
 
         // Fully fixed shape — result is a known scalar.
         let data = sym_shape!(2, 3, 4);
-        let result = Size.infer_shapes(&[data], &mut sym_gen).unwrap();
+        let result = Size.infer_shapes([data].into(), &mut sym_gen).unwrap();
         assert_eq!(result[0], SymTensor::from_scalar(SymExpr::Value(24)));
 
         // Symbolic dims — result is a scalar product expression.
         let data = sym_shape!("batch", 16, "seq");
-        let result = Size.infer_shapes(&[data], &mut sym_gen).unwrap();
+        let result = Size.infer_shapes([data].into(), &mut sym_gen).unwrap();
         assert_eq!(
             result[0],
             SymTensor::from_scalar(
@@ -772,7 +770,7 @@ mod tests {
 
         // Unknown input shape — result is a scalar with unknown value.
         let data = SymTensor::unknown("unknown");
-        let result = Size.infer_shapes(&[data], &mut sym_gen).unwrap();
+        let result = Size.infer_shapes([data].into(), &mut sym_gen).unwrap();
         assert_eq!(result[0].ndim(), Some(0));
     }
 
@@ -783,13 +781,13 @@ mod tests {
         // 4D input with block_size=2.
         let data = sym_shape!(1, 8, 4, 6);
         let op = DepthToSpace { block_size: 2 };
-        let result = op.infer_shapes(&[data], &mut sym_gen).unwrap();
+        let result = op.infer_shapes([data].into(), &mut sym_gen).unwrap();
         assert_eq!(result[0].clone().simplify(), sym_shape!(1, 2, 8, 12));
 
         // Symbolic input.
         let data = sym_shape!("batch", "chans", "h", "w");
         let op = DepthToSpace { block_size: 2 };
-        let result = op.infer_shapes(&[data], &mut sym_gen).unwrap();
+        let result = op.infer_shapes([data].into(), &mut sym_gen).unwrap();
         assert_eq!(
             result[0].clone().simplify(),
             sym_shape!(
@@ -803,13 +801,13 @@ mod tests {
         // Wrong rank.
         let data = sym_shape!(1, 8, 4);
         let op = DepthToSpace { block_size: 2 };
-        let err = op.infer_shapes(&[data], &mut sym_gen).unwrap_err();
+        let err = op.infer_shapes([data].into(), &mut sym_gen).unwrap_err();
         assert_eq!(err, InferShapesError::IncorrectRank);
 
         // Block size whose square exceeds `i32::MAX` (but fits in `u32`).
         let data = sym_shape!("batch", "chans", "h", "w");
         let op = DepthToSpace { block_size: 50_000 };
-        let err = op.infer_shapes(&[data], &mut sym_gen).unwrap_err();
+        let err = op.infer_shapes([data].into(), &mut sym_gen).unwrap_err();
         assert_eq!(err, InferShapesError::InvalidValue);
     }
 
@@ -819,49 +817,61 @@ mod tests {
         let mut sym_gen = SymbolGen::new();
         let shape = sym_shape!("foo", 1, 64);
         let axes = sym_vec!(1);
-        let result = Squeeze.infer_shapes(&[shape, axes], &mut sym_gen).unwrap();
+        let result = Squeeze
+            .infer_shapes([shape, axes].into(), &mut sym_gen)
+            .unwrap();
         assert_eq!(result[0], sym_shape!("foo", 64));
 
         // Symbolic vec to scalar
         let mut sym_gen = SymbolGen::new();
         let shape = sym_vec!("foo");
         let axes = sym_vec!(0);
-        let result = Squeeze.infer_shapes(&[shape, axes], &mut sym_gen).unwrap();
+        let result = Squeeze
+            .infer_shapes([shape, axes].into(), &mut sym_gen)
+            .unwrap();
         assert_eq!(result[0], SymTensor::from_scalar("foo".into()));
 
         // Symbolic vec to scalar, negative axis
         let shape = sym_vec!("bar");
         let axes = sym_vec!(-1);
-        let result = Squeeze.infer_shapes(&[shape, axes], &mut sym_gen).unwrap();
+        let result = Squeeze
+            .infer_shapes([shape, axes].into(), &mut sym_gen)
+            .unwrap();
         assert_eq!(result[0], SymTensor::from_scalar("bar".into()));
 
         // Symbolic vec to scalar, no axes
         let shape = sym_vec!("bar");
-        let result = Squeeze.infer_shapes(&[shape], &mut sym_gen).unwrap();
+        let result = Squeeze.infer_shapes([shape].into(), &mut sym_gen).unwrap();
         assert_eq!(result[0], SymTensor::from_scalar("bar".into()));
 
         // Non-const axes
         let mut sym_gen = SymbolGen::new();
         let shape = sym_shape!("foo");
         let axes = sym_vec!("what");
-        let result = Squeeze.infer_shapes(&[shape, axes], &mut sym_gen).unwrap();
+        let result = Squeeze
+            .infer_shapes([shape, axes].into(), &mut sym_gen)
+            .unwrap();
         assert_eq!(result[0], SymTensor::unknown("Unknown axes"));
 
         // Unknown input shape
         let shape = SymTensor::unknown("?");
         let axes = sym_vec!(0);
-        let result = Squeeze.infer_shapes(&[shape, axes], &mut sym_gen).unwrap();
+        let result = Squeeze
+            .infer_shapes([shape, axes].into(), &mut sym_gen)
+            .unwrap();
         assert_eq!(result[0], SymTensor::unknown("Unknown input shape"));
 
         // Negative axis
         let shape = sym_shape!("foo", 32, 1);
         let axes = sym_vec!(-1);
-        let result = Squeeze.infer_shapes(&[shape, axes], &mut sym_gen).unwrap();
+        let result = Squeeze
+            .infer_shapes([shape, axes].into(), &mut sym_gen)
+            .unwrap();
         assert_eq!(result[0], sym_shape!("foo", 32));
 
         // Fixed shape, no axes
         let shape = sym_shape!(32, 1, 12);
-        let result = Squeeze.infer_shapes(&[shape], &mut sym_gen).unwrap();
+        let result = Squeeze.infer_shapes([shape].into(), &mut sym_gen).unwrap();
         assert_eq!(result[0], sym_shape!(32, 12));
     }
 
@@ -874,13 +884,13 @@ mod tests {
         let op = Transpose {
             perm: Some(&[0, 2, 1]),
         };
-        let result = op.infer_shapes(&[data], &mut sym_gen).unwrap();
+        let result = op.infer_shapes([data].into(), &mut sym_gen).unwrap();
         assert_eq!(result[0], sym_shape!("batch", "cols", "rows"));
 
         // Transpose with implicit permutation.
         let data = sym_shape!("rows", "cols");
         let op = Transpose { perm: None };
-        let result = op.infer_shapes(&[data], &mut sym_gen).unwrap();
+        let result = op.infer_shapes([data].into(), &mut sym_gen).unwrap();
         assert_eq!(result[0], sym_shape!("cols", "rows"));
 
         // Transpose with explicit permutation but unknown input shape.
@@ -888,13 +898,13 @@ mod tests {
         let op = Transpose {
             perm: Some(&[0, 2, 1]),
         };
-        let result = op.infer_shapes(&[data], &mut sym_gen).unwrap();
+        let result = op.infer_shapes([data].into(), &mut sym_gen).unwrap();
         assert_eq!(result[0], sym_shape!("unknown_1", "unknown_2", "unknown_3"));
 
         // Transpose with implicit permutation and unknown input shape.
         let data = SymTensor::unknown("unknown input shape");
         let op = Transpose { perm: None };
-        let result = op.infer_shapes(&[data], &mut sym_gen).unwrap();
+        let result = op.infer_shapes([data].into(), &mut sym_gen).unwrap();
         assert_eq!(result[0], SymTensor::unknown("unknown input shape"));
     }
 
@@ -908,7 +918,7 @@ mod tests {
         let expected = sym_shape!("batch", 1, 16, 64);
 
         let result = Unsqueeze
-            .infer_shapes(&[shape, axes], &mut sym_gen)
+            .infer_shapes([shape, axes].into(), &mut sym_gen)
             .unwrap();
         assert_eq!(result[0], expected);
 
@@ -917,7 +927,7 @@ mod tests {
         let axes = sym_vec!(0);
         let expected = sym_vec!(1);
         let result = Unsqueeze
-            .infer_shapes(&[scalar, axes], &mut sym_gen)
+            .infer_shapes([scalar, axes].into(), &mut sym_gen)
             .unwrap();
         assert_eq!(result[0], expected);
     }

--- a/rten-shape-inference/src/ops/matmul.rs
+++ b/rten-shape-inference/src/ops/matmul.rs
@@ -1,6 +1,6 @@
 use smallvec::SmallVec;
 
-use crate::infer_shapes::{BinaryOp, InferShapes, InferShapesError};
+use crate::infer_shapes::{BinaryOp, InferShapes, InferShapesContext, InferShapesError};
 use crate::sym_gen::SymbolGen;
 use crate::sym_tensor::SymTensor;
 
@@ -15,12 +15,11 @@ pub struct Gemm {
 impl InferShapes for Gemm {
     fn infer_shapes(
         &self,
-        inputs: &[SymTensor],
+        inputs: InferShapesContext,
         sym_gen: &mut SymbolGen,
     ) -> Result<Vec<SymTensor>, InferShapesError> {
-        let [a, b, ..] = inputs else {
-            return Err(InferShapesError::IncorrectInputCount);
-        };
+        let a = inputs.require(0)?;
+        let b = inputs.require(1)?;
 
         let (Some(a_shape), Some(b_shape)) = (a.shape(), b.shape()) else {
             let out_shape = vec![sym_gen.gen_positive(), sym_gen.gen_positive()];
@@ -56,12 +55,11 @@ pub struct MatMul;
 impl InferShapes for MatMul {
     fn infer_shapes(
         &self,
-        inputs: &[SymTensor],
+        inputs: InferShapesContext,
         sym_gen: &mut SymbolGen,
     ) -> Result<Vec<SymTensor>, InferShapesError> {
-        let [lhs, rhs, ..] = inputs else {
-            return Err(InferShapesError::IncorrectInputCount);
-        };
+        let lhs = inputs.require(0)?;
+        let rhs = inputs.require(1)?;
         let Some(mut lhs_dims) = lhs.shape() else {
             return Ok([SymTensor::unknown("unknown lhs shape")].into());
         };
@@ -82,7 +80,7 @@ impl InferShapes for MatMul {
         let rhs_batch_dims = SymTensor::from_shape(rhs_dims.by_ref().take(rhs_ndim - 2).collect());
 
         let [batch_dims] = BinaryOp
-            .infer_shapes(&[lhs_batch_dims, rhs_batch_dims], sym_gen)?
+            .infer_shapes([lhs_batch_dims, rhs_batch_dims].into(), sym_gen)?
             .try_into()
             .expect("should have one output");
 
@@ -108,12 +106,11 @@ pub struct MatMulNBits;
 impl InferShapes for MatMulNBits {
     fn infer_shapes(
         &self,
-        inputs: &[SymTensor],
+        inputs: InferShapesContext,
         _sym_gen: &mut SymbolGen,
     ) -> Result<Vec<SymTensor>, InferShapesError> {
-        let [lhs, rhs, ..] = inputs else {
-            return Err(InferShapesError::IncorrectInputCount);
-        };
+        let lhs = inputs.require(0)?;
+        let rhs = inputs.require(1)?;
         let Some(lhs_dims) = lhs.shape() else {
             return Ok([SymTensor::unknown("unknown lhs shape")].into());
         };
@@ -157,7 +154,7 @@ mod tests {
             transpose_a: false,
             transpose_b: false,
         }
-        .infer_shapes(&[lhs, rhs], &mut sym_gen)
+        .infer_shapes([lhs, rhs].into(), &mut sym_gen)
         .unwrap();
         assert_eq!(result[0], sym_shape!("m", "n"));
 
@@ -168,7 +165,7 @@ mod tests {
             transpose_a: true,
             transpose_b: false,
         }
-        .infer_shapes(&[lhs, rhs], &mut sym_gen)
+        .infer_shapes([lhs, rhs].into(), &mut sym_gen)
         .unwrap();
         assert_eq!(result[0], sym_shape!("m", "n"));
 
@@ -179,7 +176,7 @@ mod tests {
             transpose_a: false,
             transpose_b: true,
         }
-        .infer_shapes(&[lhs, rhs], &mut sym_gen)
+        .infer_shapes([lhs, rhs].into(), &mut sym_gen)
         .unwrap();
         assert_eq!(result[0], sym_shape!("m", "n"));
 
@@ -190,7 +187,7 @@ mod tests {
             transpose_a: false,
             transpose_b: false,
         }
-        .infer_shapes(&[lhs, rhs], &mut sym_gen)
+        .infer_shapes([lhs, rhs].into(), &mut sym_gen)
         .unwrap();
         assert_eq!(result[0], sym_shape!("unknown_1", "unknown_2"));
     }
@@ -202,25 +199,33 @@ mod tests {
         // MatMul with no batch dims
         let lhs = sym_shape!("m", "k");
         let rhs = sym_shape!("k", "n");
-        let result = MatMul.infer_shapes(&[lhs, rhs], &mut sym_gen).unwrap();
+        let result = MatMul
+            .infer_shapes([lhs, rhs].into(), &mut sym_gen)
+            .unwrap();
         assert_eq!(result[0], sym_shape!("m", "n"));
 
         // MatMul with batch dim
         let lhs = sym_shape!("batch", "m", "k");
         let rhs = sym_shape!("batch", "k", "n");
-        let result = MatMul.infer_shapes(&[lhs, rhs], &mut sym_gen).unwrap();
+        let result = MatMul
+            .infer_shapes([lhs, rhs].into(), &mut sym_gen)
+            .unwrap();
         assert_eq!(result[0], sym_shape!("batch", "m", "n"));
 
         // MatMul with batch dims that are broadcast
         let lhs = sym_shape!(1, "batch_b", "m", "k");
         let rhs = sym_shape!("batch_a", 1, "k", "n");
-        let result = MatMul.infer_shapes(&[lhs, rhs], &mut sym_gen).unwrap();
+        let result = MatMul
+            .infer_shapes([lhs, rhs].into(), &mut sym_gen)
+            .unwrap();
         assert_eq!(result[0], sym_shape!("batch_a", "batch_b", "m", "n"));
 
         // Case where LHS is a vector.
         let lhs = sym_shape!("k");
         let rhs = sym_shape!("k", "n");
-        let result = MatMul.infer_shapes(&[lhs, rhs], &mut sym_gen).unwrap();
+        let result = MatMul
+            .infer_shapes([lhs, rhs].into(), &mut sym_gen)
+            .unwrap();
         assert_eq!(result[0], SymTensor::unknown("rank < 2"));
     }
 
@@ -229,7 +234,9 @@ mod tests {
         let mut sym_gen = SymbolGen::new();
         let lhs = sym_shape!("batch", "m", "k");
         let rhs = sym_shape!("n", "k_blocks", "block");
-        let result = MatMulNBits.infer_shapes(&[lhs, rhs], &mut sym_gen).unwrap();
+        let result = MatMulNBits
+            .infer_shapes([lhs, rhs].into(), &mut sym_gen)
+            .unwrap();
         assert_eq!(result[0], sym_shape!("batch", "m", "n"));
     }
 }

--- a/rten-shape-inference/src/ops/pad.rs
+++ b/rten-shape-inference/src/ops/pad.rs
@@ -1,4 +1,4 @@
-use crate::infer_shapes::{InferShapes, InferShapesError, resolve_axis};
+use crate::infer_shapes::{InferShapes, InferShapesContext, InferShapesError, resolve_axis};
 use crate::sym_expr::SymExpr;
 use crate::sym_gen::SymbolGen;
 use crate::sym_tensor::{Constant, SymTensor};
@@ -16,15 +16,11 @@ const AXES: usize = 3;
 impl InferShapes for Pad {
     fn infer_shapes(
         &self,
-        inputs: &[SymTensor],
+        inputs: InferShapesContext,
         sym_gen: &mut SymbolGen,
     ) -> Result<Vec<SymTensor>, InferShapesError> {
-        let data = inputs
-            .get(DATA)
-            .ok_or(InferShapesError::IncorrectInputCount)?;
-        let pads = inputs
-            .get(PADS)
-            .ok_or(InferShapesError::IncorrectInputCount)?;
+        let data = inputs.require(DATA)?;
+        let pads = inputs.require(PADS)?;
         let axes = inputs.get(AXES);
 
         let Some(data_dims) = data.shape() else {
@@ -79,7 +75,7 @@ impl InferShapes for Pad {
 
 #[cfg(test)]
 mod tests {
-    use crate::infer_shapes::{InferShapes, InferShapesError};
+    use crate::infer_shapes::{InferShapes, InferShapesContext, InferShapesError};
     use crate::sym_expr::SymExpr;
     use crate::sym_gen::SymbolGen;
     use crate::sym_tensor::{SymTensor, sym_shape, sym_vec};
@@ -93,13 +89,13 @@ mod tests {
         // Pad a fully-fixed shape with fixed pads.
         let data = sym_shape!(2, 3);
         let pads = sym_vec!(1, 2, 3, 4);
-        let result = Pad.infer_shapes(&[data, pads], &mut sym_gen).unwrap();
+        let result = Pad.infer_shapes([data, pads].into(), &mut sym_gen).unwrap();
         assert_eq!(result[0].clone().simplify(), sym_shape!(6, 9));
 
         // Zero pads (no-op).
         let data = sym_shape!(2, 3);
         let pads = sym_vec!(0, 0, 0, 0);
-        let result = Pad.infer_shapes(&[data, pads], &mut sym_gen).unwrap();
+        let result = Pad.infer_shapes([data, pads].into(), &mut sym_gen).unwrap();
         assert_eq!(result[0].clone().simplify(), sym_shape!(2, 3));
     }
 
@@ -110,7 +106,7 @@ mod tests {
         // Pad symbolic dims with fixed pads.
         let data = sym_shape!("batch", "seq", 64);
         let pads = sym_vec!(0, 1, 2, 0, 3, 4);
-        let result = Pad.infer_shapes(&[data, pads], &mut sym_gen).unwrap();
+        let result = Pad.infer_shapes([data, pads].into(), &mut sym_gen).unwrap();
         assert_eq!(
             result[0].clone().simplify(),
             sym_shape!("batch", SymExpr::from("seq") + SymExpr::from(4), 70)
@@ -127,7 +123,7 @@ mod tests {
         let const_val = SymTensor::unknown("unknown value");
         let axes = sym_vec!(0, 2);
         let result = Pad
-            .infer_shapes(&[data, pads, const_val, axes], &mut sym_gen)
+            .infer_shapes([data, pads, const_val, axes].into(), &mut sym_gen)
             .unwrap();
         assert_eq!(result[0].clone().simplify(), sym_shape!(6, 3, 10));
 
@@ -137,7 +133,7 @@ mod tests {
         let const_val = SymTensor::unknown("unknown value");
         let axes = sym_vec!(-1);
         let result = Pad
-            .infer_shapes(&[data, pads, const_val, axes], &mut sym_gen)
+            .infer_shapes([data, pads, const_val, axes].into(), &mut sym_gen)
             .unwrap();
         assert_eq!(result[0].clone().simplify(), sym_shape!(2, 3, 7));
     }
@@ -147,7 +143,7 @@ mod tests {
         let mut sym_gen = SymbolGen::new();
         let data = SymTensor::unknown("unknown");
         let pads = sym_vec!(1, 1, 1, 1);
-        let result = Pad.infer_shapes(&[data, pads], &mut sym_gen).unwrap();
+        let result = Pad.infer_shapes([data, pads].into(), &mut sym_gen).unwrap();
         assert_eq!(result[0].ndim(), None);
     }
 
@@ -156,7 +152,7 @@ mod tests {
         let mut sym_gen = SymbolGen::new();
         let data = sym_shape!("batch", 16, 32);
         let pads = SymTensor::unknown("unknown");
-        let result = Pad.infer_shapes(&[data, pads], &mut sym_gen).unwrap();
+        let result = Pad.infer_shapes([data, pads].into(), &mut sym_gen).unwrap();
 
         let shape: Vec<_> = result[0].shape().unwrap().collect();
         assert_eq!(shape.len(), 3);
@@ -173,7 +169,7 @@ mod tests {
         let const_val = SymTensor::from_scalar(0.into());
         let axes = SymTensor::unknown("unknown");
         let result = Pad
-            .infer_shapes(&[data, pads, const_val, axes], &mut sym_gen)
+            .infer_shapes([data, pads, const_val, axes].into(), &mut sym_gen)
             .unwrap();
 
         let shape: Vec<_> = result[0].shape().unwrap().collect();
@@ -188,7 +184,9 @@ mod tests {
         let mut sym_gen = SymbolGen::new();
         let data = sym_shape!(2, 3);
         let pads = sym_vec!(1, 1, 1);
-        let err = Pad.infer_shapes(&[data, pads], &mut sym_gen).unwrap_err();
+        let err = Pad
+            .infer_shapes([data, pads].into(), &mut sym_gen)
+            .unwrap_err();
         assert_eq!(err, InferShapesError::InvalidValue);
     }
 
@@ -196,10 +194,12 @@ mod tests {
     fn test_pad_missing_inputs() {
         let mut sym_gen = SymbolGen::new();
         let data = sym_shape!(2, 3);
-        let err = Pad.infer_shapes(&[data], &mut sym_gen).unwrap_err();
+        let err = Pad.infer_shapes([data].into(), &mut sym_gen).unwrap_err();
         assert_eq!(err, InferShapesError::IncorrectInputCount);
 
-        let err = Pad.infer_shapes(&[], &mut sym_gen).unwrap_err();
+        let err = Pad
+            .infer_shapes(InferShapesContext::new(&[]), &mut sym_gen)
+            .unwrap_err();
         assert_eq!(err, InferShapesError::IncorrectInputCount);
     }
 }

--- a/rten-shape-inference/src/ops/resize.rs
+++ b/rten-shape-inference/src/ops/resize.rs
@@ -1,4 +1,4 @@
-use crate::infer_shapes::{InferShapes, InferShapesError};
+use crate::infer_shapes::{InferShapes, InferShapesContext, InferShapesError};
 use crate::sym_expr::SymExpr;
 use crate::sym_gen::SymbolGen;
 use crate::sym_tensor::SymTensor;
@@ -16,20 +16,18 @@ const SIZES: usize = 3;
 impl InferShapes for Resize {
     fn infer_shapes(
         &self,
-        inputs: &[SymTensor],
+        inputs: InferShapesContext,
         sym_gen: &mut SymbolGen,
     ) -> Result<Vec<SymTensor>, InferShapesError> {
-        let data = inputs
-            .get(DATA)
-            .ok_or(InferShapesError::IncorrectInputCount)?;
+        let data = inputs.require(DATA)?;
 
         let Some(data_dims) = data.shape() else {
             return Ok([SymTensor::unknown("unknown input shape")].into());
         };
 
         // `sizes` takes precedence if both are provided.
-        let sizes = optional_input(inputs, SIZES);
-        let scales = optional_input(inputs, SCALES);
+        let sizes = optional_input(&inputs, SIZES);
+        let scales = optional_input(&inputs, SCALES);
 
         let out_shape: Vec<SymExpr> = if let Some(sizes) = sizes {
             if let Some(values) = sizes.as_vector() {
@@ -67,18 +65,16 @@ const UPSAMPLE_SCALES: usize = 1;
 impl InferShapes for Upsample {
     fn infer_shapes(
         &self,
-        inputs: &[SymTensor],
+        inputs: InferShapesContext,
         sym_gen: &mut SymbolGen,
     ) -> Result<Vec<SymTensor>, InferShapesError> {
-        let data = inputs
-            .get(DATA)
-            .ok_or(InferShapesError::IncorrectInputCount)?;
+        let data = inputs.require(DATA)?;
 
         let Some(data_dims) = data.shape() else {
             return Ok([SymTensor::unknown("unknown input shape")].into());
         };
 
-        let input_scales = optional_input(inputs, UPSAMPLE_SCALES).and_then(|s| s.as_vector());
+        let input_scales = optional_input(&inputs, UPSAMPLE_SCALES).and_then(|s| s.as_vector());
 
         let out_shape: Vec<SymExpr> = if let Some(scales) = input_scales {
             data_dims
@@ -98,7 +94,7 @@ impl InferShapes for Upsample {
 /// As a special case this treats an empty vector as missing. In opset < 13, the
 /// ONNX Resize op uses an empty vector to represent missing `sizes`/`scales`
 /// inputs.
-fn optional_input(inputs: &[SymTensor], idx: usize) -> Option<&SymTensor> {
+fn optional_input<'a>(inputs: &'a InferShapesContext, idx: usize) -> Option<&'a SymTensor> {
     let input = inputs.get(idx)?;
     let is_empty_vec = input.as_vector().is_some_and(|v| v.is_empty());
     if is_empty_vec {
@@ -123,7 +119,7 @@ mod tests {
 
         let mut sym_gen = SymbolGen::new();
         let result = Resize
-            .infer_shapes(&[data, sym_vec!(), sym_vec!(), sizes], &mut sym_gen)
+            .infer_shapes([data, sym_vec!(), sym_vec!(), sizes].into(), &mut sym_gen)
             .unwrap();
         assert_eq!(result[0], sym_shape!(1, 3, 448, 448));
     }
@@ -135,7 +131,7 @@ mod tests {
 
         let mut sym_gen = SymbolGen::new();
         let result = Resize
-            .infer_shapes(&[data, sym_vec!(), scales, sym_vec!()], &mut sym_gen)
+            .infer_shapes([data, sym_vec!(), scales, sym_vec!()].into(), &mut sym_gen)
             .unwrap();
         assert_eq!(
             result[0].clone().simplify(),
@@ -150,7 +146,7 @@ mod tests {
 
         let mut sym_gen = SymbolGen::new();
         let result = Resize
-            .infer_shapes(&[data, sym_vec!(), scales, sym_vec!()], &mut sym_gen)
+            .infer_shapes([data, sym_vec!(), scales, sym_vec!()].into(), &mut sym_gen)
             .unwrap();
         assert_eq!(result[0].ndim(), None);
     }
@@ -162,7 +158,7 @@ mod tests {
 
         let mut sym_gen = SymbolGen::new();
         let result = Resize
-            .infer_shapes(&[data, sym_vec!(), scales, sym_vec!()], &mut sym_gen)
+            .infer_shapes([data, sym_vec!(), scales, sym_vec!()].into(), &mut sym_gen)
             .unwrap();
 
         let shape: Vec<_> = result[0].shape().unwrap().collect();
@@ -179,7 +175,7 @@ mod tests {
 
         let mut sym_gen = SymbolGen::new();
         let result = Resize
-            .infer_shapes(&[data, sym_vec!(), sym_vec!(), sizes], &mut sym_gen)
+            .infer_shapes([data, sym_vec!(), sym_vec!(), sizes].into(), &mut sym_gen)
             .unwrap();
         let shape: Vec<_> = result[0].shape().unwrap().collect();
         assert_eq!(shape.len(), 4);
@@ -194,7 +190,10 @@ mod tests {
 
         let mut sym_gen = SymbolGen::new();
         let err = Resize
-            .infer_shapes(&[data, sym_vec!(), sym_vec!(), sym_vec!()], &mut sym_gen)
+            .infer_shapes(
+                [data, sym_vec!(), sym_vec!(), sym_vec!()].into(),
+                &mut sym_gen,
+            )
             .err()
             .unwrap();
         assert_eq!(err, InferShapesError::IncorrectInputCount);
@@ -207,7 +206,7 @@ mod tests {
 
         let mut sym_gen = SymbolGen::new();
         let result = Upsample
-            .infer_shapes(&[data, scales], &mut sym_gen)
+            .infer_shapes([data, scales].into(), &mut sym_gen)
             .unwrap();
         assert_eq!(
             result[0].clone().simplify(),
@@ -222,7 +221,7 @@ mod tests {
 
         let mut sym_gen = SymbolGen::new();
         let result = Upsample
-            .infer_shapes(&[data, scales], &mut sym_gen)
+            .infer_shapes([data, scales].into(), &mut sym_gen)
             .unwrap();
         let shape: Vec<_> = result[0].shape().unwrap().collect();
         assert_eq!(shape.len(), 4);

--- a/rten-shape-inference/src/ops/rnn.rs
+++ b/rten-shape-inference/src/ops/rnn.rs
@@ -1,4 +1,4 @@
-use crate::infer_shapes::{InferShapes, InferShapesError};
+use crate::infer_shapes::{InferShapes, InferShapesContext, InferShapesError};
 use crate::sym_expr::SymExpr;
 use crate::sym_gen::SymbolGen;
 use crate::sym_tensor::SymTensor;
@@ -78,12 +78,13 @@ pub struct GRU {
 impl InferShapes for GRU {
     fn infer_shapes(
         &self,
-        inputs: &[SymTensor],
+        inputs: InferShapesContext,
         _sym_gen: &mut SymbolGen,
     ) -> Result<Vec<SymTensor>, InferShapesError> {
-        let [input, weights, _recurrent, ..] = inputs else {
-            return Err(InferShapesError::IncorrectInputCount);
-        };
+        let input = inputs.require(0)?;
+        let weights = inputs.require(1)?;
+        // Recurrent weights (input 2) are required, though not used here.
+        inputs.require(2)?;
 
         match rnn_output_shapes(input, weights, self.direction, 3)? {
             Some((y, y_h)) => Ok([y, y_h].into()),
@@ -106,12 +107,13 @@ pub struct LSTM {
 impl InferShapes for LSTM {
     fn infer_shapes(
         &self,
-        inputs: &[SymTensor],
+        inputs: InferShapesContext,
         _sym_gen: &mut SymbolGen,
     ) -> Result<Vec<SymTensor>, InferShapesError> {
-        let [input, weights, _recurrent, ..] = inputs else {
-            return Err(InferShapesError::IncorrectInputCount);
-        };
+        let input = inputs.require(0)?;
+        let weights = inputs.require(1)?;
+        // Recurrent weights (input 2) are required, though not used here.
+        inputs.require(2)?;
 
         match rnn_output_shapes(input, weights, self.direction, 4)? {
             Some((y, y_h)) => {
@@ -153,7 +155,7 @@ mod tests {
             direction: Direction::Unidirectional,
         };
         let result = op
-            .infer_shapes(&[input, weights, recurrent], &mut sym_gen)
+            .infer_shapes([input, weights, recurrent].into(), &mut sym_gen)
             .unwrap();
         assert_eq!(result.len(), 2);
         assert_eq!(
@@ -170,7 +172,7 @@ mod tests {
             direction: Direction::Bidirectional,
         };
         let result = op
-            .infer_shapes(&[input, weights, recurrent], &mut sym_gen)
+            .infer_shapes([input, weights, recurrent].into(), &mut sym_gen)
             .unwrap();
         assert_eq!(
             result[0].clone().simplify(),
@@ -186,7 +188,7 @@ mod tests {
             direction: Direction::Unidirectional,
         };
         let result = op
-            .infer_shapes(&[input, weights, recurrent], &mut sym_gen)
+            .infer_shapes([input, weights, recurrent].into(), &mut sym_gen)
             .unwrap();
         assert_eq!(
             result[0].clone().simplify(),
@@ -209,7 +211,7 @@ mod tests {
             direction: Direction::Unidirectional,
         };
         let result = op
-            .infer_shapes(&[input, weights, recurrent], &mut sym_gen)
+            .infer_shapes([input, weights, recurrent].into(), &mut sym_gen)
             .unwrap();
         assert_eq!(result.len(), 3);
         assert_eq!(
@@ -227,7 +229,7 @@ mod tests {
             direction: Direction::Unidirectional,
         };
         let result = op
-            .infer_shapes(&[input, weights, recurrent], &mut sym_gen)
+            .infer_shapes([input, weights, recurrent].into(), &mut sym_gen)
             .unwrap();
         assert_eq!(result[0].ndim(), None);
         assert_eq!(result[1].ndim(), None);
@@ -240,7 +242,7 @@ mod tests {
         let op = LSTM {
             direction: Direction::Unidirectional,
         };
-        let result = op.infer_shapes(&[input, weights, recurrent], &mut sym_gen);
+        let result = op.infer_shapes([input, weights, recurrent].into(), &mut sym_gen);
         assert_eq!(result, Err(InferShapesError::IncorrectRank));
     }
 }

--- a/rten-shape-inference/src/ops/slice.rs
+++ b/rten-shape-inference/src/ops/slice.rs
@@ -1,6 +1,6 @@
 use rten_tensor::SliceRange;
 
-use crate::infer_shapes::{InferShapes, InferShapesError};
+use crate::infer_shapes::{InferShapes, InferShapesContext, InferShapesError};
 use crate::ops::resolve_axis;
 use crate::sym_expr::SymExpr;
 use crate::sym_gen::SymbolGen;
@@ -14,26 +14,26 @@ pub struct Slice;
 impl InferShapes for Slice {
     fn infer_shapes(
         &self,
-        inputs: &[SymTensor],
+        inputs: InferShapesContext,
         sym_gen: &mut SymbolGen,
     ) -> Result<Vec<SymTensor>, InferShapesError> {
-        let [data, starts, ends, rest @ ..] = inputs else {
-            return Err(InferShapesError::IncorrectInputCount);
-        };
+        let data = inputs.require(0)?;
+        let starts = inputs.require(1)?;
+        let ends = inputs.require(2)?;
 
         let Some(data_dims) = data.shape() else {
             return Ok([SymTensor::unknown("unknown input shape")].into());
         };
 
-        let axes = rest
-            .first()
+        let axes = inputs
+            .get(3)
             .map(|axes| axes.to_constant())
             .unwrap_or_else(|| {
                 let axes = (0..data_dims.len()).map(|i| i as i32).collect();
                 Some(Constant::Vector(axes))
             });
 
-        let steps = rest.get(1);
+        let steps = inputs.get(4);
 
         let sliced_shape = if let Some(axes) = axes {
             let mut dims: Vec<_> = data_dims.collect();
@@ -126,7 +126,7 @@ mod tests {
         let ends = sym_vec!(i32::MAX);
         let axes = sym_vec!(1);
         let result = Slice
-            .infer_shapes(&[data, starts, ends, axes], &mut sym_gen)
+            .infer_shapes([data, starts, ends, axes].into(), &mut sym_gen)
             .unwrap();
         assert_eq!(result[0], sym_shape!("batch", 32, 8));
 
@@ -144,7 +144,7 @@ mod tests {
         let ends = sym_vec!(end.clone());
         let axes = sym_vec!(0);
         let result = Slice
-            .infer_shapes(&[data, starts, ends, axes], &mut sym_gen)
+            .infer_shapes([data, starts, ends, axes].into(), &mut sym_gen)
             .unwrap();
         let batch_expr = end.min(&batch) - start.min(&batch);
         assert_eq!(result[0], sym_shape!(batch_expr, 64, 8));
@@ -157,7 +157,7 @@ mod tests {
         let ends = sym_vec!(i32::MAX);
         let axes = sym_vec!(0);
         let result = Slice
-            .infer_shapes(&[data, starts, ends, axes], &mut sym_gen)
+            .infer_shapes([data, starts, ends, axes].into(), &mut sym_gen)
             .unwrap();
         assert_eq!(result[0], sym_shape!("batch", 64, 8));
 
@@ -171,7 +171,7 @@ mod tests {
         let ends = sym_vec!(i32::MAX);
         let axes = sym_vec!("axes");
         let result = Slice
-            .infer_shapes(&[data, starts, ends, axes], &mut sym_gen)
+            .infer_shapes([data, starts, ends, axes].into(), &mut sym_gen)
             .unwrap();
         assert_eq!(result[0], sym_shape!("unknown_1", "unknown_2", "unknown_3"));
 
@@ -181,7 +181,7 @@ mod tests {
         let starts = sym_vec!(0);
         let ends = sym_vec!(0);
         let result = Slice
-            .infer_shapes(&[data, starts, ends], &mut sym_gen)
+            .infer_shapes([data, starts, ends].into(), &mut sym_gen)
             .unwrap();
         assert_eq!(result[0], SymTensor::unknown("unknown input shape"));
 
@@ -191,7 +191,7 @@ mod tests {
         let starts = sym_vec!(1);
         let ends = sym_vec!(i32::MAX);
         let result = Slice
-            .infer_shapes(&[data, starts, ends], &mut sym_gen)
+            .infer_shapes([data, starts, ends].into(), &mut sym_gen)
             .unwrap();
         assert_eq!(result[0], sym_vec!(3, "height", "width"));
 
@@ -200,7 +200,7 @@ mod tests {
         let starts = sym_vec!(i32::MIN);
         let ends = sym_vec!(-2);
         let result = Slice
-            .infer_shapes(&[data, starts, ends], &mut sym_gen)
+            .infer_shapes([data, starts, ends].into(), &mut sym_gen)
             .unwrap();
         assert_eq!(result[0], sym_vec!("s6", 6));
 
@@ -211,7 +211,7 @@ mod tests {
         let axes = sym_vec!(2);
         let steps = sym_vec!(1);
         let result = Slice
-            .infer_shapes(&[data, starts, ends, axes, steps], &mut sym_gen)
+            .infer_shapes([data, starts, ends, axes, steps].into(), &mut sym_gen)
             .unwrap();
         assert_eq!(result[0], sym_shape!("batch", 1, "seq"));
 
@@ -222,7 +222,7 @@ mod tests {
         let axes = sym_vec!(2);
         let steps = sym_vec!(1);
         let result = Slice
-            .infer_shapes(&[data, starts, ends, axes, steps], &mut sym_gen)
+            .infer_shapes([data, starts, ends, axes, steps].into(), &mut sym_gen)
             .unwrap();
         assert_eq!(result[0], sym_shape!("batch", 1, "seq"));
     }

--- a/rten-shape-inference/src/ops/split.rs
+++ b/rten-shape-inference/src/ops/split.rs
@@ -1,4 +1,4 @@
-use crate::infer_shapes::{InferShapes, InferShapesError};
+use crate::infer_shapes::{InferShapes, InferShapesContext, InferShapesError};
 use crate::ops::resolve_axis;
 use crate::sym_gen::SymbolGen;
 use crate::sym_tensor::SymTensor;
@@ -18,14 +18,12 @@ pub struct Split {
 impl InferShapes for Split {
     fn infer_shapes(
         &self,
-        inputs: &[SymTensor],
+        inputs: InferShapesContext,
         _sym_gen: &mut SymbolGen,
     ) -> Result<Vec<SymTensor>, InferShapesError> {
-        let [data, rest @ ..] = inputs else {
-            return Err(InferShapesError::IncorrectInputCount);
-        };
+        let data = inputs.require(0)?;
 
-        let Some(splits) = rest.first() else {
+        let Some(splits) = inputs.get(1) else {
             return Err(InferShapesError::UnknownOutputCount);
         };
 
@@ -75,7 +73,9 @@ mod tests {
             axis: 2,
             num_outputs: None,
         };
-        let result = op.infer_shapes(&[data, splits], &mut sym_gen).unwrap();
+        let result = op
+            .infer_shapes([data, splits].into(), &mut sym_gen)
+            .unwrap();
         assert_eq!(
             result,
             [

--- a/rten-shape-inference/src/ops/unary.rs
+++ b/rten-shape-inference/src/ops/unary.rs
@@ -1,4 +1,4 @@
-use crate::infer_shapes::{InferShapes, InferShapesError, UnaryOp};
+use crate::infer_shapes::{InferShapes, InferShapesContext, InferShapesError, UnaryOp};
 use crate::sym_gen::SymbolGen;
 use crate::sym_tensor::SymTensor;
 
@@ -10,12 +10,10 @@ pub struct Neg;
 impl InferShapes for Neg {
     fn infer_shapes(
         &self,
-        inputs: &[SymTensor],
+        inputs: InferShapesContext,
         sym_gen: &mut SymbolGen,
     ) -> Result<Vec<SymTensor>, InferShapesError> {
-        let [data] = inputs else {
-            return Err(InferShapesError::IncorrectInputCount);
-        };
+        let data = inputs.require(0)?;
         if let Some(item) = data.as_scalar() {
             return Ok([SymTensor::from_scalar(-item.clone())].into());
         } else if let Some(vec) = data.as_vector() {
@@ -39,17 +37,17 @@ mod tests {
     fn test_neg() {
         let mut sym_gen = SymbolGen::new();
         let x = sym_shape!("batch", 4, 4);
-        let result = Neg.infer_shapes(&[x], &mut sym_gen).unwrap();
+        let result = Neg.infer_shapes([x].into(), &mut sym_gen).unwrap();
         assert_eq!(result[0], sym_shape!("batch", 4, 4));
 
         // Symbolic scalar
         let x = SymTensor::from_scalar("batch".into());
-        let result = Neg.infer_shapes(&[x], &mut sym_gen).unwrap();
+        let result = Neg.infer_shapes([x].into(), &mut sym_gen).unwrap();
         assert_eq!(result[0], SymTensor::from_scalar(-SymExpr::from("batch")));
 
         // Symbolic vec
         let x = sym_vec!("batch", 64);
-        let result = Neg.infer_shapes(&[x], &mut sym_gen).unwrap();
+        let result = Neg.infer_shapes([x].into(), &mut sym_gen).unwrap();
         assert_eq!(
             result[0],
             SymTensor::from_vec(vec![-SymExpr::from("batch"), -SymExpr::from(64),])

--- a/src/infer_shapes.rs
+++ b/src/infer_shapes.rs
@@ -13,8 +13,8 @@ use crate::operator::{OutputType, OutputTypesContext};
 use crate::value::ValueType;
 
 pub use rten_shape_inference::{
-    BinaryOp, Constant, InferShapes, InferShapesError, ReductionOp, SymExpr, SymTensor, Symbol,
-    SymbolGen, UnaryOp,
+    BinaryOp, Constant, InferShapes, InferShapesContext, InferShapesError, ReductionOp, SymExpr,
+    SymTensor, Symbol, SymbolGen, UnaryOp,
 };
 
 /// Impl [`InferShapes`] for a type by delegating to another type which
@@ -27,7 +27,7 @@ macro_rules! impl_infer_shapes {
         impl rten_shape_inference::InferShapes for $op {
             fn infer_shapes(
                 &self,
-                inputs: &[rten_shape_inference::SymTensor],
+                inputs: rten_shape_inference::InferShapesContext,
                 sym_gen: &mut rten_shape_inference::SymbolGen,
             ) -> Result<
                 Vec<rten_shape_inference::SymTensor>,
@@ -193,7 +193,7 @@ pub fn infer_shapes(graph: &Graph, opts: InferShapeOptions) -> Result<InferResul
     let debug = env_flag("RTEN_INFER_SHAPES_DEBUG", false);
 
     // Temp buffer for shape inference operands.
-    let mut input_shapes: Vec<SymTensor> = Vec::new();
+    let mut input_shapes: Vec<Option<SymTensor>> = Vec::new();
 
     for op_id in ops {
         let Some(Node::Operator(op)) = graph.get_node(op_id) else {
@@ -254,15 +254,14 @@ pub fn infer_shapes(graph: &Graph, opts: InferShapeOptions) -> Result<InferResul
         if let Some(infer) = op.operator().as_infer_shapes() {
             input_shapes.clear();
             input_shapes.extend(op.input_ids().iter().map(|input_id| {
-                input_id
-                    .and_then(|id| {
-                        let node = graph.get_node(id)?;
-                        Some(sym_tensor_from_input(id, node, &values))
-                    })
-                    .unwrap_or_else(|| SymTensor::unknown("missing input"))
+                input_id.and_then(|id| {
+                    let node = graph.get_node(id)?;
+                    Some(sym_tensor_from_input(id, node, &values))
+                })
             }));
 
-            let out_shapes = infer.infer_shapes(&input_shapes, &mut symbol_gen);
+            let out_shapes =
+                infer.infer_shapes(InferShapesContext::new(&input_shapes), &mut symbol_gen);
 
             if debug {
                 println!(

--- a/src/ops/convert.rs
+++ b/src/ops/convert.rs
@@ -5,7 +5,9 @@ use rten_tensor::Tensor;
 use rten_tensor::prelude::*;
 
 use crate::buffer_pool::BufferPool;
-use crate::infer_shapes::{InferShapes, InferShapesError, SymTensor, SymbolGen, UnaryOp};
+use crate::infer_shapes::{
+    InferShapes, InferShapesContext, InferShapesError, SymTensor, SymbolGen, UnaryOp,
+};
 use crate::operator::{
     IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType, OutputTypeList,
     OutputTypesContext,
@@ -150,12 +152,10 @@ impl Operator for Cast {
 impl InferShapes for Cast {
     fn infer_shapes(
         &self,
-        inputs: &[SymTensor],
+        inputs: InferShapesContext,
         _sym_gen: &mut SymbolGen,
     ) -> Result<Vec<SymTensor>, InferShapesError> {
-        let Some(data) = inputs.first() else {
-            return Err(InferShapesError::IncorrectInputCount);
-        };
+        let data = inputs.require(0)?;
 
         // If this is a no-op cast from int to int, preserve symbolic values.
         // Otherwise preserve just the shape like a generic unary operator.

--- a/src/ops/reduce.rs
+++ b/src/ops/reduce.rs
@@ -11,7 +11,8 @@ use rten_vecmath as vecmath;
 
 use crate::buffer_pool::BufferPool;
 use crate::infer_shapes::{
-    InferShapes, InferShapesError, ReductionOp, SymTensor, SymbolGen, impl_infer_shapes,
+    InferShapes, InferShapesContext, InferShapesError, ReductionOp, SymTensor, SymbolGen,
+    impl_infer_shapes,
 };
 use crate::operator::{
     InputList, IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType,
@@ -27,7 +28,7 @@ macro_rules! impl_infer_shapes_for_reduce_op {
         impl InferShapes for $op {
             fn infer_shapes(
                 &self,
-                inputs: &[SymTensor],
+                inputs: InferShapesContext,
                 sym_gen: &mut SymbolGen,
             ) -> Result<Vec<SymTensor>, InferShapesError> {
                 ReductionOp {
@@ -45,7 +46,7 @@ macro_rules! impl_infer_shapes_for_arg_op {
         impl InferShapes for $op {
             fn infer_shapes(
                 &self,
-                inputs: &[SymTensor],
+                inputs: InferShapesContext,
                 sym_gen: &mut SymbolGen,
             ) -> Result<Vec<SymTensor>, InferShapesError> {
                 ReductionOp {


### PR DESCRIPTION
Change `InferShapes::infer_shapes` to take an `InferShapesContext` (wrapping `[Option<SymTensor>]`) instead of `&[SymTensor]`, so operators can differentiate between a missing input and one with unknown rank. Previously shape inference could only identify missing inputs in tail position.

This representation is similar to the `OpRunContext`/`InputList` used to pass arguments to operators for inference.

Part of https://github.com/robertknight/rten/issues/1291.