### PR TITLE
Put contrib operators behind a `contrib` crate feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,10 +93,12 @@ serde_json = { workspace = true }
 crate-type = ["lib", "cdylib"]
 
 [features]
-default = ["onnx_format", "rten_format"]
+default = ["contrib", "onnx_format", "rten_format"]
 
 # Enable all features that affect supported operators
 all-ops = ["fft", "random"]
+# Enable non-standard "contrib" operators from ONNX Runtime.
+contrib = ["onnx_format"]
 # Enables FFT operators (DFT, STFT etc.)
 fft = ["dep:rustfft"]
 # Enable loading models using memory mapping

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,6 +149,8 @@
 //! # Crate features
 //!
 //!  - **all-ops** - Enables all operators which are not enabled by default
+//!  - **contrib** (enabled by default) - Enables supported non-standard [contrib
+//!    operators][contrib_operators] from ONNX Runtime. Enables **onnx_format**.
 //!  - **fft** - Enables FFT operators
 //!  - **mmap** - Enable loading models with memory mapping via [`Model::load_mmap`]
 //!  - **onnx_format** (enabled by default) - Enables support for loading `.onnx` models.
@@ -158,6 +160,7 @@
 //!
 //! At least one of the **onnx_format** or **rten_format** features must be enabled.
 //!
+//! [contrib_operators]: https://onnxruntime.ai/docs/reference/operators/ContribOperators.html
 //! [security]: crate::docs::security
 //! [model_formats]: https://github.com/robertknight/rten/blob/main/docs/model-formats.md
 //! [onnx_operators]: https://onnx.ai/onnx/operators/

--- a/src/op_registry/onnx_registry.rs
+++ b/src/op_registry/onnx_registry.rs
@@ -16,9 +16,11 @@ use super::ReadOpError;
 use crate::graph::Graph;
 use crate::operator::Operator;
 use crate::ops;
+#[cfg(feature = "contrib")]
+use crate::ops::AccuracyLevel;
 use crate::ops::{
-    AccuracyLevel, BoxOrder, CoordTransformMode, DepthToSpaceMode, Direction, NearestMode, PadMode,
-    Padding, ResizeMode, ScatterReduction,
+    BoxOrder, CoordTransformMode, DepthToSpaceMode, Direction, NearestMode, PadMode, Padding,
+    ResizeMode, ScatterReduction,
 };
 use crate::value::{DataType, Scalar};
 
@@ -91,6 +93,30 @@ impl OnnxOpRegistry {
                         })
                     }
                     let id = OpId::new(stringify!($op));
+                    reg.register_op_with_factory(id, &stub);
+                }
+            };
+
+            // Variants for ops in a non-default domain. The domain (and op
+            // type, if it differs from the Rust type name) must match the
+            // op's `ReadOp::id`, as it is used to register the stub when the
+            // feature is disabled.
+            ($domain:literal, $op:ident, feature=$feature:literal) => {
+                register_op!($domain, stringify!($op), $op, feature = $feature);
+            };
+
+            ($domain:literal, $op_type:expr, $op:ident, feature=$feature:literal) => {
+                #[cfg(feature = $feature)]
+                reg.register_op::<ops::$op>();
+                #[cfg(not(feature = $feature))]
+                {
+                    fn stub(_op: &onnx::NodeProto, _ctx: &dyn OpLoadContext) -> ReadOpResult {
+                        Err(ReadOpError::FeatureNotEnabled {
+                            name: stringify!($op).to_string(),
+                            feature: $feature.to_string(),
+                        })
+                    }
+                    let id = OpId::with_domain($domain, $op_type);
                     reg.register_op_with_factory(id, &stub);
                 }
             };
