### PR TITLE
Support modifying multiple operator inputs in-place

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -16,7 +16,9 @@ use smallvec::SmallVec;
 
 use crate::buffer_pool::BufferPool;
 use crate::env::env_flag;
-use crate::operator::{InputList, OpError, OpRunContext, Operator, OutputList, PrepackedInput};
+use crate::operator::{
+    InPlaceInputs, InputList, OpRunContext, Operator, OutputList, PrepackedInput,
+};
 use crate::threading;
 use crate::timing::{Instant, ProfileFormat, Profiler, TimingFilter, TimingRecord, TimingSort};
 use crate::value::{Value, ValueMeta, ValueOrView, ValueType, ValueView};
@@ -946,52 +948,62 @@ impl Graph {
                 );
             };
 
-            // Choose the input that we'll try to modify in-place to avoid
-            // allocating a new buffer for the output. This will be passed as
-            // the first input to `Operator::run_in_place`.
+            // Choose the inputs that we'll try to modify in-place to avoid
+            // allocating new buffers for the outputs.
             //
-            // For non-commutative ops we use the specific input which the
+            // For non-commutative ops we use the specific inputs which the
             // operator reports it can modify. For commutative ops we can swap
-            // inputs around if that enables us to run an op in place.
+            // inputs around, so we pick the largest input.
             let in_place_inputs = op_node.operator().in_place_inputs();
-            if in_place_inputs.count_true() > 1 {
-                return Err(RunErrorImpl::OperatorError {
-                    name: op_node.name().unwrap_or_default().to_string(),
-                    error: OpError::UnsupportedValue(
-                        "operators with multiple in-place inputs are not yet supported",
-                    ),
-                    inputs: Vec::new(),
-                }
-                .into());
-            }
-            let try_in_place_input_id = if let Some(in_place_index) = in_place_inputs.iter().next()
+            let in_place_candidates: SmallVec<[(usize, NodeId); 2]> = if in_place_inputs.is_empty()
             {
-                if op_node.operator().is_commutative() {
-                    // Pick the largest input by number of elements. This
-                    // assumes that commutative op outputs will have a shape
-                    // that matches their largest input (eg. consider a
-                    // binary op that broadcasts inputs to a common shape).
-                    op_node
-                        .input_ids()
-                        .iter()
-                        .max_by_key(|input_id| {
-                            input_id
-                                .and_then(|id| temp_values.get(id))
-                                .map(|val| val.len())
-                                .unwrap_or(0)
-                        })
-                        .copied()
-                        .flatten()
-                } else {
-                    op_node
-                        .input_ids()
-                        .get(in_place_index as usize)
-                        .copied()
-                        .flatten()
-                }
+                SmallVec::new()
+            } else if op_node.operator().is_commutative() {
+                // Commutative ops declare a single in-place input, but any
+                // input can be used. Pick the largest by number of elements.
+                // This assumes that commutative op outputs will have a shape
+                // that matches their largest input (eg. consider a binary op
+                // that broadcasts inputs to a common shape).
+                op_node
+                    .input_ids()
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(pos, id)| id.map(|id| (pos, id)))
+                    .max_by_key(|(_pos, id)| temp_values.get(*id).map(|val| val.len()).unwrap_or(0))
+                    .into_iter()
+                    .collect()
             } else {
-                None
+                in_place_inputs
+                    .iter()
+                    .filter_map(|index| {
+                        let pos = index as usize;
+                        op_node
+                            .input_ids()
+                            .get(pos)
+                            .copied()
+                            .flatten()
+                            .map(|id| (pos, id))
+                    })
+                    .collect()
             };
+
+            // Only run in-place if all of the in-place inputs are available to
+            // take as owned values. This simplifies the cases that
+            // `Operator::run_in_place` implementations have to handle.
+            let run_in_place = !in_place_candidates.is_empty()
+                && in_place_candidates.iter().all(|&(_pos, id)| {
+                    temp_value_refcount.count(id) == 1
+                        && (temp_values.get(id).is_some()
+                            || (self.captures.contains(&id)
+                                && self
+                                    .nodes
+                                    .get(&id)
+                                    .and_then(|n| n.name())
+                                    .and_then(|name| {
+                                        captures.as_ref().map(|c| c.can_take_input(name))
+                                    })
+                                    .unwrap_or(false)))
+                });
 
             // Take a value for passing to an operator as an owned value, if
             // it won't be needed by other operators in future.
@@ -1010,15 +1022,14 @@ impl Graph {
                 }
             };
 
