### PR TITLE
Refactor tensor layouts to use separate types for tensor indices, shapes and strides

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,8 @@ jobs:
       uses: actions/checkout@v4
     - name: Install and use MSRV Rust toolchain
       run: |
-        rustup toolchain install 1.89.0 --component clippy,rustfmt
-        rustup override set 1.89.0
+        rustup toolchain install 1.93.0 --component clippy,rustfmt
+        rustup override set 1.93.0
     - name: Verify Rust version
       run: |
         rustc --version

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ homepage = "https://github.com/robertknight/rten"
 repository = "https://github.com/robertknight/rten"
 resolver = "2"
 include = ["/src", "/CHANGELOG.md", "/README.md"]
-rust-version = "1.89.0"
+rust-version = "1.93.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/rten-gemm/src/packing/int8.rs
+++ b/rten-gemm/src/packing/int8.rs
@@ -304,6 +304,8 @@ impl RowMajorLayout {
 }
 
 impl Layout for RowMajorLayout {
+    type Shape<'a> = [usize; 2];
+    type Strides<'a> = [usize; 2];
     type Index<'a> = [usize; 2];
     type Indices = NdIndices<2>;
 
@@ -327,7 +329,7 @@ impl Layout for RowMajorLayout {
     }
 
     #[inline]
-    fn shape(&self) -> Self::Index<'_> {
+    fn shape(&self) -> Self::Shape<'_> {
         self.shape
     }
 
@@ -378,7 +380,7 @@ fn pack_a_impl<const MR: usize, const K_TILE: usize, L>(
     a: TensorBase<ViewData<u8>, L>,
     zero_point: Option<&[u8]>,
 ) where
