### PR TITLE
Fix shape inference when optional inputs are present but unknown

### DIFF
--- a/rten-shape-inference/src/infer_shapes.rs
+++ b/rten-shape-inference/src/infer_shapes.rs
@@ -286,7 +286,7 @@ impl InferShapes for ReductionOp<'_> {
     fn infer_shapes(
         &self,
         inputs: InferShapesContext,
-        _sym_gen: &mut SymbolGen,
+        sym_gen: &mut SymbolGen,
     ) -> Result<Vec<SymTensor>, InferShapesError> {
         match inputs.len() {
             1 | 2 => {}
@@ -302,14 +302,27 @@ impl InferShapes for ReductionOp<'_> {
         };
 
         let ndim = data_dims.len();
-        let mut axes: SmallVec<[usize; 4]> =
-            if let Some(Constant::Vector(axes)) = inputs.get(1).and_then(|x| x.to_constant()) {
-                resolve_axes(ndim, axes.iter()).map_err(|_| InferShapesError::IncorrectRank)?
-            } else if let Some(axes) = self.axes {
-                resolve_axes(ndim, axes.iter()).map_err(|_| InferShapesError::IncorrectRank)?
-            } else {
-                (0..ndim).collect()
+        let mut axes: SmallVec<[usize; 4]> = if let Some(axes_input) = inputs.get(1) {
+            // The `axes` input is present, so its value must be known to
+            // determine which dims are reduced.
+            let Some(Constant::Vector(axes)) = axes_input.to_constant() else {
+                let out = if self.keep_dims {
+                    // Each dim is either preserved or reduced to size 1, so
+                    // the rank is known but the sizes are not.
+                    let out_shape = (0..ndim).map(|_| sym_gen.gen_positive()).collect();
+                    SymTensor::from_shape(out_shape)
+                } else {
+                    SymTensor::unknown("unknown axes")
+                };
+                return Ok([out].into());
             };
+            resolve_axes(ndim, axes.iter()).map_err(|_| InferShapesError::IncorrectRank)?
+        } else if let Some(axes) = self.axes {
+            resolve_axes(ndim, axes.iter()).map_err(|_| InferShapesError::IncorrectRank)?
+        } else {
+            // Missing `axes` reduces all dims.
+            (0..ndim).collect()
+        };
         axes.sort();
         axes.dedup();
 
@@ -567,5 +580,34 @@ mod tests {
             assert_eq!(shapes.len(), 1);
             assert_eq!(shapes[0], SymTensor::from_shape(case.expected.clone()));
         });
+    }
+
+    #[test]
+    fn test_reduction_op_unknown_axes() {
+        let mut sym_gen = SymbolGen::new();
+        let data = SymTensor::from_shape(sym_elems!(3, 4, 5));
+        let axes = SymTensor::unknown("runtime-computed axes");
+
+        // With `keep_dims=false` the output rank depends on the axes values,
+        // so nothing about the output shape is known.
+        let op = ReductionOp {
+            axes: None,
+            keep_dims: false,
+        };
+        let result = op
+            .infer_shapes([data.clone(), axes.clone()].into(), &mut sym_gen)
+            .unwrap();
+        assert_eq!(result[0].ndim(), None);
+
+        // With `keep_dims=true` the rank is preserved but each dim is either
+        // kept or reduced to size 1.
+        let op = ReductionOp {
+            axes: None,
+            keep_dims: true,
+        };
+        let result = op.infer_shapes([data, axes].into(), &mut sym_gen).unwrap();
+        let shape: Vec<_> = result[0].shape().unwrap().collect();
+        assert_eq!(shape.len(), 3);
+        assert!(shape.iter().all(|dim| matches!(dim, SymExpr::Var(_))));
     }
 }