@@ -243,16 +269,25 @@ impl OnnxOpRegistry {
         register_op!(Xor);
 
         // ai.onnx experimental
-        register_op!(SimplifiedLayerNormalization);
+        register_op!("ai.onnx", SimplifiedLayerNormalization, feature = "contrib");
 
         // com.microsoft ops.
-        register_op!(BiasGelu);
-        register_op!(GroupQueryAttention);
-        register_op!(MatMulNBits);
-        register_op!(MultiHeadAttention);
-        register_op!(SkipLayerNormalization);
-        register_op!(SkipSimplifiedLayerNormalization);
-        register_op!(RotaryEmbeddingMicrosoft);
+        register_op!("com.microsoft", BiasGelu, feature = "contrib");
+        register_op!("com.microsoft", GroupQueryAttention, feature = "contrib");
+        register_op!("com.microsoft", MatMulNBits, feature = "contrib");
+        register_op!("com.microsoft", MultiHeadAttention, feature = "contrib");
+        register_op!("com.microsoft", SkipLayerNormalization, feature = "contrib");
+        register_op!(
+            "com.microsoft",
+            SkipSimplifiedLayerNormalization,
+            feature = "contrib"
+        );
+        register_op!(
+            "com.microsoft",
+            "RotaryEmbedding",
+            RotaryEmbeddingMicrosoft,
+            feature = "contrib"
+        );
 
         reg
     }
@@ -787,6 +822,7 @@ impl_read_op!(BatchNormalization, |attrs: &Attrs| {
     Ok(ops::BatchNormalization { epsilon })
 });
 
+#[cfg(feature = "contrib")]
 impl_read_op!("com.microsoft", BiasGelu, |_attrs: &Attrs| {
     Ok(ops::BiasGelu {})
 });
