### PR TITLE
Support zero_points input in MatMulNBits operator

### DIFF
--- a/rten-gemm/src/block_quant.rs
+++ b/rten-gemm/src/block_quant.rs
@@ -101,6 +101,11 @@ impl BlockQuantizedGemm {
             };
 
         let col_block = 16;
+
+        // Per-block sums of the current LHS row, needed to correct the output
+        // if the RHS has non-default zero points. See `zero_point_correction`.
+        let mut lhs_block_sums: Vec<f32> = Vec::new();
+
         for (b, out_mat) in out.chunks_mut(n * m).enumerate() {
             // The handling of multiple rows here is inefficient. This is
             // because the initial focus is on efficient vector-matrix products.
@@ -114,6 +119,24 @@ impl BlockQuantizedGemm {
                     LhsRow::Float(lhs.slice((b, row)).data().unwrap())
                 };
 
+                lhs_block_sums.clear();
+                if rhs.has_zero_points() {
+                    let block_size = rhs.elements_per_block();
+                    match &lhs_row {
+                        LhsRow::Float(row) => lhs_block_sums.extend(
+                            row.chunks_exact(block_size)
+                                .map(|block| block.iter().sum::<f32>()),
+                        ),
+                        LhsRow::Quant { data, scales } => lhs_block_sums.extend(
+                            data.data().chunks_exact(block_size).zip(scales.iter()).map(
+                                |(block, &scale)| {
+                                    block.iter().map(|&x| x as i32).sum::<i32>() as f32 * scale
+                                },
+                            ),
+                        ),
+                    }
+                }
+
                 ParIter::from(range_chunks(0..n, col_block))
                     .zip(out_row.par_chunks_mut(col_block))
                     .for_each(|(col_range, out_row_chunk)| match lhs_row {
@@ -123,6 +146,7 @@ impl BlockQuantizedGemm {
                                 lhs_scales: scales,
                                 rhs: rhs.slice(col_range),
                                 out: out_row_chunk,
+                                lhs_block_sums: &lhs_block_sums,
                             };
                             op.dispatch();
                         }
@@ -131,6 +155,7 @@ impl BlockQuantizedGemm {
                                 lhs,
                                 rhs: rhs.slice(col_range),
                                 out: out_row_chunk,
+                                lhs_block_sums: &lhs_block_sums,
                             };
                             op.dispatch();
                         }
@@ -168,6 +193,10 @@ struct VecDotMatrix<'a> {
     lhs: &'a [f32],
     rhs: BlockQuantizedMatrix<'a, f32>,
     out: &'a mut [MaybeUninit<f32>],
+
+    /// Sums of LHS elements in each K block. Only used if `rhs` has
+    /// non-default zero points. See [`zero_point_correction`].
+    lhs_block_sums: &'a [f32],
 }
 
 impl<'a> VecDotMatrix<'a> {
@@ -184,7 +213,12 @@ impl<'a> VecDotMatrix<'a> {
         // larger or smaller than the block size of the RHS.
         let elements_per_vec = u8_ops.len() * 2;
 
-        let VecDotMatrix { lhs, rhs, out } = self;
+        let VecDotMatrix {
+            lhs,
+            rhs,
+            out,
+            lhs_block_sums,
+        } = self;
         let vecs_per_block = rhs.elements_per_block() / elements_per_vec;
 
         // Convert division into shift.
@@ -206,7 +240,9 @@ impl<'a> VecDotMatrix<'a> {
         let rhs_cols = rhs_data.chunks_exact(rhs.blocks_per_column() * rhs.bytes_per_block());
         let scale_blocks = rhs.scales.data().chunks_exact(rhs.blocks_per_column());
 
-        for ((col, col_scales), out) in rhs_cols.zip(scale_blocks).zip(out.iter_mut()) {
+        for (col_idx, ((col, col_scales), out)) in
+            rhs_cols.zip(scale_blocks).zip(out.iter_mut()).enumerate()
+        {
             let mut acc = [ops.zero(); 4];
 
             let mut row_vblocks = lhs.chunks_exact(elements_per_vec);
@@ -335,6 +371,10 @@ impl<'a> VecDotMatrix<'a> {
                 acc += tail_acc;
             }
 
+            if let Some(col_zps) = rhs.column_zero_points(col_idx) {
+                acc += zero_point_correction(isa, col_zps, col_scales, lhs_block_sums);
+            }
+
             out.write(acc);
         }
 
@@ -412,6 +452,11 @@ struct VecDotMatrixQuant<'a> {
     lhs_scales: &'a [f32],
     rhs: BlockQuantizedMatrix<'a, f32>,
     out: &'a mut [MaybeUninit<f32>],
+
+    /// Sums of quantized LHS elements in each K block, multiplied by the
+    /// block's LHS scale. Only used if `rhs` has non-default zero points.
+    /// See [`zero_point_correction`].
+    lhs_block_sums: &'a [f32],
 }
 
 impl<'a> VecDotMatrixQuant<'a> {
@@ -427,6 +472,7 @@ impl<'a> VecDotMatrixQuant<'a> {
             lhs_scales,
             rhs,
             out,
+            lhs_block_sums,
         } = self;
 
         let rhs_data = rhs.quant.data();
@@ -455,7 +501,9 @@ impl<'a> VecDotMatrixQuant<'a> {
         let lo_quad_mask = ops.first_n_mask(ops.len() / 4);
         let lo_three_quads_mask = ops.first_n_mask(3 * ops.len() / 4);
 
-        for ((col, col_scales), out) in rhs_cols.zip(scale_blocks).zip(out.iter_mut()) {
+        for (col_idx, ((col, col_scales), out)) in
+            rhs_cols.zip(scale_blocks).zip(out.iter_mut()).enumerate()
+        {
             let mut acc = [ops.zero(); 2];
 
             let zero_point = i8_ops.splat(8);
@@ -612,6 +660,10 @@ impl<'a> VecDotMatrixQuant<'a> {
                 acc += tail_acc;
             }
 
+            if let Some(col_zps) = rhs.column_zero_points(col_idx) {
+                acc += zero_point_correction(isa.isa(), col_zps, col_scales, lhs_block_sums);
+            }
+
             out.write(acc);
         }
 
@@ -658,6 +710,11 @@ pub struct BlockQuantizedMatrix<'a, T> {
     /// Scales of shape (N, k_blocks)
     scales: Contiguous<NdTensorView<'a, T, 2>>,
 
+    /// Per-block zero points of shape (N, ceil(k_blocks * bits / 8)), using
+    /// the same packed representation as `quant`. If `None`, the default
+    /// zero point (`nbit_zero_point`) is used for all blocks.
+    zero_points: Option<Contiguous<NdTensorView<'a, u8, 2>>>,
+
     /// Bits per quantized element.
     ///
     /// Must be a divisor of `block_size * 8`.
@@ -700,8 +757,50 @@ impl<'a, T: Copy> BlockQuantizedMatrix<'a, T> {
         Ok(Self {
             quant,
             scales,
+            zero_points: None,
             bits,
         })
+    }
+
+    /// Set the per-block zero points for the matrix.
+    ///
+    /// `zero_points` has shape (cols, ceil(k_blocks * bits / 8)) and uses the
+    /// same packed representation as the quantized data. For 4-bit elements
+    /// each byte contains the zero points for two consecutive K blocks, with
+    /// the first in the low 4 bits.
+    ///
+    /// Zero points are currently only supported for 4-bit elements.
+    pub fn with_zero_points(
+        mut self,
+        zero_points: Contiguous<NdTensorView<'a, u8, 2>>,
+    ) -> Result<Self, BlockQuantizedError> {
+        // The zero point consumers (packing, correction kernels) assume 4-bit
+        // packing.
+        if self.bits != 4 {
+            return Err(BlockQuantizedError::UnsupportedElementSize);
+        }
+        let zp_bytes_per_col = (self.blocks_per_column() * self.bits.as_usize()).div_ceil(8);
+        if zero_points.shape() != [self.cols(), zp_bytes_per_col] {
+            return Err(BlockQuantizedError::ZeroPointsSizeMismatch);
+        }
+        self.zero_points = Some(zero_points);
+        Ok(self)
+    }
+
+    /// Return true if the matrix has non-default zero points.
+    pub(crate) fn has_zero_points(&self) -> bool {
+        self.zero_points.is_some()
+    }
+
+    /// Return the packed zero points for all blocks in a column.
+    ///
+    /// Returns `None` if the matrix has no zero points or `col` is out of
+    /// bounds.
+    pub(crate) fn column_zero_points(&self, col: usize) -> Option<&[u8]> {
+        let zero_points = self.zero_points.as_ref()?;
+        let offset = zero_points.offset([col, 0])?;
+        let len = zero_points.size(1);
+        Some(&zero_points.data()[offset..offset + len])
     }
 
     /// Return the number of rows in the dequantized matrix.
@@ -718,7 +817,11 @@ impl<'a, T: Copy> BlockQuantizedMatrix<'a, T> {
     pub(crate) fn slice(&self, col_range: Range<usize>) -> BlockQuantizedMatrix<'a, T> {
         BlockQuantizedMatrix {
             quant: Contiguous::new(self.quant.slice(col_range.clone())).unwrap(),
-            scales: Contiguous::new(self.scales.slice(col_range)).unwrap(),
+            scales: Contiguous::new(self.scales.slice(col_range.clone())).unwrap(),
+            zero_points: self
+                .zero_points
+                .as_ref()
+                .map(|zp| Contiguous::new(zp.slice(col_range)).unwrap()),
             bits: self.bits,
         }
     }
@@ -783,6 +886,134 @@ pub const fn nbit_zero_point(n_bits: u8) -> i16 {
     1 << (n_bits - 1)
 }
 
+/// Extract the 4-bit zero point for block `block_idx` from a column's packed
+/// zero points.
+///
+/// Packing follows the quantized data format: each byte contains the zero
+/// points for two consecutive blocks, with the first in the low 4 bits.
+#[inline]
+pub(crate) fn unpack_zero_point_4bit(packed: &[u8], block_idx: usize) -> u8 {
+    let byte = packed[block_idx / 2];
+    if block_idx.is_multiple_of(2) {
+        byte & 0x0F
+    } else {
+        byte >> 4
+    }
+}
+
+/// Compute the output corrections needed when a column of a block-quantized
+/// matrix has non-default zero points.
+///
+/// The vector-matrix product kernels dequantize elements using the default
+/// zero point `Z0` (see [`nbit_zero_point`]). Since `(q - zp) = (q - Z0) +
+/// (Z0 - zp)`, the result for the actual zero points can be obtained by
+/// adding `sum((Z0 - zp_b) * scale_b * lhs_block_sum_b)` over all K blocks
+/// `b` of the column.
+///
+/// `lhs_block_sums` contains the sum of the LHS row elements in each K block,
+/// with any LHS quantization scale already applied.
+///
+/// This is marked `#[inline(always)]` so that it is compiled with the same
+/// target features as the calling kernel.
+#[inline(always)]
+fn zero_point_correction<I: Isa>(
+    isa: I,
+    col_zero_points: &[u8],
+    col_scales: &[f32],
+    lhs_block_sums: &[f32],
+) -> f32 {
+    const DEFAULT_ZERO_POINT: i8 = nbit_zero_point(4) as i8;
+
+    // Maximum supported SIMD vector width in bytes.
+    const MAX_VEC_BYTES: usize = 64;
+
+    let ops = isa.f32();
+    let u8_ops = isa.u8();
+    let i8_ops = isa.i8();
+    let i16_ops = isa.i16();
+    let i32_ops = isa.i32();
+
+    // Both slices have one entry per block in the column.
+    debug_assert_eq!(col_scales.len(), lhs_block_sums.len());
+    let n_blocks = col_scales.len();
+
+    let zero_point = i8_ops.splat(DEFAULT_ZERO_POINT);
+    let lo_mask = u8_ops.splat(0x0F);
+
+    // Each chunk processes the zero points from a full vector of packed
+    // bytes, ie. two blocks per byte. This equals the number of f32 lanes
+    // in 8 vectors.
+    let blocks_per_chunk = u8_ops.len() * 2;
+    debug_assert_eq!(blocks_per_chunk, ops.len() * 8);
+
+    // Unpack a vector of packed zero points (even blocks in the low 4 bits)
+    // into `Z0 - zp` for each block, widened to i32.
+    let unpack_zp_diffs = |bytes| {
+        let lo = u8_ops.and(bytes, lo_mask);
+        let hi = u8_ops.shift_right::<4>(bytes);
+        let (even, odd) = (
+            u8_ops.interleave_low(lo, hi),
+            u8_ops.interleave_high(lo, hi),
+        );
+        let diff_lo = i8_ops.sub(zero_point, i8_ops.from_bits(even.to_bits()));
+        let diff_hi = i8_ops.sub(zero_point, i8_ops.from_bits(odd.to_bits()));
+        let (a_i16, b_i16) = i8_ops.extend(diff_lo);
+        let (c_i16, d_i16) = i8_ops.extend(diff_hi);
+        let (a_i32, b_i32) = i16_ops.extend(a_i16);
+        let (c_i32, d_i32) = i16_ops.extend(b_i16);
+        let (e_i32, f_i32) = i16_ops.extend(c_i16);
+        let (g_i32, h_i32) = i16_ops.extend(d_i16);
+        [a_i32, b_i32, c_i32, d_i32, e_i32, f_i32, g_i32, h_i32]
+    };
+
+    let mut acc = [ops.zero(); 4];
+
+    // Accumulate `(Z0 - zp_b) * scale_b * lhs_block_sum_b` over chunks where
+    // all blocks are in range, using only full-width loads.
+    let full_blocks = n_blocks - (n_blocks % blocks_per_chunk);
+    let mut block = 0;
+    while block < full_blocks {
+        let diffs = unpack_zp_diffs(u8_ops.load(&col_zero_points[block / 2..]));
+        let scales = ops.load_many::<8>(&col_scales[block..]);
+        let sums = ops.load_many::<8>(&lhs_block_sums[block..]);
+        for i in 0..8 {
+            let diff = i32_ops.to_float(diffs[i]);
+            acc[i % acc.len()] = ops.mul_add(diff, ops.mul(scales[i], sums[i]), acc[i % acc.len()]);
+        }
+        block += blocks_per_chunk;
+    }
+
+    // Handle the final partial chunk by copying the inputs into zero-padded
+    // buffers so that the same full-width loads can be used. This avoids
+    // masked loads, which are slow on ISAs without native support (eg. NEON).
+    // Padded lanes contribute nothing to the result because the scale and
+    // LHS sum lanes are zero.
+    if block < n_blocks {
+        assert!(u8_ops.len() <= MAX_VEC_BYTES && ops.len() * 8 <= MAX_VEC_BYTES * 2);
+
+        let rem_blocks = n_blocks - block;
+        let rem_bytes = rem_blocks.div_ceil(2);
+        let mut zp_buf = [0u8; MAX_VEC_BYTES];
+        let mut scale_buf = [0.; MAX_VEC_BYTES * 2];
+        let mut sum_buf = [0.; MAX_VEC_BYTES * 2];
+        zp_buf[..rem_bytes].copy_from_slice(&col_zero_points[block / 2..][..rem_bytes]);
+        scale_buf[..rem_blocks].copy_from_slice(&col_scales[block..n_blocks]);
+        sum_buf[..rem_blocks].copy_from_slice(&lhs_block_sums[block..n_blocks]);
+
+        let diffs = unpack_zp_diffs(u8_ops.load(&zp_buf));
+        let scales = ops.load_many::<8>(&scale_buf);
+        let sums = ops.load_many::<8>(&sum_buf);
+        for i in 0..8 {
+            let diff = i32_ops.to_float(diffs[i]);
+            acc[i % acc.len()] = ops.mul_add(diff, ops.mul(scales[i], sums[i]), acc[i % acc.len()]);
+        }
+    }
+
+    let acc_01 = ops.add(acc[0], acc[1]);
+    let acc_23 = ops.add(acc[2], acc[3]);
+    ops.sum(ops.add(acc_01, acc_23))
+}
+
 #[cfg(test)]
 pub fn pack_4bit_elements(vals: &[i8], zero_point: i8) -> Vec<u8> {
     let (chunks, tail) = vals.as_chunks::<2>();
@@ -809,18 +1040,19 @@ mod tests {
 
     use super::{
         BlockQuantizedGemm, BlockQuantizedMatrix, ComputeMode, nbit_zero_point, pack_4bit_elements,
-        quantize,
+        quantize, unpack_zero_point_4bit,
     };
+    use crate::errors::BlockQuantizedError;
 
     fn reference_gemm_f32_with_block_quantized_rhs(
         lhs: NdTensorView<f32, 2>,
         rhs: NdTensorView<u8, 3>,
         rhs_scales: NdTensorView<f32, 2>,
+        rhs_zero_points: Option<NdTensorView<u8, 2>>,
     ) -> NdTensor<f32, 2> {
         let [m, k] = lhs.shape();
         let [n, _k_blocks, block_size] = rhs.shape();
         let elems_per_block = block_size * 2;
-        let zero_point = 8;
 
         let mut out = NdTensor::zeros([m, n]);
 
@@ -831,6 +1063,11 @@ mod tests {
                     let k_block = ki / elems_per_block;
                     let block_idx = ki % elems_per_block;
                     let scale = rhs_scales[[col, k_block]];
+                    let zero_point = rhs_zero_points
+                        .map(|zps| {
+                            unpack_zero_point_4bit(zps.slice(col).data().unwrap(), k_block) as i32
+                        })
+                        .unwrap_or(8);
 
                     let byte = rhs[[col, k_block, block_idx / 2]];
                     let elem = if ki % 2 == 0 { byte & 0x0F } else { byte >> 4 };
@@ -885,6 +1122,50 @@ mod tests {
         assert_eq!(mat.column_data(4, 1, 1), None);
         // Out of bounds K block.
         assert_eq!(mat.column_data(3, 2, 1), None);
+
+        // No zero points by default.
+        assert!(!mat.has_zero_points());
+        assert_eq!(mat.column_zero_points(0), None);
+
+        // Add zero points. Two 4-bit zero points per column, packed into one
+        // byte.
+        let zps = NdTensor::from([[0x21u8], [0x43], [0x65], [0x87]]);
+        let mat = mat
+            .with_zero_points(Contiguous::new(zps.view()).unwrap())
+            .unwrap();
+        assert!(mat.has_zero_points());
+        assert_eq!(mat.column_zero_points(1), Some([0x43u8].as_slice()));
+        assert_eq!(mat.column_zero_points(4), None);
+        assert_eq!(
+            mat.column_zero_points(3)
+                .map(|zp| [unpack_zero_point_4bit(zp, 0), unpack_zero_point_4bit(zp, 1)]),
+            Some([7, 8])
+        );
+
+        // Zero points with the wrong shape.
+        let wrong_zps = NdTensor::<u8, 2>::zeros([4, 2]);
+        assert_eq!(
+            mat.with_zero_points(Contiguous::new(wrong_zps.view()).unwrap())
+                .err(),
+            Some(BlockQuantizedError::ZeroPointsSizeMismatch)
+        );
+
+        // Zero points are only supported for 4-bit elements.
+        let quant_8bit = NdTensor::<u8, 3>::zeros([4, 2, 16]);
+        let scales_8bit = NdTensor::<f32, 2>::zeros([4, 2]);
+        let mat_8bit = BlockQuantizedMatrix::new(
+            Contiguous::new(quant_8bit.view()).unwrap(),
+            Contiguous::new(scales_8bit.view()).unwrap(),
+            8, /* bits */
+        )
+        .unwrap();
+        let zps_8bit = NdTensor::<u8, 2>::zeros([4, 2]);
+        assert_eq!(
+            mat_8bit
+                .with_zero_points(Contiguous::new(zps_8bit.view()).unwrap())
+                .err(),
+            Some(BlockQuantizedError::UnsupportedElementSize)
+        );
     }
 
     // The ONNX Runtime definition of MatMulNBits specifies that the block
@@ -938,6 +1219,7 @@ mod tests {
             n_cols: usize,
             n_blocks: usize,
             compute: ComputeMode,
+            zero_points: bool,
             tolerance: Option<f32>,
         }
 
@@ -946,51 +1228,89 @@ mod tests {
 
         let mut cases = Vec::new();
 
-        for block_size in BLOCK_SIZES {
+        for zero_points in [false, true] {
+            for block_size in BLOCK_SIZES {
+                cases.push(Case {
+                    n_rows: 1,
+                    n_cols: 3,
+                    n_blocks: (max_vblock_size / block_size).max(1),
+                    block_size,
+                    compute: ComputeMode::Float,
+                    zero_points,
+                    tolerance: None,
+                });
+            }
+
+            // Add a case that will exercise both the main and tail loops.
             cases.push(Case {
                 n_rows: 1,
-                n_cols: 3,
-                n_blocks: (max_vblock_size / block_size).max(1),
-                block_size,
+                n_cols: 1,
+                // 16 x u4 = 64 bits, smaller than vector length.
+                block_size: 16,
+                // (max_vblock_size / 16) to use main loop once, plus one for a tail.
+                n_blocks: (max_vblock_size / 16) + 1,
                 compute: ComputeMode::Float,
+                zero_points,
                 tolerance: None,
             });
-        }
 
-        // Add a case that will exercise both the main and tail loops.
-        cases.push(Case {
-            n_rows: 1,
-            n_cols: 1,
-            // 16 x u4 = 64 bits, smaller than vector length.
-            block_size: 16,
-            // (max_vblock_size / 16) to use main loop once, plus one for a tail.
-            n_blocks: (max_vblock_size / 16) + 1,
-            compute: ComputeMode::Float,
-            tolerance: None,
-        });
+            // Add cases that use int8 quantization of the LHS.
+            for (block_size, atol) in [(16, 0.1), (32, 0.1), (64, 0.2), (128, 0.2), (256, 0.3)] {
+                cases.push(Case {
+                    n_rows: 1,
+                    n_cols: 3,
+                    block_size,
+                    n_blocks: (max_vblock_size / block_size).max(1),
+                    compute: ComputeMode::Int8,
+                    zero_points,
+                    tolerance: Some(atol),
+                });
+            }
 
-        // Add cases that use int8 quantization of the LHS.
-        for (block_size, atol) in [(16, 0.1), (32, 0.1), (64, 0.2), (128, 0.2), (256, 0.3)] {
+            // Add a case that will exercise both the main and tail loops using int8.
             cases.push(Case {
                 n_rows: 1,
-                n_cols: 3,
-                block_size,
-                n_blocks: (max_vblock_size / block_size).max(1),
+                n_cols: 1,
+                // 16 x u4 = 64 bits, smaller than vector length.
+                block_size: 16,
+                // (max_vblock_size / 16) to use main loop once, plus one for a tail.
+                n_blocks: (max_vblock_size / 16) + 1,
                 compute: ComputeMode::Int8,
-                tolerance: Some(atol),
+                zero_points,
+                tolerance: Some(0.1),
             });
         }
 
-        // Add a case that will exercise both the main and tail loops using int8.
+        // Cases with enough K blocks to exercise the full-chunk path of the
+        // vectorized zero-point correction, which processes two blocks per
+        // u8 vector lane (up to 128 blocks) per iteration.
         cases.push(Case {
             n_rows: 1,
-            n_cols: 1,
-            // 16 x u4 = 64 bits, smaller than vector length.
+            n_cols: 3,
+            block_size: 32,
+            n_blocks: 48,
+            compute: ComputeMode::Float,
+            zero_points: true,
+            tolerance: Some(1e-4),
+        });
+        cases.push(Case {
+            n_rows: 1,
+            n_cols: 3,
             block_size: 16,
-            // (max_vblock_size / 16) to use main loop once, plus one for a tail.
-            n_blocks: (max_vblock_size / 16) + 1,
+            n_blocks: 129,
+            compute: ComputeMode::Float,
+            zero_points: true,
+            tolerance: Some(1e-4),
+        });
+        cases.push(Case {
+            n_rows: 1,
+            n_cols: 3,
+            block_size: 16,
+            n_blocks: 129,
             compute: ComputeMode::Int8,
-            tolerance: Some(0.1),
+            zero_points: true,
+            // Int8 LHS quantization error grows with K.
+            tolerance: Some(2.0),
         });
 
         // Test K=0. The output must still be initialized even though there
@@ -1001,6 +1321,7 @@ mod tests {
             block_size: 32,
             n_blocks: 0,
             compute: ComputeMode::Int8,
+            zero_points: false,
             tolerance: None,
         });
         cases.push(Case {
@@ -1009,6 +1330,7 @@ mod tests {
             block_size: 32,
             n_blocks: 0,
             compute: ComputeMode::Float,
+            zero_points: false,
             tolerance: None,
         });
 
@@ -1019,6 +1341,7 @@ mod tests {
                 n_blocks,
                 block_size,
                 compute,
+                zero_points,
                 tolerance,
             } = case;
 
@@ -1028,17 +1351,25 @@ mod tests {
             let lhs = NdTensor::<f32, 2>::rand([n_rows, n_blocks * block_size], &mut rng);
             let rhs_data = NdTensor::<u8, 3>::rand([n_cols, n_blocks, block_size / 2], &mut rng);
             let rhs_scales = NdTensor::<f32, 2>::rand([n_cols, n_blocks], &mut rng);
-            let bqm = BlockQuantizedMatrix::new(
+            let rhs_zero_points = zero_points
+                .then(|| NdTensor::<u8, 2>::rand([n_cols, n_blocks.div_ceil(2)], &mut rng));
+            let mut bqm = BlockQuantizedMatrix::new(
                 Contiguous::new(rhs_data.view()).unwrap(),
                 Contiguous::new(rhs_scales.view()).unwrap(),
                 4,
             )
             .unwrap();
+            if let Some(zps) = &rhs_zero_points {
+                bqm = bqm
+                    .with_zero_points(Contiguous::new(zps.view()).unwrap())
+                    .unwrap();
+            }
 
             let expected = reference_gemm_f32_with_block_quantized_rhs(
                 lhs.view(),
                 rhs_data.view(),
                 rhs_scales.view(),
+                rhs_zero_points.as_ref().map(|zps| zps.view()),
             );
 
             let mut out = Vec::with_capacity(n_cols);

--- a/rten-gemm/src/errors.rs
+++ b/rten-gemm/src/errors.rs
@@ -69,6 +69,8 @@ pub enum BlockQuantizedError {
     UnsupportedBlockSize,
     /// The number of bits per element is unsupported.
     UnsupportedElementSize,
+    /// The zero points shape does not match the quantized data shape.
+    ZeroPointsSizeMismatch,
 }
 
 impl Display for BlockQuantizedError {
@@ -76,6 +78,9 @@ impl Display for BlockQuantizedError {
         match self {
             Self::UnsupportedBlockSize => write!(f, "block size is unsupported"),
             Self::UnsupportedElementSize => write!(f, "unsupported bits-per-element"),
+            Self::ZeroPointsSizeMismatch => {
+                write!(f, "zero points shape does not match quantized data")
+            }
         }
     }
 }

--- a/rten-gemm/src/packing.rs
+++ b/rten-gemm/src/packing.rs
@@ -7,7 +7,7 @@ use rten_tensor::storage::Alloc;
 use rten_tensor::{AssumeInit, Matrix, MatrixLayout, Storage};
 
 use super::kernels::PackedLayout;
-use crate::block_quant::{BlockQuantizedMatrix, nbit_zero_point};
+use crate::block_quant::{BlockQuantizedMatrix, nbit_zero_point, unpack_zero_point_4bit};
 
 pub mod int8;
 
@@ -268,10 +268,19 @@ impl<'a, const NR: usize> BlockQuantizedMatrixPacker<'a, f32, NR> {
         // padding region.
         let mut pad_data: Vec<u8> = Vec::new();
         let mut pad_scales: Vec<f32> = Vec::new();
+        let mut pad_zero_points: Vec<u8> = Vec::new();
 
         if !cols.len().is_multiple_of(NR) {
             pad_data.resize(block_size * n_blocks, ZERO_POINT as u8);
             pad_scales.resize(n_blocks, 0.);
+            if self.mat.has_zero_points() {
+                // Both nibbles set to the default zero point. The value doesn't
+                // affect the output since the padding scales are zero.
+                pad_zero_points.resize(
+                    self.mat.blocks_per_column().div_ceil(2),
+                    (ZERO_POINT | (ZERO_POINT << N_BITS)) as u8,
+                );
+            }
         }
 
         let block_bytes = self.mat.bytes_per_block();
@@ -293,9 +302,27 @@ impl<'a, const NR: usize> BlockQuantizedMatrixPacker<'a, f32, NR> {
                     .unwrap_or(&pad_scales)
             });
 
+            // Packed zero points for whole columns, if the matrix has
+            // non-default zero points. Unlike `data` and `scales` these are
+            // indexed by absolute block index rather than relative to
+            // `start_block`.
+            let zero_points: Option<[&[u8]; NR]> = self.mat.has_zero_points().then(|| {
+                std::array::from_fn(|col| {
+                    self.mat
+                        .column_zero_points(start_col + col)
+                        .unwrap_or(&pad_zero_points)
+                })
+            });
+
             // Dequantize K blocks.
             for block_idx in 0..n_blocks {
                 let block_scales = scales.map(|bs| *unsafe { bs.get_unchecked(block_idx) });
+                let block_zero_points: [i16; NR] = match &zero_points {
+                    Some(zps) => std::array::from_fn(|c| {
+                        unpack_zero_point_4bit(zps[c], start_block + block_idx) as i16
+                    }),
+                    None => [ZERO_POINT; NR],
+                };
 
                 for k in 0..block_bytes {
                     let bytes: [u8; NR] = std::array::from_fn(|c| unsafe {
@@ -304,14 +331,14 @@ impl<'a, const NR: usize> BlockQuantizedMatrixPacker<'a, f32, NR> {
 
                     // First row from low 4 bits.
                     for c in 0..NR {
-                        let elem = (bytes[c] & 0x0F) as i16 - ZERO_POINT;
+                        let elem = (bytes[c] & 0x0F) as i16 - block_zero_points[c];
                         let dequant = elem as f32 * block_scales[c];
                         unsafe { out.write_unchecked(dequant) };
                     }
 
                     // Second row from high 4 bits.
                     for c in 0..NR {
-                        let elem = (bytes[c] >> 4) as i16 - ZERO_POINT;
+                        let elem = (bytes[c] >> 4) as i16 - block_zero_points[c];
                         let dequant = elem as f32 * block_scales[c];
                         unsafe { out.write_unchecked(dequant) };
                     }
@@ -432,7 +459,9 @@ mod tests {
     use std::mem::MaybeUninit;
 
     use super::{BlockQuantizedMatrixPacker, PackedLayout, PackingBuffer};
-    use crate::block_quant::{BlockQuantizedMatrix, nbit_zero_point, pack_4bit_elements};
+    use crate::block_quant::{
+        BlockQuantizedMatrix, nbit_zero_point, pack_4bit_elements, unpack_zero_point_4bit,
+    };
 
     #[test]
     fn test_packing_buffer() {
@@ -516,6 +545,67 @@ mod tests {
                         panel,
                         row,
                         panel_col
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_block_quantized_matrix_packer_zero_points() {
+        let cols = 4;
+        let k_blocks = 2;
+        let n_bits = 4;
+        let zero_point = nbit_zero_point(n_bits);
+
+        let elems: Vec<i8> = (-8..8).cycle().take(256).collect();
+        let packed_elems = pack_4bit_elements(&elems, zero_point as i8);
+        let data = NdTensor::from_data([cols, k_blocks, 16], packed_elems);
+        let data = data.to_contiguous();
+        let scales = NdTensorView::from_data([cols, k_blocks], &[1., 2., 3., 4., 5., 6., 7., 8.]);
+        let scales = scales.to_contiguous();
+
+        // Two 4-bit zero points per column, packed into one byte with the
+        // first block's zero point in the low 4 bits.
+        let zps = NdTensor::from([[0x21u8], [0x43], [0x65], [0x87]]);
+        let zps = zps.to_contiguous();
+        let mat = BlockQuantizedMatrix::new(data.view(), scales.view(), n_bits)
+            .unwrap()
+            .with_zero_points(zps.view())
+            .unwrap();
+
+        const NR: usize = 2;
+        let packer = BlockQuantizedMatrixPacker::<f32, NR>::new(mat);
+
+        // Dequantized column panels
+        let mut dequantized = Vec::with_capacity(elems.len());
+        let dequantized = packer.pack(
+            dequantized.spare_capacity_mut(),
+            0..mat.rows(),
+            0..mat.cols(),
+        );
+
+        for panel in 0..cols / NR {
+            for row in 0..mat.rows() {
+                for panel_col in 0..NR {
+                    let col = panel * NR + panel_col;
+                    let dequant_offset = panel * mat.rows() * NR + row * NR + panel_col;
+                    let input_offset = col * mat.rows() + row;
+
+                    let block_idx = row / mat.elements_per_block();
+                    let scale = mat.column_scales(col, block_idx, 1).unwrap()[0];
+                    let zp =
+                        unpack_zero_point_4bit(mat.column_zero_points(col).unwrap(), block_idx);
+
+                    // `elems` are quantized with the default zero point, so
+                    // the raw quantized value is `elem + zero_point`.
+                    let expected =
+                        (elems[input_offset] as i16 + zero_point - zp as i16) as f32 * scale;
+
+                    assert_eq!(
+                        dequantized[dequant_offset], expected,
+                        "mismatch at panel {} row {} col {}",
+                        panel, row, panel_col
                     );
                 }
             }

--- a/rten-gemm/src/tests.rs
+++ b/rten-gemm/src/tests.rs
@@ -5,8 +5,10 @@ use rten_base::num::AsUsize;
 use rten_bench::run_bench;
 use rten_tensor::prelude::*;
 use rten_tensor::rng::XorShiftRng;
-use rten_tensor::test_util::{ApproxEq, expect_equal};
-use rten_tensor::{Matrix, MatrixLayout, MatrixMut, NdTensor, NdTensorView, RandomSource};
+use rten_tensor::test_util::{ApproxEq, expect_equal, expect_equal_with_tolerance};
+use rten_tensor::{
+    Contiguous, Matrix, MatrixLayout, MatrixMut, NdTensor, NdTensorView, RandomSource,
+};
 use rten_testing::TestCases;
 
 use super::{
@@ -946,11 +948,11 @@ fn reference_gemm_f32_with_block_quantized_rhs(
     lhs: NdTensorView<f32, 2>,
     rhs: NdTensorView<u8, 3>,
     rhs_scales: NdTensorView<f32, 2>,
+    rhs_zero_points: Option<NdTensorView<u8, 2>>,
 ) -> NdTensor<f32, 2> {
     let [m, k] = lhs.shape();
     let [n, _k_blocks, block_size] = rhs.shape();
     let elems_per_block = block_size * 2;
-    let zero_point = 8;
 
     let mut out = NdTensor::zeros([m, n]);
 
@@ -961,6 +963,17 @@ fn reference_gemm_f32_with_block_quantized_rhs(
                 let k_block = ki / elems_per_block;
                 let block_idx = ki % elems_per_block;
                 let scale = rhs_scales[[col, k_block]];
+                let zero_point = rhs_zero_points
+                    .map(|zps| {
+                        let byte = zps[[col, k_block / 2]];
+                        let zp = if k_block % 2 == 0 {
+                            byte & 0x0F
+                        } else {
+                            byte >> 4
+                        };
+                        zp as i32
+                    })
+                    .unwrap_or(8);
 
                 let byte = rhs[[col, k_block, block_idx / 2]];
                 let elem = if ki % 2 == 0 { byte & 0x0F } else { byte >> 4 };
@@ -984,49 +997,59 @@ fn test_gemm_f32_with_block_quantized_rhs() {
         k: usize,
         // Number of elements in each quantized K block. Must be >= 16.
         block_size: usize,
+        zero_points: bool,
     }
 
-    let cases = [
-        // Vector-matrix product
-        Case {
-            m: 1,
-            n: 17,
-            k: 32,
-            block_size: 16,
-        },
-        Case {
-            m: 1,
-            n: 17,
-            k: 32,
-            block_size: 32,
-        },
-        // Matrix-matrix product
-        Case {
-            m: 4,
-            n: 17,
-            k: 32,
-            block_size: 16,
-        },
-        Case {
-            m: 4,
-            n: 16,
-            k: 32,
-            block_size: 32,
-        },
-        Case {
-            m: 4,
-            n: 16,
-            k: 64,
-            block_size: 64,
-        },
-        // Smallest supported input
-        Case {
-            m: 1,
-            n: 1,
-            k: 16,
-            block_size: 16,
-        },
-    ];
+    let mut cases = Vec::new();
+    for zero_points in [false, true] {
+        cases.extend([
+            // Vector-matrix product
+            Case {
+                m: 1,
+                n: 17,
+                k: 32,
+                block_size: 16,
+                zero_points,
+            },
+            Case {
+                m: 1,
+                n: 17,
+                k: 32,
+                block_size: 32,
+                zero_points,
+            },
+            // Matrix-matrix product
+            Case {
+                m: 4,
+                n: 17,
+                k: 32,
+                block_size: 16,
+                zero_points,
+            },
+            Case {
+                m: 4,
+                n: 16,
+                k: 32,
+                block_size: 32,
+                zero_points,
+            },
+            Case {
+                m: 4,
+                n: 16,
+                k: 64,
+                block_size: 64,
+                zero_points,
+            },
+            // Smallest supported input
+            Case {
+                m: 1,
+                n: 1,
+                k: 16,
+                block_size: 16,
+                zero_points,
+            },
+        ]);
+    }
 
     cases.test_each_clone(|case| {
         let Case {
@@ -1034,19 +1057,28 @@ fn test_gemm_f32_with_block_quantized_rhs() {
             n,
             k,
             block_size,
+            zero_points,
         } = case;
 
         let n_bits = 4 as u8;
         let elements_per_byte = 8 / n_bits.as_usize();
         let block_bytes = block_size / elements_per_byte;
+        let k_blocks = k / block_size;
 
         let mut rng = XorShiftRng::new(1234);
         let lhs = NdTensor::<f32, 2>::rand([m, k], &mut rng);
-        let rhs = NdTensor::<u8, 3>::rand([n, k / block_size, block_bytes], &mut rng);
+        let rhs = NdTensor::<u8, 3>::rand([n, k_blocks, block_bytes], &mut rng);
         let rhs = rhs.to_contiguous();
-        let rhs_scales = NdTensor::<f32, 2>::rand([n, k / block_size], &mut rng);
+        let rhs_scales = NdTensor::<f32, 2>::rand([n, k_blocks], &mut rng);
         let rhs_scales = rhs_scales.to_contiguous();
-        let rhs_bqm = BlockQuantizedMatrix::new(rhs.view(), rhs_scales.view(), n_bits).unwrap();
+        let rhs_zero_points =
+            zero_points.then(|| NdTensor::<u8, 2>::rand([n, k_blocks.div_ceil(2)], &mut rng));
+        let mut rhs_bqm = BlockQuantizedMatrix::new(rhs.view(), rhs_scales.view(), n_bits).unwrap();
+        if let Some(zps) = &rhs_zero_points {
+            rhs_bqm = rhs_bqm
+                .with_zero_points(Contiguous::new(zps.view()).unwrap())
+                .unwrap();
+        }
         assert_eq!(rhs_bqm.elements_per_block(), block_size);
         assert_eq!(lhs.cols(), rhs_bqm.rows());
 
@@ -1054,6 +1086,7 @@ fn test_gemm_f32_with_block_quantized_rhs() {
             lhs.view(),
             rhs.view().into(),
             rhs_scales.view().into(),
+            rhs_zero_points.as_ref().map(|zps| zps.view()),
         );
 
         for gemm in all_gemms() {
@@ -1066,7 +1099,15 @@ fn test_gemm_f32_with_block_quantized_rhs() {
             )
             .unwrap();
 
-            expect_equal(&output, &expected).unwrap();
+            if zero_points {
+                // Non-default zero points bias the dequantized values, which
+                // can cause more cancellation in the K sums and thus a larger
+                // rounding difference vs the reference on near-zero outputs.
+                let (atol, rtol) = (1e-6, 1e-5);
+                expect_equal_with_tolerance(&output, &expected, atol, rtol).unwrap();
+            } else {
+                expect_equal(&output, &expected).unwrap();
+            }
         }
     });
 }

--- a/src/ops/matmul.rs
+++ b/src/ops/matmul.rs
@@ -825,6 +825,7 @@ mod contrib {
         lhs: TensorView<f32>,
         rhs: NdTensorView<u8, 3>,
         scales: NdTensorView<f32, 2>,
+        zero_points: Option<NdTensorView<u8, 2>>,
         bits: u8,
         accuracy: AccuracyLevel,
     ) -> Result<Tensor<f32>, OpError> {
@@ -838,13 +839,26 @@ mod contrib {
 
         let rhs = rhs.to_contiguous_in(pool);
         let scales = scales.to_contiguous_in(pool);
+        let zero_points = zero_points.map(|zp| zp.to_contiguous_in(pool));
 
-        let b_mat = BlockQuantizedMatrix::new(rhs.view(), scales.view(), bits).map_err(|err| {
+        let map_bq_err = |err| {
             OpError::UnsupportedValue(match err {
                 BlockQuantizedError::UnsupportedBlockSize => "Unsupported K block size",
                 BlockQuantizedError::UnsupportedElementSize => "Unsupported bits-per-element",
+                BlockQuantizedError::ZeroPointsSizeMismatch => {
+                    "zero_points size does not match B input"
+                }
             })
-        })?;
+        };
+
+        let mut b_mat =
+            BlockQuantizedMatrix::new(rhs.view(), scales.view(), bits).map_err(map_bq_err)?;
+
+        if let Some(zero_points) = &zero_points {
+            b_mat = b_mat
+                .with_zero_points(zero_points.view())
+                .map_err(map_bq_err)?;
+        }
 
         let batch_len = batch_dims.iter().product();
         let out_shape: SmallVec<[usize; 4]> = batch_dims
@@ -928,51 +942,83 @@ mod contrib {
         pub accuracy_level: AccuracyLevel,
     }
 
+    /// Convert the `scales` or `zero_points` input of [`MatMulNBits`] into a
+    /// matrix with shape `shape`.
+    ///
+    /// The current spec requires these inputs to be 2D, but earlier versions
+    /// used 1D inputs, which are validated against `shape` and reshaped. See
+    /// https://github.com/microsoft/onnxruntime/pull/24828.
+    fn to_matrix<'a, T: Clone>(
+        pool: &BufferPool,
+        input: TensorView<'a, T>,
+        shape: [usize; 2],
+        len_error: &'static str,
+        ndim_error: &'static str,
+    ) -> Result<CowNdTensor<'a, T, 2>, OpError> {
+        match input.ndim() {
+            2 => Ok(input
+                .to_contiguous_in(pool)
+                .into_inner()
+                .try_into()
+                .unwrap()),
+            1 => {
+                if input.len() != shape.iter().product::<usize>() {
+                    return Err(OpError::InvalidValue(len_error));
+                }
+                Ok(input.reshaped(shape))
+            }
+            _ => Err(OpError::InvalidValue(ndim_error)),
+        }
+    }
+
     impl Operator for MatMulNBits {
         fn name(&self) -> &str {
             "MatMulNBits"
         }
 
         fn max_inputs(&self) -> Option<usize> {
-            Some(3)
+            Some(6)
         }
 
         fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
             let lhs: TensorView<f32> = ctx.inputs().require_as(0)?;
             let rhs: NdTensorView<u8, 3> = ctx.inputs().require_as(1)?;
 
-            // Current spec requires scales to be 2D, but earlier versions used 1D
-            // scales. See https://github.com/microsoft/onnxruntime/pull/24828.
             let scales: TensorView<f32> = ctx.inputs().require_as(2)?;
-
-            let scales: CowNdTensor<f32, 2> = match scales.ndim() {
-                2 => scales
-                    .to_contiguous_in(ctx.pool())
-                    .into_inner()
-                    .try_into()
-                    .unwrap(),
-                1 => {
-                    let k = lhs.ndim().checked_sub(1).map(|d| lhs.size(d)).unwrap_or(1);
-                    let k_blocks = k.checked_div(self.block_size).unwrap_or(0);
-                    let rhs_cols = rhs.size(0);
-
-                    if scales.len() != rhs_cols * k_blocks {
-                        return Err(OpError::InvalidValue(
-                            "Expected 1D `scales` size to match columns * block_size",
-                        ));
-                    }
-                    scales.reshaped([rhs_cols, k_blocks])
-                }
-                _ => {
-                    return Err(OpError::InvalidValue(
-                        "Expected `scales` to have one or two dims",
-                    ));
-                }
+            let scales: CowNdTensor<f32, 2> = {
+                let k = lhs.ndim().checked_sub(1).map(|d| lhs.size(d)).unwrap_or(1);
+                let k_blocks = k.checked_div(self.block_size).unwrap_or(0);
+                let rhs_cols = rhs.size(0);
+                to_matrix(
+                    ctx.pool(),
+                    scales,
+                    [rhs_cols, k_blocks],
+                    "Expected 1D `scales` size to match columns * block_size",
+                    "Expected `scales` to have one or two dims",
+                )?
             };
 
-            if ctx.inputs().len() > 3 {
+            // Only zero points with the same packed representation as the B
+            // input are supported. Unpacked (float) zero points will fail
+            // with a type error here.
+            let zero_points: Option<TensorView<u8>> = ctx.inputs().get_as(3)?;
+            let zero_points: Option<CowNdTensor<u8, 2>> = zero_points
+                .map(|zero_points| {
+                    let [rhs_cols, k_blocks, _block_bytes] = rhs.shape();
+                    let bytes_per_col = (k_blocks * self.bits as usize).div_ceil(8);
+                    to_matrix(
+                        ctx.pool(),
+                        zero_points,
+                        [rhs_cols, bytes_per_col],
+                        "Expected 1D `zero_points` size to match columns * bytes_per_column",
+                        "Expected `zero_points` to have one or two dims",
+                    )
+                })
+                .transpose()?;
+
+            if ctx.inputs().get(4).is_some() || ctx.inputs().get(5).is_some() {
                 return Err(OpError::UnsupportedValue(
-                    "zero_points, g_idx and bias inputs are unsupported",
+                    "g_idx and bias inputs are unsupported",
                 ));
             }
 
@@ -981,6 +1027,7 @@ mod contrib {
                 lhs,
                 rhs,
                 scales.view(),
+                zero_points.as_ref().map(|zp| zp.view()),
                 self.bits,
                 self.accuracy_level,
             )
@@ -1936,6 +1983,7 @@ mod tests {
         lhs: TensorView<f32>,
         rhs: NdTensorView<u8, 3>,
         scales: NdTensorView<f32, 2>,
+        zero_points: Option<NdTensorView<u8, 2>>,
         n_bits: u8,
     ) -> Tensor<f32> {
         let batch_dims = &lhs.shape()[..lhs.ndim() - 2];
@@ -1947,7 +1995,11 @@ mod tests {
 
         let rhs = rhs.to_contiguous();
         let scales = scales.to_contiguous();
-        let bqm = BlockQuantizedMatrix::new(rhs.view(), scales.view(), n_bits).unwrap();
+        let mut bqm = BlockQuantizedMatrix::new(rhs.view(), scales.view(), n_bits).unwrap();
+        let zero_points = zero_points.map(|zps| zps.to_contiguous());
+        if let Some(zps) = &zero_points {
+            bqm = bqm.with_zero_points(zps.view()).unwrap();
+        }
 
         let out_shape: Vec<usize> = batch_dims.iter().copied().chain([m, n]).collect();
         let mut out = Tensor::zeros(&out_shape);
@@ -1971,59 +2023,73 @@ mod tests {
             batch_dims: Vec<usize>,
             m: usize,
             accuracy_level: AccuracyLevel,
+            zero_points: bool,
             tolerance: Option<f32>,
         }
 
-        let cases = [
-            // Vector-matrix product
-            Case {
-                batch_dims: [2].into(),
-                m: 1,
-                accuracy_level: AccuracyLevel::Float,
-                tolerance: None,
-            },
-            Case {
-                batch_dims: [2].into(),
-                m: 1,
-                accuracy_level: AccuracyLevel::Int8,
-                tolerance: Some(0.1),
-            },
-            // Matrix-matrix product
-            Case {
-                batch_dims: [2].into(),
-                m: 4,
-                accuracy_level: AccuracyLevel::Float,
-                tolerance: None,
-            },
-            Case {
-                batch_dims: [2].into(),
-                m: 4,
-                accuracy_level: AccuracyLevel::Int8,
-                // MatMulNBits currently falls back to float compute for
-                // matrix-matrix products, so no tolerance is required.
-                tolerance: None,
-            },
-            // Matrix-matrix product with 2 batch dims.
-            Case {
-                batch_dims: [2, 2].into(),
-                m: 4,
-                accuracy_level: AccuracyLevel::Float,
-                tolerance: None,
-            },
-            // Matrix-matrix product with 0 batch dims.
-            Case {
-                batch_dims: [].into(),
-                m: 4,
-                accuracy_level: AccuracyLevel::Float,
-                tolerance: None,
-            },
-        ];
+        let mut cases = Vec::new();
+        for zero_points in [false, true] {
+            cases.extend([
+                // Vector-matrix product
+                Case {
+                    batch_dims: [2].into(),
+                    m: 1,
+                    accuracy_level: AccuracyLevel::Float,
+                    zero_points,
+                    // The vector-matrix kernel applies zero points as a
+                    // separate output correction, which may round differently
+                    // than the reference.
+                    tolerance: zero_points.then_some(1e-4),
+                },
+                Case {
+                    batch_dims: [2].into(),
+                    m: 1,
+                    accuracy_level: AccuracyLevel::Int8,
+                    zero_points,
+                    tolerance: Some(0.1),
+                },
+                // Matrix-matrix product
+                Case {
+                    batch_dims: [2].into(),
+                    m: 4,
+                    accuracy_level: AccuracyLevel::Float,
+                    zero_points,
+                    tolerance: None,
+                },
+                Case {
+                    batch_dims: [2].into(),
+                    m: 4,
+                    accuracy_level: AccuracyLevel::Int8,
+                    zero_points,
+                    // MatMulNBits currently falls back to float compute for
+                    // matrix-matrix products, so no tolerance is required.
+                    tolerance: None,
+                },
+                // Matrix-matrix product with 2 batch dims.
+                Case {
+                    batch_dims: [2, 2].into(),
+                    m: 4,
+                    accuracy_level: AccuracyLevel::Float,
+                    zero_points,
+                    tolerance: None,
+                },
+                // Matrix-matrix product with 0 batch dims.
+                Case {
+                    batch_dims: [].into(),
+                    m: 4,
+                    accuracy_level: AccuracyLevel::Float,
+                    zero_points,
+                    tolerance: None,
+                },
+            ]);
+        }
 
         cases.test_each_clone(|case| {
             let Case {
                 batch_dims,
                 m,
                 accuracy_level,
+                zero_points,
                 tolerance,
             } = case;
 
@@ -2032,16 +2098,25 @@ mod tests {
             let block_size = 16;
             let block_bytes = block_size / 2;
             let k = block_size * 2;
+            let k_blocks = k / block_size;
             let n = 8;
             let n_bits = 4;
 
             let lhs_shape: Vec<usize> = batch_dims.iter().copied().chain([m, k]).collect();
             let lhs = Tensor::rand(&lhs_shape, &mut rng);
-            let rhs = NdTensor::<u8, 3>::rand([n, k / block_size, block_bytes], &mut rng);
-            let scales = NdTensor::<f32, 2>::rand([n, k / block_size], &mut rng);
+            let rhs = NdTensor::<u8, 3>::rand([n, k_blocks, block_bytes], &mut rng);
+            let scales = NdTensor::<f32, 2>::rand([n, k_blocks], &mut rng);
+            let zps =
+                zero_points.then(|| NdTensor::<u8, 2>::rand([n, k_blocks.div_ceil(2)], &mut rng));
 
             // nb. Reference result is always computed in full precision.
-            let expected = reference_matmul_nbits(lhs.as_dyn(), rhs.view(), scales.view(), n_bits);
+            let expected = reference_matmul_nbits(
+                lhs.as_dyn(),
+                rhs.view(),
+                scales.view(),
+                zps.as_ref().map(|zps| zps.view()),
+                n_bits,
+            );
 
             let op = MatMulNBits {
                 bits: n_bits,
@@ -2049,30 +2124,48 @@ mod tests {
                 accuracy_level,
             };
 
-            // With 2D scales.
-            let result: Tensor<f32> = op
-                .run_simple((lhs.view(), rhs.view(), scales.view()))
-                .unwrap();
-            if let Some(atol) = tolerance {
-                let rtol = 0.;
-                expect_equal_with_tolerance(&result, &expected, atol, rtol).unwrap();
-            } else {
-                expect_equal(&result, &expected).unwrap();
-            }
+            let check_result = |result: Tensor<f32>| {
+                if let Some(atol) = tolerance {
+                    let rtol = 0.;
+                    expect_equal_with_tolerance(&result, &expected, atol, rtol).unwrap();
+                } else {
+                    expect_equal(&result, &expected).unwrap();
+                }
+            };
 
-            // With 1D scales (older models)
-            let result: Tensor<f32> = op
-                .run_simple((
-                    lhs.view(),
-                    rhs.view(),
-                    scales.reshaped([scales.len()]).view(),
-                ))
-                .unwrap();
-            if let Some(atol) = tolerance {
-                let rtol = 0.;
-                expect_equal_with_tolerance(&result, &expected, atol, rtol).unwrap();
+            if let Some(zps) = &zps {
+                // With 2D scales and 2D zero points.
+                let result: Tensor<f32> = op
+                    .run_simple((lhs.view(), rhs.view(), scales.view(), zps.view()))
+                    .unwrap();
+                check_result(result);
+
+                // With 1D zero points (older models)
+                let result: Tensor<f32> = op
+                    .run_simple((
+                        lhs.view(),
+                        rhs.view(),
+                        scales.view(),
+                        zps.reshaped([zps.len()]).view(),
+                    ))
+                    .unwrap();
+                check_result(result);
             } else {
-                expect_equal(&result, &expected).unwrap();
+                // With 2D scales.
+                let result: Tensor<f32> = op
+                    .run_simple((lhs.view(), rhs.view(), scales.view()))
+                    .unwrap();
+                check_result(result);
+
+                // With 1D scales (older models)
+                let result: Tensor<f32> = op
+                    .run_simple((
+                        lhs.view(),
+                        rhs.view(),
+                        scales.reshaped([scales.len()]).view(),
+                    ))
+                    .unwrap();
+                check_result(result);
             }
         });
     }
@@ -2107,6 +2200,37 @@ mod tests {
                 op.run_simple((lhs.view(), rhs.view(), scales.view()));
             assert_eq!(result.err().unwrap(), case.expected);
         });
+    }
+
+    #[test]
+    fn test_matmul_nbits_invalid_zero_points() {
+        let op = MatMulNBits {
+            bits: 4,
+            block_size: 16,
+            accuracy_level: AccuracyLevel::Float,
+        };
+        let lhs = Tensor::<f32>::zeros(&[2, 32]);
+        let rhs = Tensor::<u8>::zeros(&[8, 2, 8]);
+        let scales = Tensor::<f32>::zeros(&[8, 2]);
+
+        // Expected size is N=8 columns x 1 byte per column.
+        let zero_points = Tensor::<u8>::zeros(&[8, 3]);
+        let result: Result<Tensor<f32>, _> =
+            op.run_simple((lhs.view(), rhs.view(), scales.view(), zero_points.view()));
+        assert_eq!(
+            result.err().unwrap(),
+            OpError::UnsupportedValue("zero_points size does not match B input")
+        );
+
+        // Unpacked (float) zero points are unsupported.
+        let float_zero_points = Tensor::<f32>::zeros(&[8, 2]);
+        let result: Result<Tensor<f32>, _> = op.run_simple((
+            lhs.view(),
+            rhs.view(),
+            scales.view(),
+            float_zero_points.view(),
+        ));
+        assert!(result.is_err());
     }
 
     #[test]


### PR DESCRIPTION
Add support for the optional `zero_points` input to MatMulNBits.

Per the [spec](https://github.com/microsoft/onnxruntime/blob/main/docs/ContribOperators.md#commicrosoftmatmulnbits):

> Per-block zero point for dequantization. It can be either packed or unpacked: Packed (uint8) format has shape (N, ceil(k_blocks * bits / 8)), and it uses same bit-packing method as Input B. Unpacked (same type as A) format has shape (N, k_blocks). If not provided, a default zero point is used: 2^(bits - 1) (e.g., 8 for 4-bit quantization, 128 for 8-bit).

Currently only the packed format is supported. Both the 2D layout from the current spec and the 1D layout from earlier versions (see https://github.com/microsoft/onnxruntime/pull/24828) are accepted.

Tested with the Gemma 4 model from
https://huggingface.co/onnx-community/gemma-4-E2B-it-ONNX. Decode latency on an M3 Pro is ~61-63ms per token.