--- a/rten-shape-inference/src/ops/fft.rs
+++ b/rten-shape-inference/src/ops/fft.rs
@@ -82,7 +82,7 @@ impl InferShapes for DFT {
     fn infer_shapes(
         &self,
         inputs: InferShapesContext,
-        _sym_gen: &mut SymbolGen,
+        sym_gen: &mut SymbolGen,
     ) -> Result<Vec<SymTensor>, InferShapesError> {
         let input = inputs.require(0)?;
         let dft_length = inputs.get(1);
@@ -118,13 +118,16 @@ impl InferShapes for DFT {
 
         let signal_len = shape[dft_axis].clone();
 
-        // `n_fft` (the real signal length) comes from the `dft_length` input if
-        // it's a known scalar. For IRFFT the input is the half spectrum of
-        // length `floor(n_fft / 2) + 1`, so the default is `2 * (signal_len - 1)`.
-        let n_fft = if let Some(dl) = dft_length
-            && let Some(val) = dl.as_scalar()
-        {
-            val.clone()
+        // `n_fft` (the real signal length) comes from the `dft_length` input
+        // when it is present, so its value must be known. If `dft_length` is
+        // missing, the signal length is used. For IRFFT the input is the half
+        // spectrum of length `floor(n_fft / 2) + 1`, so the default is
+        // `2 * (signal_len - 1)`.
+        let n_fft = if let Some(dl) = dft_length {
+            match dl.as_scalar() {
+                Some(val) => val.clone(),
+                None => sym_gen.gen_positive(),
+            }
         } else if irfft {
             (signal_len - SymExpr::Value(1)) * SymExpr::Value(2)
         } else {
@@ -308,12 +311,10 @@ mod tests {
         input: SymTensor,
         dft_length: Option<SymTensor>,
     ) -> SymTensor {
-        // `axis` is input 2. `dft_length` (input 1) is optional, so a
-        // placeholder is needed when it is absent.
         let inputs = vec![
-            input,
-            dft_length.unwrap_or_else(|| SymTensor::unknown("no dft_length")),
-            SymTensor::from_scalar(SymExpr::Value(axis)),
+            Some(input),
+            dft_length,
+            Some(SymTensor::from_scalar(SymExpr::Value(axis))),
         ];
         let mut sym_gen = SymbolGen::new();
         let mut result = DFT { inverse, onesided }
@@ -402,5 +403,23 @@ mod tests {
             );
             assert_eq!(out, case.expected);
         });
+    }
+
+    #[test]
+    fn test_dft_unknown_dft_length() {
+        // If `dft_length` is present but its value is unknown, the size of
+        // the transformed axis is unknown.
+        let out = infer_dft(
+            -2,
+            false,
+            false,
+            sym_shape!("batch", 8, 1),
+            Some(SymTensor::unknown("runtime-computed dft_length")),
+        );
+        let shape: Vec<_> = out.shape().unwrap().collect();
+        assert_eq!(shape.len(), 3);
+        assert_eq!(shape[0], SymExpr::from("batch"));
+        assert!(matches!(shape[1], SymExpr::Var(_)));
+        assert_eq!(shape[2], SymExpr::Value(2));
     }
 }

--- a/rten-shape-inference/src/ops/slice.rs
+++ b/rten-shape-inference/src/ops/slice.rs
@@ -40,7 +40,8 @@ impl InferShapes for Slice {
 
             let starts = starts.as_vector();
             let ends = ends.as_vector();
-            let steps = steps.and_then(|s| s.as_vector());
+            let step_values = steps.map(|s| s.as_vector());
+            let default_step = SymExpr::Value(1);
 
             for (i, axis) in axes.values().iter().copied().enumerate() {
                 let axis =
@@ -48,11 +49,18 @@ impl InferShapes for Slice {
 
                 let start = starts.and_then(|s| s.get(i));
                 let end = ends.and_then(|e| e.get(i));
-                let step = steps.and_then(|s| s.get(i)).unwrap_or(&SymExpr::Value(1));
+
+                // The step is 1 if the `steps` input is missing. If it is
+                // present, its value for this axis must be known, otherwise
+                // the size of the sliced dimension is unknown.
+                let step = match step_values {
+                    None => Some(&default_step),
+                    Some(values) => values.and_then(|s| s.get(i)),
+                };
 
                 if let Some(SymExpr::Value(start)) = start
                     && let Some(SymExpr::Value(end)) = end
-                    && let SymExpr::Value(step) = step
+                    && let Some(SymExpr::Value(step)) = step
                     && let SymExpr::Value(size) = dims[axis]
                 {
                     let end = match *end {
@@ -77,7 +85,7 @@ impl InferShapes for Slice {
                     && (start == &SymExpr::Value(0) || *start == -dims[axis].clone())
                     && let Some(end) = end
                     && (end == &SymExpr::Value(i32::MAX) || *end == dims[axis])
-                    && step == &SymExpr::Value(1)
+                    && step == Some(&SymExpr::Value(1))
                 {
                     // This is a no-op slice that doesn't alter the dimension
                     // size.
@@ -85,7 +93,7 @@ impl InferShapes for Slice {
                     && start.is_positive()
                     && let Some(end) = end
                     && end.is_positive()
-                    && step == &SymExpr::Value(1)
+                    && step == Some(&SymExpr::Value(1))
                 {
                     // nb. This assumes start <= end.
                     let size = dims[axis].clone();
@@ -225,5 +233,20 @@ mod tests {
             .infer_shapes([data, starts, ends, axes, steps].into(), &mut sym_gen)
             .unwrap();
         assert_eq!(result[0], sym_shape!("batch", 1, "seq"));
+
+        // Slice where the `steps` input is present but its value is unknown.
+        //
+        // The step may not be 1, so the size of the sliced dimension is
+        // unknown even for an otherwise no-op 0..i32::MAX range.
+        let mut sym_gen = SymbolGen::new();
+        let data = sym_shape!("batch", 64, 8);
+        let starts = sym_vec!(0);
+        let ends = sym_vec!(i32::MAX);
+        let axes = sym_vec!(1);
+        let steps = SymTensor::unknown("runtime-computed steps");
+        let result = Slice
+            .infer_shapes([data, starts, ends, axes, steps].into(), &mut sym_gen)
+            .unwrap();
+        assert_eq!(result[0], sym_shape!("batch", "unknown_1", 8));
     }
 }


### PR DESCRIPTION
Following https://github.com/robertknight/rten/pull/1329 this PR fixes several issues where shape inference would conflate missing optional inputs with ones that were present with an unknown value:

- Slice assumed a step of 1 when the `steps` input was present with an unknown value. With e.g. an actual step of 2, the inferred dimension size would be twice the real one.

- Reduce* ops (via `ReductionOp`) reduced over all dimensions when the `axes` input (opset 18+) was present with an unknown value. Now the output is rank-preserving with unknown sizes if `keep_dims` is set, or fully unknown otherwise.

- DFT used the signal length (or the IRFFT default) as `n_fft` when the `dft_length` input was present with an unknown value, inferring the wrong size for the transformed axis.

In each case a present-but-unknown input now produces unknown output dimensions instead. This is a follow-up to
https://github.com/robertknight/rten/pull/1330, which fixed the same issue for attention operators.

Part of https://github.com/robertknight/rten/issues/1291.