### PR TITLE
Make CI fail if clippy produces warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,10 @@ docs:
 
 .PHONY: lint
 lint:
-	cargo clippy --workspace
+	# `-D warnings` triggers non-zero exit on warnings. `-A unknown_lints` allows
+	# for compiling with an older Rust version (eg. MSRV) that doesn't know about
+	# some lints referenced in config/attributes.
+	cargo clippy --workspace -- -D warnings -A unknown_lints
 
 .PHONY: miri
 miri:

--- a/rten-simd/src/isa_detection.rs
+++ b/rten-simd/src/isa_detection.rs
@@ -89,6 +89,7 @@ pub mod macos {
 /// because that can return incorrect results on macOS.
 #[cfg(target_arch = "x86_64")]
 pub fn is_avx512_supported() -> bool {
+    #[allow(clippy::needless_bool)]
     if is_x86_feature_detected!("avx512f")
         && is_x86_feature_detected!("avx512vl")
         && is_x86_feature_detected!("avx512bw")

--- a/src/graph/value_map.rs
+++ b/src/graph/value_map.rs
@@ -74,3 +74,9 @@ impl ValueMap {
         self.max_bytes
     }
 }
+
+impl Default for ValueMap {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/model/external_data.rs
+++ b/src/model/external_data.rs
@@ -223,8 +223,8 @@ impl FileLoader {
             get_or_open_file(&mut files, &self.dir_path, Path::new(&location.path))?;
 
         // Subsequent errors refer to the resolved data file path.
-        let make_err = |kind| ExternalDataError::new(&file_path, kind);
-        let make_io_err = |err| ExternalDataError::from_io_error(&file_path, err);
+        let make_err = |kind| ExternalDataError::new(file_path, kind);
+        let make_io_err = |err| ExternalDataError::from_io_error(file_path, err);
 
         file.seek(SeekFrom::Start(location.offset))
             .map_err(make_io_err)?;
@@ -390,7 +390,7 @@ impl MmapLoader {
         let data_path = Path::new(data_path);
         if !is_allowed_external_data_path(data_path) {
             return Err(ExternalDataError::new(
-                &data_path,
+                data_path,
                 ExternalDataErrorKind::DisallowedPath,
             ));
         }
@@ -424,7 +424,7 @@ impl DataLoader for MmapLoader {
         let end_offset = location.offset.saturating_add(location.length);
         if end_offset > storage.data().len() as u64 {
             return Err(ExternalDataError::new(
-                &file_path,
+                file_path,
                 ExternalDataErrorKind::TooShort {
                     required_len: end_offset as usize,
                     actual_len: storage.data().len(),


### PR DESCRIPTION
Change `make lint` to fail with a non-zero status if there are warnings. This will prevent future changes from introducing new warnings that go unnoticed in CI. Also fix existing warnings.