### PR TITLE
Refactor in-place execution to support multiple outputs and modifying an input that is not the first

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -16,7 +16,7 @@ use smallvec::SmallVec;
 
 use crate::buffer_pool::BufferPool;
 use crate::env::env_flag;
-use crate::operator::{InputList, OpRunContext, Operator, OutputList, PrepackedInput};
+use crate::operator::{InputList, OpError, OpRunContext, Operator, OutputList, PrepackedInput};
 use crate::threading;
 use crate::timing::{Instant, ProfileFormat, Profiler, TimingFilter, TimingRecord, TimingSort};
 use crate::value::{Value, ValueMeta, ValueOrView, ValueType, ValueView};
@@ -950,10 +950,22 @@ impl Graph {
             // allocating a new buffer for the output. This will be passed as
             // the first input to `Operator::run_in_place`.
             //
-            // For non-commutative ops we have to use the first input. For
-            // commutative ops we can swap inputs around if that enables us to
-            // run an op in place.
-            let try_in_place_input_id = if op_node.operator().can_run_in_place() {
+            // For non-commutative ops we use the specific input which the
+            // operator reports it can modify. For commutative ops we can swap
+            // inputs around if that enables us to run an op in place.
+            let in_place_inputs = op_node.operator().in_place_inputs();
+            if in_place_inputs.count_true() > 1 {
+                return Err(RunErrorImpl::OperatorError {
+                    name: op_node.name().unwrap_or_default().to_string(),
+                    error: OpError::UnsupportedValue(
+                        "operators with multiple in-place inputs are not yet supported",
+                    ),
+                    inputs: Vec::new(),
+                }
+                .into());
+            }
+            let try_in_place_input_id = if let Some(in_place_index) = in_place_inputs.iter().next()
+            {
                 if op_node.operator().is_commutative() {
                     // Pick the largest input by number of elements. This
                     // assumes that commutative op outputs will have a shape
@@ -971,7 +983,11 @@ impl Graph {
                         .copied()
                         .flatten()
                 } else {
-                    op_node.input_ids().first().copied().flatten()
+                    op_node
+                        .input_ids()
+                        .get(in_place_index as usize)
+                        .copied()
+                        .flatten()
                 }
             } else {
                 None
@@ -1095,19 +1111,16 @@ impl Graph {
             let op_result = if let Some((_id, value)) = in_place_input {
                 let input_dtype = value.dtype();
                 let input_shape = value.shape();
-                op_node
-                    .operator()
-                    .run_in_place(value, &ctx)
-                    .map_err(|e| {
-                        // The error here is currently missing information about operator inputs.
-                        RunError::in_place_op_error(
-                            op_node.name().unwrap_or_default(),
-                            e,
-                            &ctx,
-                            input_dtype,
-                            &input_shape,
-                        )
-                    })
+                op_node.operator().run_in_place(value, &ctx).map_err(|e| {
+                    // The error here is currently missing information about operator inputs.
+                    RunError::in_place_op_error(
+                        op_node.name().unwrap_or_default(),
+                        e,
+                        &ctx,
+                        input_dtype,
+                        &input_shape,
+                    )
+                })
             } else if let Some(subgraph_op) = subgraph_op {
                 let capture_env = CaptureEnv::new(
                     captures.as_ref(),

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1046,7 +1046,8 @@ impl Graph {
                         && node_id == id
                     {
                         // This input is being passed separately as a mutable
-                        // value.
+                        // value, so leave a `None` placeholder in its position.
+                        op_inputs.push(None);
                         continue;
                     }
 
@@ -1073,22 +1074,24 @@ impl Graph {
 
             // Collect input metadata if we'll need it for timing or logging.
             let input_meta = if opts.timing_by_shape || opts.verbose {
-                // Record the input value IDs and metadata together here because
-                // inputs may be reordered if the operator is commutative.
-                let mut meta: Vec<(Option<NodeId>, Option<ValueMeta>)> = Vec::new();
-                if let Some((id, value)) = &in_place_input {
-                    meta.push((Some(*id), Some(value.to_meta())));
-                }
-                for (id, input) in op_node
+                // `op_inputs` has a `None` placeholder at the in-place input's
+                // position, so fill in the metadata for that input separately.
+                op_node
                     .input_ids()
                     .iter()
                     .copied()
-                    .filter(|id| *id != in_place_input.as_ref().map(|(id, _value)| *id))
                     .zip(&op_inputs)
-                {
-                    meta.push((id, input.as_ref().map(|i| i.to_meta())))
-                }
-                meta
+                    .map(|(id, input)| {
+                        let meta = if let Some((ip_id, ip_value)) = &in_place_input
+                            && id == Some(*ip_id)
+                        {
+                            Some(ip_value.to_meta())
+                        } else {
+                            input.as_ref().map(|i| i.to_meta())
+                        };
+                        (id, meta)
+                    })
+                    .collect()
             } else {
                 Vec::new()
             };
@@ -1102,21 +1105,24 @@ impl Graph {
                     .flatten()
                     .and_then(|node_id| weight_cache.and_then(|wc| wc.get(node_id)))
             };
-            let inputs = InputList::from_optional(&op_inputs)
-                .with_prepacked(&get_prepacked)
-                .with_first_input_omitted(in_place_input.is_some());
+            let inputs = InputList::from_optional(&op_inputs).with_prepacked(&get_prepacked);
             let mut ctx = OpRunContext::new(pool, &inputs, op_node.output_mask());
             ctx.set_name(op_node.name());
 
-            let op_result = if let Some((_id, value)) = in_place_input {
+            let op_result = if let Some((id, value)) = in_place_input {
                 let input_dtype = value.dtype();
                 let input_shape = value.shape();
+                let in_place_index = op_node
+                    .input_ids()
+                    .iter()
+                    .position(|input_id| *input_id == Some(id))
+                    .unwrap_or(0);
                 op_node.operator().run_in_place(value, &ctx).map_err(|e| {
-                    // The error here is currently missing information about operator inputs.
                     RunError::in_place_op_error(
                         op_node.name().unwrap_or_default(),
                         e,
                         &ctx,
+                        in_place_index,
                         input_dtype,
                         &input_shape,
                     )

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1098,7 +1098,6 @@ impl Graph {
                 op_node
                     .operator()
                     .run_in_place(value, &ctx)
-                    .map(|out| [out].into())
                     .map_err(|e| {
                         // The error here is currently missing information about operator inputs.
                         RunError::in_place_op_error(

--- a/src/graph/planner.rs
+++ b/src/graph/planner.rs
@@ -359,7 +359,7 @@ impl<'a> PlanBuilder<'a> {
             // inputs available for in-place execution.
             let op_pos = frontier
                 .iter()
-                .position(|(_id, op)| !op.operator().can_run_in_place())
+                .position(|(_id, op)| op.operator().in_place_inputs().is_empty())
                 .unwrap_or(0);
             let (next_op_id, op_node) = frontier.remove(op_pos);
             output_plan.push(next_op_id);

--- a/src/graph/run_error.rs
+++ b/src/graph/run_error.rs
@@ -44,15 +44,29 @@ impl RunError {
         name: &str,
         error: OpError,
         ctx: &OpRunContext,
+        in_place_index: usize,
         main_input_dtype: ValueType,
         main_input_shape: &[usize],
     ) -> Self {
-        let meta = ValueMeta {
-            dtype: main_input_dtype,
-            shape: main_input_shape.to_vec(),
-        };
-        let mut inputs: Vec<_> = [Some(meta)].into();
-        inputs.extend(ctx.inputs().iter().map(|inp| inp.map(|inp| inp.to_meta())));
+        let inputs: Vec<_> = ctx
+            .inputs()
+            .iter()
+            .enumerate()
+            .map(|(index, input)| {
+                if index == in_place_index {
+                    // `ctx.inputs()` has a `None` placeholder at the in-place
+                    // input's position, since that input is passed separately.
+                    // Fill it in so the metadata reflects all of the inputs.
+                    Some(ValueMeta {
+                        dtype: main_input_dtype,
+                        shape: main_input_shape.to_vec(),
+                    })
+                } else {
+                    input.map(|input| input.to_meta())
+                }
+            })
+            .collect();
+
         RunErrorImpl::OperatorError {
             name: name.to_string(),
             error,

--- a/src/graph/tests.rs
+++ b/src/graph/tests.rs
@@ -90,7 +90,7 @@ impl<Op: Operator> Operator for TrackUsage<Op> {
         self.inner.run(ctx)
     }
 
-    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<Value, OpError> {
+    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         {
             let mut m = self.metrics.lock().unwrap();
             m.run_in_place_count += 1;
@@ -872,12 +872,12 @@ impl Operator for AddOneInPlace {
         input.to_tensor().into_op_result()
     }
 
-    fn run_in_place(&self, input: Value, _ctx: &OpRunContext) -> Result<Value, OpError> {
+    fn run_in_place(&self, input: Value, _ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let mut output = input.into_tensor::<f32>().unwrap();
         for x in output.iter_mut() {
             *x = *x + 1.0;
         }
-        Ok(output.into())
+        output.into_op_result()
     }
 
     fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {

--- a/src/graph/tests.rs
+++ b/src/graph/tests.rs
@@ -58,8 +58,8 @@ impl<Op: Operator> Operator for TrackUsage<Op> {
         self.inner.name()
     }
 
-    fn can_run_in_place(&self) -> bool {
-        self.inner.can_run_in_place()
+    fn in_place_inputs(&self) -> BitSet<u16> {
+        self.inner.in_place_inputs()
     }
 
     fn is_commutative(&self) -> bool {
@@ -860,8 +860,8 @@ impl Operator for AddOneInPlace {
         None
     }
 
-    fn can_run_in_place(&self) -> bool {
-        true
+    fn in_place_inputs(&self) -> BitSet<u16> {
+        BitSet::from_indices([0])
     }
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
@@ -992,6 +992,85 @@ fn test_runs_commutative_op_in_place() {
     let op2_metrics = op2_metrics.lock().unwrap();
     assert_eq!(op2_metrics.run_count, 0);
     assert_eq!(op2_metrics.run_in_place_count, 1);
+}
+
+/// Operator that runs in-place on its second input.
+#[derive(Debug)]
+struct InPlaceSecondInput {}
+
+impl Operator for InPlaceSecondInput {
+    fn name(&self) -> &str {
+        "InPlaceSecondInput"
+    }
+
+    fn max_inputs(&self) -> Option<usize> {
+        Some(2)
+    }
+
+    fn output_types(&self, _ctx: &OutputTypesContext) -> Option<OutputTypeList> {
+        None
+    }
+
+    fn in_place_inputs(&self) -> BitSet<u16> {
+        BitSet::from_indices([1])
+    }
+
+    fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+        let second: TensorView<f32> = ctx.inputs().require_as(1)?;
+        second.to_tensor().into_op_result()
+    }
+
+    fn run_in_place(&self, input: Value, _ctx: &OpRunContext) -> Result<OutputList, OpError> {
+        let mut output = input.into_tensor::<f32>().unwrap();
+        for x in output.iter_mut() {
+            *x += 1.0;
+        }
+        output.into_op_result()
+    }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        None
+    }
+}
+
+#[test]
+fn test_runs_non_commutative_op_in_place_with_non_first_input() {
+    let mut g = Graph::new();
+    let first_id = g.add_value(Some("first"), None, None);
+    let second_id = g.add_value(Some("second"), None, None);
+
+    let (_, second_temp) = g.add_simple_op("identity", Identity {}, &[second_id]);
+    let op = TrackUsage::new(InPlaceSecondInput {});
+    let op_metrics = op.metrics();
+    let (_, op_out) = g.add_simple_op("op", op, &[first_id, second_temp]);
+
+    let first = Tensor::from([1.0f32, 2.0, 3.0]);
+    let second = Tensor::from([10.0f32, 20.0, 30.0]);
+    let results = g
+        .run(
+            vec![
+                (first_id, first.view().into()),
+                (second_id, second.view().into()),
+            ],
+            &[op_out],
+            None,
+            None,
+        )
+        .unwrap();
+
+    assert_eq!(
+        results[0]
+            .as_tensor_view::<f32>()
+            .unwrap()
+            .iter()
+            .copied()
+            .collect::<Vec<_>>(),
+        &[11., 21., 31.]
+    );
+
+    let op_metrics = op_metrics.lock().unwrap();
+    assert_eq!(op_metrics.run_count, 0);
+    assert_eq!(op_metrics.run_in_place_count, 1);
 }
 
 /// Test operator that produces multiple outputs

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -441,8 +441,10 @@ pub trait Operator: Any + Debug {
     ///
     /// This may only be called if `in_place_inputs` returns a non-empty set.
     ///
-    /// `input` is the first input, which the implementation may modify and
-    /// return as an output. `ctx.inputs()` contains the remaining inputs.
+    /// `input` is one of the inputs from that set, which the implementation may
+    /// modify and return as an output. `ctx.inputs()` contains all of the
+    /// operator's inputs, with the position of the in-place `input` set to
+    /// `None`.
     ///
     /// Operators may fall back to allocating a new output if some property of
     /// the input data or shapes means in-place operation is not possible. In
@@ -578,11 +580,6 @@ pub struct InputList<'a> {
     /// Callback that retrieves the pre-packed copy of an input with a given
     /// index.
     get_prepacked: Option<&'a dyn Fn(usize) -> Option<&'a PrepackedInput>>,
-
-    /// True if the input list does not contain the first operator input because
-    /// it is being passed separately. In this case input indices are offset by
-    /// one (eg. `inputs.require(0)` will return the second input to the operator).
-    first_input_omitted: bool,
 }
 
 impl<'a> InputList<'a> {
@@ -591,18 +588,7 @@ impl<'a> InputList<'a> {
         InputList {
             inputs: Cow::Owned(vec![]),
             get_prepacked: None,
-            first_input_omitted: false,
         }
-    }
-
-    /// Mark this input list as not containing the first input to the operator.
-    ///
-    /// This is used together with [`Operator::run_in_place`] where the first
-    /// input is passed separately. When this flag is set the input index is
-    /// adjusted in errors to reflect the real index.
-    pub fn with_first_input_omitted(mut self, offset: bool) -> Self {
-        self.first_input_omitted = offset;
-        self
     }
 
     pub fn len(&self) -> usize {
@@ -635,7 +621,6 @@ impl<'a> InputList<'a> {
         InputList {
             inputs: inputs.iter().cloned().map(Some).collect(),
             get_prepacked: None,
-            first_input_omitted: false,
         }
     }
 
@@ -646,7 +631,6 @@ impl<'a> InputList<'a> {
         InputList {
             inputs: Cow::Borrowed(inputs),
             get_prepacked: None,
-            first_input_omitted: false,
         }
     }
 
@@ -684,10 +668,9 @@ impl<'a> InputList<'a> {
     {
         self.get(index)
             .map(|input| {
-                input.try_into().map_err(|error| OpError::InputCastFailed {
-                    index: self.to_real_index(index),
-                    error,
-                })
+                input
+                    .try_into()
+                    .map_err(|error| OpError::InputCastFailed { index, error })
             })
             .transpose()
     }
@@ -703,11 +686,29 @@ impl<'a> InputList<'a> {
         T: TryFrom<ValueView<'a>, Error = TryFromValueError>,
     {
         self.require(index).and_then(|input| {
-            input.try_into().map_err(|error| OpError::InputCastFailed {
-                index: self.to_real_index(index),
-                error,
-            })
+            input
+                .try_into()
+                .map_err(|error| OpError::InputCastFailed { index, error })
         })
+    }
+
+    /// Return the index of the first input which is present (not `None`).
+    ///
+    /// This is useful for commutative operators running in-place, where the
+    /// single non-in-place input may be at a different position depending on
+    /// which input was selected for in-place execution.
+    pub fn first_present(&self) -> Option<usize> {
+        self.inputs.iter().position(|input| input.is_some())
+    }
+
+    /// Convert the [`first_present`](Self::first_present) input into a tensor
+    /// or scalar.
+    pub fn require_first_present_as<T>(&self) -> Result<T, OpError>
+    where
+        T: TryFrom<ValueView<'a>, Error = TryFromValueError>,
+    {
+        let index = self.first_present().ok_or(OpError::MissingInputs)?;
+        self.require_as(index)
     }
 
     /// Return an iterator over provided inputs.
@@ -715,16 +716,6 @@ impl<'a> InputList<'a> {
     /// Use [`Iterator::flatten`] to skip missing optional inputs.
     pub fn iter<'b>(&'b self) -> impl Iterator<Item = Option<ValueView<'a>>> + 'b {
         self.inputs.iter().cloned()
-    }
-
-    /// Map an index into this input list back to an index in the full
-    /// sequence of operator inputs.
-    fn to_real_index(&self, index: usize) -> usize {
-        if self.first_input_omitted {
-            index + 1
-        } else {
-            index
-        }
     }
 }
 
@@ -824,15 +815,11 @@ mod tests {
     use crate::ops::{Add, Sub};
 
     #[test]
-    fn test_input_list_first_input_omitted() {
+    fn test_input_list_require_as_error_index() {
         let tensor = Tensor::<f32>::zeros(&[2, 2]);
 
-        let inputs = InputList::from(&[tensor.view().into()]).with_first_input_omitted(false);
-        let err = inputs.require_as::<TensorView<i32>>(0).err().unwrap();
-        assert!(matches!(err, OpError::InputCastFailed { index: 0, .. }));
-
-        let inputs = InputList::from(&[tensor.view().into()]).with_first_input_omitted(true);
-        let err = inputs.require_as::<TensorView<i32>>(0).err().unwrap();
+        let inputs = InputList::from(&[tensor.view().into(), tensor.view().into()]);
+        let err = inputs.require_as::<TensorView<i32>>(1).err().unwrap();
         assert!(matches!(err, OpError::InputCastFailed { index: 1, .. }));
     }
 

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -389,14 +389,19 @@ pub trait Operator: Any + Debug {
     /// Return the rules for determining the types of this operator's outputs.
     fn output_types(&self, ctx: &OutputTypesContext) -> Option<OutputTypeList>;
 
-    /// Return true if this operator supports in-place execution via
-    /// `run_in_place`.
+    /// Return the set of inputs which this operator can modify in-place via
+    /// [`run_in_place`](Operator::run_in_place).
     ///
-    /// In-place execution returns results by modifying an existing tensor
-    /// instead of allocating a new one. Reducing memory allocations can
+    /// In-place execution returns results by modifying an existing input
+    /// instead of allocating a new tensor. Reducing memory allocations can
     /// significantly speed up graph runs.
-    fn can_run_in_place(&self) -> bool {
-        false
+    ///
+    /// The returned bit set contains the index of each input the operator is
+    /// able to modify. An empty set (the default) means in-place execution is
+    /// not supported. Only the first 16 inputs are candidates for in-place
+    /// modification.
+    fn in_place_inputs(&self) -> BitSet<u16> {
+        BitSet::new()
     }
 
     /// Return true if this operator is commutative, meaning that its inputs
@@ -434,7 +439,7 @@ pub trait Operator: Any + Debug {
 
     /// Execute this operator in-place on an existing tensor.
     ///
-    /// This may only be called if `can_run_in_place` returns true.
+    /// This may only be called if `in_place_inputs` returns a non-empty set.
     ///
     /// `input` is the first input, which the implementation may modify and
     /// return as an output. `ctx.inputs()` contains the remaining inputs.

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -437,7 +437,7 @@ pub trait Operator: Any + Debug {
     /// This may only be called if `can_run_in_place` returns true.
     ///
     /// `input` is the first input, which the implementation may modify and
-    /// return as the output. `ctx.inputs()` contains the remaining inputs.
+    /// return as an output. `ctx.inputs()` contains the remaining inputs.
     ///
     /// Operators may fall back to allocating a new output if some property of
     /// the input data or shapes means in-place operation is not possible. In
@@ -448,7 +448,7 @@ pub trait Operator: Any + Debug {
         &self,
         #[allow(unused)] input: Value,
         #[allow(unused)] ctx: &OpRunContext,
-    ) -> Result<Value, OpError> {
+    ) -> Result<OutputList, OpError> {
         Err(OpError::InvalidValue("In-place execution not supported"))
     }
 
@@ -548,8 +548,8 @@ pub trait OperatorExt: Operator {
         let pool = BufferPool::new();
         let inputs = inputs.into();
         let ctx = OpRunContext::new(&pool, &inputs, BitSet::ones(1));
-        let output = self.run_in_place(mut_input.into(), &ctx)?;
-        let typed_output = output.try_into()?;
+        let mut outputs = self.run_in_place(mut_input.into(), &ctx)?;
+        let typed_output = outputs.remove(0).try_into()?;
         Ok(typed_output)
     }
 }

--- a/src/ops/attention.rs
+++ b/src/ops/attention.rs
@@ -126,7 +126,7 @@ impl Operator for AddSoftmax {
         true
     }
 
-    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<Value, OpError> {
+    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let qk: Tensor = input.try_into()?;
         let m: TensorView = ctx.inputs().require_as(0)?;
 
@@ -145,7 +145,7 @@ impl Operator for AddSoftmax {
             }
         };
 
-        add_softmax_in_place(ctx.pool(), qk, m, self.nan_handling()).map(|qk| qk.into())
+        add_softmax_in_place(ctx.pool(), qk, m, self.nan_handling()).into_op_result()
     }
 
     fn output_types(&self, _ctx: &OutputTypesContext) -> Option<OutputTypeList> {

--- a/src/ops/attention.rs
+++ b/src/ops/attention.rs
@@ -3,6 +3,7 @@
 use std::mem::MaybeUninit;
 
 use rayon::prelude::*;
+use rten_base::bit_set::BitSet;
 use rten_gemm::{GemmExecutor, GemmInputA, GemmInputB, GemmUninitOptions};
 use rten_shape_inference::ops as shape_ops;
 use rten_simd::SimdOp;
@@ -122,8 +123,8 @@ impl Operator for AddSoftmax {
         true
     }
 
-    fn can_run_in_place(&self) -> bool {
-        true
+    fn in_place_inputs(&self) -> BitSet<u16> {
+        BitSet::from_indices([0])
     }
 
     fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {

--- a/src/ops/attention.rs
+++ b/src/ops/attention.rs
@@ -129,7 +129,9 @@ impl Operator for AddSoftmax {
 
     fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let qk: Tensor = input.try_into()?;
-        let m: TensorView = ctx.inputs().require_as(0)?;
+        // This operator is commutative, so the other input may be at either
+        // position depending on which was selected for in-place execution.
+        let m: TensorView = ctx.inputs().require_first_present_as()?;
 
         let out_shape = broadcast_shapes(qk.shape(), m.shape());
         let qk = match out_shape.as_deref() {

--- a/src/ops/binary_elementwise.rs
+++ b/src/ops/binary_elementwise.rs
@@ -460,10 +460,10 @@ macro_rules! run_typed_op_in_place {
             let b = $other.require_as(0)?;
             if can_run_binary_op_in_place(&a, &b) {
                 $in_place_op_func(a.view_mut(), b).into_unit_result()?;
-                Ok(a.into())
+                a.into_op_result()
             } else {
                 let a = a.auto_return($pool);
-                $op_func($pool, a.view(), b.view()).map(|t| t.into())
+                $op_func($pool, a.view(), b.view()).into_op_result()
             }
         })
     }};
@@ -514,7 +514,7 @@ impl Operator for Add {
         true
     }
 
-    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<Value, OpError> {
+    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         run_typed_op_in_place!(ctx.pool(), input, ctx.inputs(), add_in_place, add)
     }
 
@@ -667,7 +667,7 @@ impl Operator for Div {
         true
     }
 
-    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<Value, OpError> {
+    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         run_typed_op_in_place!(ctx.pool(), input, ctx.inputs(), div_in_place, div)
     }
 
@@ -909,7 +909,7 @@ impl Operator for Mul {
         true
     }
 
-    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<Value, OpError> {
+    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         run_typed_op_in_place!(ctx.pool(), input, ctx.inputs(), mul_in_place, mul)
     }
 
@@ -1053,9 +1053,9 @@ impl Operator for Pow {
         true
     }
 
-    fn run_in_place(&self, base: Value, ctx: &OpRunContext) -> Result<Value, OpError> {
+    fn run_in_place(&self, base: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let exponent = ctx.inputs().require(0)?;
-        if can_run_binary_op_in_place(&base, &exponent) {
+        let result = if can_run_binary_op_in_place(&base, &exponent) {
             match (base, exponent) {
                 (Value::FloatTensor(mut base), ValueView::FloatTensor(exponent)) => {
                     pow_in_place(base.view_mut(), exponent);
@@ -1075,7 +1075,8 @@ impl Operator for Pow {
             }
         } else {
             self.eval(ctx, base.as_view(), exponent)
-        }
+        };
+        result.into_op_result()
     }
 
     fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
@@ -1124,7 +1125,7 @@ impl Operator for Sub {
         true
     }
 
-    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<Value, OpError> {
+    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         run_typed_op_in_place!(ctx.pool(), input, ctx.inputs(), sub_in_place, sub)
     }
 
@@ -1390,14 +1391,14 @@ mod tests {
         let inputs: InputList = (&b).into();
         let ctx = OpRunContext::new(&pool, &inputs, BitSet::ones(1));
         let result = op.run_in_place(Value::FloatTensor(a_copy), &ctx).unwrap();
-        expect_equal(&result.as_tensor_view().unwrap(), &expected.view())?;
+        expect_equal(&result[0].as_tensor_view().unwrap(), &expected.view())?;
 
         // Run `Add` operator in-place with inputs that don't support in-place
         // addition. The operator should fall back to creating a new output tensor.
         let scalar = Tensor::from(1.0);
         let expected = Tensor::from_data(&[2, 2], vec![11., 21., 31., 41.]);
         let result = op.run_in_place(Value::FloatTensor(scalar), &ctx).unwrap();
-        expect_equal(&result.as_tensor_view().unwrap(), &expected.view())?;
+        expect_equal(&result[0].as_tensor_view().unwrap(), &expected.view())?;
 
         // In-place addition where the second input must be broadcast to the
         // shape of the first.

--- a/src/ops/binary_elementwise.rs
+++ b/src/ops/binary_elementwise.rs
@@ -458,7 +458,9 @@ impl IntoUnitResult for Result<(), OpError> {
 macro_rules! run_typed_op_in_place {
     ($pool:expr, $input:expr, $other: expr, $in_place_op_func:ident, $op_func:ident) => {{
         map_value!($input, a, [FloatTensor, Int32Tensor], {
-            let b = $other.require_as(0)?;
+            // The in-place input is passed separately, so the other operand is
+            // the sole remaining input.
+            let b = $other.require_first_present_as()?;
             if can_run_binary_op_in_place(&a, &b) {
                 $in_place_op_func(a.view_mut(), b).into_unit_result()?;
                 a.into_op_result()
@@ -1055,7 +1057,7 @@ impl Operator for Pow {
     }
 
     fn run_in_place(&self, base: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
-        let exponent = ctx.inputs().require(0)?;
+        let exponent = ctx.inputs().require(1)?;
         let result = if can_run_binary_op_in_place(&base, &exponent) {
             match (base, exponent) {
                 (Value::FloatTensor(mut base), ValueView::FloatTensor(exponent)) => {

--- a/src/ops/binary_elementwise.rs
+++ b/src/ops/binary_elementwise.rs
@@ -3,6 +3,7 @@ use std::fmt::Debug;
 use std::iter::repeat_n;
 use std::mem::MaybeUninit;
 
+use rten_base::bit_set::BitSet;
 use rten_base::num::{AsBool, Identities, IsInt};
 use rten_shape_inference::ops as shape_ops;
 use rten_tensor::prelude::*;
@@ -502,8 +503,8 @@ impl Operator for Add {
         run_typed_op!(ctx.pool(), ctx.inputs(), add)
     }
 
-    fn can_run_in_place(&self) -> bool {
-        true
+    fn in_place_inputs(&self) -> BitSet<u16> {
+        BitSet::from_indices([0])
     }
 
     fn is_commutative(&self) -> bool {
@@ -663,8 +664,8 @@ impl Operator for Div {
         run_typed_op!(ctx.pool(), ctx.inputs(), div)
     }
 
-    fn can_run_in_place(&self) -> bool {
-        true
+    fn in_place_inputs(&self) -> BitSet<u16> {
+        BitSet::from_indices([0])
     }
 
     fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
@@ -897,8 +898,8 @@ impl Operator for Mul {
         run_typed_op!(ctx.pool(), ctx.inputs(), mul)
     }
 
-    fn can_run_in_place(&self) -> bool {
-        true
+    fn in_place_inputs(&self) -> BitSet<u16> {
+        BitSet::from_indices([0])
     }
 
     fn is_commutative(&self) -> bool {
@@ -1049,8 +1050,8 @@ impl Operator for Pow {
         self.eval(ctx, base, exponent).into_op_result()
     }
 
-    fn can_run_in_place(&self) -> bool {
-        true
+    fn in_place_inputs(&self) -> BitSet<u16> {
+        BitSet::from_indices([0])
     }
 
     fn run_in_place(&self, base: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
@@ -1121,8 +1122,8 @@ impl Operator for Sub {
         run_typed_op!(ctx.pool(), ctx.inputs(), sub)
     }
 
-    fn can_run_in_place(&self) -> bool {
-        true
+    fn in_place_inputs(&self) -> BitSet<u16> {
+        BitSet::from_indices([0])
     }
 
     fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {

--- a/src/ops/concat.rs
+++ b/src/ops/concat.rs
@@ -293,7 +293,7 @@ impl Operator for Tile {
     }
 
     fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
-        let repeats: NdTensorView<i32, 1> = ctx.inputs().require_as(0)?;
+        let repeats: NdTensorView<i32, 1> = ctx.inputs().require_as(1)?;
 
         if repeats.iter().all(|n| *n == 1) {
             return input.into_op_result();

--- a/src/ops/concat.rs
+++ b/src/ops/concat.rs
@@ -1,5 +1,6 @@
 use std::mem::MaybeUninit;
 
+use rten_base::bit_set::BitSet;
 use rten_shape_inference::ops as shape_ops;
 use rten_tensor::prelude::*;
 use rten_tensor::{AssumeInit, NdTensorView, Tensor, TensorView};
@@ -126,7 +127,7 @@ impl Operator for Concat {
         })
     }
 
-    fn can_run_in_place(&self) -> bool {
+    fn in_place_inputs(&self) -> BitSet<u16> {
         // This operator can run in place in several cases:
         //
         // - There is only one input
@@ -136,7 +137,7 @@ impl Operator for Concat {
         //   spare capacity.
         // - Capacity was specifically reserved (via `Tensor::with_capacity`)
         //   by higher-level code which anticipated the concatenation.
-        true
+        BitSet::from_indices([0])
     }
 
     fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
@@ -286,9 +287,9 @@ impl Operator for Tile {
         })
     }
 
-    fn can_run_in_place(&self) -> bool {
+    fn in_place_inputs(&self) -> BitSet<u16> {
         // Tile can run in place if it is a noop, ie. all the repeats are 1.
-        true
+        BitSet::from_indices([0])
     }
 
     fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {

--- a/src/ops/concat.rs
+++ b/src/ops/concat.rs
@@ -139,10 +139,10 @@ impl Operator for Concat {
         true
     }
 
-    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<Value, OpError> {
+    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         map_value!(input, input, [FloatTensor, Int32Tensor], {
             let typed_inputs = typed_inputs(ctx.inputs(), input.view())?;
-            concat_in_place(ctx.pool(), input, &typed_inputs, self.axis).map(|t| t.into())
+            concat_in_place(ctx.pool(), input, &typed_inputs, self.axis).into_op_result()
         })
     }
 
@@ -291,15 +291,15 @@ impl Operator for Tile {
         true
     }
 
-    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<Value, OpError> {
+    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let repeats: NdTensorView<i32, 1> = ctx.inputs().require_as(0)?;
 
         if repeats.iter().all(|n| *n == 1) {
-            return Ok(input);
+            return input.into_op_result();
         }
 
         map_value!(input, input, [FloatTensor, Int32Tensor], {
-            tile(ctx.pool(), input.view(), repeats).map(|t| t.into())
+            tile(ctx.pool(), input.view(), repeats).into_op_result()
         })
     }
 

--- a/src/ops/convert.rs
+++ b/src/ops/convert.rs
@@ -129,13 +129,13 @@ impl Operator for Cast {
         true
     }
 
-    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<Value, OpError> {
+    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         match cast_in_place(input, self.to) {
-            Ok(output) => Ok(output),
+            Ok(output) => output.into_op_result(),
             Err(input) => {
                 let converted = cast(ctx.pool(), input.as_view(), self.to)?;
                 input.add_to_pool(ctx.pool());
-                Ok(converted)
+                converted.into_op_result()
             }
         }
     }
@@ -195,7 +195,7 @@ impl Operator for CastLike {
         true
     }
 
-    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<Value, OpError> {
+    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let target_type = ctx.inputs().require(0)?;
         let ValueType::Tensor(to) = target_type.dtype() else {
             return Err(OpError::InvalidValue("expected target_type to be a tensor"));

--- a/src/ops/convert.rs
+++ b/src/ops/convert.rs
@@ -1,3 +1,4 @@
+use rten_base::bit_set::BitSet;
 use rten_base::byte_cast::{FromByteArray, cast_vec};
 use rten_base::num;
 
@@ -123,10 +124,10 @@ impl Operator for Cast {
         cast(ctx.pool(), input, self.to).into_op_result()
     }
 
-    fn can_run_in_place(&self) -> bool {
+    fn in_place_inputs(&self) -> BitSet<u16> {
         // Cast can run in place if the input's dtype already matches `self.to`
         // or both dtypes have the same element size.
-        true
+        BitSet::from_indices([0])
     }
 
     fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
@@ -191,8 +192,8 @@ impl Operator for CastLike {
         Cast { to }.run(ctx)
     }
 
-    fn can_run_in_place(&self) -> bool {
-        true
+    fn in_place_inputs(&self) -> BitSet<u16> {
+        BitSet::from_indices([0])
     }
 
     fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {

--- a/src/ops/convert.rs
+++ b/src/ops/convert.rs
@@ -197,7 +197,7 @@ impl Operator for CastLike {
     }
 
     fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
-        let target_type = ctx.inputs().require(0)?;
+        let target_type = ctx.inputs().require(1)?;
         let ValueType::Tensor(to) = target_type.dtype() else {
             return Err(OpError::InvalidValue("expected target_type to be a tensor"));
         };

--- a/src/ops/identity.rs
+++ b/src/ops/identity.rs
@@ -1,3 +1,4 @@
+use rten_base::bit_set::BitSet;
 use rten_shape_inference::ops as shape_ops;
 use rten_tensor::prelude::*;
 use rten_tensor::{Tensor, TensorView};
@@ -32,8 +33,8 @@ impl Operator for Identity {
         map_value_view!(input, x, { identity(ctx.pool(), x).into_op_result() })
     }
 
-    fn can_run_in_place(&self) -> bool {
-        true
+    fn in_place_inputs(&self) -> BitSet<u16> {
+        BitSet::from_indices([0])
     }
 
     fn run_in_place(&self, input: Value, _ctx: &OpRunContext) -> Result<OutputList, OpError> {

--- a/src/ops/identity.rs
+++ b/src/ops/identity.rs
@@ -36,8 +36,8 @@ impl Operator for Identity {
         true
     }
 
-    fn run_in_place(&self, input: Value, _ctx: &OpRunContext) -> Result<Value, OpError> {
-        Ok(input)
+    fn run_in_place(&self, input: Value, _ctx: &OpRunContext) -> Result<OutputList, OpError> {
+        input.into_op_result()
     }
 
     fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {

--- a/src/ops/layout.rs
+++ b/src/ops/layout.rs
@@ -194,18 +194,18 @@ impl Operator for Expand {
         true
     }
 
-    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<Value, OpError> {
+    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let shape = ctx.inputs().require_as(0)?;
 
         let out_shape = expand_output_shape(&input.shape(), &shape)?;
         if input.shape() == out_shape {
-            return Ok(input);
+            return input.into_op_result();
         }
 
         map_value!(input, input, {
             let input = input.auto_return(ctx.pool());
             let output = expand_to(ctx.pool(), input.view(), &out_shape);
-            Ok(output.into())
+            output.into_op_result()
         })
     }
 
@@ -275,10 +275,10 @@ impl Operator for Flatten {
         true
     }
 
-    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<Value, OpError> {
+    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         map_value!(input, x, {
             flatten_in_place(ctx.pool(), &mut x, self.axis)?;
-            Ok(x.into())
+            x.into_op_result()
         })
     }
 
@@ -424,12 +424,12 @@ impl Operator for Reshape {
         true
     }
 
-    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<Value, OpError> {
+    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let shape = ctx.inputs().require_as(0)?;
 
         map_value!(input, output, {
             reshape_in_place(ctx.pool(), &mut output, &shape, self.allow_zero)?;
-            Ok(output.into())
+            output.into_op_result()
         })
     }
 
@@ -600,12 +600,12 @@ impl Operator for Squeeze {
         true
     }
 
-    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<Value, OpError> {
+    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let axes = ctx.inputs().get_as(0)?;
 
         map_value!(input, output, {
             squeeze_in_place(&mut output, axes)?;
-            Ok(output.into())
+            output.into_op_result()
         })
     }
 
@@ -741,11 +741,11 @@ impl Operator for Unsqueeze {
         true
     }
 
-    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<Value, OpError> {
+    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let axes = ctx.inputs().require_as(0)?;
 
         map_value!(input, output, {
-            Ok(unsqueeze_in_place(output, &axes)?.into())
+            unsqueeze_in_place(output, &axes)?.into_op_result()
         })
     }
 

--- a/src/ops/layout.rs
+++ b/src/ops/layout.rs
@@ -1,6 +1,7 @@
 //! Operators which query or change the shape of a tensor, or copy/move/reorder
 //! elements.
 
+use rten_base::bit_set::BitSet;
 use rten_base::num::AsUsize;
 use rten_shape_inference::ops as shape_ops;
 use rten_tensor::layout::is_valid_permutation;
@@ -188,10 +189,10 @@ impl Operator for Expand {
         map_value_view!(input, x, { expand(ctx.pool(), x, &shape).into_op_result() })
     }
 
-    fn can_run_in_place(&self) -> bool {
+    fn in_place_inputs(&self) -> BitSet<u16> {
         // Expand can run in place if it is a noop, ie. if the broadcasted
         // shape is the same as the input shape.
-        true
+        BitSet::from_indices([0])
     }
 
     fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
@@ -271,8 +272,8 @@ impl Operator for Flatten {
         })
     }
 
-    fn can_run_in_place(&self) -> bool {
-        true
+    fn in_place_inputs(&self) -> BitSet<u16> {
+        BitSet::from_indices([0])
     }
 
     fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
@@ -420,8 +421,8 @@ impl Operator for Reshape {
         })
     }
 
-    fn can_run_in_place(&self) -> bool {
-        true
+    fn in_place_inputs(&self) -> BitSet<u16> {
+        BitSet::from_indices([0])
     }
 
     fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
@@ -596,8 +597,8 @@ impl Operator for Squeeze {
         map_value_view!(input, x, { squeeze(ctx.pool(), x, axes).into_op_result() })
     }
 
-    fn can_run_in_place(&self) -> bool {
-        true
+    fn in_place_inputs(&self) -> BitSet<u16> {
+        BitSet::from_indices([0])
     }
 
     fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
@@ -737,8 +738,8 @@ impl Operator for Unsqueeze {
         })
     }
 
-    fn can_run_in_place(&self) -> bool {
-        true
+    fn in_place_inputs(&self) -> BitSet<u16> {
+        BitSet::from_indices([0])
     }
 
     fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {

--- a/src/ops/layout.rs
+++ b/src/ops/layout.rs
@@ -196,7 +196,7 @@ impl Operator for Expand {
     }
 
     fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
-        let shape = ctx.inputs().require_as(0)?;
+        let shape = ctx.inputs().require_as(1)?;
 
         let out_shape = expand_output_shape(&input.shape(), &shape)?;
         if input.shape() == out_shape {
@@ -426,7 +426,7 @@ impl Operator for Reshape {
     }
 
     fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
-        let shape = ctx.inputs().require_as(0)?;
+        let shape = ctx.inputs().require_as(1)?;
 
         map_value!(input, output, {
             reshape_in_place(ctx.pool(), &mut output, &shape, self.allow_zero)?;
@@ -602,7 +602,7 @@ impl Operator for Squeeze {
     }
 
     fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
-        let axes = ctx.inputs().get_as(0)?;
+        let axes = ctx.inputs().get_as(1)?;
 
         map_value!(input, output, {
             squeeze_in_place(&mut output, axes)?;
@@ -743,7 +743,7 @@ impl Operator for Unsqueeze {
     }
 
     fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
-        let axes = ctx.inputs().require_as(0)?;
+        let axes = ctx.inputs().require_as(1)?;
 
         map_value!(input, output, {
             unsqueeze_in_place(output, &axes)?.into_op_result()

--- a/src/ops/norm.rs
+++ b/src/ops/norm.rs
@@ -276,7 +276,7 @@ impl Operator for BatchNormalization {
         true
     }
 
-    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<Value, OpError> {
+    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let inputs = ctx.inputs();
         let mut output: Tensor = input.try_into()?;
         let scale = inputs.require_as(0)?;
@@ -286,7 +286,7 @@ impl Operator for BatchNormalization {
 
         batch_norm_in_place(&mut output, &scale, &bias, &mean, &var, self.epsilon)?;
 
-        Ok(output.into())
+        output.into_op_result()
     }
 
     fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
@@ -373,7 +373,7 @@ impl Operator for InstanceNormalization {
         true
     }
 
-    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<Value, OpError> {
+    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let mut output: Tensor = input.try_into()?;
         let inputs = ctx.inputs();
         let scale = inputs.require_as(0)?;
@@ -381,7 +381,7 @@ impl Operator for InstanceNormalization {
 
         instance_normalization_in_place(&mut output, scale, bias, self.epsilon)?;
 
-        Ok(output.into())
+        output.into_op_result()
     }
 
     fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
@@ -697,10 +697,10 @@ impl Operator for LogSoftmax {
         true
     }
 
-    fn run_in_place(&self, input: Value, _ctx: &OpRunContext) -> Result<Value, OpError> {
+    fn run_in_place(&self, input: Value, _ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let mut output: Tensor = input.try_into()?;
         log_softmax_in_place(&mut output, self.axis)?;
-        Ok(output.into())
+        output.into_op_result()
     }
 
     fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
@@ -789,10 +789,10 @@ impl Operator for Softmax {
         true
     }
 
-    fn run_in_place(&self, input: Value, _ctx: &OpRunContext) -> Result<Value, OpError> {
+    fn run_in_place(&self, input: Value, _ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let mut output = input.try_into()?;
         softmax_in_place(&mut output, self.axis, self.nan_handling())?;
-        Ok(output.into())
+        output.into_op_result()
     }
 
     fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {

--- a/src/ops/norm.rs
+++ b/src/ops/norm.rs
@@ -280,10 +280,10 @@ impl Operator for BatchNormalization {
     fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let inputs = ctx.inputs();
         let mut output: Tensor = input.try_into()?;
-        let scale = inputs.require_as(0)?;
-        let bias = inputs.require_as(1)?;
-        let mean = inputs.require_as(2)?;
-        let var = inputs.require_as(3)?;
+        let scale = inputs.require_as(1)?;
+        let bias = inputs.require_as(2)?;
+        let mean = inputs.require_as(3)?;
+        let var = inputs.require_as(4)?;
 
         batch_norm_in_place(&mut output, &scale, &bias, &mean, &var, self.epsilon)?;
 
@@ -377,8 +377,8 @@ impl Operator for InstanceNormalization {
     fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let mut output: Tensor = input.try_into()?;
         let inputs = ctx.inputs();
-        let scale = inputs.require_as(0)?;
-        let bias = inputs.require_as(1)?;
+        let scale = inputs.require_as(1)?;
+        let bias = inputs.require_as(2)?;
 
         instance_normalization_in_place(&mut output, scale, bias, self.epsilon)?;
 

--- a/src/ops/norm.rs
+++ b/src/ops/norm.rs
@@ -2,6 +2,7 @@ use std::mem::MaybeUninit;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use rayon::prelude::*;
+use rten_base::bit_set::BitSet;
 use rten_simd::SimdOp;
 use rten_tensor::prelude::*;
 use rten_tensor::{NdTensorView, Tensor, TensorView};
@@ -272,8 +273,8 @@ impl Operator for BatchNormalization {
         batch_norm(ctx.pool(), input, &scale, &bias, &mean, &var, self.epsilon).into_op_result()
     }
 
-    fn can_run_in_place(&self) -> bool {
-        true
+    fn in_place_inputs(&self) -> BitSet<u16> {
+        BitSet::from_indices([0])
     }
 
     fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
@@ -369,8 +370,8 @@ impl Operator for InstanceNormalization {
         instance_normalization(ctx.pool(), input, scale, bias, self.epsilon).into_op_result()
     }
 
-    fn can_run_in_place(&self) -> bool {
-        true
+    fn in_place_inputs(&self) -> BitSet<u16> {
+        BitSet::from_indices([0])
     }
 
     fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
@@ -693,8 +694,8 @@ impl Operator for LogSoftmax {
         log_softmax(ctx.pool(), input, self.axis).into_op_result()
     }
 
-    fn can_run_in_place(&self) -> bool {
-        true
+    fn in_place_inputs(&self) -> BitSet<u16> {
+        BitSet::from_indices([0])
     }
 
     fn run_in_place(&self, input: Value, _ctx: &OpRunContext) -> Result<OutputList, OpError> {
@@ -785,8 +786,8 @@ impl Operator for Softmax {
         softmax(ctx.pool(), input, self.axis, self.nan_handling()).into_op_result()
     }
 
-    fn can_run_in_place(&self) -> bool {
-        true
+    fn in_place_inputs(&self) -> BitSet<u16> {
+        BitSet::from_indices([0])
     }
 
     fn run_in_place(&self, input: Value, _ctx: &OpRunContext) -> Result<OutputList, OpError> {

--- a/src/ops/resize.rs
+++ b/src/ops/resize.rs
@@ -527,7 +527,7 @@ impl Operator for Resize {
         // See note in `run` about the `roi` input.
 
         let other = ctx.inputs();
-        let target = target_from_scale_size_inputs(other, 1)?;
+        let target = target_from_scale_size_inputs(other, 2)?;
         let output_size = calc_output_size(&input.shape(), target)?;
 
         // If this is a no-op resize, just return the input.

--- a/src/ops/resize.rs
+++ b/src/ops/resize.rs
@@ -522,7 +522,7 @@ impl Operator for Resize {
         true
     }
 
-    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<Value, OpError> {
+    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         // See note in `run` about the `roi` input.
 
         let other = ctx.inputs();
@@ -531,7 +531,7 @@ impl Operator for Resize {
 
         // If this is a no-op resize, just return the input.
         if input.shape().as_slice() == output_size {
-            return Ok(input);
+            return input.into_op_result();
         }
 
         let input = Tensor::<f32>::try_from(input)?.auto_return(ctx.pool());
@@ -545,7 +545,7 @@ impl Operator for Resize {
                 nearest_mode: self.nearest_mode,
             },
         )
-        .map(|t| t.into())
+        .into_op_result()
     }
 }
 

--- a/src/ops/resize.rs
+++ b/src/ops/resize.rs
@@ -2,6 +2,7 @@ use std::mem::MaybeUninit;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use rayon::prelude::*;
+use rten_base::bit_set::BitSet;
 use rten_base::iter::range_chunks;
 use rten_parallel::par_iter::ParIter;
 use rten_shape_inference::ops as shape_ops;
@@ -516,10 +517,10 @@ impl Operator for Resize {
         Some(self)
     }
 
-    fn can_run_in_place(&self) -> bool {
+    fn in_place_inputs(&self) -> BitSet<u16> {
         // Resize can run in place if the computed output size is the same
         // as the input size. In that case the in-place operation is a noop.
-        true
+        BitSet::from_indices([0])
     }
 
     fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {

--- a/src/ops/sequence.rs
+++ b/src/ops/sequence.rs
@@ -160,10 +160,10 @@ impl Operator for SequenceErase {
             .into_op_result()
     }
 
-    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<Value, OpError> {
+    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let seq: Sequence = input.try_into()?;
         let pos: Option<i32> = ctx.inputs().get_as(0)?;
-        sequence_erase(seq, pos).map(Value::from)
+        sequence_erase(seq, pos).map(Value::from).into_op_result()
     }
 
     fn output_types(&self, _ctx: &OutputTypesContext) -> Option<OutputTypeList> {
@@ -229,11 +229,13 @@ impl Operator for SequenceInsert {
             .into_op_result()
     }
 
-    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<Value, OpError> {
+    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let seq: Sequence = input.try_into()?;
         let value = ctx.inputs().require(0)?;
         let pos: Option<i32> = ctx.inputs().get_as(1)?;
-        sequence_insert(ctx.pool(), seq, pos, value).map(Value::from)
+        sequence_insert(ctx.pool(), seq, pos, value)
+            .map(Value::from)
+            .into_op_result()
     }
 
     fn output_types(&self, _ctx: &OutputTypesContext) -> Option<OutputTypeList> {

--- a/src/ops/sequence.rs
+++ b/src/ops/sequence.rs
@@ -163,7 +163,7 @@ impl Operator for SequenceErase {
 
     fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let seq: Sequence = input.try_into()?;
-        let pos: Option<i32> = ctx.inputs().get_as(0)?;
+        let pos: Option<i32> = ctx.inputs().get_as(1)?;
         sequence_erase(seq, pos).map(Value::from).into_op_result()
     }
 
@@ -232,8 +232,8 @@ impl Operator for SequenceInsert {
 
     fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let seq: Sequence = input.try_into()?;
-        let value = ctx.inputs().require(0)?;
-        let pos: Option<i32> = ctx.inputs().get_as(1)?;
+        let value = ctx.inputs().require(1)?;
+        let pos: Option<i32> = ctx.inputs().get_as(2)?;
         sequence_insert(ctx.pool(), seq, pos, value)
             .map(Value::from)
             .into_op_result()

--- a/src/ops/sequence.rs
+++ b/src/ops/sequence.rs
@@ -1,3 +1,4 @@
+use rten_base::bit_set::BitSet;
 use rten_tensor::prelude::*;
 use rten_tensor::{Tensor, TensorView};
 
@@ -148,8 +149,8 @@ impl Operator for SequenceErase {
         Some(2)
     }
 
-    fn can_run_in_place(&self) -> bool {
-        true
+    fn in_place_inputs(&self) -> BitSet<u16> {
+        BitSet::from_indices([0])
     }
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
@@ -216,8 +217,8 @@ impl Operator for SequenceInsert {
         Some(3)
     }
 
-    fn can_run_in_place(&self) -> bool {
-        true
+    fn in_place_inputs(&self) -> BitSet<u16> {
+        BitSet::from_indices([0])
     }
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {

--- a/src/ops/slice.rs
+++ b/src/ops/slice.rs
@@ -1,3 +1,4 @@
+use rten_base::bit_set::BitSet;
 use rten_shape_inference::ops as shape_ops;
 use rten_tensor::prelude::*;
 use rten_tensor::{NdTensorView, SliceItem, SliceRange, Tensor, TensorView};
@@ -141,8 +142,8 @@ impl Operator for Slice {
         result.into_op_result()
     }
 
-    fn can_run_in_place(&self) -> bool {
-        true
+    fn in_place_inputs(&self) -> BitSet<u16> {
+        BitSet::from_indices([0])
     }
 
     fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {

--- a/src/ops/slice.rs
+++ b/src/ops/slice.rs
@@ -145,7 +145,7 @@ impl Operator for Slice {
         true
     }
 
-    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<Value, OpError> {
+    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let other = ctx.inputs();
         let starts = other.require_as(0)?;
         let ends = other.require_as(1)?;
@@ -168,12 +168,12 @@ impl Operator for Slice {
 
             let input_list = InputList::from(&inputs);
             let ctx = OpRunContext::new(ctx.pool(), &input_list, ctx.outputs());
-            return self.run(&ctx).map(|mut outputs| outputs.remove(0));
+            return self.run(&ctx);
         }
 
         map_value!(input, output, {
             slice_in_place(&mut output, &starts, &ends, axes.as_ref())?;
-            Ok(output.into())
+            output.into_op_result()
         })
     }
 

--- a/src/ops/slice.rs
+++ b/src/ops/slice.rs
@@ -148,11 +148,11 @@ impl Operator for Slice {
 
     fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let other = ctx.inputs();
-        let starts = other.require_as(0)?;
-        let ends = other.require_as(1)?;
+        let starts = other.require_as(1)?;
+        let ends = other.require_as(2)?;
 
-        let axes = other.get_as(2)?;
-        let steps = other.get_as::<NdTensorView<i32, 1>>(3)?;
+        let axes = other.get_as(3)?;
+        let steps = other.get_as::<NdTensorView<i32, 1>>(4)?;
 
         // Fall back to copying if non-default steps are given.
         if let Some(steps) = steps

--- a/src/ops/transform_inputs.rs
+++ b/src/ops/transform_inputs.rs
@@ -142,9 +142,7 @@ impl Operator for TransformInputs {
             transform,
         } in &self.transforms
         {
-            // We don't allow in-place execution if any input has index 0, so
-            // the index should always be > 0 here.
-            let Some(input) = inputs.get_mut(*input_index - 1) else {
+            let Some(input) = inputs.get_mut(*input_index) else {
                 return Err(OpError::MissingInputs);
             };
             transform.transform(input)?;
@@ -168,12 +166,12 @@ impl Operator for TransformInputs {
 mod tests {
     use std::sync::Arc;
 
-    use rten_tensor::Tensor;
     use rten_tensor::prelude::*;
+    use rten_tensor::{Tensor, TensorView};
     use rten_testing::TestCases;
 
     use super::TransformInputsBuilder;
-    use crate::operator::{Operator, OperatorExt};
+    use crate::operator::{InputList, Operator, OperatorExt};
     use crate::ops::Sub;
 
     #[test]
@@ -276,7 +274,12 @@ mod tests {
             );
 
             if let Some(expected) = expected {
-                let output: Tensor<i32> = fused_transpose.run_simple_in_place(a, b.view()).unwrap();
+                // The in-place input occupies index 0, so `b` is passed at
+                // index 1 with a `None` placeholder at index 0.
+                let mut inputs = InputList::new();
+                inputs.push_optional(None::<TensorView<i32>>);
+                inputs.push(b.view());
+                let output: Tensor<i32> = fused_transpose.run_simple_in_place(a, inputs).unwrap();
                 assert_eq!(output, expected);
             }
         })

--- a/src/ops/transform_inputs.rs
+++ b/src/ops/transform_inputs.rs
@@ -125,7 +125,7 @@ impl Operator for TransformInputs {
         self.inner.can_run_in_place() && !self.transforms.iter().any(|t| t.input_index == 0)
     }
 
-    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<Value, OpError> {
+    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let mut inputs = ctx.inputs().clone();
         for TransformIndex {
             input_index,

--- a/src/ops/transform_inputs.rs
+++ b/src/ops/transform_inputs.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use rten_base::bit_set::BitSet;
 use rten_tensor::prelude::*;
 
 use crate::infer_shapes::InferShapes;
@@ -119,10 +120,19 @@ impl Operator for TransformInputs {
         self.inner.run(&inner_ctx)
     }
 
-    fn can_run_in_place(&self) -> bool {
-        // Allow in-place execution if supported by the wrapped operator and
-        // no transforms are applied to the in-place input.
-        self.inner.can_run_in_place() && !self.transforms.iter().any(|t| t.input_index == 0)
+    fn in_place_inputs(&self) -> BitSet<u16> {
+        // Allow in-place execution unless a transform is applied to one of the
+        // in-place inputs.
+        let in_place = self.inner.in_place_inputs();
+        let transforms_in_place_input = self
+            .transforms
+            .iter()
+            .any(|t| t.input_index < u16::BITS as usize && in_place.get(t.input_index as u32));
+        if transforms_in_place_input {
+            BitSet::new()
+        } else {
+            in_place
+        }
     }
 
     fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
@@ -260,7 +270,10 @@ mod tests {
             let fused_transpose = TransformInputsBuilder::new()
                 .permute(transpose_input, Some([1, 0].into()))
                 .build(Arc::new(sub_op));
-            assert_eq!(fused_transpose.can_run_in_place(), expected.is_some());
+            assert_eq!(
+                !fused_transpose.in_place_inputs().is_empty(),
+                expected.is_some()
+            );
 
             if let Some(expected) = expected {
                 let output: Tensor<i32> = fused_transpose.run_simple_in_place(a, b.view()).unwrap();

--- a/src/ops/unary_elementwise.rs
+++ b/src/ops/unary_elementwise.rs
@@ -143,11 +143,11 @@ macro_rules! impl_operator {
                 })
             }
 
-            fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<Value, OpError> {
+            fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
                 map_value!(input, input, $types, {
                     let kernel = self.get_kernel();
                     let result = unary_op_in_place(ctx.pool(), input, &kernel);
-                    Ok(result.into())
+                    result.into_op_result()
                 })
             }
 
@@ -331,12 +331,12 @@ impl Operator for Clip {
         true
     }
 
-    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<Value, OpError> {
+    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         map_value!(input, input, [FloatTensor, Int32Tensor], {
             let min = ctx.inputs().get_as(0)?;
             let max = ctx.inputs().get_as(1)?;
             clip_in_place(&mut input, min, max);
-            Ok(input.into())
+            input.into_op_result()
         })
     }
 
@@ -574,10 +574,10 @@ impl Operator for Not {
         true
     }
 
-    fn run_in_place(&self, input: Value, _ctx: &OpRunContext) -> Result<Value, OpError> {
+    fn run_in_place(&self, input: Value, _ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let mut output: Tensor<i32> = input.try_into()?;
         not_in_place(output.view_mut());
-        Ok(output.into())
+        output.into_op_result()
     }
 
     fn output_types(&self, _ctx: &OutputTypesContext) -> Option<OutputTypeList> {

--- a/src/ops/unary_elementwise.rs
+++ b/src/ops/unary_elementwise.rs
@@ -338,8 +338,8 @@ impl Operator for Clip {
 
     fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         map_value!(input, input, [FloatTensor, Int32Tensor], {
-            let min = ctx.inputs().get_as(0)?;
-            let max = ctx.inputs().get_as(1)?;
+            let min = ctx.inputs().get_as(1)?;
+            let max = ctx.inputs().get_as(2)?;
             clip_in_place(&mut input, min, max);
             input.into_op_result()
         })

--- a/src/ops/unary_elementwise.rs
+++ b/src/ops/unary_elementwise.rs
@@ -3,6 +3,7 @@ use rayon::prelude::*;
 use std::fmt::Debug;
 use std::mem::MaybeUninit;
 
+use rten_base::bit_set::BitSet;
 use rten_base::num::AsBool;
 use rten_shape_inference::ops as shape_ops;
 use rten_simd::SimdUnaryOp;
@@ -131,8 +132,8 @@ macro_rules! impl_operator {
                 Some(1)
             }
 
-            fn can_run_in_place(&self) -> bool {
-                true
+            fn in_place_inputs(&self) -> BitSet<u16> {
+                BitSet::from_indices([0])
             }
 
             fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
@@ -143,7 +144,11 @@ macro_rules! impl_operator {
                 })
             }
 
-            fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+            fn run_in_place(
+                &self,
+                input: Value,
+                ctx: &OpRunContext,
+            ) -> Result<OutputList, OpError> {
                 map_value!(input, input, $types, {
                     let kernel = self.get_kernel();
                     let result = unary_op_in_place(ctx.pool(), input, &kernel);
@@ -327,8 +332,8 @@ impl Operator for Clip {
         })
     }
 
-    fn can_run_in_place(&self) -> bool {
-        true
+    fn in_place_inputs(&self) -> BitSet<u16> {
+        BitSet::from_indices([0])
     }
 
     fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
@@ -570,8 +575,8 @@ impl Operator for Not {
         not(ctx.pool(), input).into_op_result()
     }
 
-    fn can_run_in_place(&self) -> bool {
-        true
+    fn in_place_inputs(&self) -> BitSet<u16> {
+        BitSet::from_indices([0])
     }
 
     fn run_in_place(&self, input: Value, _ctx: &OpRunContext) -> Result<OutputList, OpError> {


### PR DESCRIPTION
In preparation for enabling attention operators to modify the `past_key` and `past_value` inputs in-place, change the APIs for in-place execution so that operators can specify any inputs, from the first 16, they wish to modify in-place, and can return multiple outputs from in-place execution.

The `Operator::run_in_place` method still accepts only a single owned input, so operators are still limited to modifying a single input in-place. This restriction will be lifted in future PRs.

The handling of non-owned inputs passed to `run_in_place` has been changed so that the `InputList` returned by `ctx.inputs()` has `None` placeholders in positions that correspond to owned inputs, instead of omitting the first input and requiring input indices to be adjusted accordingly.

Part of https://github.com/robertknight/rten/issues/1305.