@@ -1290,6 +1326,7 @@ impl_read_op!(LSTM, |attrs: &Attrs| {
 impl_read_op!(MatMul);
 impl_read_op!(MatMulInteger);
 
+#[cfg(feature = "contrib")]
 impl_read_op!("com.microsoft", MatMulNBits, |attrs: &Attrs| {
     // Spec allows any value between 2 and 8.
     attrs.check_eq("bits", 4)?;
@@ -1380,6 +1417,7 @@ impl_read_op!(Mod, |attrs: &Attrs| {
 
 impl_read_op!(Mul);
 
+#[cfg(feature = "contrib")]
 impl_read_op!("com.microsoft", GroupQueryAttention, |attrs: &Attrs| {
     let num_heads = attrs.require("num_heads")?.cast_int()?;
     let kv_num_heads = attrs.require("kv_num_heads")?.cast_int()?;
@@ -1407,6 +1445,7 @@ impl_read_op!("com.microsoft", GroupQueryAttention, |attrs: &Attrs| {
     })
 });
 
+#[cfg(feature = "contrib")]
 impl_read_op!("com.microsoft", MultiHeadAttention, |attrs: &Attrs| {
     let mask_filter_value: f32 = attrs.get_as("mask_filter_value").unwrap_or(-10000.0);
     let num_heads = attrs.require("num_heads")?.cast_int()?;
@@ -1673,6 +1712,7 @@ impl_read_op!(Upsample, |attrs: &Attrs| {
     Ok(ParsedOp::new(ops::Upsample { mode }).with_inputs(const_inputs))
 });
 
+#[cfg(feature = "contrib")]
 impl_read_op!(
     "com.microsoft",
     "RotaryEmbedding",
@@ -1764,6 +1804,7 @@ impl_read_op!(Shape, |attrs: &Attrs| {
 impl_read_op!(Sigmoid);
 impl_read_op!(Sign);
 
+#[cfg(feature = "contrib")]
 impl_read_op!("ai.onnx", SimplifiedLayerNormalization, |attrs: &Attrs| {
     let axis = attrs.get_as_int("axis")?.unwrap_or(-1);
     let epsilon = attrs.get_as("epsilon");
@@ -1776,12 +1817,14 @@ impl_read_op!(Sin);
 impl_read_op!(Sinh);
 impl_read_op!(Size);
 
+#[cfg(feature = "contrib")]
 impl_read_op!("com.microsoft", SkipLayerNormalization, |attrs: &Attrs| {
     let epsilon = attrs.require("epsilon")?.as_f32();
 
     Ok(ops::SkipLayerNormalization { epsilon })
 });
 
+#[cfg(feature = "contrib")]
 impl_read_op!(
     "com.microsoft",
     SkipSimplifiedLayerNormalization,
@@ -1905,11 +1948,13 @@ mod tests {
     use super::{ConstInput, OnnxOpRegistry, OpLoadContext, ReadOpError};
     use crate::graph::Graph;
     use crate::model::onnx_builder::{NodeProtoExt, TensorData, create_node, create_tensor};
+    #[cfg(feature = "contrib")]
     use crate::operator::Operator;
     use crate::ops::{
-        ArgMax, ConstantOfShape, Conv, GroupQueryAttention, Padding, ResizeMode, RotaryEmbedding,
-        RotaryEmbeddingMicrosoft, Upsample,
+        ArgMax, ConstantOfShape, Conv, Padding, ResizeMode, RotaryEmbedding, Upsample,
     };
+    #[cfg(feature = "contrib")]
+    use crate::ops::{GroupQueryAttention, RotaryEmbeddingMicrosoft};
     use crate::value::Scalar;
 
     #[derive(Default)]
@@ -1948,6 +1993,7 @@ mod tests {
         assert_eq!(op.name(), "MatMul");
     }
 
+    #[cfg(feature = "contrib")]
     #[test]
     fn test_read_domain_op_with_distinct_impl_name() {
         let reg = OnnxOpRegistry::with_all_ops();
@@ -1965,6 +2011,7 @@ mod tests {
         assert_eq!(rotary.name(), "com.microsoft.RotaryEmbedding");
     }
 
+    #[cfg(feature = "contrib")]
     #[test]
     fn test_read_group_query_attention_local_window_size() {
         let reg = OnnxOpRegistry::with_all_ops();
@@ -2010,6 +2057,7 @@ mod tests {
         assert_eq!(rotary.num_heads, 0);
     }
 
+    #[cfg(feature = "contrib")]
     #[test]
     fn test_read_rotary_embedding_microsoft_allows_missing_num_heads() {
         let reg = OnnxOpRegistry::with_all_ops();
@@ -2130,6 +2178,28 @@ mod tests {
         assert!(
             matches!(op, Err(ReadOpError::OperatorUnavailable { name }) if name == Some("com.foobar/MatMul".to_string()))
         );
+    }
+
+    // Contrib ops load when the `contrib` feature is enabled and report which
+    // feature is missing when it is not.
+    #[test]
+    fn test_read_contrib_op() {
+        let reg = OnnxOpRegistry::with_all_ops();
+        let node = create_node("MatMulNBits")
+            .with_domain("com.microsoft")
+            .with_attr("bits", 4i64)
+            .with_attr("block_size", 32i64);
+        let result = reg.read_op(&node, &FakeOpLoadContext::default());
+
+        #[cfg(feature = "contrib")]
+        assert!(result.is_ok());
+
+        #[cfg(not(feature = "contrib"))]
+        assert!(matches!(
+            result,
+            Err(ReadOpError::FeatureNotEnabled { name, feature })
+                if name == "MatMulNBits" && feature == "contrib"
+        ));
     }
 
     #[test]

--- a/src/ops/attention.rs
+++ b/src/ops/attention.rs
@@ -507,66 +507,6 @@ fn concat_past_kv<'a, 'b>(
     }
 }
 
-/// Build the present key or value cache for grouped-query attention.
-///
-/// `new` contains the new key or value tokens with shape `(batch, seq,
-/// kv_heads, head_size)`. `past`, if present, has shape `(batch, kv_heads,
-/// past_seq, head_size)`. `past_len(b)` is the offset at which batch `b`'s new
-/// tokens are written (which can be less than `past_seq` when the cache is
-/// right-padded). The result has shape `(batch, kv_heads, present_seq,
-/// head_size)`.
-///
-/// The `past` cache is extended in-place if possible.
-fn gqa_present_cache(
-    pool: &BufferPool,
-    past: Option<PastCache>,
-    new: NdTensorView<f32, 4>,
-    past_len: impl Fn(usize) -> usize,
-    present_seq: usize,
-) -> NdTensor<f32, 4> {
-    let [batch, seq, kv_heads, head_size] = new.shape();
-    let past_seq = past.as_ref().map(|p| p.shape()[2]).unwrap_or(0);
-    let is_append = (0..batch).all(|b| past_len(b) == past_seq);
-
-    // Extend owned past cache in-place if possible.
-    let past = match past {
-        Some(PastCache::Owned(mut past)) if is_append && past.has_capacity(2, present_seq) => {
-            // `new` is (batch, seq, kv_heads, head_size); the cache is
-            // (batch, kv_heads, seq, head_size).
-            past.append(2, &new.permuted([0, 2, 1, 3]))
-                .expect("cache has capacity");
-            return past;
-        }
-        past => past,
-    };
-
-    // Otherwise allocate a new present cache with both past and new tokens.
-    let mut present = NdTensor::zeros_in(pool, [batch, kv_heads, present_seq, head_size]);
-    {
-        let past = past.as_ref().map(|p| p.view());
-        for b in 0..batch {
-            let past_b = past_len(b);
-            for h in 0..kv_heads {
-                if let Some(past) = past.as_ref() {
-                    present
-                        .slice_mut((b, h, ..past_b))
-                        .copy_from(&past.slice((b, h, ..past_b)));
-                }
-                present
-                    .slice_mut((b, h, past_b..past_b + seq))
-                    .copy_from(&new.slice((b, .., h)));
-            }
-        }
-    }
-
-    // Return the old owned buffer to the pool.
-    if let Some(PastCache::Owned(past)) = past {
-        past.auto_return(pool);
-    }
-
-    present
-}
-
 /// Compute scaled dot-product attention for a single (batch, head):
 ///
 /// `out = softmax(score_mod(scale · Q Kᵀ)) · V`
@@ -1032,10 +972,10 @@ impl_infer_shapes!(
     }
 );
 
-#[cfg(feature = "onnx_format")]
+#[cfg(feature = "contrib")]
 pub use contrib::{GroupQueryAttention, MultiHeadAttention};
 
-#[cfg(feature = "onnx_format")]
+#[cfg(feature = "contrib")]
 mod contrib;
 
 #[cfg(test)]

--- a/src/ops/attention/contrib.rs
+++ b/src/ops/attention/contrib.rs
@@ -8,7 +8,7 @@ use rten_shape_inference::ops as shape_ops;
 use rten_tensor::prelude::*;
 use rten_tensor::{NdTensor, NdTensorView, TensorView};
 
-use crate::buffer_pool::AutoReturn;
+use crate::buffer_pool::{AutoReturn, BufferPool};
 use crate::infer_shapes::{InferShapes, impl_infer_shapes};
 use crate::operator::{
     InPlaceInputs, OpError, OpRunContext, Operator, OutputList, OutputType, OutputTypeList,
@@ -17,7 +17,7 @@ use crate::operator::{
 use crate::ops::{binary_elementwise::add, embedding::rotary_embedding};
 
 use super::{
-    BROADCAST_ERROR, PastCache, apply_softcap, causal_mask_row, concat_past_kv, gqa_present_cache,
+    BROADCAST_ERROR, PastCache, apply_softcap, causal_mask_row, concat_past_kv,
     merge_attention_heads, sdpa_head, sdpa_multi_head, split_attention_heads, take_past_kv,
 };
 
@@ -355,6 +355,66 @@ impl_infer_shapes!(
         num_heads: op.num_heads,
     }
 );
+
+/// Build the present key or value cache for grouped-query attention.
+///
+/// `new` contains the new key or value tokens with shape `(batch, seq,
+/// kv_heads, head_size)`. `past`, if present, has shape `(batch, kv_heads,
+/// past_seq, head_size)`. `past_len(b)` is the offset at which batch `b`'s new
+/// tokens are written (which can be less than `past_seq` when the cache is
+/// right-padded). The result has shape `(batch, kv_heads, present_seq,
+/// head_size)`.
+///
+/// The `past` cache is extended in-place if possible.
+fn gqa_present_cache(
+    pool: &BufferPool,
+    past: Option<PastCache>,
+    new: NdTensorView<f32, 4>,
+    past_len: impl Fn(usize) -> usize,
+    present_seq: usize,
+) -> NdTensor<f32, 4> {
+    let [batch, seq, kv_heads, head_size] = new.shape();
+    let past_seq = past.as_ref().map(|p| p.shape()[2]).unwrap_or(0);
+    let is_append = (0..batch).all(|b| past_len(b) == past_seq);
+
+    // Extend owned past cache in-place if possible.
+    let past = match past {
+        Some(PastCache::Owned(mut past)) if is_append && past.has_capacity(2, present_seq) => {
+            // `new` is (batch, seq, kv_heads, head_size); the cache is
+            // (batch, kv_heads, seq, head_size).
+            past.append(2, &new.permuted([0, 2, 1, 3]))
+                .expect("cache has capacity");
+            return past;
+        }
+        past => past,
+    };
+
+    // Otherwise allocate a new present cache with both past and new tokens.
+    let mut present = NdTensor::zeros_in(pool, [batch, kv_heads, present_seq, head_size]);
+    {
+        let past = past.as_ref().map(|p| p.view());
+        for b in 0..batch {
+            let past_b = past_len(b);
+            for h in 0..kv_heads {
+                if let Some(past) = past.as_ref() {
+                    present
+                        .slice_mut((b, h, ..past_b))
+                        .copy_from(&past.slice((b, h, ..past_b)));
+                }
+                present
+                    .slice_mut((b, h, past_b..past_b + seq))
+                    .copy_from(&new.slice((b, .., h)));
+            }
+        }
+    }
+
+    // Return the old owned buffer to the pool.
+    if let Some(PastCache::Owned(past)) = past {
+        past.auto_return(pool);
+    }
+
+    present
+}
 
 /// Fused grouped-query attention contrib operator.
 ///

--- a/src/ops/embedding.rs
+++ b/src/ops/embedding.rs
@@ -243,10 +243,10 @@ impl Operator for RotaryEmbedding {
     }
 }
 
-#[cfg(feature = "onnx_format")]
+#[cfg(feature = "contrib")]
 pub use contrib::RotaryEmbeddingMicrosoft;
 
-#[cfg(feature = "onnx_format")]
+#[cfg(feature = "contrib")]
 mod contrib;
 
 #[cfg(test)]

--- a/src/ops/matmul.rs
+++ b/src/ops/matmul.rs
@@ -797,10 +797,10 @@ impl Operator for MatMulIntegerToFloat {
     }
 }
 
-#[cfg(feature = "onnx_format")]
+#[cfg(feature = "contrib")]
 pub use contrib::{AccuracyLevel, MatMulNBits};
 
-#[cfg(feature = "onnx_format")]
+#[cfg(feature = "contrib")]
 mod contrib;
 
 #[cfg(test)]

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -123,7 +123,7 @@ pub(crate) use {
 // are supported.
 //
 // See https://onnxruntime.ai/docs/reference/operators/ContribOperators.html.
-#[cfg(feature = "onnx_format")]
+#[cfg(feature = "contrib")]
 pub(crate) use {
     attention::{GroupQueryAttention, MultiHeadAttention},
     embedding::RotaryEmbeddingMicrosoft,

--- a/src/ops/norm.rs
+++ b/src/ops/norm.rs
@@ -820,12 +820,12 @@ impl Operator for Softmax {
     }
 }
 
-#[cfg(feature = "onnx_format")]
+#[cfg(feature = "contrib")]
 pub use contrib::{
     SimplifiedLayerNormalization, SkipLayerNormalization, SkipSimplifiedLayerNormalization,
 };
 
-#[cfg(feature = "onnx_format")]
+#[cfg(feature = "contrib")]
 mod contrib;
 
 #[cfg(test)]

--- a/src/ops/unary_elementwise.rs
+++ b/src/ops/unary_elementwise.rs
@@ -757,10 +757,10 @@ impl_operator!(Tanh, [FloatTensor]);
 impl_operator_fn!(Tanh, tanh);
 impl_get_kernel!(Tanh, f32, SimdKernel(vecmath::Tanh {}));
 
-#[cfg(feature = "onnx_format")]
+#[cfg(feature = "contrib")]
 pub use contrib::BiasGelu;
 
-#[cfg(feature = "onnx_format")]
+#[cfg(feature = "contrib")]
 mod contrib;
 
 #[cfg(test)]


### PR DESCRIPTION
Add a `contrib` crate feature which enables supported non-standard "contrib" operators from ONNX Runtime. This feature is currently enabled by default - I might change this in future.

Disabling this feature will reduce binary size and build times for users who are working with models that only use standard ONNX ops.