-            // If the operator can run in place, try to get the owned tensor to
-            // use as an output. This requires that the tensor is not a constant
-            // (eg. weights) and is not going to be used by other ops in future.
-            let in_place_input: Option<(NodeId, Value)> = if let Some(id) = try_in_place_input_id
-                && let Some(value) = take_value(id)
-            {
-                Some((id, value))
+            // Take the in-place inputs as owned values.
+            let in_place_taken: SmallVec<[(usize, NodeId, Value); 2]> = if run_in_place {
+                in_place_candidates
+                    .iter()
+                    .map(|&(pos, id)| (pos, id, take_value(id).expect("input is available")))
+                    .collect()
             } else {
-                None
+                SmallVec::new()
             };
 
             // Extract values used by the operator's subgraphs which can be
@@ -1040,17 +1051,18 @@ impl Graph {
             // Collect all or remaining inputs for the operator
             let mut op_inputs: SmallVec<[Option<ValueView>; 4]> =
                 SmallVec::with_capacity(op_node.input_ids().len());
-            for node_id in op_node.input_ids().iter() {
-                if let Some(node_id) = node_id {
-                    if let Some((id, _value)) = &in_place_input
-                        && node_id == id
-                    {
-                        // This input is being passed separately as a mutable
-                        // value, so leave a `None` placeholder in its position.
-                        op_inputs.push(None);
-                        continue;
-                    }
+            for (pos, node_id) in op_node.input_ids().iter().enumerate() {
+                if in_place_taken
+                    .iter()
+                    .any(|(taken_pos, ..)| *taken_pos == pos)
+                {
+                    // This input is being passed separately as a mutable value,
+                    // so leave a `None` placeholder in its position.
+                    op_inputs.push(None);
+                    continue;
+                }
 
+                if let Some(node_id) = node_id {
                     if let Some(value) = get_value_from_constant_or_input(*node_id) {
                         op_inputs.push(Some(value));
                     } else if let Some(value) = temp_values.get(*node_id) {
@@ -1074,18 +1086,20 @@ impl Graph {
 
             // Collect input metadata if we'll need it for timing or logging.
             let input_meta = if opts.timing_by_shape || opts.verbose {
-                // `op_inputs` has a `None` placeholder at the in-place input's
-                // position, so fill in the metadata for that input separately.
+                // `op_inputs` has a `None` placeholder at each in-place input's
+                // position, so fill in the metadata for those inputs separately.
                 op_node
                     .input_ids()
                     .iter()
                     .copied()
+                    .enumerate()
                     .zip(&op_inputs)
-                    .map(|(id, input)| {
-                        let meta = if let Some((ip_id, ip_value)) = &in_place_input
-                            && id == Some(*ip_id)
+                    .map(|((pos, id), input)| {
+                        let meta = if let Some((.., value)) = in_place_taken
+                            .iter()
+                            .find(|(taken_pos, ..)| *taken_pos == pos)
                         {
-                            Some(ip_value.to_meta())
+                            Some(value.to_meta())
                         } else {
                             input.as_ref().map(|i| i.to_meta())
                         };
@@ -1109,24 +1123,29 @@ impl Graph {
             let mut ctx = OpRunContext::new(pool, &inputs, op_node.output_mask());
             ctx.set_name(op_node.name());
 
-            let op_result = if let Some((id, value)) = in_place_input {
-                let input_dtype = value.dtype();
-                let input_shape = value.shape();
-                let in_place_index = op_node
-                    .input_ids()
+            let op_result = if !in_place_taken.is_empty() {
+                // Record the metadata of the in-place inputs before they are
+                // moved into the operator, for use in error messages.
+                let in_place_metas: SmallVec<[(usize, ValueMeta); 2]> = in_place_taken
                     .iter()
-                    .position(|input_id| *input_id == Some(id))
-                    .unwrap_or(0);
-                op_node.operator().run_in_place(value, &ctx).map_err(|e| {
-                    RunError::in_place_op_error(
-                        op_node.name().unwrap_or_default(),
-                        e,
-                        &ctx,
-                        in_place_index,
-                        input_dtype,
-                        &input_shape,
-                    )
-                })
+                    .map(|(pos, _id, value)| (*pos, value.to_meta()))
+                    .collect();
+                let in_place = InPlaceInputs::from_iter(
+                    in_place_taken
+                        .into_iter()
+                        .map(|(pos, _id, value)| (pos, value)),
+                );
+                op_node
+                    .operator()
+                    .run_in_place(in_place, &ctx)
+                    .map_err(|e| {
+                        RunError::in_place_op_error(
+                            op_node.name().unwrap_or_default(),
+                            e,
+                            &ctx,
+                            &in_place_metas,
+                        )
+                    })
             } else if let Some(subgraph_op) = subgraph_op {
                 let capture_env = CaptureEnv::new(
                     captures.as_ref(),

--- a/src/graph/capture_env.rs
+++ b/src/graph/capture_env.rs
@@ -158,6 +158,19 @@ impl<'a> CaptureEnv<'a> {
         self.parent.and_then(|parent| parent.get_input(name))
     }
 
+    /// Return true if [`take_input`](Self::take_input) would return a value for
+    /// `name`.
+    pub fn can_take_input(&self, name: &str) -> bool {
+        self.graph
+            .and_then(|g| g.get_node_id(name))
+            .and_then(|node_id| {
+                self.temp_values
+                    .as_ref()
+                    .map(|tv| tv.contains_key(&node_id))
+            })
+            .unwrap_or(false)
+    }
+
     /// Remove and return a value from the capture environment's map of by-value
     /// captures.
     pub fn take_input(&mut self, name: &str) -> Option<Value> {

--- a/src/graph/run_error.rs
+++ b/src/graph/run_error.rs
@@ -2,7 +2,7 @@ use std::error::Error;
 use std::fmt::{Display, Formatter};
 
 use crate::operator::{OpError, OpRunContext};
-use crate::value::{ValueMeta, ValueType};
+use crate::value::ValueMeta;
 
 /// Errors that occur when running a model.
 #[derive(Debug)]
@@ -44,26 +44,21 @@ impl RunError {
         name: &str,
         error: OpError,
         ctx: &OpRunContext,
-        in_place_index: usize,
-        main_input_dtype: ValueType,
-        main_input_shape: &[usize],
+        in_place_metas: &[(usize, ValueMeta)],
     ) -> Self {
         let inputs: Vec<_> = ctx
             .inputs()
             .iter()
             .enumerate()
             .map(|(index, input)| {
-                if index == in_place_index {
-                    // `ctx.inputs()` has a `None` placeholder at the in-place
-                    // input's position, since that input is passed separately.
-                    // Fill it in so the metadata reflects all of the inputs.
-                    Some(ValueMeta {
-                        dtype: main_input_dtype,
-                        shape: main_input_shape.to_vec(),
-                    })
-                } else {
-                    input.map(|input| input.to_meta())
-                }
+                // `ctx.inputs()` has a `None` placeholder at each in-place
+                // input's position, since those inputs are passed separately.
+                // Fill them in so the metadata reflects all of the inputs.
+                in_place_metas
+                    .iter()
+                    .find(|(pos, _)| *pos == index)
+                    .map(|(_, meta)| meta.clone())
+                    .or_else(|| input.map(|input| input.to_meta()))
             })
             .collect();
 

--- a/src/graph/tests.rs
+++ b/src/graph/tests.rs
@@ -16,8 +16,8 @@ use crate::graph::{
 };
 use crate::infer_shapes::InferShapes;
 use crate::operator::{
-    IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputTypeList, OutputTypesContext,
-    PrepackedInput, SubgraphOperator,
+    InPlaceInputs, IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputTypeList,
+    OutputTypesContext, PrepackedInput, SubgraphOperator,
 };
 use crate::ops::{Add, Concat, Conv, Identity, If, MatMul, Mul, Relu, Shape};
 use crate::timing::Profiler;
@@ -90,12 +90,16 @@ impl<Op: Operator> Operator for TrackUsage<Op> {
         self.inner.run(ctx)
     }
 
-    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+    fn run_in_place(
+        &self,
+        in_place: InPlaceInputs,
+        ctx: &OpRunContext,
+    ) -> Result<OutputList, OpError> {
         {
             let mut m = self.metrics.lock().unwrap();
             m.run_in_place_count += 1;
         }
-        self.inner.run_in_place(input, ctx)
+        self.inner.run_in_place(in_place, ctx)
     }
 
     fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
@@ -872,8 +876,12 @@ impl Operator for AddOneInPlace {
         input.to_tensor().into_op_result()
     }
 
-    fn run_in_place(&self, input: Value, _ctx: &OpRunContext) -> Result<OutputList, OpError> {
-        let mut output = input.into_tensor::<f32>().unwrap();
+    fn run_in_place(
+        &self,
+        in_place: InPlaceInputs,
+        _ctx: &OpRunContext,
+    ) -> Result<OutputList, OpError> {
+        let mut output = in_place.into_single().into_tensor::<f32>().unwrap();
         for x in output.iter_mut() {
             *x = *x + 1.0;
         }
@@ -1020,8 +1028,12 @@ impl Operator for InPlaceSecondInput {
         second.to_tensor().into_op_result()
     }
 
-    fn run_in_place(&self, input: Value, _ctx: &OpRunContext) -> Result<OutputList, OpError> {
-        let mut output = input.into_tensor::<f32>().unwrap();
+    fn run_in_place(
+        &self,
+        in_place: InPlaceInputs,
+        _ctx: &OpRunContext,
+    ) -> Result<OutputList, OpError> {
+        let mut output = in_place.into_single().into_tensor::<f32>().unwrap();
         for x in output.iter_mut() {
             *x += 1.0;
         }
@@ -1071,6 +1083,138 @@ fn test_runs_non_commutative_op_in_place_with_non_first_input() {
     let op_metrics = op_metrics.lock().unwrap();
     assert_eq!(op_metrics.run_count, 0);
     assert_eq!(op_metrics.run_in_place_count, 1);
+}
+
+/// Test operator that can modify both of its inputs in-place.
+#[derive(Debug)]
+struct AddTwoInPlace {}
+impl Operator for AddTwoInPlace {
+    fn name(&self) -> &str {
+        "AddTwoInPlace"
+    }
+
+    fn max_inputs(&self) -> Option<usize> {
+        Some(2)
+    }
+
+    fn output_types(&self, _ctx: &OutputTypesContext) -> Option<OutputTypeList> {
+        None
+    }
+
+    fn in_place_inputs(&self) -> BitSet<u16> {
+        BitSet::from_indices([0, 1])
+    }
+
+    fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+        let first: TensorView<f32> = ctx.inputs().require_as(0)?;
+        first.to_tensor().into_op_result()
+    }
+
+    fn run_in_place(
+        &self,
+        in_place: InPlaceInputs,
+        _ctx: &OpRunContext,
+    ) -> Result<OutputList, OpError> {
+        let mut inputs: Vec<(usize, Tensor<f32>)> = in_place
+            .into_iter()
+            .map(|(index, value)| (index, value.into_tensor::<f32>().unwrap()))
+            .collect();
+        inputs.sort_by_key(|(index, _)| *index);
+        let (_, mut a) = inputs.remove(0);
+        let (_, b) = inputs.remove(0);
+        for (x, y) in a.iter_mut().zip(b.iter()) {
+            *x += *y;
+        }
+        a.into_op_result()
+    }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        None
+    }
+}
+
+// Test that an operator with multiple in-place inputs runs in-place only when
+// all of those inputs are available to take as owned values.
+#[test]
+fn test_runs_op_in_place_with_multiple_inputs() {
+    let first = Tensor::from([1.0f32, 2.0, 3.0]);
+    let second = Tensor::from([10.0f32, 20.0, 30.0]);
+
+    // Both inputs are owned temporaries, so the operator runs in-place.
+    {
+        let mut g = Graph::new();
+        let first_id = g.add_value(Some("first"), None, None);
+        let second_id = g.add_value(Some("second"), None, None);
+        let (_, first_temp) = g.add_simple_op("id1", Identity {}, &[first_id]);
+        let (_, second_temp) = g.add_simple_op("id2", Identity {}, &[second_id]);
+
+        let op = TrackUsage::new(AddTwoInPlace {});
+        let op_metrics = op.metrics();
+        let (_, op_out) = g.add_simple_op("op", op, &[first_temp, second_temp]);
+
+        let results = g
+            .run(
+                vec![
+                    (first_id, first.view().into()),
+                    (second_id, second.view().into()),
+                ],
+                &[op_out],
+                None,
+                None,
+            )
+            .unwrap();
+        assert_eq!(
+            results[0]
+                .as_tensor_view::<f32>()
+                .unwrap()
+                .iter()
+                .copied()
+                .collect::<Vec<_>>(),
+            &[11., 22., 33.]
+        );
+
+        let op_metrics = op_metrics.lock().unwrap();
+        assert_eq!(op_metrics.run_count, 0);
+        assert_eq!(op_metrics.run_in_place_count, 1);
+    }
+
+    // The first input is a graph input passed by view, so it cannot be taken.
+    // With the all-or-nothing approach the operator does not run in-place.
+    {
+        let mut g = Graph::new();
+        let first_id = g.add_value(Some("first"), None, None);
+        let second_id = g.add_value(Some("second"), None, None);
+        let (_, second_temp) = g.add_simple_op("id2", Identity {}, &[second_id]);
+
+        let op = TrackUsage::new(AddTwoInPlace {});
+        let op_metrics = op.metrics();
+        let (_, op_out) = g.add_simple_op("op", op, &[first_id, second_temp]);
+
+        let results = g
+            .run(
+                vec![
+                    (first_id, first.view().into()),
+                    (second_id, second.view().into()),
+                ],
+                &[op_out],
+                None,
+                None,
+            )
+            .unwrap();
+        assert_eq!(
+            results[0]
+                .as_tensor_view::<f32>()
+                .unwrap()
+                .iter()
+                .copied()
+                .collect::<Vec<_>>(),
+            &[1., 2., 3.]
+        );
+
+        let op_metrics = op_metrics.lock().unwrap();
+        assert_eq!(op_metrics.run_count, 1);
+        assert_eq!(op_metrics.run_in_place_count, 0);
+    }
 }
 
 /// Test operator that produces multiple outputs

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -352,6 +352,65 @@ pub struct OutputTypesContext {
 /// exactly one output.
 pub type OutputList = SmallVec<[Value; 1]>;
 
+/// Owned input values which an operator should modify in-place.
+///
+/// This is a list of `(input_index, value)` for owned inputs passed to
+/// [`Operator::run_in_place`].
+#[derive(Debug)]
+pub struct InPlaceInputs {
+    inputs: SmallVec<[(usize, Value); 1]>,
+}
+
+impl InPlaceInputs {
+    /// Return the number of in-place inputs.
+    pub fn len(&self) -> usize {
+        self.inputs.len()
+    }
+
+    /// Return true if there are no in-place inputs.
+    pub fn is_empty(&self) -> bool {
+        self.inputs.is_empty()
+    }
+
+    /// Return the single in-place input.
+    ///
+    /// Panics if the list does not have exactly one element.
+    pub fn into_single(self) -> Value {
+        assert_eq!(
+            self.inputs.len(),
+            1,
+            "expected exactly one in-place input, got {}",
+            self.inputs.len()
+        );
+        self.inputs.into_iter().next().unwrap().1
+    }
+}
+
+impl From<(usize, Value)> for InPlaceInputs {
+    fn from(input: (usize, Value)) -> Self {
+        InPlaceInputs {
+            inputs: [input].into_iter().collect(),
+        }
+    }
+}
+
+impl FromIterator<(usize, Value)> for InPlaceInputs {
+    fn from_iter<I: IntoIterator<Item = (usize, Value)>>(iter: I) -> Self {
+        InPlaceInputs {
+            inputs: iter.into_iter().collect(),
+        }
+    }
+}
+
+impl IntoIterator for InPlaceInputs {
+    type Item = (usize, Value);
+    type IntoIter = smallvec::IntoIter<[(usize, Value); 1]>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.inputs.into_iter()
+    }
+}
+
 /// An Operator performs a computation step when executing a data flow graph.
 ///
 /// Operators take zero or more dynamic input values, plus a set of static
@@ -437,14 +496,14 @@ pub trait Operator: Any + Debug {
         true
     }
 
-    /// Execute this operator in-place on an existing tensor.
+    /// Execute this operator in-place on one or more existing tensors.
     ///
     /// This may only be called if `in_place_inputs` returns a non-empty set.
     ///
-    /// `input` is one of the inputs from that set, which the implementation may
-    /// modify and return as an output. `ctx.inputs()` contains all of the
-    /// operator's inputs, with the position of the in-place `input` set to
-    /// `None`.
+    /// `in_place` holds the owned values for the inputs from that set, which the
+    /// implementation may modify and return as outputs. `ctx.inputs()` contains
+    /// all of the operator's inputs, with the positions of the in-place inputs
+    /// set to `None`.
     ///
     /// Operators may fall back to allocating a new output if some property of
     /// the input data or shapes means in-place operation is not possible. In
@@ -453,7 +512,7 @@ pub trait Operator: Any + Debug {
     /// temporary buffers created during execution.
     fn run_in_place(
         &self,
-        #[allow(unused)] input: Value,
+        #[allow(unused)] in_place: InPlaceInputs,
         #[allow(unused)] ctx: &OpRunContext,
     ) -> Result<OutputList, OpError> {
         Err(OpError::InvalidValue("In-place execution not supported"))
@@ -555,7 +614,8 @@ pub trait OperatorExt: Operator {
         let pool = BufferPool::new();
         let inputs = inputs.into();
         let ctx = OpRunContext::new(&pool, &inputs, BitSet::ones(1));
-        let mut outputs = self.run_in_place(mut_input.into(), &ctx)?;
+        let in_place = InPlaceInputs::from((0, mut_input.into()));
+        let mut outputs = self.run_in_place(in_place, &ctx)?;
         let typed_output = outputs.remove(0).try_into()?;
         Ok(typed_output)
     }

--- a/src/ops/attention.rs
+++ b/src/ops/attention.rs
@@ -14,8 +14,8 @@ use rten_vecmath::Softmax;
 use crate::buffer_pool::{AutoReturn, BufferPool, PoolRef};
 use crate::infer_shapes::{InferShapes, impl_infer_shapes};
 use crate::operator::{
-    IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType, OutputTypeList,
-    OutputTypesContext,
+    InPlaceInputs, IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType,
+    OutputTypeList, OutputTypesContext,
 };
 use crate::ops::{
     binary_elementwise::broadcast_shapes, layout::expand_to, norm::NanHandling, resolve_axis,
@@ -127,8 +127,12 @@ impl Operator for AddSoftmax {
         BitSet::from_indices([0])
     }
 
-    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
-        let qk: Tensor = input.try_into()?;
+    fn run_in_place(
+        &self,
+        in_place: InPlaceInputs,
+        ctx: &OpRunContext,
+    ) -> Result<OutputList, OpError> {
+        let qk: Tensor = in_place.into_single().try_into()?;
         // This operator is commutative, so the other input may be at either
         // position depending on which was selected for in-place execution.
         let m: TensorView = ctx.inputs().require_first_present_as()?;

--- a/src/ops/binary_elementwise.rs
+++ b/src/ops/binary_elementwise.rs
@@ -13,8 +13,8 @@ use rten_tensor::{Tensor, TensorView, TensorViewMut};
 use crate::buffer_pool::{AutoReturn, BufferPool};
 use crate::infer_shapes::{BinaryOp, InferShapes};
 use crate::operator::{
-    IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType, OutputTypeList,
-    OutputTypesContext,
+    InPlaceInputs, IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType,
+    OutputTypeList, OutputTypesContext,
 };
 use crate::ops::{map_value, map_value_view};
 use crate::value::{DataType, Value, ValueType, ValueView};
@@ -517,8 +517,18 @@ impl Operator for Add {
         true
     }
 
-    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
-        run_typed_op_in_place!(ctx.pool(), input, ctx.inputs(), add_in_place, add)
+    fn run_in_place(
+        &self,
+        in_place: InPlaceInputs,
+        ctx: &OpRunContext,
+    ) -> Result<OutputList, OpError> {
+        run_typed_op_in_place!(
+            ctx.pool(),
+            in_place.into_single(),
+            ctx.inputs(),
+            add_in_place,
+            add
+        )
     }
 
     fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
@@ -670,8 +680,18 @@ impl Operator for Div {
         BitSet::from_indices([0])
     }
 
-    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
-        run_typed_op_in_place!(ctx.pool(), input, ctx.inputs(), div_in_place, div)
+    fn run_in_place(
+        &self,
+        in_place: InPlaceInputs,
+        ctx: &OpRunContext,
+    ) -> Result<OutputList, OpError> {
+        run_typed_op_in_place!(
+            ctx.pool(),
+            in_place.into_single(),
+            ctx.inputs(),
+            div_in_place,
+            div
+        )
     }
 
     fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
@@ -912,8 +932,18 @@ impl Operator for Mul {
         true
     }
 
-    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
-        run_typed_op_in_place!(ctx.pool(), input, ctx.inputs(), mul_in_place, mul)
+    fn run_in_place(
+        &self,
+        in_place: InPlaceInputs,
+        ctx: &OpRunContext,
+    ) -> Result<OutputList, OpError> {
+        run_typed_op_in_place!(
+            ctx.pool(),
+            in_place.into_single(),
+            ctx.inputs(),
+            mul_in_place,
+            mul
+        )
     }
 
     fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
@@ -1056,7 +1086,12 @@ impl Operator for Pow {
         BitSet::from_indices([0])
     }
 
-    fn run_in_place(&self, base: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+    fn run_in_place(
+        &self,
+        in_place: InPlaceInputs,
+        ctx: &OpRunContext,
+    ) -> Result<OutputList, OpError> {
+        let base = in_place.into_single();
         let exponent = ctx.inputs().require(1)?;
         let result = if can_run_binary_op_in_place(&base, &exponent) {
             match (base, exponent) {
@@ -1128,8 +1163,18 @@ impl Operator for Sub {
         BitSet::from_indices([0])
     }
 
-    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
-        run_typed_op_in_place!(ctx.pool(), input, ctx.inputs(), sub_in_place, sub)
+    fn run_in_place(
+        &self,
+        in_place: InPlaceInputs,
+        ctx: &OpRunContext,
+    ) -> Result<OutputList, OpError> {
+        run_typed_op_in_place!(
+            ctx.pool(),
+            in_place.into_single(),
+            ctx.inputs(),
+            sub_in_place,
+            sub
+        )
     }
 
     fn output_types(&self, _ctx: &OutputTypesContext) -> Option<OutputTypeList> {
@@ -1393,14 +1438,18 @@ mod tests {
         let op = Add {};
         let inputs: InputList = (&b).into();
         let ctx = OpRunContext::new(&pool, &inputs, BitSet::ones(1));
-        let result = op.run_in_place(Value::FloatTensor(a_copy), &ctx).unwrap();
+        let result = op
+            .run_in_place((0, Value::FloatTensor(a_copy)).into(), &ctx)
+            .unwrap();
         expect_equal(&result[0].as_tensor_view().unwrap(), &expected.view())?;
 
         // Run `Add` operator in-place with inputs that don't support in-place
         // addition. The operator should fall back to creating a new output tensor.
         let scalar = Tensor::from(1.0);
         let expected = Tensor::from_data(&[2, 2], vec![11., 21., 31., 41.]);
-        let result = op.run_in_place(Value::FloatTensor(scalar), &ctx).unwrap();
+        let result = op
+            .run_in_place((0, Value::FloatTensor(scalar)).into(), &ctx)
+            .unwrap();
         expect_equal(&result[0].as_tensor_view().unwrap(), &expected.view())?;
 
         // In-place addition where the second input must be broadcast to the

--- a/src/ops/concat.rs
+++ b/src/ops/concat.rs
@@ -10,8 +10,8 @@ use smallvec::SmallVec;
 use crate::buffer_pool::{AutoReturn, BufferPool};
 use crate::infer_shapes::{InferShapes, impl_infer_shapes};
 use crate::operator::{
-    InputList, IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType,
-    OutputTypeList, OutputTypesContext,
+    InPlaceInputs, InputList, IntoOpResult, OpError, OpRunContext, Operator, OutputList,
+    OutputType, OutputTypeList, OutputTypesContext,
 };
 use crate::ops::{map_value, map_value_view, resolve_axis};
 use crate::value::{TryFromValueError, Value, ValueView};
@@ -140,7 +140,12 @@ impl Operator for Concat {
         BitSet::from_indices([0])
     }
 
-    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+    fn run_in_place(
+        &self,
+        in_place: InPlaceInputs,
+        ctx: &OpRunContext,
+    ) -> Result<OutputList, OpError> {
+        let input = in_place.into_single();
         map_value!(input, input, [FloatTensor, Int32Tensor], {
             let typed_inputs = typed_inputs(ctx.inputs(), input.view())?;
             concat_in_place(ctx.pool(), input, &typed_inputs, self.axis).into_op_result()
@@ -292,7 +297,12 @@ impl Operator for Tile {
         BitSet::from_indices([0])
     }
 
-    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+    fn run_in_place(
+        &self,
+        in_place: InPlaceInputs,
+        ctx: &OpRunContext,
+    ) -> Result<OutputList, OpError> {
+        let input = in_place.into_single();
         let repeats: NdTensorView<i32, 1> = ctx.inputs().require_as(1)?;
 
         if repeats.iter().all(|n| *n == 1) {

--- a/src/ops/convert.rs
+++ b/src/ops/convert.rs
@@ -10,8 +10,8 @@ use crate::infer_shapes::{
     InferShapes, InferShapesContext, InferShapesError, SymTensor, SymbolGen, UnaryOp,
 };
 use crate::operator::{
-    IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType, OutputTypeList,
-    OutputTypesContext,
+    InPlaceInputs, IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType,
+    OutputTypeList, OutputTypesContext,
 };
 use crate::value::{DataType, Value, ValueType, ValueView};
 
@@ -130,7 +130,12 @@ impl Operator for Cast {
         BitSet::from_indices([0])
     }
 
-    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+    fn run_in_place(
+        &self,
+        in_place: InPlaceInputs,
+        ctx: &OpRunContext,
+    ) -> Result<OutputList, OpError> {
+        let input = in_place.into_single();
         match cast_in_place(input, self.to) {
             Ok(output) => output.into_op_result(),
             Err(input) => {
@@ -196,12 +201,16 @@ impl Operator for CastLike {
         BitSet::from_indices([0])
     }
 
-    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+    fn run_in_place(
+        &self,
+        in_place: InPlaceInputs,
+        ctx: &OpRunContext,
+    ) -> Result<OutputList, OpError> {
         let target_type = ctx.inputs().require(1)?;
         let ValueType::Tensor(to) = target_type.dtype() else {
             return Err(OpError::InvalidValue("expected target_type to be a tensor"));
         };
-        Cast { to }.run_in_place(input, ctx)
+        Cast { to }.run_in_place(in_place, ctx)
     }
 
     fn output_types(&self, _ctx: &OutputTypesContext) -> Option<OutputTypeList> {

--- a/src/ops/identity.rs
+++ b/src/ops/identity.rs
@@ -6,11 +6,11 @@ use rten_tensor::{Tensor, TensorView};
 use crate::buffer_pool::BufferPool;
 use crate::infer_shapes::InferShapes;
 use crate::operator::{
-    IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType, OutputTypeList,
-    OutputTypesContext,
+    InPlaceInputs, IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType,
+    OutputTypeList, OutputTypesContext,
 };
 use crate::ops::map_value_view;
-use crate::value::{Value, ValueView};
+use crate::value::ValueView;
 
 fn identity<T: Copy>(pool: &BufferPool, src: TensorView<T>) -> Tensor<T> {
     src.to_tensor_in(pool)
@@ -37,8 +37,12 @@ impl Operator for Identity {
         BitSet::from_indices([0])
     }
 
-    fn run_in_place(&self, input: Value, _ctx: &OpRunContext) -> Result<OutputList, OpError> {
-        input.into_op_result()
+    fn run_in_place(
+        &self,
+        in_place: InPlaceInputs,
+        _ctx: &OpRunContext,
+    ) -> Result<OutputList, OpError> {
+        in_place.into_single().into_op_result()
     }
 
     fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {

--- a/src/ops/layout.rs
+++ b/src/ops/layout.rs
@@ -12,8 +12,8 @@ use smallvec::SmallVec;
 use crate::buffer_pool::{AutoReturn, BufferPool};
 use crate::infer_shapes::{InferShapes, impl_infer_shapes};
 use crate::operator::{
-    IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType, OutputTypeList,
-    OutputTypesContext, static_dims,
+    InPlaceInputs, IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType,
+    OutputTypeList, OutputTypesContext, static_dims,
 };
 use crate::ops::binary_elementwise::{broadcast_shapes, fast_broadcast_cycles_repeats};
 use crate::ops::{map_value, map_value_view, resolve_axes, resolve_axis};
@@ -195,7 +195,12 @@ impl Operator for Expand {
         BitSet::from_indices([0])
     }
 
-    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+    fn run_in_place(
+        &self,
+        in_place: InPlaceInputs,
+        ctx: &OpRunContext,
+    ) -> Result<OutputList, OpError> {
+        let input = in_place.into_single();
         let shape = ctx.inputs().require_as(1)?;
 
         let out_shape = expand_output_shape(&input.shape(), &shape)?;
@@ -276,7 +281,12 @@ impl Operator for Flatten {
         BitSet::from_indices([0])
     }
 
-    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+    fn run_in_place(
+        &self,
+        in_place: InPlaceInputs,
+        ctx: &OpRunContext,
+    ) -> Result<OutputList, OpError> {
+        let input = in_place.into_single();
         map_value!(input, x, {
             flatten_in_place(ctx.pool(), &mut x, self.axis)?;
             x.into_op_result()
@@ -425,7 +435,12 @@ impl Operator for Reshape {
         BitSet::from_indices([0])
     }
 
-    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+    fn run_in_place(
+        &self,
+        in_place: InPlaceInputs,
+        ctx: &OpRunContext,
+    ) -> Result<OutputList, OpError> {
+        let input = in_place.into_single();
         let shape = ctx.inputs().require_as(1)?;
 
         map_value!(input, output, {
@@ -601,7 +616,12 @@ impl Operator for Squeeze {
         BitSet::from_indices([0])
     }
 
-    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+    fn run_in_place(
+        &self,
+        in_place: InPlaceInputs,
+        ctx: &OpRunContext,
+    ) -> Result<OutputList, OpError> {
+        let input = in_place.into_single();
         let axes = ctx.inputs().get_as(1)?;
 
         map_value!(input, output, {
@@ -742,7 +762,12 @@ impl Operator for Unsqueeze {
         BitSet::from_indices([0])
     }
 
-    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+    fn run_in_place(
+        &self,
+        in_place: InPlaceInputs,
+        ctx: &OpRunContext,
+    ) -> Result<OutputList, OpError> {
+        let input = in_place.into_single();
         let axes = ctx.inputs().require_as(1)?;
 
         map_value!(input, output, {

--- a/src/ops/norm.rs
+++ b/src/ops/norm.rs
@@ -11,12 +11,11 @@ use rten_vecmath as vecmath;
 use crate::buffer_pool::BufferPool;
 use crate::infer_shapes::{InferShapes, UnaryOp};
 use crate::operator::{
-    IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType, OutputTypeList,
-    OutputTypesContext, check_eq,
+    InPlaceInputs, IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType,
+    OutputTypeList, OutputTypesContext, check_eq,
 };
 use crate::ops::resolve_axis;
 use crate::slice_reductions::slice_max;
-use crate::value::Value;
 
 /// Specifies how to normalize the mean and variance.
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -277,9 +276,13 @@ impl Operator for BatchNormalization {
         BitSet::from_indices([0])
     }
 
-    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+    fn run_in_place(
+        &self,
+        in_place: InPlaceInputs,
+        ctx: &OpRunContext,
+    ) -> Result<OutputList, OpError> {
         let inputs = ctx.inputs();
-        let mut output: Tensor = input.try_into()?;
+        let mut output: Tensor = in_place.into_single().try_into()?;
         let scale = inputs.require_as(1)?;
         let bias = inputs.require_as(2)?;
         let mean = inputs.require_as(3)?;
@@ -374,8 +377,12 @@ impl Operator for InstanceNormalization {
         BitSet::from_indices([0])
     }
 
-    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
-        let mut output: Tensor = input.try_into()?;
+    fn run_in_place(
+        &self,
+        in_place: InPlaceInputs,
+        ctx: &OpRunContext,
+    ) -> Result<OutputList, OpError> {
+        let mut output: Tensor = in_place.into_single().try_into()?;
         let inputs = ctx.inputs();
         let scale = inputs.require_as(1)?;
         let bias = inputs.require_as(2)?;
@@ -698,8 +705,12 @@ impl Operator for LogSoftmax {
         BitSet::from_indices([0])
     }
 
-    fn run_in_place(&self, input: Value, _ctx: &OpRunContext) -> Result<OutputList, OpError> {
-        let mut output: Tensor = input.try_into()?;
+    fn run_in_place(
+        &self,
+        in_place: InPlaceInputs,
+        _ctx: &OpRunContext,
+    ) -> Result<OutputList, OpError> {
+        let mut output: Tensor = in_place.into_single().try_into()?;
         log_softmax_in_place(&mut output, self.axis)?;
         output.into_op_result()
     }
@@ -790,8 +801,12 @@ impl Operator for Softmax {
         BitSet::from_indices([0])
     }
 
-    fn run_in_place(&self, input: Value, _ctx: &OpRunContext) -> Result<OutputList, OpError> {
-        let mut output = input.try_into()?;
+    fn run_in_place(
+        &self,
+        in_place: InPlaceInputs,
+        _ctx: &OpRunContext,
+    ) -> Result<OutputList, OpError> {
+        let mut output = in_place.into_single().try_into()?;
         softmax_in_place(&mut output, self.axis, self.nan_handling())?;
         output.into_op_result()
     }

--- a/src/ops/resize.rs
+++ b/src/ops/resize.rs
@@ -12,10 +12,10 @@ use rten_tensor::{NdTensor, NdTensorView, NdTensorViewMut, Tensor, TensorView};
 use crate::buffer_pool::{AutoReturn, BufferPool};
 use crate::infer_shapes::{InferShapes, impl_infer_shapes};
 use crate::operator::{
-    InputList, IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType,
-    OutputTypeList, OutputTypesContext, static_dims,
+    InPlaceInputs, InputList, IntoOpResult, OpError, OpRunContext, Operator, OutputList,
+    OutputType, OutputTypeList, OutputTypesContext, static_dims,
 };
-use crate::value::{TryFromValueError, Value, ValueView};
+use crate::value::{TryFromValueError, ValueView};
 
 /// Specifies an output size for a resize operation.
 pub enum ResizeTarget<'a> {
@@ -523,9 +523,14 @@ impl Operator for Resize {
         BitSet::from_indices([0])
     }
 
-    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+    fn run_in_place(
+        &self,
+        in_place: InPlaceInputs,
+        ctx: &OpRunContext,
+    ) -> Result<OutputList, OpError> {
         // See note in `run` about the `roi` input.
 
+        let input = in_place.into_single();
         let other = ctx.inputs();
         let target = target_from_scale_size_inputs(other, 2)?;
         let output_size = calc_output_size(&input.shape(), target)?;

--- a/src/ops/sequence.rs
+++ b/src/ops/sequence.rs
@@ -5,8 +5,8 @@ use rten_tensor::{Tensor, TensorView};
 use crate::buffer_pool::BufferPool;
 use crate::infer_shapes::InferShapes;
 use crate::operator::{
-    InputList, IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType,
-    OutputTypeList, OutputTypesContext,
+    InPlaceInputs, InputList, IntoOpResult, OpError, OpRunContext, Operator, OutputList,
+    OutputType, OutputTypeList, OutputTypesContext,
 };
 use crate::ops::split::SplitSizes;
 use crate::ops::split::split;
@@ -161,8 +161,12 @@ impl Operator for SequenceErase {
             .into_op_result()
     }
 
-    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
-        let seq: Sequence = input.try_into()?;
+    fn run_in_place(
+        &self,
+        in_place: InPlaceInputs,
+        ctx: &OpRunContext,
+    ) -> Result<OutputList, OpError> {
+        let seq: Sequence = in_place.into_single().try_into()?;
         let pos: Option<i32> = ctx.inputs().get_as(1)?;
         sequence_erase(seq, pos).map(Value::from).into_op_result()
     }
@@ -230,8 +234,12 @@ impl Operator for SequenceInsert {
             .into_op_result()
     }
 
-    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
-        let seq: Sequence = input.try_into()?;
+    fn run_in_place(
+        &self,
+        in_place: InPlaceInputs,
+        ctx: &OpRunContext,
+    ) -> Result<OutputList, OpError> {
+        let seq: Sequence = in_place.into_single().try_into()?;
         let value = ctx.inputs().require(1)?;
         let pos: Option<i32> = ctx.inputs().get_as(2)?;
         sequence_insert(ctx.pool(), seq, pos, value)

--- a/src/ops/slice.rs
+++ b/src/ops/slice.rs
@@ -8,8 +8,8 @@ use smallvec::SmallVec;
 use crate::buffer_pool::{AutoReturn, BufferPool};
 use crate::infer_shapes::InferShapes;
 use crate::operator::{
-    InputList, IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType,
-    OutputTypeList, OutputTypesContext,
+    InPlaceInputs, InputList, IntoOpResult, OpError, OpRunContext, Operator, OutputList,
+    OutputType, OutputTypeList, OutputTypesContext,
 };
 use crate::ops::{map_value, map_value_view, resolve_axis};
 use crate::value::{Value, ValueView};
@@ -146,7 +146,12 @@ impl Operator for Slice {
         BitSet::from_indices([0])
     }
 
-    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+    fn run_in_place(
+        &self,
+        in_place: InPlaceInputs,
+        ctx: &OpRunContext,
+    ) -> Result<OutputList, OpError> {
+        let input = in_place.into_single();
         let other = ctx.inputs();
         let starts = other.require_as(1)?;
         let ends = other.require_as(2)?;

--- a/src/ops/transform_inputs.rs
+++ b/src/ops/transform_inputs.rs
@@ -5,10 +5,10 @@ use rten_tensor::prelude::*;
 
 use crate::infer_shapes::InferShapes;
 use crate::operator::{
-    OpError, OpRunContext, Operator, OutputList, OutputTypeList, OutputTypesContext,
+    InPlaceInputs, OpError, OpRunContext, Operator, OutputList, OutputTypeList, OutputTypesContext,
 };
 use crate::ops::map_value_view;
-use crate::value::{Value, ValueView};
+use crate::value::ValueView;
 
 trait TransformInput {
     fn transform(&self, input: &mut ValueView) -> Result<(), OpError>;
@@ -135,7 +135,11 @@ impl Operator for TransformInputs {
         }
     }
 
-    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+    fn run_in_place(
+        &self,
+        in_place: InPlaceInputs,
+        ctx: &OpRunContext,
+    ) -> Result<OutputList, OpError> {
         let mut inputs = ctx.inputs().clone();
         for TransformIndex {
             input_index,
@@ -148,7 +152,7 @@ impl Operator for TransformInputs {
             transform.transform(input)?;
         }
         let inner_ctx = OpRunContext::new(ctx.pool(), &inputs, ctx.outputs());
-        self.inner.run_in_place(input, &inner_ctx)
+        self.inner.run_in_place(in_place, &inner_ctx)
     }
 
     fn output_types(&self, _ctx: &OutputTypesContext) -> Option<OutputTypeList> {

--- a/src/ops/unary_elementwise.rs
+++ b/src/ops/unary_elementwise.rs
@@ -15,8 +15,8 @@ use rten_vecmath as vecmath;
 use crate::buffer_pool::{AutoReturn, BufferPool};
 use crate::infer_shapes::{InferShapes, UnaryOp};
 use crate::operator::{
-    IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType, OutputTypeList,
-    OutputTypesContext,
+    InPlaceInputs, IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType,
+    OutputTypeList, OutputTypesContext,
 };
 use crate::ops::binary_elementwise::binary_op;
 use crate::ops::{map_value, map_value_view};
@@ -146,9 +146,10 @@ macro_rules! impl_operator {
 
             fn run_in_place(
                 &self,
-                input: Value,
+                in_place: InPlaceInputs,
                 ctx: &OpRunContext,
             ) -> Result<OutputList, OpError> {
+                let input = in_place.into_single();
                 map_value!(input, input, $types, {
                     let kernel = self.get_kernel();
                     let result = unary_op_in_place(ctx.pool(), input, &kernel);
@@ -336,7 +337,12 @@ impl Operator for Clip {
         BitSet::from_indices([0])
     }
 
-    fn run_in_place(&self, input: Value, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+    fn run_in_place(
+        &self,
+        in_place: InPlaceInputs,
+        ctx: &OpRunContext,
+    ) -> Result<OutputList, OpError> {
+        let input = in_place.into_single();
         map_value!(input, input, [FloatTensor, Int32Tensor], {
             let min = ctx.inputs().get_as(1)?;
             let max = ctx.inputs().get_as(2)?;
@@ -579,8 +585,12 @@ impl Operator for Not {
         BitSet::from_indices([0])
     }
 
-    fn run_in_place(&self, input: Value, _ctx: &OpRunContext) -> Result<OutputList, OpError> {
-        let mut output: Tensor<i32> = input.try_into()?;
+    fn run_in_place(
+        &self,
+        in_place: InPlaceInputs,
+        _ctx: &OpRunContext,
+    ) -> Result<OutputList, OpError> {
+        let mut output: Tensor<i32> = in_place.into_single().try_into()?;
         not_in_place(output.view_mut());
         output.into_op_result()
     }


### PR DESCRIPTION
Following on from https://github.com/robertknight/rten/pull/1341, change `Operator::run_in_place` so that operators can receive and modify multiple inputs in-place. `run_in_place` now receives an `InPlaceInputs` as the first input which is a list of `(input_index, Value)` instead of a single `Value`.

The graph executor takes an all-or-nothing approach when deciding whether to run in-place: it gathers all of the inputs the operator reports it can modify and only runs in-place if all of them are available to take as an owned value, otherwise it runs the operator normally.

Part of https://github.com/robertknight/rten/issues/1305.