-    L: Clone + for<'a> Layout<Index<'a> = [usize; 2]>,
+    L: Clone + for<'a> Layout<Shape<'a> = [usize; 2]> + 'static,
     [usize; 2]: AsIndex<L>,
 {
     let [a_rows, a_cols] = a.shape();

--- a/rten-tensor/src/contiguous.rs
+++ b/rten-tensor/src/contiguous.rs
@@ -1,6 +1,6 @@
 use std::ops::Deref;
 
-use crate::layout::MutLayout;
+use crate::layout::FromShape;
 use crate::storage::{CowData, ViewData};
 use crate::{AsView, Layout, Storage, TensorBase};
 
@@ -65,7 +65,7 @@ impl<T, L: Clone + Layout> Contiguous<TensorBase<Vec<T>, L>> {
     /// are copied into a new buffer.
     pub fn from_owned(mut inner: TensorBase<Vec<T>, L>) -> Self
     where
-        L: MutLayout,
+        L: FromShape,
         T: Clone,
     {
         inner.make_contiguous();

--- a/rten-tensor/src/impl_debug.rs
+++ b/rten-tensor/src/impl_debug.rs
@@ -1,6 +1,6 @@
 use std::fmt::{Debug, Error, Formatter};
 
-use crate::layout::{Layout, MatrixLayout};
+use crate::layout::{Layout, MatrixLayout, SizeArray};
 use crate::{AsView, NdTensorView, Storage, TensorBase};
 
 /// Entry in the formatted representation of a tensor's data.
@@ -119,7 +119,7 @@ where
                 let outer_dims = n - 2;
                 write!(f, "{}", "[".repeat(outer_dims))?;
 
-                let n_matrices: usize = tensor.shape().as_ref().iter().take(outer_dims).product();
+                let n_matrices: usize = tensor.shape().iter().take(outer_dims).product();
 
                 for (i, mat) in tensor
                     .inner_iter::<2>()

--- a/rten-tensor/src/impl_serialize.rs
+++ b/rten-tensor/src/impl_serialize.rs
@@ -4,7 +4,7 @@ use serde::de::{Deserialize, Deserializer, Error, MapAccess, Visitor};
 use serde::ser::{Serialize, SerializeStruct, Serializer};
 
 use crate::iterators::Iter;
-use crate::layout::MutLayout;
+use crate::layout::{FromShape, MutLayout};
 use crate::{AsView, Layout, Storage, TensorBase};
 
 struct TensorData<'a, T> {
@@ -31,8 +31,12 @@ where
     where
         Sr: Serializer,
     {
+        use crate::SizeArray;
+
+        let shape: Vec<_> = self.shape().iter().collect();
+
         let mut tensor = serializer.serialize_struct("Tensor", 2)?;
-        tensor.serialize_field("shape", self.shape().as_ref())?;
+        tensor.serialize_field("shape", &shape)?;
         tensor.serialize_field("data", &TensorData { iter: self.iter() })?;
         tensor.end()
     }
@@ -46,8 +50,7 @@ struct TensorVisitor<T, L> {
 impl<'de, T, L> Visitor<'de> for TensorVisitor<T, L>
 where
     T: Deserialize<'de>,
-    L: MutLayout,
-    for<'a> L::Index<'a>: TryFrom<&'a [usize]>,
+    L: for<'a> Layout<Shape<'a>: TryFrom<&'a [usize]>> + FromShape,
 {
     type Value = TensorBase<Vec<T>, L>;
 
@@ -89,7 +92,7 @@ where
             return Err(A::Error::missing_field("data"));
         };
 
-        let Ok(shape_ref): Result<L::Index<'_>, _> = shape.as_slice().try_into() else {
+        let Ok(shape_ref): Result<L::Shape<'_>, _> = shape.as_slice().try_into() else {
             return Err(A::Error::custom("incorrect shape length for tensor rank"));
         };
 
@@ -98,10 +101,10 @@ where
     }
 }
 
-impl<'de, T, L: MutLayout> Deserialize<'de> for TensorBase<Vec<T>, L>
+impl<'de, T, L> Deserialize<'de> for TensorBase<Vec<T>, L>
 where
     T: Deserialize<'de>,
-    for<'a> L::Index<'a>: TryFrom<&'a [usize]>,
+    L: for<'a> Layout<Shape<'a>: TryFrom<&'a [usize]>> + FromShape,
 {
     fn deserialize<D>(deserializer: D) -> Result<TensorBase<Vec<T>, L>, D::Error>
     where

--- a/rten-tensor/src/iterators.rs
+++ b/rten-tensor/src/iterators.rs
@@ -5,9 +5,10 @@ use std::mem::transmute;
 use std::ops::Range;
 
 use rten_base::iter::SplitIterator;
+use smallvec::SmallVec;
 
 use super::{AsView, DynLayout, NdTensorView, NdTensorViewMut, TensorBase, TensorViewMut};
-use crate::layout::{Layout, MutLayout, NdLayout, OverlapPolicy, RemoveDim, merge_axes};
+use crate::layout::{Layout, MutLayout, NdLayout, OverlapPolicy, RemoveDim, SizeArray, merge_axes};
 use crate::storage::{StorageMut, ViewData, ViewMutData};
 
 mod parallel;
@@ -105,7 +106,7 @@ impl OffsetsBase {
     fn new<L: Layout>(layout: &L) -> OffsetsBase {
         // Merge axes to maximize the number of iterations that use the fast
         // path for stepping over the inner dimensions.
-        let merged = merge_axes(layout.shape().as_ref(), layout.strides().as_ref());
+        let merged = merge_axes(&layout.shape(), &layout.strides());
 
         let inner_pos_pad = INNER_NDIM.saturating_sub(merged.len());
         let n_outer = merged.len().saturating_sub(INNER_NDIM);
@@ -970,7 +971,11 @@ impl<L: Layout + Clone> InnerIterBase<L> {
         let outer_dims = parent_layout.ndim() - inner_dims;
         let parent_shape = parent_layout.shape();
         let parent_strides = parent_layout.strides();
-        let (outer_shape, inner_shape) = parent_shape.as_ref().split_at(outer_dims);
+
+        let parent_dims: SmallVec<[usize; 5]> = parent_shape.iter().collect();
+        let (outer_shape, inner_shape) = parent_dims.as_ref().split_at(outer_dims);
+
+        let parent_strides: SmallVec<[usize; 5]> = parent_strides.iter().collect();
         let (outer_strides, inner_strides) = parent_strides.as_ref().split_at(outer_dims);
 
         let outer_layout = DynLayout::from_shape_and_strides(

--- a/rten-tensor/src/layout.rs
+++ b/rten-tensor/src/layout.rs
@@ -220,6 +220,27 @@ pub trait Layout {
             .sum();
         max_offset + 1
     }
+
+    /// Return a new layout formed by reshaping this one to `shape`.
+    ///
+    /// This has the same requirements as
+    /// [`reshaped_for_copy`](Layout::reshaped_for_copy) but also requires
+    /// that the layout is contiguous.
+    fn reshaped_for_view<S: IntoLayout>(&self, shape: S) -> Result<S::Layout, ReshapeError> {
+        if !self.is_contiguous() {
+            return Err(ReshapeError::NotContiguous);
+        }
+        self.reshaped_for_copy(shape)
+    }
+
+    /// Return a new layout formed by reshaping this one to `shape`.
+    fn reshaped_for_copy<S: IntoLayout>(&self, shape: S) -> Result<S::Layout, ReshapeError> {
+        let layout = shape.into_layout();
+        if layout.len() != self.len() {
+            return Err(ReshapeError::LengthMismatch);
+        }
+        Ok(layout)
+    }
 }
 
 /// A layout which upholds guarantees on returned storage offsets.
@@ -695,9 +716,6 @@ impl<const N: usize> From<NdLayout<N>> for DynLayout {
 /// [`from_shape_and_strides`](MutLayout::from_shape_and_strides) the intended
 /// usage is specified via an [`OverlapPolicy`].
 pub trait MutLayout: Layout + Clone {
-    /// Create a new contiguous layout with a given shape.
-    fn from_shape(shape: Self::Index<'_>) -> Self;
-
     /// Create a layout with custom strides.
     ///
     /// The strides specify the offset gap between successive entries along a
@@ -731,27 +749,6 @@ pub trait MutLayout: Layout + Clone {
 
     /// Return a layout with the axes permuted according to the given order.
     fn permuted(&self, order: Self::Index<'_>) -> Self;
-
-    /// Return a new layout formed by reshaping this one to `shape`.
-    ///
-    /// This has the same requirements as
-    /// [`reshaped_for_copy`](MutLayout::reshaped_for_copy) but also requires
-    /// that the layout is contiguous.
-    fn reshaped_for_view<S: IntoLayout>(&self, shape: S) -> Result<S::Layout, ReshapeError> {
-        if !self.is_contiguous() {
-            return Err(ReshapeError::NotContiguous);
-        }
-        self.reshaped_for_copy(shape)
-    }
-
-    /// Return a new layout formed by reshaping this one to `shape`.
-    fn reshaped_for_copy<S: IntoLayout>(&self, shape: S) -> Result<S::Layout, ReshapeError> {
-        let layout = shape.into_layout();
-        if layout.len() != self.len() {
-            return Err(ReshapeError::LengthMismatch);
-        }
-        Ok(layout)
-    }
 
     // Modify the size of a dimension. This does not alter the strides.
     fn resize_dim(&mut self, dim: usize, size: usize);
@@ -812,6 +809,12 @@ pub trait MutLayout: Layout + Clone {
     /// Returns a tuple of `(left, right)` where each item is an `(offset_range,
     /// layout)` tuple.
     fn split(&self, axis: usize, mid: usize) -> ((Range<usize>, Self), (Range<usize>, Self));
+}
+
+/// Trait for creating a layout from a shape.
+pub trait FromShape: Layout {
+    /// Create a new contiguous layout with a given shape.
+    fn from_shape(shape: Self::Index<'_>) -> Self;
 }
 
 /// Trait for broadcasting a layout from one shape to another.
@@ -880,14 +883,16 @@ impl<const N: usize> BroadcastLayout<NdLayout<N>> for DynLayout {
     }
 }
 
-impl<const N: usize> MutLayout for NdLayout<N> {
+impl<const N: usize> FromShape for NdLayout<N> {
     fn from_shape(shape: [usize; N]) -> Self {
         Self {
             shape,
             strides: Self::contiguous_strides(shape),
         }
     }
+}
 
+impl<const N: usize> MutLayout for NdLayout<N> {
     fn from_shape_and_strides(
         shape: Self::Index<'_>,
         strides: Self::Index<'_>,
@@ -1006,13 +1011,15 @@ impl<const N: usize> MutLayout for NdLayout<N> {
     }
 }
 
-impl MutLayout for DynLayout {
+impl FromShape for DynLayout {
     fn from_shape(shape: &[usize]) -> Self {
         DynLayout {
             shape_and_strides: Self::contiguous_shape_and_strides(shape),
         }
     }
+}
 
+impl MutLayout for DynLayout {
     fn from_shape_and_strides(
         shape: &[usize],
         strides: &[usize],
@@ -1508,7 +1515,7 @@ mod tests {
     use super::OverlapPolicy;
     use crate::SliceItem;
     use crate::errors::{ReshapeError, SliceError};
-    use crate::layout::{DynLayout, Layout, MutLayout, NdLayout, ResizeLayout};
+    use crate::layout::{DynLayout, FromShape, Layout, MutLayout, NdLayout, ResizeLayout};
 
     fn layout_with_strides<const N: usize>(shape: [usize; N], strides: [usize; N]) -> NdLayout<N> {
         NdLayout::from_shape_and_strides(shape, strides, OverlapPolicy::AllowOverlap).unwrap()

--- a/rten-tensor/src/layout.rs
+++ b/rten-tensor/src/layout.rs
@@ -24,15 +24,19 @@ pub fn is_valid_permutation(ndim: usize, permutation: &[usize]) -> bool {
 /// single dimension with size N1 * N2 and stride S2 if S1 = N1 * S2;
 ///
 /// Returns a vector of `(size, stride)` tuples for the merged dimensions.
-pub(crate) fn merge_axes(shape: &[usize], strides: &[usize]) -> SmallVec<[(usize, usize); 4]> {
-    let (Some(prev_size), Some(prev_stride)) = (shape.last(), strides.last()) else {
+pub(crate) fn merge_axes<S: SizeArray, St: SizeArray>(
+    shape: &S,
+    strides: &St,
+) -> SmallVec<[(usize, usize); 4]> {
+    let last_dim = shape.len().saturating_sub(1);
+    let (Some(prev_size), Some(prev_stride)) = (shape.get(last_dim), strides.get(last_dim)) else {
         return SmallVec::new();
     };
 
     let mut merged: SmallVec<[(usize, usize); 4]> = SmallVec::with_capacity(shape.len());
-    merged.push((*prev_size, *prev_stride));
+    merged.push((prev_size, prev_stride));
 
-    for (&outer_size, &outer_stride) in shape.iter().zip(strides.iter()).rev().skip(1) {
+    for (outer_size, outer_stride) in shape.iter().zip(strides.iter()).rev().skip(1) {
         let (inner_size, inner_stride) = merged.last_mut().unwrap();
         let can_merge = outer_size == 1 || (outer_stride == *inner_stride * *inner_size);
         if can_merge {
@@ -59,6 +63,41 @@ macro_rules! debug_assert_dim_valid {
     };
 }
 
+/// Array of dimension sizes or strides.
+///
+/// This trait is an abstraction around slices and arrays of [`usize`]s. Unlike
+/// `AsRef<[usize]>` this does not require the data to actually be stored in
+/// memory. This allows for strides which are computed on-demand or stored in a
+/// smaller data type (eg. `u32`) and expanded to `usize`.
+pub trait SizeArray: Clone + std::fmt::Debug + PartialEq<Self> {
+    /// Return the length of the array.
+    fn len(&self) -> usize;
+
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Return the `index`'th entry.
+    fn get(&self, index: usize) -> Option<usize>;
+
+    /// Return an iterator over the entries.
+    fn iter(&self) -> impl ExactSizeIterator<Item = usize> + DoubleEndedIterator;
+}
+
+impl<T: Clone + AsRef<[usize]> + std::fmt::Debug + PartialEq<Self>> SizeArray for T {
+    fn len(&self) -> usize {
+        self.as_ref().len()
+    }
+
+    fn get(&self, index: usize) -> Option<usize> {
+        self.as_ref().get(index).copied()
+    }
+
+    fn iter(&self) -> impl ExactSizeIterator<Item = usize> + DoubleEndedIterator {
+        self.as_ref().iter().copied()
+    }
+}
+
 /// Describes the shape and strides of a tensor.
 ///
 /// The `Layout` trait provides methods to query the shape of a tensor, i.e. the
@@ -70,10 +109,17 @@ macro_rules! debug_assert_dim_valid {
 /// such as [`NdLayout`] (for tensors with a static number of dimensions) and
 /// [`DynLayout`] (for tensors with a dynamic number of dimensions).
 pub trait Layout {
+    /// Type used to represent the layout's shape.
+    type Shape<'a>: SizeArray
+    where
+        Self: 'a;
+
+    /// Type used to represent the layout's strides.
+    type Strides<'a>: SizeArray
+    where
+        Self: 'a;
+
     /// Type used to represent indices.
-    ///
-    /// It is assumed that this type can also represent the shape and strides
-    /// of the tensor.
     type Index<'a>: AsRef<[usize]> + Clone + std::fmt::Debug + PartialEq<Self::Index<'a>>;
 
     /// Iterator over indices in this tensor.
@@ -89,8 +135,8 @@ pub trait Layout {
         index
             .as_ref()
             .iter()
-            .zip(self.strides().as_ref())
-            .map(|(idx, stride)| *idx * *stride)
+            .zip(self.strides().iter())
+            .map(|(idx, stride)| *idx * stride)
             .sum()
     }
 
@@ -112,13 +158,13 @@ pub trait Layout {
     /// Return true if this layout describes a contiguous tensor, where the
     /// logical order of elements matches the order in which they are stored.
     fn is_contiguous(&self) -> bool {
-        is_contiguous(self.shape(), self.strides())
+        is_contiguous(&self.shape(), &self.strides())
     }
 
     /// Return true if iterating over elements in this layout will visit
     /// elements multiple times.
     fn is_broadcast(&self) -> bool {
-        !self.is_empty() && self.strides().as_ref().contains(&0)
+        !self.is_empty() && self.strides().iter().any(|s| s == 0)
     }
 
     /// Returns true if the array has no elements.
@@ -127,21 +173,19 @@ pub trait Layout {
     }
 
     /// Returns an array of the sizes of each dimension.
-    fn shape(&self) -> Self::Index<'_>;
+    fn shape(&self) -> Self::Shape<'_>;
 
     /// Returns the size of the dimension `dim`.
     fn size(&self, dim: usize) -> usize {
-        debug_assert_dim_valid!(self, dim);
-        self.shape().as_ref()[dim]
+        self.shape().get(dim).expect("invalid dim index")
     }
 
     /// Returns an array of the strides of each dimension.
-    fn strides(&self) -> Self::Index<'_>;
+    fn strides(&self) -> Self::Strides<'_>;
 
     /// Returns the offset between adjacent indices along dimension `dim`.
     fn stride(&self, dim: usize) -> usize {
-        debug_assert_dim_valid!(self, dim);
-        self.strides().as_ref()[dim]
+        self.strides().get(dim).expect("invalid dimension")
     }
 
     /// Return an iterator over all valid indices in this tensor.
@@ -149,9 +193,7 @@ pub trait Layout {
 
     /// Return true if this layout's shape can be broadcast to the given shape.
     fn can_broadcast_to(&self, target_shape: &[usize]) -> bool {
-        if self.shape().as_ref() == target_shape {
-            return true;
-        } else if self.ndim() > target_shape.len() {
+        if self.ndim() > target_shape.len() {
             return false;
         }
 
@@ -160,14 +202,12 @@ pub trait Layout {
         //
         // If the tensor has fewer dimensions, pretend that it was prefixed with
         // 1-length dimensions to make the dimension counts equal.
-        let target_dims = target_shape[target_shape.len() - self.shape().as_ref().len()..]
+        let target_dims = target_shape[target_shape.len() - self.shape().len()..]
             .iter()
             .copied();
 
         self.shape()
-            .as_ref()
             .iter()
-            .copied()
             .zip(target_dims)
             .all(|(a, b)| a == b || a == 1)
     }
@@ -182,24 +222,19 @@ pub trait Layout {
     /// See <https://github.com/onnx/onnx/blob/main/docs/Broadcasting.md> for
     /// conditions in which broadcasting is allowed.
     fn can_broadcast_with(&self, shape: &[usize]) -> bool {
-        if self.shape().as_ref() == shape {
-            return true;
-        }
-
         // For two shapes to be compatible for broadcasting, each dimension must
         // either be the same or be 1.
         //
         // If the tensor has fewer dimensions, pretend that it was prefixed with
         // 1-length dimensions to make the dimension counts equal.
 
-        let current_shape = self.shape();
-        let a = current_shape.as_ref();
+        let a = self.shape();
         let b = shape;
 
         let a_pad = b.len().saturating_sub(a.len());
         let b_pad = a.len().saturating_sub(b.len());
 
-        let a_iter = a.iter().copied().rev().chain(repeat_n(1, a_pad));
+        let a_iter = a.iter().rev().chain(repeat_n(1, a_pad));
         let b_iter = b.iter().copied().rev().chain(repeat_n(1, b_pad));
 
         a_iter.zip(b_iter).all(|(a, b)| a == b || a == 1 || b == 1)
@@ -208,14 +243,13 @@ pub trait Layout {
     /// Return the minimum length required for the element data buffer used
     /// with this layout.
     fn min_data_len(&self) -> usize {
-        if self.shape().as_ref().contains(&0) {
+        if self.shape().iter().any(|d| d == 0) {
             return 0;
         }
         let max_offset: usize = self
             .shape()
-            .as_ref()
             .iter()
-            .zip(self.strides().as_ref())
+            .zip(self.strides().iter())
             .map(|(size, stride)| (size - 1) * stride)
             .sum();
         max_offset + 1
@@ -267,7 +301,7 @@ pub(crate) trait LayoutExt: Layout {
             panic!(
                 "index {:?} out of bounds for shape {:?}",
                 index.as_ref(),
-                self.shape().as_ref()
+                self.shape()
             )
         })
     }
@@ -302,6 +336,8 @@ pub struct NdLayout<const N: usize> {
 }
 
 impl<const N: usize> Layout for NdLayout<N> {
+    type Shape<'a> = [usize; N];
+    type Strides<'a> = [usize; N];
     type Index<'a> = [usize; N];
     type Indices = NdIndices<N>;
 
@@ -331,12 +367,12 @@ impl<const N: usize> Layout for NdLayout<N> {
     }
 
     #[inline]
-    fn shape(&self) -> Self::Index<'_> {
+    fn shape(&self) -> Self::Shape<'_> {
         self.shape
     }
 
     #[inline]
-    fn strides(&self) -> Self::Index<'_> {
+    fn strides(&self) -> [usize; N] {
         self.strides
     }
 
@@ -348,6 +384,14 @@ impl<const N: usize> Layout for NdLayout<N> {
 unsafe impl<const N: usize> TrustedLayout for NdLayout<N> {}
 
 impl<L: Layout> Layout for &L {
+    type Shape<'b>
+        = L::Shape<'b>
+    where
+        Self: 'b;
+    type Strides<'b>
+        = L::Strides<'b>
+    where
+        Self: 'b;
     type Index<'b> = L::Index<'b>;
     type Indices = L::Indices;
 
@@ -367,11 +411,11 @@ impl<L: Layout> Layout for &L {
         (*self).offset_unchecked(index)
     }
 
-    fn shape(&self) -> Self::Index<'_> {
+    fn shape(&self) -> Self::Shape<'_> {
         (*self).shape()
     }
 
-    fn strides(&self) -> Self::Index<'_> {
+    fn strides(&self) -> Self::Strides<'_> {
         (*self).strides()
     }
 
@@ -413,22 +457,21 @@ impl MatrixLayout for NdLayout<2> {
 ///
 /// This function is generic to allow for specialized variants to be generated
 /// when slicing with statically known input or output shape sizes.
-fn slice_layout<I: AsRef<[usize]>, O: AsMut<[usize]>>(
-    in_shape: I,
-    in_strides: I,
-    mut out_shape: O,
-    mut out_strides: O,
+fn slice_layout(
+    in_shape: impl AsRef<[usize]>,
+    in_strides: impl AsRef<[usize]>,
+    mut out_shape: impl AsMut<[usize]>,
+    mut out_strides: impl AsMut<[usize]>,
     range: &[SliceItem],
 ) -> Result<(usize, usize), SliceError> {
     let in_shape = in_shape.as_ref();
-    let in_strides = in_strides.as_ref();
     let out_shape = out_shape.as_mut();
     let out_strides = out_strides.as_mut();
 
     let mut ndim = 0;
     let mut offset = 0;
 
-    for (in_dim, (&size, &stride)) in in_shape.iter().zip(in_strides.iter()).enumerate() {
+    for (in_dim, (&size, &stride)) in in_shape.iter().zip(in_strides.as_ref()).enumerate() {
         let (offset_adjust, new_size_stride) = match range.get(in_dim) {
             Some(&SliceItem::Index(idx)) => {
                 let pos_idx = if idx >= 0 { idx } else { idx + size as isize };
@@ -489,7 +532,7 @@ fn broadcast_strides<'a>(
     to_shape: &'a [usize],
 ) -> impl Iterator<Item = usize> + 'a {
     let pad = to_shape.len() - from_shape.len();
-    repeat_n(0, pad).chain(from_shape.iter().zip(from_strides.iter()).enumerate().map(
+    repeat_n(0, pad).chain(from_shape.iter().zip(from_strides).enumerate().map(
         move |(i, (size, stride))| {
             if *size == 1 && to_shape[i + pad] > 1 {
                 0
@@ -573,6 +616,8 @@ impl Clone for DynLayout {
 }
 
 impl Layout for DynLayout {
+    type Shape<'a> = &'a [usize];
+    type Strides<'a> = &'a [usize];
     type Index<'a> = &'a [usize];
     type Indices = DynIndices;
 
@@ -587,7 +632,7 @@ impl Layout for DynLayout {
         let strides = self.strides();
         let mut valid = index.as_ref().len() == shape.len();
         let mut offset = 0;
-        for (idx, (size, stride)) in index.as_ref().iter().zip(shape.iter().zip(strides.iter())) {
+        for (idx, (size, stride)) in index.as_ref().iter().zip(shape.iter().zip(strides)) {
             valid = valid && idx < size;
             offset += idx * stride;
         }
@@ -619,7 +664,7 @@ impl Layout for DynLayout {
 
     /// Return the stride (offset between elements) in the tensor's element array.
     #[inline]
-    fn strides(&self) -> &[usize] {
+    fn strides(&self) -> Self::Strides<'_> {
         &self.shape_and_strides[self.ndim()..]
     }
 
@@ -643,10 +688,8 @@ impl DynLayout {
     }
 
     fn permute_iter<I: Clone + Iterator<Item = usize>>(&mut self, dims: I) {
-        let strides = self.strides();
-        let shape = self.shape();
-        let shape_iter = dims.clone().map(|dim| shape[dim]);
-        let stride_iter = dims.map(|dim| strides[dim]);
+        let shape_iter = dims.clone().map(|dim| self.size(dim));
+        let stride_iter = dims.map(|dim| self.stride(dim));
         self.shape_and_strides = shape_iter.chain(stride_iter).collect();
     }
 
@@ -680,12 +723,10 @@ impl DynLayout {
 
 impl<L: Layout> From<&L> for DynLayout {
     fn from(layout: &L) -> DynLayout {
-        DynLayout::from_shape_and_strides(
-            layout.shape().as_ref(),
-            layout.strides().as_ref(),
-            OverlapPolicy::AllowOverlap,
-        )
-        .expect("invalid layout")
+        let shape: SmallVec<[usize; 5]> = layout.shape().iter().collect();
+        let strides: SmallVec<[usize; 5]> = layout.strides().iter().collect();
+        DynLayout::from_shape_and_strides(&shape, &strides, OverlapPolicy::AllowOverlap)
+            .expect("invalid layout")
     }
 }
 
@@ -723,8 +764,8 @@ pub trait MutLayout: Layout + Clone {
     /// multiple indices to the same element. This can be true for immutable
     /// views, but must be false for tensors or views that are mutable.
     fn from_shape_and_strides(
-        shape: Self::Index<'_>,
-        strides: Self::Index<'_>,
+        shape: Self::Shape<'_>,
+        strides: Self::Strides<'_>,
         overlap: OverlapPolicy,
     ) -> Result<Self, FromDataError>;
 
@@ -814,7 +855,7 @@ pub trait MutLayout: Layout + Clone {
 /// Trait for creating a layout from a shape.
 pub trait FromShape: Layout {
     /// Create a new contiguous layout with a given shape.
-    fn from_shape(shape: Self::Index<'_>) -> Self;
+    fn from_shape(shape: Self::Shape<'_>) -> Self;
 }
 
 /// Trait for broadcasting a layout from one shape to another.
@@ -902,7 +943,7 @@ impl<const N: usize> MutLayout for NdLayout<N> {
 
         match overlap {
             OverlapPolicy::DisallowOverlap => {
-                if may_have_internal_overlap(&layout.shape, &layout.strides) {
+                if may_have_internal_overlap(layout.shape, layout.strides) {
                     return Err(FromDataError::MayOverlap);
                 }
             }
@@ -954,7 +995,7 @@ impl<const N: usize> MutLayout for NdLayout<N> {
         let mut strides: [usize; M] = [0; M];
 
         let (ndim, offset) =
-            slice_layout(&self.shape, &self.strides, &mut shape, &mut strides, range)?;
+            slice_layout(self.shape, self.strides, &mut shape, &mut strides, range)?;
 
         if ndim != M {
             return Err(SliceError::OutputDimsMismatch {
@@ -1123,7 +1164,7 @@ impl MutLayout for DynLayout {
         let mut left_shape_strides: SmallVec<[usize; 8]> = (0..self.ndim())
             .map(|i| if i == axis { mid } else { self.size(i) })
             .collect();
-        left_shape_strides.extend(self.strides().iter().copied());
+        left_shape_strides.extend_from_slice(self.strides());
 
         let mut right_shape_strides: SmallVec<[usize; 8]> = (0..self.ndim())
             .map(|i| {
@@ -1134,7 +1175,7 @@ impl MutLayout for DynLayout {
                 }
             })
             .collect();
-        right_shape_strides.extend(self.strides().iter().copied());
+        right_shape_strides.extend_from_slice(self.strides());
 
         let left = DynLayout {
             shape_and_strides: left_shape_strides,
@@ -1253,7 +1294,7 @@ impl ResizeLayout for DynLayout {
     }
 
     fn merge_axes(&mut self) {
-        let merged = merge_axes(self.shape(), self.strides());
+        let merged = merge_axes(&self.shape(), &self.strides());
         self.shape_and_strides = merged
             .iter()
             .map(|dim| dim.0)
@@ -1286,6 +1327,30 @@ impl<const N: usize> AsIndex<NdLayout<N>> for [usize; N] {
 
 impl AsIndex<NdLayout<1>> for usize {
     fn as_index(&self) -> [usize; 1] {
+        [*self]
+    }
+}
+
+/// Trait for converting types into shapes for a given layout.
+pub trait AsShape<L: Layout> {
+    /// Convert `self` into an index for use the layout `L`.
+    fn as_shape(&self) -> L::Shape<'_>;
+}
+
+impl<T: AsRef<[usize]>> AsShape<DynLayout> for T {
+    fn as_shape(&self) -> &[usize] {
+        self.as_ref()
+    }
+}
+
+impl<const N: usize> AsShape<NdLayout<N>> for [usize; N] {
+    fn as_shape(&self) -> [usize; N] {
+        *self
+    }
+}
+
+impl AsShape<NdLayout<1>> for usize {
+    fn as_shape(&self) -> [usize; 1] {
         [*self]
     }
 }

--- a/rten-tensor/src/lib.rs
+++ b/rten-tensor/src/lib.rs
@@ -86,7 +86,7 @@ pub trait RandomSource<T> {
 pub use assume_init::AssumeInit;
 pub use contiguous::Contiguous;
 pub use index_iterator::{DynIndices, Indices, NdIndices};
-pub use layout::{DynLayout, InsertDim, Layout, MatrixLayout, NdLayout};
+pub use layout::{DynLayout, InsertDim, Layout, MatrixLayout, NdLayout, SizeArray};
 pub use slice_range::{SliceItem, SliceRange};
 pub use storage::Storage;
 pub use tensor::{

--- a/rten-tensor/src/overlap.rs
+++ b/rten-tensor/src/overlap.rs
@@ -1,10 +1,12 @@
 use smallvec::SmallVec;
 
+use crate::layout::SizeArray;
+
 /// Return true if a given shape and strides describe a contiguous layout in
 /// row-major ("C") order.
-pub fn is_contiguous<S: AsRef<[usize]>>(shape: S, strides: S) -> bool {
+pub fn is_contiguous<S: SizeArray, Strides: SizeArray>(shape: &S, strides: &Strides) -> bool {
     let mut product = 1;
-    for (&size, &stride) in shape.as_ref().iter().zip(strides.as_ref().iter()).rev() {
+    for (size, stride) in shape.iter().zip(strides.iter()).rev() {
         // Dimensions of size 1 cannot affect whether the tensor is contiguous,
         // since the only valid index is 0 and `0 * stride = 0` for any stride.
         if size == 1 {
@@ -40,21 +42,21 @@ pub fn is_contiguous<S: AsRef<[usize]>>(shape: S, strides: S) -> bool {
 ///     and in particular references to internal overlap.
 /// [2] See also references to "memory overlap" in PyTorch source and
 ///     issues.
-pub fn may_have_internal_overlap(shape: &[usize], strides: &[usize]) -> bool {
+pub fn may_have_internal_overlap(shape: impl SizeArray, strides: impl SizeArray) -> bool {
     // If the tensor is empty (ie. there are no valid indices), there can't be
     // any overlap.
-    if shape.contains(&0) {
+    if shape.iter().any(|d| d == 0) {
         return false;
     }
 
     // Fast path for common case of contiguous tensor.
-    if is_contiguous(shape, strides) {
+    if is_contiguous(&shape, &strides) {
         return false;
     }
 
     // Sort dimensions in order of increasing stride.
     let mut stride_shape: SmallVec<[(usize, usize); 8]> =
-        strides.iter().copied().zip(shape.iter().copied()).collect();
+        strides.iter().zip(shape.iter()).collect();
     stride_shape.sort_unstable();
 
     // Verify that the stride for each dimension fully "steps over" the
@@ -157,7 +159,7 @@ mod tests {
         ];
 
         cases.test_each(|case| {
-            assert_eq!(is_contiguous(case.shape, case.strides), case.contiguous);
+            assert_eq!(is_contiguous(&case.shape, &case.strides), case.contiguous);
         })
     }
 }

--- a/rten-tensor/src/tensor.rs
+++ b/rten-tensor/src/tensor.rs
@@ -15,8 +15,9 @@ use crate::iterators::{
     Lanes, LanesMut, for_each_mut,
 };
 use crate::layout::{
-    AsIndex, BroadcastLayout, DynLayout, InsertDim, IntoLayout, Layout, LayoutExt, MatrixLayout,
-    MutLayout, NdLayout, OverlapPolicy, RemoveDim, ResizeLayout, SliceWith, TrustedLayout,
+    AsIndex, BroadcastLayout, DynLayout, FromShape, InsertDim, IntoLayout, Layout, LayoutExt,
+    MatrixLayout, MutLayout, NdLayout, OverlapPolicy, RemoveDim, ResizeLayout, SliceWith,
+    TrustedLayout,
 };
 use crate::overlap::may_have_internal_overlap;
 use crate::slice_range::{IntoSliceItems, SliceItem};
@@ -230,7 +231,7 @@ pub trait AsView: Layout {
     fn map<F, U>(&self, f: F) -> TensorBase<Vec<U>, Self::Layout>
     where
         F: Fn(&Self::Elem) -> U,
-        Self::Layout: MutLayout,
+        Self::Layout: FromShape,
     {
         self.view().map(f)
     }
@@ -239,7 +240,7 @@ pub trait AsView: Layout {
     fn map_in<A: Alloc, F, U>(&self, alloc: A, f: F) -> TensorBase<Vec<U>, Self::Layout>
     where
         F: Fn(&Self::Elem) -> U,
-        Self::Layout: MutLayout,
+        Self::Layout: FromShape,
     {
         self.view().map_in(alloc, f)
     }
@@ -302,7 +303,6 @@ pub trait AsView: Layout {
     ) -> TensorBase<CowData<'_, Self::Elem>, S::Layout>
     where
         Self::Elem: Clone,
-        Self::Layout: MutLayout,
     {
         self.view().reshaped(shape)
     }
@@ -316,7 +316,6 @@ pub trait AsView: Layout {
     ) -> TensorBase<CowData<'_, Self::Elem>, S::Layout>
     where
         Self::Elem: Clone,
-        Self::Layout: MutLayout,
     {
         self.view().reshaped_in(alloc, shape)
     }
@@ -402,7 +401,7 @@ pub trait AsView: Layout {
         Self::Layout: SliceWith<
                 R,
                 R::Count,
-                Layout: for<'a> Layout<Index<'a>: TryFrom<&'a [usize], Error: Debug>>,
+                Layout: FromShape + for<'a> Layout<Index<'a>: TryFrom<&'a [usize], Error: Debug>>,
             >,
     {
         self.slice_copy_in(GlobalAlloc::new(), range)
@@ -420,7 +419,7 @@ pub trait AsView: Layout {
         Self::Layout: SliceWith<
                 R,
                 R::Count,
-                Layout: for<'a> Layout<Index<'a>: TryFrom<&'a [usize], Error: Debug>>,
+                Layout: FromShape + for<'a> Layout<Index<'a>: TryFrom<&'a [usize], Error: Debug>>,
             >,
     {
         // Fast path for slice ranges supported by `Tensor::slice`. This includes
@@ -491,7 +490,7 @@ pub trait AsView: Layout {
     fn to_contiguous(&self) -> Contiguous<TensorBase<CowData<'_, Self::Elem>, Self::Layout>>
     where
         Self::Elem: Clone,
-        Self::Layout: MutLayout,
+        Self::Layout: FromShape,
     {
         self.view().to_contiguous()
     }
@@ -504,7 +503,7 @@ pub trait AsView: Layout {
     ) -> Contiguous<TensorBase<CowData<'_, Self::Elem>, Self::Layout>>
     where
         Self::Elem: Clone,
-        Self::Layout: MutLayout,
+        Self::Layout: FromShape,
     {
         self.view().to_contiguous_in(alloc)
     }
@@ -512,8 +511,7 @@ pub trait AsView: Layout {
     /// Return a copy of this tensor with a given shape.
     fn to_shape<S: IntoLayout>(&self, shape: S) -> TensorBase<Vec<Self::Elem>, S::Layout>
     where
-        Self::Elem: Clone,
-        Self::Layout: MutLayout;
+        Self::Elem: Clone;
 
     /// Return a slice containing the elements of this tensor in their logical
     /// order, ie. as if the tensor were flattened into one dimension.
@@ -532,7 +530,7 @@ pub trait AsView: Layout {
     fn to_tensor(&self) -> TensorBase<Vec<Self::Elem>, Self::Layout>
     where
         Self::Elem: Clone,
-        Self::Layout: MutLayout,
+        Self::Layout: FromShape,
     {
         self.to_tensor_in(GlobalAlloc::new())
     }
@@ -541,7 +539,7 @@ pub trait AsView: Layout {
     fn to_tensor_in<A: Alloc>(&self, alloc: A) -> TensorBase<Vec<Self::Elem>, Self::Layout>
     where
         Self::Elem: Clone,
-        Self::Layout: MutLayout,
+        Self::Layout: FromShape,
     {
         TensorBase::from_data(self.layout().shape(), self.to_vec_in(alloc))
     }
@@ -560,8 +558,8 @@ impl<S: Storage, L: Layout> TensorBase<S, L> {
     #[track_caller]
     pub fn from_data<D: IntoStorage<Output = S>>(shape: L::Index<'_>, data: D) -> TensorBase<S, L>
     where
+        L: FromShape,
         for<'a> L::Index<'a>: Clone,
-        L: MutLayout,
     {
         let data = data.into_storage();
         let len = data.len();
@@ -583,7 +581,7 @@ impl<S: Storage, L: Layout> TensorBase<S, L> {
         data: D,
     ) -> Result<TensorBase<S, L>, FromDataError>
     where
-        L: MutLayout,
+        L: FromShape,
     {
         let data = data.into_storage();
         let layout = L::from_shape(shape);
@@ -916,10 +914,7 @@ impl<S: StorageMut, L: Clone + Layout> TensorBase<S, L> {
     }
 
     /// Return a mutable iterator over the N innermost dimensions of this tensor.
-    pub fn inner_iter_mut<const N: usize>(&mut self) -> InnerIterMut<'_, S::Elem, NdLayout<N>>
-    where
-        L: MutLayout,
-    {
+    pub fn inner_iter_mut<const N: usize>(&mut self) -> InnerIterMut<'_, S::Elem, NdLayout<N>> {
         InnerIterMut::new(self.view_mut())
     }
 
@@ -927,10 +922,7 @@ impl<S: StorageMut, L: Clone + Layout> TensorBase<S, L> {
     ///
     /// Prefer [`inner_iter_mut`](TensorBase::inner_iter_mut) if `N` is known
     /// at compile time.
-    pub fn inner_iter_dyn_mut(&mut self, n: usize) -> InnerIterMut<'_, S::Elem, DynLayout>
-    where
-        L: MutLayout,
-    {
+    pub fn inner_iter_dyn_mut(&mut self, n: usize) -> InnerIterMut<'_, S::Elem, DynLayout> {
         InnerIterMut::new_dyn(self.view_mut(), n)
     }
 
@@ -983,10 +975,7 @@ impl<S: StorageMut, L: Clone + Layout> TensorBase<S, L> {
     pub fn reshaped_mut<SH: IntoLayout>(
         &mut self,
         shape: SH,
-    ) -> Result<TensorBase<ViewMutData<'_, S::Elem>, SH::Layout>, ReshapeError>
-    where
-        L: MutLayout,
-    {
+    ) -> Result<TensorBase<ViewMutData<'_, S::Elem>, SH::Layout>, ReshapeError> {
         let layout = self.layout.reshaped_for_view(shape)?;
         Ok(TensorBase {
             layout,
@@ -1073,7 +1062,7 @@ impl<T, L: Clone + Layout> TensorBase<Vec<T>, L> {
     where
         T: Copy + PartialOrd + From<bool> + std::ops::Add<Output = T>,
         [usize; 1]: AsIndex<L>,
-        L: MutLayout,
+        L: FromShape,
     {
         let step = step.unwrap_or((true).into());
         let mut data = Vec::new();
@@ -1132,7 +1121,7 @@ impl<T, L: Clone + Layout> TensorBase<Vec<T>, L> {
     pub fn from_vec(vec: Vec<T>) -> TensorBase<Vec<T>, L>
     where
         [usize; 1]: AsIndex<L>,
-        L: MutLayout,
+        L: FromShape,
     {
         TensorBase::from_data([vec.len()].as_index(), vec)
     }
@@ -1247,7 +1236,6 @@ impl<T, L: Clone + Layout> TensorBase<Vec<T>, L> {
     pub fn into_shape<S: Copy + IntoLayout>(self, shape: S) -> TensorBase<Vec<T>, S::Layout>
     where
         T: Clone,
-        L: MutLayout,
     {
         let Ok(layout) = self.layout.reshaped_for_copy(shape) else {
             panic!(
@@ -1275,7 +1263,7 @@ impl<T, L: Clone + Layout> TensorBase<Vec<T>, L> {
     where
         L::Indices: Iterator<Item = Idx>,
         Idx: AsIndex<L>,
-        L: MutLayout,
+        L: FromShape,
     {
         Self::from_fn_in(GlobalAlloc::new(), shape, f)
     }
@@ -1289,7 +1277,7 @@ impl<T, L: Clone + Layout> TensorBase<Vec<T>, L> {
     where
         L::Indices: Iterator<Item = Idx>,
         Idx: AsIndex<L>,
-        L: MutLayout,
+        L: FromShape,
     {
         let layout = L::from_shape(shape);
         let mut data = alloc.alloc(layout.len());
@@ -1301,7 +1289,7 @@ impl<T, L: Clone + Layout> TensorBase<Vec<T>, L> {
     /// `f` repeatedly.
     pub fn from_simple_fn<F: FnMut() -> T>(shape: L::Index<'_>, f: F) -> TensorBase<Vec<T>, L>
     where
-        L: MutLayout,
+        L: FromShape,
     {
         Self::from_simple_fn_in(GlobalAlloc::new(), shape, f)
     }
@@ -1314,7 +1302,7 @@ impl<T, L: Clone + Layout> TensorBase<Vec<T>, L> {
         mut f: F,
     ) -> TensorBase<Vec<T>, L>
     where
-        L: MutLayout,
+        L: FromShape,
     {
         let len = shape.as_ref().iter().product();
         let mut data = alloc.alloc(len);
@@ -1326,7 +1314,7 @@ impl<T, L: Clone + Layout> TensorBase<Vec<T>, L> {
     pub fn from_scalar(value: T) -> TensorBase<Vec<T>, L>
     where
         [usize; 0]: AsIndex<L>,
-        L: MutLayout,
+        L: FromShape,
     {
         TensorBase::from_data([].as_index(), vec![value])
     }
@@ -1335,7 +1323,7 @@ impl<T, L: Clone + Layout> TensorBase<Vec<T>, L> {
     pub fn full(shape: L::Index<'_>, value: T) -> TensorBase<Vec<T>, L>
     where
         T: Clone,
-        L: MutLayout,
+        L: FromShape,
     {
         Self::full_in(GlobalAlloc::new(), shape, value)
     }
@@ -1344,7 +1332,7 @@ impl<T, L: Clone + Layout> TensorBase<Vec<T>, L> {
     pub fn full_in<A: Alloc>(alloc: A, shape: L::Index<'_>, value: T) -> TensorBase<Vec<T>, L>
     where
         T: Clone,
-        L: MutLayout,
+        L: FromShape,
     {
         let len = shape.as_ref().iter().product();
         let mut data = alloc.alloc(len);
@@ -1361,7 +1349,7 @@ impl<T, L: Clone + Layout> TensorBase<Vec<T>, L> {
     pub fn make_contiguous(&mut self)
     where
         T: Clone,
-        L: MutLayout,
+        L: FromShape,
     {
         if self.is_contiguous() {
             return;
@@ -1377,7 +1365,7 @@ impl<T, L: Clone + Layout> TensorBase<Vec<T>, L> {
     pub fn into_contiguous(self) -> Contiguous<Self>
     where
         T: Clone,
-        L: MutLayout,
+        L: FromShape,
     {
         Contiguous::from_owned(self)
     }
@@ -1389,7 +1377,7 @@ impl<T, L: Clone + Layout> TensorBase<Vec<T>, L> {
     /// function is [`from_simple_fn`](Self::from_simple_fn).
     pub fn rand<R: RandomSource<T>>(shape: L::Index<'_>, rand_src: &mut R) -> TensorBase<Vec<T>, L>
     where
-        L: MutLayout,
+        L: FromShape,
     {
         Self::from_simple_fn(shape, || rand_src.next())
     }
@@ -1399,7 +1387,7 @@ impl<T, L: Clone + Layout> TensorBase<Vec<T>, L> {
     pub fn zeros(shape: L::Index<'_>) -> TensorBase<Vec<T>, L>
     where
         T: Clone + Default,
-        L: MutLayout,
+        L: FromShape,
     {
         Self::zeros_in(GlobalAlloc::new(), shape)
     }
@@ -1408,7 +1396,7 @@ impl<T, L: Clone + Layout> TensorBase<Vec<T>, L> {
     pub fn zeros_in<A: Alloc>(alloc: A, shape: L::Index<'_>) -> TensorBase<Vec<T>, L>
     where
         T: Clone + Default,
-        L: MutLayout,
+        L: FromShape,
     {
         // We delegate to `full_in` here and rely on compiler optimizations to
         // take advantage of the value being statically known to be zero.
@@ -1423,7 +1411,7 @@ impl<T, L: Clone + Layout> TensorBase<Vec<T>, L> {
     pub fn uninit(shape: L::Index<'_>) -> TensorBase<Vec<MaybeUninit<T>>, L>
     where
         MaybeUninit<T>: Clone,
-        L: MutLayout,
+        L: FromShape,
     {
         Self::uninit_in(GlobalAlloc::new(), shape)
     }
@@ -1431,7 +1419,7 @@ impl<T, L: Clone + Layout> TensorBase<Vec<T>, L> {
     /// Variant of [`uninit`](TensorBase::uninit) which takes an allocator.
     pub fn uninit_in<A: Alloc>(alloc: A, shape: L::Index<'_>) -> TensorBase<Vec<MaybeUninit<T>>, L>
     where
-        L: MutLayout,
+        L: FromShape,
     {
         let len = shape.as_ref().iter().product();
         let mut data = alloc.alloc(len);
@@ -1454,7 +1442,7 @@ impl<T, L: Clone + Layout> TensorBase<Vec<T>, L> {
     ) -> Result<TensorBase<Vec<T>, L>, ExpandError>
     where
         T: Copy,
-        L: MutLayout,
+        L: FromShape + MutLayout,
     {
         let first = tensors.first().ok_or(ExpandError::ShapeMismatch)?;
         let total_dim_size: usize = tensors.iter().map(|t| t.size(dim)).sum();
@@ -1478,7 +1466,7 @@ impl<T, L: Clone + Layout> TensorBase<Vec<T>, L> {
     pub fn with_capacity(shape: L::Index<'_>, expand_dim: usize) -> TensorBase<Vec<T>, L>
     where
         T: Copy,
-        L: MutLayout,
+        L: FromShape + MutLayout,
     {
         Self::with_capacity_in(GlobalAlloc::new(), shape, expand_dim)
     }
@@ -1491,7 +1479,7 @@ impl<T, L: Clone + Layout> TensorBase<Vec<T>, L> {
     ) -> TensorBase<Vec<T>, L>
     where
         T: Copy,
-        L: MutLayout,
+        L: FromShape + MutLayout,
     {
         let mut tensor = Self::uninit_in(alloc, shape);
         tensor.clip_dim(expand_dim, 0..0);
@@ -1521,7 +1509,7 @@ impl<'a, T, L: Layout> TensorBase<CowData<'a, T>, L> {
     /// This is cheap if the data is already owned or requires a copy otherwise.
     pub fn into_owned(self) -> TensorBase<Vec<T>, L>
     where
-        L: MutLayout,
+        L: Clone + FromShape,
         T: Clone,
     {
         self.into_owned_in(GlobalAlloc::new())
@@ -1530,7 +1518,7 @@ impl<'a, T, L: Layout> TensorBase<CowData<'a, T>, L> {
     /// Variant of [`into_owned`](Self) that takes an allocator.
     pub fn into_owned_in<A: Alloc>(self, alloc: A) -> TensorBase<Vec<T>, L>
     where
-        L: MutLayout,
+        L: Clone + FromShape,
         T: Clone,
     {
         match self.data {
@@ -1555,7 +1543,7 @@ impl<'a, T, L: Layout> TensorBase<CowData<'a, T>, L> {
     ) -> TensorBase<CowData<'a, T>, S::Layout>
     where
         T: Clone,
-        L: MutLayout,
+        L: Clone,
     {
         self.into_shape_in(GlobalAlloc::new(), shape)
     }
@@ -1568,7 +1556,7 @@ impl<'a, T, L: Layout> TensorBase<CowData<'a, T>, L> {
     ) -> TensorBase<CowData<'a, T>, S::Layout>
     where
         T: Clone,
-        L: MutLayout,
+        L: Clone,
     {
         if let Ok(layout) = self.layout.reshaped_for_view(shape.clone()) {
             TensorBase {
@@ -1868,7 +1856,6 @@ impl<'a, T, L: Clone + Layout> TensorBase<ViewData<'a, T>, L> {
     pub fn reshaped<S: Copy + IntoLayout>(&self, shape: S) -> TensorBase<CowData<'a, T>, S::Layout>
     where
         T: Clone,
-        L: MutLayout,
     {
         self.reshaped_in(GlobalAlloc::new(), shape)
     }
@@ -1881,7 +1868,6 @@ impl<'a, T, L: Clone + Layout> TensorBase<ViewData<'a, T>, L> {
     ) -> TensorBase<CowData<'a, T>, S::Layout>
     where
         T: Clone,
-        L: MutLayout,
     {
         if let Ok(layout) = self.layout.reshaped_for_view(shape) {
             TensorBase {
@@ -2003,7 +1989,7 @@ impl<'a, T, L: Clone + Layout> TensorBase<ViewData<'a, T>, L> {
     pub fn to_contiguous(&self) -> Contiguous<TensorBase<CowData<'a, T>, L>>
     where
         T: Clone,
-        L: MutLayout,
+        L: FromShape,
     {
         self.to_contiguous_in(GlobalAlloc::new())
     }
@@ -2013,7 +1999,7 @@ impl<'a, T, L: Clone + Layout> TensorBase<ViewData<'a, T>, L> {
     pub fn to_contiguous_in<A: Alloc>(&self, alloc: A) -> Contiguous<TensorBase<CowData<'a, T>, L>>
     where
         T: Clone,
-        L: MutLayout,
+        L: FromShape,
     {
         let tensor = if let Some(data) = self.data() {
             TensorBase {
@@ -2204,7 +2190,7 @@ impl<T, S: Storage<Elem = T>, L: Layout + Clone> AsView for TensorBase<S, L> {
     fn map<F, U>(&self, f: F) -> TensorBase<Vec<U>, L>
     where
         F: Fn(&Self::Elem) -> U,
-        L: MutLayout,
+        L: FromShape,
     {
         self.map_in(GlobalAlloc::new(), f)
     }
@@ -2212,7 +2198,7 @@ impl<T, S: Storage<Elem = T>, L: Layout + Clone> AsView for TensorBase<S, L> {
     fn map_in<A: Alloc, F, U>(&self, alloc: A, f: F) -> TensorBase<Vec<U>, L>
     where
         F: Fn(&Self::Elem) -> U,
-        L: MutLayout,
+        L: FromShape,
     {
         let len = self.len();
         let mut buf = alloc.alloc(len);
@@ -2296,7 +2282,6 @@ impl<T, S: Storage<Elem = T>, L: Layout + Clone> AsView for TensorBase<S, L> {
     fn to_shape<SH: IntoLayout>(&self, shape: SH) -> TensorBase<Vec<Self::Elem>, SH::Layout>
     where
         T: Clone,
-        L: MutLayout,
     {
         TensorBase {
             data: self.to_vec(),
@@ -2421,7 +2406,7 @@ impl<'a, T, L: Layout> TensorBase<ViewMutData<'a, T>, L> {
     }
 }
 
-impl<T, L: MutLayout> FromIterator<T> for TensorBase<Vec<T>, L>
+impl<T, L: FromShape> FromIterator<T> for TensorBase<Vec<T>, L>
 where
     [usize; 1]: AsIndex<L>,
 {
@@ -2434,7 +2419,7 @@ where
     }
 }
 
-impl<T, L: MutLayout> From<Vec<T>> for TensorBase<Vec<T>, L>
+impl<T, L: FromShape> From<Vec<T>> for TensorBase<Vec<T>, L>
 where
     [usize; 1]: AsIndex<L>,
 {
@@ -2444,7 +2429,7 @@ where
     }
 }
 
-impl<'a, T, L: MutLayout> From<&'a [T]> for TensorBase<ViewData<'a, T>, L>
+impl<'a, T, L: FromShape> From<&'a [T]> for TensorBase<ViewData<'a, T>, L>
 where
     [usize; 1]: AsIndex<L>,
 {
@@ -2454,7 +2439,7 @@ where
     }
 }
 
-impl<'a, T, L: MutLayout, const N: usize> From<&'a [T; N]> for TensorBase<ViewData<'a, T>, L>
+impl<'a, T, L: FromShape, const N: usize> From<&'a [T; N]> for TensorBase<ViewData<'a, T>, L>
 where
     [usize; 1]: AsIndex<L>,
 {
@@ -2704,7 +2689,7 @@ impl_scalar!(String);
 // impl for a nested array literal, as it prevents `T` from matching an array
 // type.
 
-impl<T: Clone + Scalar, L: MutLayout> From<T> for TensorBase<Vec<T>, L>
+impl<T: Clone + Scalar, L: Clone + FromShape> From<T> for TensorBase<Vec<T>, L>
 where
     [usize; 0]: AsIndex<L>,
 {
@@ -2714,7 +2699,7 @@ where
     }
 }
 
-impl<T: Clone + Scalar, L: MutLayout, const D0: usize> From<[T; D0]> for TensorBase<Vec<T>, L>
+impl<T: Clone + Scalar, L: FromShape, const D0: usize> From<[T; D0]> for TensorBase<Vec<T>, L>
 where
     [usize; 1]: AsIndex<L>,
 {
@@ -2725,7 +2710,7 @@ where
     }
 }
 
-impl<T: Clone + Scalar, L: MutLayout, const D0: usize, const D1: usize> From<[[T; D1]; D0]>
+impl<T: Clone + Scalar, L: FromShape, const D0: usize, const D1: usize> From<[[T; D1]; D0]>
     for TensorBase<Vec<T>, L>
 where
     [usize; 2]: AsIndex<L>,
@@ -2737,7 +2722,7 @@ where
     }
 }
 
-impl<T: Clone + Scalar, L: MutLayout, const D0: usize, const D1: usize, const D2: usize>
+impl<T: Clone + Scalar, L: FromShape, const D0: usize, const D1: usize, const D2: usize>
     From<[[[T; D2]; D1]; D0]> for TensorBase<Vec<T>, L>
 where
     [usize; 3]: AsIndex<L>,

--- a/rten-tensor/src/tensor.rs
+++ b/rten-tensor/src/tensor.rs
@@ -15,9 +15,9 @@ use crate::iterators::{
     Lanes, LanesMut, for_each_mut,
 };
 use crate::layout::{
-    AsIndex, BroadcastLayout, DynLayout, FromShape, InsertDim, IntoLayout, Layout, LayoutExt,
-    MatrixLayout, MutLayout, NdLayout, OverlapPolicy, RemoveDim, ResizeLayout, SliceWith,
-    TrustedLayout,
+    AsIndex, AsShape, BroadcastLayout, DynLayout, FromShape, InsertDim, IntoLayout, Layout,
+    LayoutExt, MatrixLayout, MutLayout, NdLayout, OverlapPolicy, RemoveDim, ResizeLayout,
+    SizeArray, SliceWith, TrustedLayout,
 };
 use crate::overlap::may_have_internal_overlap;
 use crate::slice_range::{IntoSliceItems, SliceItem};
@@ -401,7 +401,7 @@ pub trait AsView: Layout {
         Self::Layout: SliceWith<
                 R,
                 R::Count,
-                Layout: FromShape + for<'a> Layout<Index<'a>: TryFrom<&'a [usize], Error: Debug>>,
+                Layout: FromShape + for<'a> Layout<Shape<'a>: TryFrom<&'a [usize], Error: Debug>>,
             >,
     {
         self.slice_copy_in(GlobalAlloc::new(), range)
@@ -419,7 +419,7 @@ pub trait AsView: Layout {
         Self::Layout: SliceWith<
                 R,
                 R::Count,
-                Layout: FromShape + for<'a> Layout<Index<'a>: TryFrom<&'a [usize], Error: Debug>>,
+                Layout: FromShape + for<'a> Layout<Shape<'a>: TryFrom<&'a [usize], Error: Debug>>,
             >,
     {
         // Fast path for slice ranges supported by `Tensor::slice`. This includes
@@ -556,20 +556,16 @@ impl<S: Storage, L: Layout> TensorBase<S, L> {
     ///
     /// Panics if the data length does not match the product of `shape`.
     #[track_caller]
-    pub fn from_data<D: IntoStorage<Output = S>>(shape: L::Index<'_>, data: D) -> TensorBase<S, L>
+    pub fn from_data<D: IntoStorage<Output = S>>(shape: L::Shape<'_>, data: D) -> TensorBase<S, L>
     where
         L: FromShape,
-        for<'a> L::Index<'a>: Clone,
+        for<'a> L::Shape<'a>: Clone,
     {
         let data = data.into_storage();
         let len = data.len();
         match Self::try_from_data(shape.clone(), data) {
             Ok(data) => data,
-            Err(_) => panic!(
-                "data length {} does not match shape {:?}",
-                len,
-                shape.as_ref()
-            ),
+            Err(_) => panic!("data length {} does not match shape {:?}", len, shape),
         }
     }
 
@@ -577,7 +573,7 @@ impl<S: Storage, L: Layout> TensorBase<S, L> {
     ///
     /// This will fail if the data length does not match the product of `shape`.
     pub fn try_from_data<D: IntoStorage<Output = S>>(
-        shape: L::Index<'_>,
+        shape: L::Shape<'_>,
         data: D,
     ) -> Result<TensorBase<S, L>, FromDataError>
     where
@@ -597,10 +593,7 @@ impl<S: Storage, L: Layout> TensorBase<S, L> {
     /// is mutable and the layout may map multiple indices to the same offset.
     pub fn from_storage_and_layout(data: S, layout: L) -> TensorBase<S, L> {
         assert!(data.len() >= layout.min_data_len());
-        assert!(
-            !S::MUTABLE
-                || !may_have_internal_overlap(layout.shape().as_ref(), layout.strides().as_ref())
-        );
+        assert!(!S::MUTABLE || !may_have_internal_overlap(layout.shape(), layout.strides()));
         TensorBase { data, layout }
     }
 
@@ -613,10 +606,7 @@ impl<S: Storage, L: Layout> TensorBase<S, L> {
     /// same offset.
     pub(crate) unsafe fn from_storage_and_layout_unchecked(data: S, layout: L) -> TensorBase<S, L> {
         debug_assert!(data.len() >= layout.min_data_len());
-        debug_assert!(
-            !S::MUTABLE
-                || !may_have_internal_overlap(layout.shape().as_ref(), layout.strides().as_ref())
-        );
+        debug_assert!(!S::MUTABLE || !may_have_internal_overlap(layout.shape(), layout.strides()));
         TensorBase { data, layout }
     }
 
@@ -628,9 +618,9 @@ impl<S: Storage, L: Layout> TensorBase<S, L> {
     /// See also [`TensorBase::from_slice_with_strides`] which is a similar method
     /// for immutable views that does allow overlapping strides.
     pub fn from_data_with_strides<D: IntoStorage<Output = S>>(
-        shape: L::Index<'_>,
+        shape: L::Shape<'_>,
         data: D,
-        strides: L::Index<'_>,
+        strides: L::Strides<'_>,
     ) -> Result<TensorBase<S, L>, FromDataError>
     where
         L: MutLayout,
@@ -1061,7 +1051,7 @@ impl<T, L: Clone + Layout> TensorBase<Vec<T>, L> {
     pub fn arange(start: T, end: T, step: Option<T>) -> TensorBase<Vec<T>, L>
     where
         T: Copy + PartialOrd + From<bool> + std::ops::Add<Output = T>,
-        [usize; 1]: AsIndex<L>,
+        [usize; 1]: AsShape<L>,
         L: FromShape,
     {
         let step = step.unwrap_or((true).into());
@@ -1071,7 +1061,7 @@ impl<T, L: Clone + Layout> TensorBase<Vec<T>, L> {
             data.push(curr);
             curr = curr + step;
         }
-        TensorBase::from_data([data.len()].as_index(), data)
+        TensorBase::from_data([data.len()].as_shape(), data)
     }
 
     /// Append elements from `other` to this tensor along a given axis.
@@ -1120,10 +1110,10 @@ impl<T, L: Clone + Layout> TensorBase<Vec<T>, L> {
     /// Create a new 1D tensor from a `Vec<T>`.
     pub fn from_vec(vec: Vec<T>) -> TensorBase<Vec<T>, L>
     where
-        [usize; 1]: AsIndex<L>,
+        [usize; 1]: AsShape<L>,
         L: FromShape,
     {
-        TensorBase::from_data([vec.len()].as_index(), vec)
+        TensorBase::from_data([vec.len()].as_shape(), vec)
     }
 
     /// Clip dimension `dim` to `[range.start, range.end)`. The new size for
@@ -1176,10 +1166,7 @@ impl<T, L: Clone + Layout> TensorBase<Vec<T>, L> {
         let new_data_len = new_layout.min_data_len();
 
         let has_capacity = new_data_len <= self.data.capacity()
-            && !may_have_internal_overlap(
-                new_layout.shape().as_ref(),
-                new_layout.strides().as_ref(),
-            );
+            && !may_have_internal_overlap(new_layout.shape(), new_layout.strides());
 
         has_capacity.then_some(new_layout)
     }
@@ -1257,7 +1244,7 @@ impl<T, L: Clone + Layout> TensorBase<Vec<T>, L> {
     /// corresponding value. If the function does not need this index, use
     /// [`from_simple_fn`](TensorBase::from_simple_fn) instead, as it is faster.
     pub fn from_fn<F: FnMut(L::Index<'_>) -> T, Idx>(
-        shape: L::Index<'_>,
+        shape: L::Shape<'_>,
         f: F,
     ) -> TensorBase<Vec<T>, L>
     where
@@ -1271,7 +1258,7 @@ impl<T, L: Clone + Layout> TensorBase<Vec<T>, L> {
     /// Variant of [`from_fn`](TensorBase::from_fn) that takes an allocator.
     pub fn from_fn_in<A: Alloc, F: FnMut(L::Index<'_>) -> T, Idx>(
         alloc: A,
-        shape: L::Index<'_>,
+        shape: L::Shape<'_>,
         mut f: F,
     ) -> TensorBase<Vec<T>, L>
     where
@@ -1287,7 +1274,7 @@ impl<T, L: Clone + Layout> TensorBase<Vec<T>, L> {
 
     /// Create a new tensor with a given shape and values generated by calling
     /// `f` repeatedly.
-    pub fn from_simple_fn<F: FnMut() -> T>(shape: L::Index<'_>, f: F) -> TensorBase<Vec<T>, L>
+    pub fn from_simple_fn<F: FnMut() -> T>(shape: L::Shape<'_>, f: F) -> TensorBase<Vec<T>, L>
     where
         L: FromShape,
     {
@@ -1298,13 +1285,13 @@ impl<T, L: Clone + Layout> TensorBase<Vec<T>, L> {
     /// an allocator.
     pub fn from_simple_fn_in<A: Alloc, F: FnMut() -> T>(
         alloc: A,
-        shape: L::Index<'_>,
+        shape: L::Shape<'_>,
         mut f: F,
     ) -> TensorBase<Vec<T>, L>
     where
         L: FromShape,
     {
-        let len = shape.as_ref().iter().product();
+        let len = shape.iter().product();
         let mut data = alloc.alloc(len);
         data.extend(std::iter::from_fn(|| Some(f())).take(len));
         TensorBase::from_data(shape, data)
@@ -1313,14 +1300,14 @@ impl<T, L: Clone + Layout> TensorBase<Vec<T>, L> {
     /// Create a new 0D tensor from a scalar value.
     pub fn from_scalar(value: T) -> TensorBase<Vec<T>, L>
     where
-        [usize; 0]: AsIndex<L>,
+        [usize; 0]: AsShape<L>,
         L: FromShape,
     {
-        TensorBase::from_data([].as_index(), vec![value])
+        TensorBase::from_data([].as_shape(), vec![value])
     }
 
     /// Create a new tensor with a given shape and all elements set to `value`.
-    pub fn full(shape: L::Index<'_>, value: T) -> TensorBase<Vec<T>, L>
+    pub fn full(shape: L::Shape<'_>, value: T) -> TensorBase<Vec<T>, L>
     where
         T: Clone,
         L: FromShape,
@@ -1329,12 +1316,12 @@ impl<T, L: Clone + Layout> TensorBase<Vec<T>, L> {
     }
 
     /// Variant of [`full`](TensorBase::full) which takes an allocator.
-    pub fn full_in<A: Alloc>(alloc: A, shape: L::Index<'_>, value: T) -> TensorBase<Vec<T>, L>
+    pub fn full_in<A: Alloc>(alloc: A, shape: L::Shape<'_>, value: T) -> TensorBase<Vec<T>, L>
     where
         T: Clone,
         L: FromShape,
     {
-        let len = shape.as_ref().iter().product();
+        let len = shape.iter().product();
         let mut data = alloc.alloc(len);
         data.resize(len, value);
         TensorBase::from_data(shape, data)
@@ -1375,7 +1362,7 @@ impl<T, L: Clone + Layout> TensorBase<Vec<T>, L> {
     ///
     /// A more general version of this method that generates values using any
     /// function is [`from_simple_fn`](Self::from_simple_fn).
-    pub fn rand<R: RandomSource<T>>(shape: L::Index<'_>, rand_src: &mut R) -> TensorBase<Vec<T>, L>
+    pub fn rand<R: RandomSource<T>>(shape: L::Shape<'_>, rand_src: &mut R) -> TensorBase<Vec<T>, L>
     where
         L: FromShape,
     {
@@ -1384,7 +1371,7 @@ impl<T, L: Clone + Layout> TensorBase<Vec<T>, L> {
 
     /// Create a new tensor with a given shape, with all elements set to their
     /// default value (ie. zero for numeric types).
-    pub fn zeros(shape: L::Index<'_>) -> TensorBase<Vec<T>, L>
+    pub fn zeros(shape: L::Shape<'_>) -> TensorBase<Vec<T>, L>
     where
         T: Clone + Default,
         L: FromShape,
@@ -1393,7 +1380,7 @@ impl<T, L: Clone + Layout> TensorBase<Vec<T>, L> {
     }
 
     /// Variant of [`zeros`](TensorBase::zeros) which takes an allocator.
-    pub fn zeros_in<A: Alloc>(alloc: A, shape: L::Index<'_>) -> TensorBase<Vec<T>, L>
+    pub fn zeros_in<A: Alloc>(alloc: A, shape: L::Shape<'_>) -> TensorBase<Vec<T>, L>
     where
         T: Clone + Default,
         L: FromShape,
@@ -1408,7 +1395,7 @@ impl<T, L: Clone + Layout> TensorBase<Vec<T>, L> {
     /// The caller must initialize elements and then call
     /// [`assume_init`](TensorBase::assume_init) to convert to an initialized
     /// `Tensor<T>`.
-    pub fn uninit(shape: L::Index<'_>) -> TensorBase<Vec<MaybeUninit<T>>, L>
+    pub fn uninit(shape: L::Shape<'_>) -> TensorBase<Vec<MaybeUninit<T>>, L>
     where
         MaybeUninit<T>: Clone,
         L: FromShape,
@@ -1417,11 +1404,11 @@ impl<T, L: Clone + Layout> TensorBase<Vec<T>, L> {
     }
 
     /// Variant of [`uninit`](TensorBase::uninit) which takes an allocator.
-    pub fn uninit_in<A: Alloc>(alloc: A, shape: L::Index<'_>) -> TensorBase<Vec<MaybeUninit<T>>, L>
+    pub fn uninit_in<A: Alloc>(alloc: A, shape: L::Shape<'_>) -> TensorBase<Vec<MaybeUninit<T>>, L>
     where
         L: FromShape,
     {
-        let len = shape.as_ref().iter().product();
+        let len = shape.iter().product();
         let mut data = alloc.alloc(len);
 
         // Safety: Since the contents of the `Vec` are `MaybeUninit`, we don't
@@ -1463,7 +1450,7 @@ impl<T, L: Clone + Layout> TensorBase<Vec<T>, L> {
     /// `shape` specifies the maximum shape that the tensor can be expanded to
     /// without reallocating. The initial shape will be the same, except for
     /// the dimension specified by `expand_dim`, which will be zero.
-    pub fn with_capacity(shape: L::Index<'_>, expand_dim: usize) -> TensorBase<Vec<T>, L>
+    pub fn with_capacity(shape: L::Shape<'_>, expand_dim: usize) -> TensorBase<Vec<T>, L>
     where
         T: Copy,
         L: FromShape + MutLayout,
@@ -1474,7 +1461,7 @@ impl<T, L: Clone + Layout> TensorBase<Vec<T>, L> {
     /// Variant of [`with_capacity`](Self::with_capacity) which takes an allocator.
     pub fn with_capacity_in<A: Alloc>(
         alloc: A,
-        shape: L::Index<'_>,
+        shape: L::Shape<'_>,
         expand_dim: usize,
     ) -> TensorBase<Vec<T>, L>
     where
@@ -1734,9 +1721,9 @@ impl<'a, T, L: Clone + Layout> TensorBase<ViewData<'a, T>, L> {
     /// instead. This method is similar to [`TensorBase::from_data_with_strides`],
     /// but allows strides that lead to internal overlap (see [`OverlapPolicy`]).
     pub fn from_slice_with_strides(
-        shape: L::Index<'_>,
+        shape: L::Shape<'_>,
         data: &'a [T],
-        strides: L::Index<'_>,
+        strides: L::Strides<'_>,
     ) -> Result<TensorBase<ViewData<'a, T>, L>, FromDataError>
     where
         L: MutLayout,
@@ -2075,6 +2062,14 @@ impl<'a, T, L: Clone + Layout> TensorBase<ViewData<'a, T>, L> {
 }
 
 impl<S: Storage, L: Layout> Layout for TensorBase<S, L> {
+    type Shape<'a>
+        = L::Shape<'a>
+    where
+        Self: 'a;
+    type Strides<'a>
+        = L::Strides<'a>
+    where
+        Self: 'a;
     type Index<'a> = L::Index<'a>;
     type Indices = L::Indices;
 
@@ -2090,7 +2085,7 @@ impl<S: Storage, L: Layout> Layout for TensorBase<S, L> {
         self.layout.is_empty()
     }
 
-    fn shape(&self) -> Self::Index<'_> {
+    fn shape(&self) -> Self::Shape<'_> {
         self.layout.shape()
     }
 
@@ -2098,7 +2093,7 @@ impl<S: Storage, L: Layout> Layout for TensorBase<S, L> {
         self.layout.size(dim)
     }
 
-    fn strides(&self) -> Self::Index<'_> {
+    fn strides(&self) -> Self::Strides<'_> {
         self.layout.strides()
     }
 
@@ -2408,44 +2403,44 @@ impl<'a, T, L: Layout> TensorBase<ViewMutData<'a, T>, L> {
 
 impl<T, L: FromShape> FromIterator<T> for TensorBase<Vec<T>, L>
 where
-    [usize; 1]: AsIndex<L>,
+    [usize; 1]: AsShape<L>,
 {
     /// Create a new 1D tensor filled with an arithmetic sequence of values
     /// in the range `[start, end)` separated by `step`. If `step` is omitted,
     /// it defaults to 1.
     fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> TensorBase<Vec<T>, L> {
         let data: Vec<T> = iter.into_iter().collect();
-        TensorBase::from_data([data.len()].as_index(), data)
+        TensorBase::from_data([data.len()].as_shape(), data)
     }
 }
 
 impl<T, L: FromShape> From<Vec<T>> for TensorBase<Vec<T>, L>
 where
-    [usize; 1]: AsIndex<L>,
+    [usize; 1]: AsShape<L>,
 {
     /// Create a 1D tensor from a vector.
     fn from(vec: Vec<T>) -> Self {
-        Self::from_data([vec.len()].as_index(), vec)
+        Self::from_data([vec.len()].as_shape(), vec)
     }
 }
 
 impl<'a, T, L: FromShape> From<&'a [T]> for TensorBase<ViewData<'a, T>, L>
 where
-    [usize; 1]: AsIndex<L>,
+    [usize; 1]: AsShape<L>,
 {
     /// Create a 1D view from a slice.
     fn from(slice: &'a [T]) -> Self {
-        Self::from_data([slice.len()].as_index(), slice)
+        Self::from_data([slice.len()].as_shape(), slice)
     }
 }
 
 impl<'a, T, L: FromShape, const N: usize> From<&'a [T; N]> for TensorBase<ViewData<'a, T>, L>
 where
-    [usize; 1]: AsIndex<L>,
+    [usize; 1]: AsShape<L>,
 {
     /// Create a 1D view from a slice of known length.
     fn from(slice: &'a [T; N]) -> Self {
-        Self::from_data([slice.len()].as_index(), slice.as_slice())
+        Self::from_data([slice.len()].as_shape(), slice.as_slice())
     }
 }
 
@@ -2614,7 +2609,7 @@ impl<T: PartialEq, S: Storage<Elem = T>, L: Layout + Clone, V: AsView<Elem = T>>
     for TensorBase<S, L>
 {
     fn eq(&self, other: &V) -> bool {
-        self.shape().as_ref() == other.shape().as_ref() && self.iter().eq(other.iter())
+        self.shape().iter().eq(other.shape().iter()) && self.iter().eq(other.iter())
     }
 }
 
@@ -2622,7 +2617,9 @@ impl<T: Eq, S: Storage<Elem = T>, L: Layout + Clone> Eq for TensorBase<S, L> {}
 
 impl<T: Hash, S: Storage<Elem = T>, L: Layout + Clone> Hash for TensorBase<S, L> {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.shape().as_ref().hash(state);
+        for dim in self.shape().iter() {
+            dim.hash(state);
+        }
         for elem in self.iter() {
             elem.hash(state);
         }
@@ -2691,7 +2688,7 @@ impl_scalar!(String);
 
 impl<T: Clone + Scalar, L: Clone + FromShape> From<T> for TensorBase<Vec<T>, L>
 where
-    [usize; 0]: AsIndex<L>,
+    [usize; 0]: AsShape<L>,
 {
     /// Construct a scalar tensor from a scalar value.
     fn from(value: T) -> Self {
@@ -2701,31 +2698,31 @@ where
 
 impl<T: Clone + Scalar, L: FromShape, const D0: usize> From<[T; D0]> for TensorBase<Vec<T>, L>
 where
-    [usize; 1]: AsIndex<L>,
+    [usize; 1]: AsShape<L>,
 {
     /// Construct a 1D tensor from a 1D array.
     fn from(value: [T; D0]) -> Self {
         let data: Vec<T> = value.iter().cloned().collect();
-        Self::from_data([D0].as_index(), data)
+        Self::from_data([D0].as_shape(), data)
     }
 }
 
 impl<T: Clone + Scalar, L: FromShape, const D0: usize, const D1: usize> From<[[T; D1]; D0]>
     for TensorBase<Vec<T>, L>
 where
-    [usize; 2]: AsIndex<L>,
+    [usize; 2]: AsShape<L>,
 {
     /// Construct a 2D tensor from a nested array.
     fn from(value: [[T; D1]; D0]) -> Self {
         let data: Vec<_> = value.iter().flat_map(|y| y.iter()).cloned().collect();
-        Self::from_data([D0, D1].as_index(), data)
+        Self::from_data([D0, D1].as_shape(), data)
     }
 }
 
 impl<T: Clone + Scalar, L: FromShape, const D0: usize, const D1: usize, const D2: usize>
     From<[[[T; D2]; D1]; D0]> for TensorBase<Vec<T>, L>
 where
-    [usize; 3]: AsIndex<L>,
+    [usize; 3]: AsShape<L>,
 {
     /// Construct a 3D tensor from a nested array.
     fn from(value: [[[T; D2]; D1]; D0]) -> Self {
@@ -2734,7 +2731,7 @@ where
             .flat_map(|y| y.iter().flat_map(|z| z.iter()))
             .cloned()
             .collect();
-        Self::from_data([D0, D1, D2].as_index(), data)
+        Self::from_data([D0, D1, D2].as_shape(), data)
     }
 }
 
@@ -2750,6 +2747,14 @@ pub struct WeaklyCheckedView<S: Storage, L: Layout> {
 }
 
 impl<T, S: Storage<Elem = T>, L: Layout> Layout for WeaklyCheckedView<S, L> {
+    type Shape<'a>
+        = L::Shape<'a>
+    where
+        Self: 'a;
+    type Strides<'a>
+        = L::Strides<'a>
+    where
+        Self: 'a;
     type Index<'a> = L::Index<'a>;
     type Indices = L::Indices;
 
@@ -2765,11 +2770,11 @@ impl<T, S: Storage<Elem = T>, L: Layout> Layout for WeaklyCheckedView<S, L> {
         self.base.len()
     }
 
-    fn shape(&self) -> Self::Index<'_> {
+    fn shape(&self) -> Self::Shape<'_> {
         self.base.shape()
     }
 
-    fn strides(&self) -> Self::Index<'_> {
+    fn strides(&self) -> Self::Strides<'_> {
         self.base.strides()
     }
 

--- a/rten-tensor/src/tensor/tests.rs
+++ b/rten-tensor/src/tensor/tests.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use super::{AsView, NdTensor, NdTensorView, NdTensorViewMut, Tensor, TensorView};
 use crate::errors::{DimensionError, ExpandError, FromDataError};
-use crate::layout::{DynLayout, MatrixLayout, MutLayout};
+use crate::layout::{DynLayout, FromShape, MatrixLayout};
 use crate::prelude::*;
 use crate::rng::XorShiftRng;
 use crate::storage::{Alloc, IntoStorage};

--- a/rten-tensor/src/test_util.rs
+++ b/rten-tensor/src/test_util.rs
@@ -1,6 +1,7 @@
 use std::error::Error;
 use std::fmt::{Debug, Display, Formatter};
 
+use crate::layout::SizeArray;
 use crate::{AsView, Layout, TensorView};
 
 /// Trait that tests whether two values are approximately equal.
@@ -93,7 +94,7 @@ impl_approx_eq_for_ints!(i8, i16, i32, i64, u8, u16, u32, u64);
 /// Return the N-dimensional index in a tensor with a given `shape` that
 /// corresponds to a linear index (ie. the index if the tensor was flattened to
 /// 1D).
-fn index_from_linear_index(shape: &[usize], lin_index: usize) -> Vec<usize> {
+fn index_from_linear_index(shape: impl SizeArray, lin_index: usize) -> Vec<usize> {
     assert!(
         lin_index < shape.iter().product(),
         "Linear index {} is out of bounds for shape {:?}",
@@ -102,8 +103,8 @@ fn index_from_linear_index(shape: &[usize], lin_index: usize) -> Vec<usize> {
     );
     (0..shape.len())
         .map(|dim| {
-            let elts_per_index: usize = shape[dim + 1..].iter().product();
-            let lin_index_for_dim = lin_index % (shape[dim] * elts_per_index);
+            let elts_per_index: usize = shape.iter().skip(dim + 1).product();
+            let lin_index_for_dim = lin_index % (shape.get(dim).unwrap() * elts_per_index);
             lin_index_for_dim / elts_per_index
         })
         .collect()
@@ -170,7 +171,7 @@ where
         .enumerate()
         .filter_map(|(i, (xi, yi))| {
             if !xi.approx_eq_with_atol_rtol(yi, atol.clone(), rtol.clone()) {
-                Some((index_from_linear_index(x.shape().as_ref(), i), xi, yi))
+                Some((index_from_linear_index(x.shape(), i), xi, yi))
             } else {
                 None
             }

--- a/src/ops/binary_elementwise.rs
+++ b/src/ops/binary_elementwise.rs
@@ -56,7 +56,10 @@ pub fn broadcast_shapes(a: &[usize], b: &[usize]) -> Option<SmallVec<[usize; 4]>
 /// Return true if an elementwise binary operation can be performed in-place
 /// on `a` given `b` as the other argument.
 fn can_run_binary_op_in_place<L1: Layout, L2: Layout>(a: &L1, b: &L2) -> bool {
-    b.can_broadcast_to(a.shape().as_ref())
+    use rten_tensor::SizeArray;
+
+    let shape: SmallVec<[usize; 5]> = a.shape().iter().collect();
+    b.can_broadcast_to(&shape)
 }
 
 /// Check whether a tensor of shape `from_shape` can be broadcast to `to_shape`

--- a/src/ops/layout.rs
+++ b/src/ops/layout.rs
@@ -542,8 +542,8 @@ pub fn squeeze_in_place<T: Clone>(
 ) -> Result<(), OpError> {
     let sorted_axes = if let Some(axes) = axes {
         let axes = resolve_axes(input.ndim(), axes.iter())?;
-        for &axis in axes.iter() {
-            if input.size(axis) != 1 {
+        for axis in axes.iter() {
+            if input.size(*axis) != 1 {
                 return Err(OpError::InvalidValue(
                     "Can only remove dimensions of size 1",
                 ));

--- a/src/ops/reduce.rs
+++ b/src/ops/reduce.rs
@@ -431,7 +431,7 @@ fn reduce<T: Copy>(
         let reduced_inner_dims: Option<usize> = resolved_axes
             .iter()
             .enumerate()
-            .all(|(i, &axis)| axis == input.ndim() - 1 - i)
+            .all(|(i, axis)| *axis == input.ndim() - 1 - i)
             .then_some(resolved_axes.len());
 
         match (reduced_inner_dims, input.data()) {
@@ -491,7 +491,7 @@ fn reduce<T: Copy>(
 
     if !keep_dims {
         let resolved_axes_i32: NdTensor<i32, 1> =
-            resolved_axes.iter().map(|&axis| axis as i32).collect();
+            resolved_axes.iter().map(|axis| *axis as i32).collect();
         squeeze_in_place(&mut reduced, Some(resolved_axes_i32.view())).expect("Invalid axis");
     }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -196,6 +196,14 @@ impl<'a> From<&'a DynLayout> for ValueLayout<'a> {
 /// underlying layout.
 macro_rules! impl_proxy_layout {
     () => {
+        type Shape<'b>
+            = SmallVec<[usize; 4]>
+        where
+            Self: 'b;
+        type Strides<'b>
+            = SmallVec<[usize; 4]>
+        where
+            Self: 'b;
         type Index<'b> = SmallVec<[usize; 4]>;
         type Indices = DynIndices;
 
@@ -229,7 +237,7 @@ macro_rules! impl_proxy_layout {
             }
         }
 
-        fn shape(&self) -> Self::Index<'_> {
+        fn shape(&self) -> Self::Shape<'_> {
             match self.layout() {
                 ValueLayout::Tensor(layout) => SmallVec::from_slice(layout.shape()),
                 ValueLayout::Vector(len) => SmallVec::from_slice(&[len]),
@@ -243,7 +251,7 @@ macro_rules! impl_proxy_layout {
             }
         }
 
-        fn strides(&self) -> Self::Index<'_> {
+        fn strides(&self) -> Self::Strides<'_> {
             match self.layout() {
                 ValueLayout::Tensor(layout) => SmallVec::from_slice(layout.strides()),
                 ValueLayout::Vector(_) => SmallVec::from_slice(&[1]),


### PR DESCRIPTION
The `Layout` trait had a single associated type `Index` used for indices, shapes and strides. This PR refactors this to use separate associated types. It also moves the `from_shape` method out of `MutLayout` and into a separate `FromShape` trait. The `Layout::{Shape, Strides}` associated types have a `SizeArray` bound unlike the `AsRef<[usize]>` bound of `Index`. The `SizeArray` trait is an abstraction over slices and arrays like `AsRef<[usize]>`, but doesn't require the data to actually be stored as `usize`s in memory. This makes it possible to create layouts which store sizes in smaller types or don't store the shape and/or strides at all.

I created a proof of concept `SmallLayout` (not included in this PR) which is a dynamic rank layout that saves space by storing dimension size as `u32`s and computes strides on-demand. A `TensorView`-like type with this layout is 40 bytes instead of 88.

This change bumps the MSRV from Rust v1.89 to Rust v1.93 to avoid a borrow checker limitation in earlier versions.