### PR TITLE
rten-simd: Split `NumOps` trait into `BitOps` base trait and `NumOps` sub-trait

### DIFF
--- a/rten-gemm/src/block_quant.rs
+++ b/rten-gemm/src/block_quant.rs
@@ -7,7 +7,7 @@ use rayon::prelude::*;
 use rten_base::iter::range_chunks;
 use rten_base::num::AsUsize;
 use rten_parallel::par_iter::ParIter;
-use rten_simd::ops::{Extend, IntOps, Interleave, NumOps, ToFloat};
+use rten_simd::ops::{BitOps, Extend, IntOps, Interleave, NumOps, ToFloat};
 use rten_simd::{Isa, Simd, SimdOp};
 use rten_tensor::{AsView, AssumeInit, Contiguous, Layout, NdTensor, NdTensorView};
 

--- a/rten-gemm/src/i8dot.rs
+++ b/rten-gemm/src/i8dot.rs
@@ -320,7 +320,7 @@ mod x86_64 {
 
 #[cfg(test)]
 mod tests {
-    use rten_simd::ops::NumOps;
+    use rten_simd::ops::{BitOps, NumOps};
     use rten_simd::{Isa, SimdIterable};
 
     use super::{Int8DotIsa, SimdInt8DotOp};

--- a/rten-gemm/src/im2col.rs
+++ b/rten-gemm/src/im2col.rs
@@ -2,7 +2,7 @@ use std::mem::MaybeUninit;
 use std::ops::Range;
 
 use rten_base::byte_cast::{AsBytes, cast_uninit_mut_slice};
-use rten_simd::ops::{MaskOps, NumOps};
+use rten_simd::ops::{BitOps, MaskOps, NumOps};
 use rten_simd::{Isa, Mask, Simd};
 use rten_tensor::{NdTensorView, Storage};
 

--- a/rten-gemm/src/kernels/aarch64.rs
+++ b/rten-gemm/src/kernels/aarch64.rs
@@ -491,7 +491,7 @@ unsafe impl Kernel<u8, i8, i32> for ArmInt8MlalKernel {
     ) {
         use rten_simd::{
             Isa, Simd,
-            ops::{Extend, NumOps},
+            ops::{BitOps, Extend},
         };
         use std::arch::aarch64::{vget_low_u16, vmlal_high_laneq_u16, vmlal_laneq_u16};
 
@@ -896,7 +896,7 @@ unsafe impl Kernel<u8, i8, i32> for ArmInt8MMKernel {
     ) {
         use rten_simd::{
             Isa,
-            ops::{Concat, NumOps},
+            ops::{BitOps, Concat},
         };
 
         const MR: usize = ArmInt8MMKernel::MR;

--- a/rten-gemm/src/kernels/simd_generic.rs
+++ b/rten-gemm/src/kernels/simd_generic.rs
@@ -1,6 +1,6 @@
 use rten_base::iter::range_chunks_exact;
 use rten_base::unroll::{unroll_loop, unroll_loop_x4};
-use rten_simd::ops::{Extend, Interleave, NumOps};
+use rten_simd::ops::{BitOps, Extend, Interleave, NumOps};
 use rten_simd::{Isa, Simd};
 use rten_tensor::{Matrix, MatrixLayout, Storage};
 

--- a/rten-generate/src/filter.rs
+++ b/rten-generate/src/filter.rs
@@ -3,7 +3,7 @@
 //! This module defines the [`LogitsFilter`] trait implemented by all filters,
 //! plus convenience functions to simplify implementing filters.
 
-use rten_simd::ops::{MaskOps, NumOps};
+use rten_simd::ops::{BitOps, MaskOps, NumOps};
 use rten_simd::{Isa, Simd, SimdIterable, SimdOp};
 use rten_vecmath::Softmax;
 

--- a/rten-simd/src/arch/aarch64.rs
+++ b/rten-simd/src/arch/aarch64.rs
@@ -21,8 +21,8 @@ use std::arch::aarch64::{
 use std::mem::transmute;
 
 use crate::ops::{
-    Concat, Extend, FloatOps, IntOps, Interleave, MaskOps, NarrowSaturate, NumOps, SignedIntOps,
-    ToFloat,
+    BitOps, Concat, Extend, FloatOps, IntOps, Interleave, MaskOps, NarrowSaturate, NumOps,
+    SignedIntOps, ToFloat,
 };
 use crate::{Isa, Mask, Simd};
 
@@ -117,7 +117,7 @@ macro_rules! simd_ops_common {
             type Elem = <$simd as Simd>::Elem;
 
             let mask_array = Mask::to_array(mask);
-            let mut vec = Simd::to_array(<Self as NumOps<Elem>>::zero(self));
+            let mut vec = Simd::to_array(<Self as BitOps<Elem>>::zero(self));
             for i in 0..mask_array.len() {
                 if mask_array[i] {
                     vec[i] = *ptr.add(i);
@@ -137,7 +137,7 @@ macro_rules! simd_ops_common {
 
             let mask_array = Mask::to_array(mask);
             let x_array = Simd::to_array(x);
-            for i in 0..<Self as NumOps<Elem>>::len(self) {
+            for i in 0..<Self as BitOps<Elem>>::len(self) {
                 if mask_array[i] {
                     *ptr.add(i) = x_array[i];
                 }
@@ -189,9 +189,47 @@ macro_rules! simd_ops_common {
     };
 }
 
-unsafe impl NumOps<f32> for ArmNeonIsa {
+unsafe impl BitOps<f32> for ArmNeonIsa {
     simd_ops_common!(float32x4_t, uint32x4_t);
 
+    #[inline]
+    fn broadcast_lane<const LANE: i32>(self, x: float32x4_t) -> float32x4_t {
+        unsafe { vdupq_laneq_f32(x, LANE) }
+    }
+
+    #[inline]
+    fn splat(self, x: f32) -> float32x4_t {
+        unsafe { vdupq_n_f32(x) }
+    }
+
+    #[inline]
+    unsafe fn load_ptr(self, ptr: *const f32) -> float32x4_t {
+        unsafe { vld1q_f32(ptr) }
+    }
+
+    #[inline]
+    fn first_n_mask(self, n: usize) -> uint32x4_t {
+        let mask: [u32; 4] = std::array::from_fn(|i| if i < n { u32::MAX } else { 0 });
+        unsafe { vld1q_u32(mask.as_ptr()) }
+    }
+
+    #[inline]
+    fn select(
+        self,
+        x: float32x4_t,
+        y: float32x4_t,
+        mask: <float32x4_t as Simd>::Mask,
+    ) -> float32x4_t {
+        unsafe { vbslq_f32(mask, x, y) }
+    }
+
+    #[inline]
+    unsafe fn store_ptr(self, x: float32x4_t, ptr: *mut f32) {
+        unsafe { vst1q_f32(ptr, x) }
+    }
+}
+
+unsafe impl NumOps<f32> for ArmNeonIsa {
     #[inline]
     fn add(self, x: float32x4_t, y: float32x4_t) -> float32x4_t {
         unsafe { vaddq_f32(x, y) }
@@ -248,42 +286,6 @@ unsafe impl NumOps<f32> for ArmNeonIsa {
     }
 
     #[inline]
-    fn broadcast_lane<const LANE: i32>(self, x: float32x4_t) -> float32x4_t {
-        unsafe { vdupq_laneq_f32(x, LANE) }
-    }
-
-    #[inline]
-    fn splat(self, x: f32) -> float32x4_t {
-        unsafe { vdupq_n_f32(x) }
-    }
-
-    #[inline]
-    unsafe fn load_ptr(self, ptr: *const f32) -> float32x4_t {
-        unsafe { vld1q_f32(ptr) }
-    }
-
-    #[inline]
-    fn first_n_mask(self, n: usize) -> uint32x4_t {
-        let mask: [u32; 4] = std::array::from_fn(|i| if i < n { u32::MAX } else { 0 });
-        unsafe { vld1q_u32(mask.as_ptr()) }
-    }
-
-    #[inline]
-    fn select(
-        self,
-        x: float32x4_t,
-        y: float32x4_t,
-        mask: <float32x4_t as Simd>::Mask,
-    ) -> float32x4_t {
-        unsafe { vbslq_f32(mask, x, y) }
-    }
-
-    #[inline]
-    unsafe fn store_ptr(self, x: float32x4_t, ptr: *mut f32) {
-        unsafe { vst1q_f32(ptr, x) }
-    }
-
-    #[inline]
     fn sum(self, x: float32x4_t) -> f32 {
         unsafe { vaddvq_f32(x) }
     }
@@ -328,42 +330,12 @@ impl FloatOps<f32> for ArmNeonIsa {
     }
 }
 
-unsafe impl NumOps<i32> for ArmNeonIsa {
+unsafe impl BitOps<i32> for ArmNeonIsa {
     simd_ops_common!(int32x4_t, uint32x4_t);
-
-    #[inline]
-    fn add(self, x: int32x4_t, y: int32x4_t) -> int32x4_t {
-        unsafe { vaddq_s32(x, y) }
-    }
-
-    #[inline]
-    fn sub(self, x: int32x4_t, y: int32x4_t) -> int32x4_t {
-        unsafe { vsubq_s32(x, y) }
-    }
-
-    #[inline]
-    fn mul(self, x: int32x4_t, y: int32x4_t) -> int32x4_t {
-        unsafe { vmulq_s32(x, y) }
-    }
 
     #[inline]
     fn splat(self, x: i32) -> int32x4_t {
         unsafe { vdupq_n_s32(x) }
-    }
-
-    #[inline]
-    fn eq(self, x: int32x4_t, y: int32x4_t) -> uint32x4_t {
-        unsafe { vceqq_s32(x, y) }
-    }
-
-    #[inline]
-    fn ge(self, x: int32x4_t, y: int32x4_t) -> uint32x4_t {
-        unsafe { vcgeq_s32(x, y) }
-    }
-
-    #[inline]
-    fn gt(self, x: int32x4_t, y: int32x4_t) -> uint32x4_t {
-        unsafe { vcgtq_s32(x, y) }
     }
 
     #[inline]
@@ -385,6 +357,38 @@ unsafe impl NumOps<i32> for ArmNeonIsa {
     #[inline]
     unsafe fn store_ptr(self, x: int32x4_t, ptr: *mut i32) {
         unsafe { vst1q_s32(ptr, x) }
+    }
+}
+
+unsafe impl NumOps<i32> for ArmNeonIsa {
+    #[inline]
+    fn add(self, x: int32x4_t, y: int32x4_t) -> int32x4_t {
+        unsafe { vaddq_s32(x, y) }
+    }
+
+    #[inline]
+    fn sub(self, x: int32x4_t, y: int32x4_t) -> int32x4_t {
+        unsafe { vsubq_s32(x, y) }
+    }
+
+    #[inline]
+    fn mul(self, x: int32x4_t, y: int32x4_t) -> int32x4_t {
+        unsafe { vmulq_s32(x, y) }
+    }
+
+    #[inline]
+    fn eq(self, x: int32x4_t, y: int32x4_t) -> uint32x4_t {
+        unsafe { vceqq_s32(x, y) }
+    }
+
+    #[inline]
+    fn ge(self, x: int32x4_t, y: int32x4_t) -> uint32x4_t {
+        unsafe { vcgeq_s32(x, y) }
+    }
+
+    #[inline]
+    fn gt(self, x: int32x4_t, y: int32x4_t) -> uint32x4_t {
+        unsafe { vcgtq_s32(x, y) }
     }
 }
 
@@ -462,9 +466,37 @@ impl NarrowSaturate<i16, u8> for ArmNeonIsa {
     }
 }
 
-unsafe impl NumOps<i16> for ArmNeonIsa {
+unsafe impl BitOps<i16> for ArmNeonIsa {
     simd_ops_common!(int16x8_t, uint16x8_t);
 
+    #[inline]
+    fn splat(self, x: i16) -> int16x8_t {
+        unsafe { vdupq_n_s16(x) }
+    }
+
+    #[inline]
+    unsafe fn load_ptr(self, ptr: *const i16) -> int16x8_t {
+        unsafe { vld1q_s16(ptr) }
+    }
+
+    #[inline]
+    fn first_n_mask(self, n: usize) -> uint16x8_t {
+        let mask: [u16; 8] = std::array::from_fn(|i| if i < n { u16::MAX } else { 0 });
+        unsafe { vld1q_u16(mask.as_ptr()) }
+    }
+
+    #[inline]
+    fn select(self, x: int16x8_t, y: int16x8_t, mask: <int16x8_t as Simd>::Mask) -> int16x8_t {
+        unsafe { vbslq_s16(mask, x, y) }
+    }
+
+    #[inline]
+    unsafe fn store_ptr(self, x: int16x8_t, ptr: *mut i16) {
+        unsafe { vst1q_s16(ptr, x) }
+    }
+}
+
+unsafe impl NumOps<i16> for ArmNeonIsa {
     #[inline]
     fn add(self, x: int16x8_t, y: int16x8_t) -> int16x8_t {
         unsafe { vaddq_s16(x, y) }
@@ -478,11 +510,6 @@ unsafe impl NumOps<i16> for ArmNeonIsa {
     #[inline]
     fn mul(self, x: int16x8_t, y: int16x8_t) -> int16x8_t {
         unsafe { vmulq_s16(x, y) }
-    }
-
-    #[inline]
-    fn splat(self, x: i16) -> int16x8_t {
-        unsafe { vdupq_n_s16(x) }
     }
 
     #[inline]
@@ -508,27 +535,6 @@ unsafe impl NumOps<i16> for ArmNeonIsa {
     #[inline]
     fn gt(self, x: int16x8_t, y: int16x8_t) -> uint16x8_t {
         unsafe { vcgtq_s16(x, y) }
-    }
-
-    #[inline]
-    unsafe fn load_ptr(self, ptr: *const i16) -> int16x8_t {
-        unsafe { vld1q_s16(ptr) }
-    }
-
-    #[inline]
-    fn first_n_mask(self, n: usize) -> uint16x8_t {
-        let mask: [u16; 8] = std::array::from_fn(|i| if i < n { u16::MAX } else { 0 });
-        unsafe { vld1q_u16(mask.as_ptr()) }
-    }
-
-    #[inline]
-    fn select(self, x: int16x8_t, y: int16x8_t, mask: <int16x8_t as Simd>::Mask) -> int16x8_t {
-        unsafe { vbslq_s16(mask, x, y) }
-    }
-
-    #[inline]
-    unsafe fn store_ptr(self, x: int16x8_t, ptr: *mut i16) {
-        unsafe { vst1q_s16(ptr, x) }
     }
 }
 
@@ -576,9 +582,37 @@ impl Interleave<i16> for ArmNeonIsa {
     }
 }
 
-unsafe impl NumOps<i8> for ArmNeonIsa {
+unsafe impl BitOps<i8> for ArmNeonIsa {
     simd_ops_common!(int8x16_t, uint8x16_t);
 
+    #[inline]
+    fn splat(self, x: i8) -> int8x16_t {
+        unsafe { vdupq_n_s8(x) }
+    }
+
+    #[inline]
+    unsafe fn load_ptr(self, ptr: *const i8) -> int8x16_t {
+        unsafe { vld1q_s8(ptr) }
+    }
+
+    #[inline]
+    fn first_n_mask(self, n: usize) -> uint8x16_t {
+        let mask: [u8; 16] = std::array::from_fn(|i| if i < n { u8::MAX } else { 0 });
+        unsafe { vld1q_u8(mask.as_ptr()) }
+    }
+
+    #[inline]
+    fn select(self, x: int8x16_t, y: int8x16_t, mask: <int8x16_t as Simd>::Mask) -> int8x16_t {
+        unsafe { vbslq_s8(mask, x, y) }
+    }
+
+    #[inline]
+    unsafe fn store_ptr(self, x: int8x16_t, ptr: *mut i8) {
+        unsafe { vst1q_s8(ptr, x) }
+    }
+}
+
+unsafe impl NumOps<i8> for ArmNeonIsa {
     #[inline]
     fn add(self, x: int8x16_t, y: int8x16_t) -> int8x16_t {
         unsafe { vaddq_s8(x, y) }
@@ -592,11 +626,6 @@ unsafe impl NumOps<i8> for ArmNeonIsa {
     #[inline]
     fn mul(self, x: int8x16_t, y: int8x16_t) -> int8x16_t {
         unsafe { vmulq_s8(x, y) }
-    }
-
-    #[inline]
-    fn splat(self, x: i8) -> int8x16_t {
-        unsafe { vdupq_n_s8(x) }
     }
 
     #[inline]
@@ -622,27 +651,6 @@ unsafe impl NumOps<i8> for ArmNeonIsa {
     #[inline]
     fn gt(self, x: int8x16_t, y: int8x16_t) -> uint8x16_t {
         unsafe { vcgtq_s8(x, y) }
-    }
-
-    #[inline]
-    unsafe fn load_ptr(self, ptr: *const i8) -> int8x16_t {
-        unsafe { vld1q_s8(ptr) }
-    }
-
-    #[inline]
-    fn first_n_mask(self, n: usize) -> uint8x16_t {
-        let mask: [u8; 16] = std::array::from_fn(|i| if i < n { u8::MAX } else { 0 });
-        unsafe { vld1q_u8(mask.as_ptr()) }
-    }
-
-    #[inline]
-    fn select(self, x: int8x16_t, y: int8x16_t, mask: <int8x16_t as Simd>::Mask) -> int8x16_t {
-        unsafe { vbslq_s8(mask, x, y) }
-    }
-
-    #[inline]
-    unsafe fn store_ptr(self, x: int8x16_t, ptr: *mut i8) {
-        unsafe { vst1q_s8(ptr, x) }
     }
 }
 
@@ -690,9 +698,37 @@ impl Interleave<i8> for ArmNeonIsa {
     }
 }
 
-unsafe impl NumOps<u8> for ArmNeonIsa {
+unsafe impl BitOps<u8> for ArmNeonIsa {
     simd_ops_common!(uint8x16_t, uint8x16_t);
 
+    #[inline]
+    fn splat(self, x: u8) -> uint8x16_t {
+        unsafe { vdupq_n_u8(x) }
+    }
+
+    #[inline]
+    unsafe fn load_ptr(self, ptr: *const u8) -> uint8x16_t {
+        unsafe { vld1q_u8(ptr) }
+    }
+
+    #[inline]
+    fn first_n_mask(self, n: usize) -> uint8x16_t {
+        let mask: [u8; 16] = std::array::from_fn(|i| if i < n { u8::MAX } else { 0 });
+        unsafe { vld1q_u8(mask.as_ptr()) }
+    }
+
+    #[inline]
+    fn select(self, x: uint8x16_t, y: uint8x16_t, mask: <uint8x16_t as Simd>::Mask) -> uint8x16_t {
+        unsafe { vbslq_u8(mask, x, y) }
+    }
+
+    #[inline]
+    unsafe fn store_ptr(self, x: uint8x16_t, ptr: *mut u8) {
+        unsafe { vst1q_u8(ptr, x) }
+    }
+}
+
+unsafe impl NumOps<u8> for ArmNeonIsa {
     #[inline]
     fn add(self, x: uint8x16_t, y: uint8x16_t) -> uint8x16_t {
         unsafe { vaddq_u8(x, y) }
@@ -706,11 +742,6 @@ unsafe impl NumOps<u8> for ArmNeonIsa {
     #[inline]
     fn mul(self, x: uint8x16_t, y: uint8x16_t) -> uint8x16_t {
         unsafe { vmulq_u8(x, y) }
-    }
-
-    #[inline]
-    fn splat(self, x: u8) -> uint8x16_t {
-        unsafe { vdupq_n_u8(x) }
     }
 
     #[inline]
@@ -736,27 +767,6 @@ unsafe impl NumOps<u8> for ArmNeonIsa {
     #[inline]
     fn gt(self, x: uint8x16_t, y: uint8x16_t) -> uint8x16_t {
         unsafe { vcgtq_u8(x, y) }
-    }
-
-    #[inline]
-    unsafe fn load_ptr(self, ptr: *const u8) -> uint8x16_t {
-        unsafe { vld1q_u8(ptr) }
-    }
-
-    #[inline]
-    fn first_n_mask(self, n: usize) -> uint8x16_t {
-        let mask: [u8; 16] = std::array::from_fn(|i| if i < n { u8::MAX } else { 0 });
-        unsafe { vld1q_u8(mask.as_ptr()) }
-    }
-
-    #[inline]
-    fn select(self, x: uint8x16_t, y: uint8x16_t, mask: <uint8x16_t as Simd>::Mask) -> uint8x16_t {
-        unsafe { vbslq_u8(mask, x, y) }
-    }
-
-    #[inline]
-    unsafe fn store_ptr(self, x: uint8x16_t, ptr: *mut u8) {
-        unsafe { vst1q_u8(ptr, x) }
     }
 }
 
@@ -797,9 +807,37 @@ impl Interleave<u8> for ArmNeonIsa {
     }
 }
 
-unsafe impl NumOps<u16> for ArmNeonIsa {
+unsafe impl BitOps<u16> for ArmNeonIsa {
     simd_ops_common!(uint16x8_t, uint16x8_t);
 
+    #[inline]
+    fn splat(self, x: u16) -> uint16x8_t {
+        unsafe { vdupq_n_u16(x) }
+    }
+
+    #[inline]
+    unsafe fn load_ptr(self, ptr: *const u16) -> uint16x8_t {
+        unsafe { vld1q_u16(ptr) }
+    }
+
+    #[inline]
+    fn first_n_mask(self, n: usize) -> uint16x8_t {
+        let mask: [u16; 8] = std::array::from_fn(|i| if i < n { u16::MAX } else { 0 });
+        unsafe { vld1q_u16(mask.as_ptr()) }
+    }
+
+    #[inline]
+    fn select(self, x: uint16x8_t, y: uint16x8_t, mask: <uint16x8_t as Simd>::Mask) -> uint16x8_t {
+        unsafe { vbslq_u16(mask, x, y) }
+    }
+
+    #[inline]
+    unsafe fn store_ptr(self, x: uint16x8_t, ptr: *mut u16) {
+        unsafe { vst1q_u16(ptr, x) }
+    }
+}
+
+unsafe impl NumOps<u16> for ArmNeonIsa {
     #[inline]
     fn add(self, x: uint16x8_t, y: uint16x8_t) -> uint16x8_t {
         unsafe { vaddq_u16(x, y) }
@@ -813,11 +851,6 @@ unsafe impl NumOps<u16> for ArmNeonIsa {
     #[inline]
     fn mul(self, x: uint16x8_t, y: uint16x8_t) -> uint16x8_t {
         unsafe { vmulq_u16(x, y) }
-    }
-
-    #[inline]
-    fn splat(self, x: u16) -> uint16x8_t {
-        unsafe { vdupq_n_u16(x) }
     }
 
     #[inline]
@@ -843,27 +876,6 @@ unsafe impl NumOps<u16> for ArmNeonIsa {
     #[inline]
     fn gt(self, x: uint16x8_t, y: uint16x8_t) -> uint16x8_t {
         unsafe { vcgtq_u16(x, y) }
-    }
-
-    #[inline]
-    unsafe fn load_ptr(self, ptr: *const u16) -> uint16x8_t {
-        unsafe { vld1q_u16(ptr) }
-    }
-
-    #[inline]
-    fn first_n_mask(self, n: usize) -> uint16x8_t {
-        let mask: [u16; 8] = std::array::from_fn(|i| if i < n { u16::MAX } else { 0 });
-        unsafe { vld1q_u16(mask.as_ptr()) }
-    }
-
-    #[inline]
-    fn select(self, x: uint16x8_t, y: uint16x8_t, mask: <uint16x8_t as Simd>::Mask) -> uint16x8_t {
-        unsafe { vbslq_u16(mask, x, y) }
-    }
-
-    #[inline]
-    unsafe fn store_ptr(self, x: uint16x8_t, ptr: *mut u16) {
-        unsafe { vst1q_u16(ptr, x) }
     }
 }
 

--- a/rten-simd/src/arch/generic.rs
+++ b/rten-simd/src/arch/generic.rs
@@ -2,8 +2,8 @@ use std::array;
 use std::mem::transmute;
 
 use crate::ops::{
-    Concat, Extend, FloatOps, IntOps, Interleave, MaskOps, NarrowSaturate, NumOps, SignedIntOps,
-    ToFloat,
+    BitOps, Concat, Extend, FloatOps, IntOps, Interleave, MaskOps, NarrowSaturate, NumOps,
+    SignedIntOps, ToFloat,
 };
 use crate::{Isa, Mask, Simd};
 
@@ -143,7 +143,7 @@ unsafe impl Isa for GenericIsa {
     }
 }
 
-macro_rules! simd_ops_common {
+macro_rules! bit_ops_common {
     ($simd:ident, $elem:ty, $len:expr, $mask:ident) => {
         #[inline]
         fn len(self) -> usize {
@@ -163,7 +163,7 @@ macro_rules! simd_ops_common {
             mask: <$simd as Simd>::Mask,
         ) -> $simd {
             let mask_array = mask.0;
-            let mut vec = <Self as NumOps<$elem>>::zero(self).0;
+            let mut vec = <Self as BitOps<$elem>>::zero(self).0;
             for i in 0..mask_array.len() {
                 if mask_array[i] != 0 {
                     vec[i] = *ptr.add(i);
@@ -181,13 +181,41 @@ macro_rules! simd_ops_common {
         ) {
             let mask_array = mask.0;
             let x_array = x.0;
-            for i in 0..<Self as NumOps<$elem>>::len(self) {
+            for i in 0..<Self as BitOps<$elem>>::len(self) {
                 if mask_array[i] != 0 {
                     *ptr.add(i) = x_array[i];
                 }
             }
         }
 
+        #[inline]
+        fn splat(self, x: $elem) -> $simd {
+            $simd([x; $len])
+        }
+
+        #[inline]
+        unsafe fn load_ptr(self, ptr: *const $elem) -> $simd {
+            let xs = array::from_fn(|i| *ptr.add(i));
+            $simd(xs)
+        }
+
+        #[inline]
+        fn select(self, x: $simd, y: $simd, mask: <$simd as Simd>::Mask) -> $simd {
+            let xs = array::from_fn(|i| if mask.0[i] != 0 { x.0[i] } else { y.0[i] });
+            $simd(xs)
+        }
+
+        #[inline]
+        unsafe fn store_ptr(self, x: $simd, ptr: *mut $elem) {
+            for i in 0..$len {
+                *ptr.add(i) = x.0[i];
+            }
+        }
+    };
+}
+
+macro_rules! num_ops_common {
+    ($simd:ident, $mask:ident) => {
         #[inline]
         fn add(self, x: $simd, y: $simd) -> $simd {
             x.map_with(y, |x, y| x + y)
@@ -233,30 +261,6 @@ macro_rules! simd_ops_common {
         fn max(self, x: $simd, y: $simd) -> $simd {
             x.map_with(y, |x, y| x.max(y))
         }
-
-        #[inline]
-        fn splat(self, x: $elem) -> $simd {
-            $simd([x; $len])
-        }
-
-        #[inline]
-        unsafe fn load_ptr(self, ptr: *const $elem) -> $simd {
-            let xs = array::from_fn(|i| *ptr.add(i));
-            $simd(xs)
-        }
-
-        #[inline]
-        fn select(self, x: $simd, y: $simd, mask: <$simd as Simd>::Mask) -> $simd {
-            let xs = array::from_fn(|i| if mask.0[i] != 0 { x.0[i] } else { y.0[i] });
-            $simd(xs)
-        }
-
-        #[inline]
-        unsafe fn store_ptr(self, x: $simd, ptr: *mut $elem) {
-            for i in 0..$len {
-                *ptr.add(i) = x.0[i];
-            }
-        }
     };
 }
 
@@ -284,10 +288,10 @@ macro_rules! simd_int_ops_common {
     };
 }
 
-unsafe impl NumOps<f32> for GenericIsa {
+unsafe impl BitOps<f32> for GenericIsa {
     type Simd = F32x4;
 
-    simd_ops_common!(F32x4, f32, 4, M32);
+    bit_ops_common!(F32x4, f32, 4, M32);
 
     #[inline]
     fn and(self, x: F32x4, y: F32x4) -> F32x4 {
@@ -308,6 +312,10 @@ unsafe impl NumOps<f32> for GenericIsa {
     fn xor(self, x: F32x4, y: F32x4) -> F32x4 {
         x.map_with(y, |x, y| f32::from_bits(x.to_bits() ^ y.to_bits()))
     }
+}
+
+unsafe impl NumOps<f32> for GenericIsa {
+    num_ops_common!(F32x4, M32);
 }
 
 impl FloatOps<f32> for GenericIsa {
@@ -346,11 +354,15 @@ impl FloatOps<f32> for GenericIsa {
 
 macro_rules! impl_simd_int_ops {
     ($simd:ident, $elem:ty, $len:expr, $mask:ident) => {
-        unsafe impl NumOps<$elem> for GenericIsa {
+        unsafe impl BitOps<$elem> for GenericIsa {
             type Simd = $simd;
 
-            simd_ops_common!($simd, $elem, $len, $mask);
+            bit_ops_common!($simd, $elem, $len, $mask);
             simd_int_ops_common!($simd);
+        }
+
+        unsafe impl NumOps<$elem> for GenericIsa {
+            num_ops_common!($simd, $mask);
         }
 
         impl IntOps<$elem> for GenericIsa {

--- a/rten-simd/src/arch/wasm32.rs
+++ b/rten-simd/src/arch/wasm32.rs
@@ -21,8 +21,8 @@ use std::arch::wasm32::{f32x4_relaxed_madd, f32x4_relaxed_nmadd};
 
 use super::{lanes, simd_type};
 use crate::ops::{
-    Concat, Extend, FloatOps, IntOps, Interleave, MaskOps, NarrowSaturate, NumOps, SignedIntOps,
-    ToFloat,
+    BitOps, Concat, Extend, FloatOps, IntOps, Interleave, MaskOps, NarrowSaturate, NumOps,
+    SignedIntOps, ToFloat,
 };
 use crate::{Isa, Mask, Simd};
 
@@ -142,7 +142,7 @@ macro_rules! simd_ops_common {
         unsafe fn load_ptr_mask(self, ptr: *const <$simd as Simd>::Elem, mask: $mask) -> $simd {
             type Elem = <$simd as Simd>::Elem;
             let mask_array = Mask::to_array(mask);
-            let mut vec = Simd::to_array(NumOps::<Elem>::zero(self));
+            let mut vec = Simd::to_array(BitOps::<Elem>::zero(self));
             for i in 0..mask_array.len() {
                 if mask_array[i] {
                     vec[i] = *ptr.add(i);
@@ -162,7 +162,7 @@ macro_rules! simd_ops_common {
 
             let mask_array = Mask::to_array(mask);
             let x_array = Simd::to_array(x);
-            for i in 0..NumOps::<Elem>::len(self) {
+            for i in 0..BitOps::<Elem>::len(self) {
                 if mask_array[i] {
                     *ptr.add(i) = x_array[i];
                 }
@@ -196,9 +196,16 @@ macro_rules! simd_ops_common {
     };
 }
 
-unsafe impl NumOps<f32> for Wasm32Isa {
+unsafe impl BitOps<f32> for Wasm32Isa {
     simd_ops_common!(F32x4, M32, i32);
 
+    #[inline]
+    fn splat(self, x: f32) -> F32x4 {
+        F32x4(f32x4_splat(x))
+    }
+}
+
+unsafe impl NumOps<f32> for Wasm32Isa {
     #[inline]
     fn add(self, x: F32x4, y: F32x4) -> F32x4 {
         F32x4(f32x4_add(x.0, y.0))
@@ -262,11 +269,6 @@ unsafe impl NumOps<f32> for Wasm32Isa {
     }
 
     #[inline]
-    fn splat(self, x: f32) -> F32x4 {
-        F32x4(f32x4_splat(x))
-    }
-
-    #[inline]
     fn sum(self, x: F32x4) -> f32 {
         // See https://github.com/WebAssembly/simd/issues/20.
         let lo_2 = x.0;
@@ -325,9 +327,16 @@ impl FloatOps<f32> for Wasm32Isa {
     }
 }
 
-unsafe impl NumOps<i32> for Wasm32Isa {
+unsafe impl BitOps<i32> for Wasm32Isa {
     simd_ops_common!(I32x4, M32, i32);
 
+    #[inline]
+    fn splat(self, x: i32) -> I32x4 {
+        I32x4(i32x4_splat(x))
+    }
+}
+
+unsafe impl NumOps<i32> for Wasm32Isa {
     #[inline]
     fn add(self, x: I32x4, y: I32x4) -> I32x4 {
         I32x4(i32x4_add(x.0, y.0))
@@ -341,11 +350,6 @@ unsafe impl NumOps<i32> for Wasm32Isa {
     #[inline]
     fn mul(self, x: I32x4, y: I32x4) -> I32x4 {
         I32x4(i32x4_mul(x.0, y.0))
-    }
-
-    #[inline]
-    fn splat(self, x: i32) -> I32x4 {
-        I32x4(i32x4_splat(x))
     }
 
     #[inline]
@@ -413,9 +417,16 @@ impl ToFloat<i32> for Wasm32Isa {
     }
 }
 
-unsafe impl NumOps<i16> for Wasm32Isa {
+unsafe impl BitOps<i16> for Wasm32Isa {
     simd_ops_common!(I16x8, M16, i16);
 
+    #[inline]
+    fn splat(self, x: i16) -> I16x8 {
+        I16x8(i16x8_splat(x))
+    }
+}
+
+unsafe impl NumOps<i16> for Wasm32Isa {
     #[inline]
     fn add(self, x: I16x8, y: I16x8) -> I16x8 {
         I16x8(i16x8_add(x.0, y.0))
@@ -429,11 +440,6 @@ unsafe impl NumOps<i16> for Wasm32Isa {
     #[inline]
     fn mul(self, x: I16x8, y: I16x8) -> I16x8 {
         I16x8(i16x8_mul(x.0, y.0))
-    }
-
-    #[inline]
-    fn splat(self, x: i16) -> I16x8 {
-        I16x8(i16x8_splat(x))
     }
 
     #[inline]
@@ -503,9 +509,16 @@ impl NarrowSaturate<i16, u8> for Wasm32Isa {
     }
 }
 
-unsafe impl NumOps<i8> for Wasm32Isa {
+unsafe impl BitOps<i8> for Wasm32Isa {
     simd_ops_common!(I8x16, M8, i8);
 
+    #[inline]
+    fn splat(self, x: i8) -> I8x16 {
+        I8x16(i8x16_splat(x))
+    }
+}
+
+unsafe impl NumOps<i8> for Wasm32Isa {
     #[inline]
     fn add(self, x: I8x16, y: I8x16) -> I8x16 {
         I8x16(i8x16_add(x.0, y.0))
@@ -528,11 +541,6 @@ unsafe impl NumOps<i8> for Wasm32Isa {
         );
 
         I8x16(prod_i8)
-    }
-
-    #[inline]
-    fn splat(self, x: i8) -> I8x16 {
-        I8x16(i8x16_splat(x))
     }
 
     #[inline]
@@ -594,9 +602,16 @@ impl Interleave<i8> for Wasm32Isa {
     }
 }
 
-unsafe impl NumOps<u8> for Wasm32Isa {
+unsafe impl BitOps<u8> for Wasm32Isa {
     simd_ops_common!(U8x16, M8, i8);
 
+    #[inline]
+    fn splat(self, x: u8) -> U8x16 {
+        U8x16(u8x16_splat(x))
+    }
+}
+
+unsafe impl NumOps<u8> for Wasm32Isa {
     #[inline]
     fn add(self, x: U8x16, y: U8x16) -> U8x16 {
         U8x16(u8x16_add(x.0, y.0))
@@ -622,11 +637,6 @@ unsafe impl NumOps<u8> for Wasm32Isa {
     }
 
     #[inline]
-    fn splat(self, x: u8) -> U8x16 {
-        U8x16(u8x16_splat(x))
-    }
-
-    #[inline]
     fn eq(self, x: U8x16, y: U8x16) -> M8 {
         M8(u8x16_eq(x.0, y.0))
     }
@@ -642,9 +652,16 @@ unsafe impl NumOps<u8> for Wasm32Isa {
     }
 }
 
-unsafe impl NumOps<u16> for Wasm32Isa {
+unsafe impl BitOps<u16> for Wasm32Isa {
     simd_ops_common!(U16x8, M16, u16);
 
+    #[inline]
+    fn splat(self, x: u16) -> U16x8 {
+        U16x8(u16x8_splat(x))
+    }
+}
+
+unsafe impl NumOps<u16> for Wasm32Isa {
     #[inline]
     fn add(self, x: U16x8, y: U16x8) -> U16x8 {
         U16x8(u16x8_add(x.0, y.0))
@@ -658,11 +675,6 @@ unsafe impl NumOps<u16> for Wasm32Isa {
     #[inline]
     fn mul(self, x: U16x8, y: U16x8) -> U16x8 {
         U16x8(u16x8_mul(x.0, y.0))
-    }
-
-    #[inline]
-    fn splat(self, x: u16) -> U16x8 {
-        U16x8(u16x8_splat(x))
     }
 
     #[inline]

--- a/rten-simd/src/arch/x86_64/avx2.rs
+++ b/rten-simd/src/arch/x86_64/avx2.rs
@@ -25,7 +25,7 @@ use std::mem::transmute;
 
 use super::super::{lanes, simd_type};
 use crate::ops::{
-    Concat, Extend, FloatOps, IntOps, Interleave, MaskOps, Narrow, NarrowSaturate, NumOps,
+    BitOps, Concat, Extend, FloatOps, IntOps, Interleave, MaskOps, Narrow, NarrowSaturate, NumOps,
     SignedIntOps, ToFloat,
 };
 use crate::{Isa, Mask, Simd};
@@ -164,7 +164,7 @@ macro_rules! simd_int_ops_common {
     };
 }
 
-unsafe impl NumOps<f32> for Avx2Isa {
+unsafe impl BitOps<f32> for Avx2Isa {
     simd_ops_common!(F32x8, M32);
 
     #[inline]
@@ -173,6 +173,59 @@ unsafe impl NumOps<f32> for Avx2Isa {
         M32::from_float(unsafe { _mm256_loadu_ps(mask.as_ptr() as *const f32) })
     }
 
+    #[inline]
+    fn and(self, x: F32x8, y: F32x8) -> F32x8 {
+        unsafe { _mm256_and_ps(x.0, y.0) }.into()
+    }
+
+    #[inline]
+    fn not(self, x: F32x8) -> F32x8 {
+        let all_ones: F32x8 = self.splat(f32::from_bits(0xFFFFFFFF));
+        unsafe { _mm256_andnot_ps(x.0, all_ones.0) }.into()
+    }
+
+    #[inline]
+    fn or(self, x: F32x8, y: F32x8) -> F32x8 {
+        unsafe { _mm256_or_ps(x.0, y.0) }.into()
+    }
+
+    #[inline]
+    fn xor(self, x: F32x8, y: F32x8) -> F32x8 {
+        unsafe { _mm256_xor_ps(x.0, y.0) }.into()
+    }
+
+    #[inline]
+    fn splat(self, x: f32) -> F32x8 {
+        unsafe { _mm256_set1_ps(x) }.into()
+    }
+
+    #[inline]
+    unsafe fn load_ptr(self, ptr: *const f32) -> F32x8 {
+        unsafe { _mm256_loadu_ps(ptr) }.into()
+    }
+
+    #[inline]
+    fn select(self, x: F32x8, y: F32x8, mask: M32) -> F32x8 {
+        unsafe { _mm256_blendv_ps(y.0, x.0, mask.as_float()) }.into()
+    }
+
+    #[inline]
+    unsafe fn load_ptr_mask(self, ptr: *const f32, mask: M32) -> F32x8 {
+        unsafe { _mm256_maskload_ps(ptr, mask.0) }.into()
+    }
+
+    #[inline]
+    unsafe fn store_ptr_mask(self, x: F32x8, ptr: *mut f32, mask: M32) {
+        unsafe { _mm256_maskstore_ps(ptr, mask.0, x.0) }
+    }
+
+    #[inline]
+    unsafe fn store_ptr(self, x: F32x8, ptr: *mut f32) {
+        unsafe { _mm256_storeu_ps(ptr, x.0) }
+    }
+}
+
+unsafe impl NumOps<f32> for Avx2Isa {
     #[inline]
     fn add(self, x: F32x8, y: F32x8) -> F32x8 {
         unsafe { _mm256_add_ps(x.0, y.0) }.into()
@@ -226,57 +279,6 @@ unsafe impl NumOps<f32> for Avx2Isa {
     #[inline]
     fn max(self, x: F32x8, y: F32x8) -> F32x8 {
         unsafe { _mm256_max_ps(x.0, y.0) }.into()
-    }
-
-    #[inline]
-    fn and(self, x: F32x8, y: F32x8) -> F32x8 {
-        unsafe { _mm256_and_ps(x.0, y.0) }.into()
-    }
-
-    #[inline]
-    fn not(self, x: F32x8) -> F32x8 {
-        let all_ones: F32x8 = self.splat(f32::from_bits(0xFFFFFFFF));
-        unsafe { _mm256_andnot_ps(x.0, all_ones.0) }.into()
-    }
-
-    #[inline]
-    fn or(self, x: F32x8, y: F32x8) -> F32x8 {
-        unsafe { _mm256_or_ps(x.0, y.0) }.into()
-    }
-
-    #[inline]
-    fn xor(self, x: F32x8, y: F32x8) -> F32x8 {
-        unsafe { _mm256_xor_ps(x.0, y.0) }.into()
-    }
-
-    #[inline]
-    fn splat(self, x: f32) -> F32x8 {
-        unsafe { _mm256_set1_ps(x) }.into()
-    }
-
-    #[inline]
-    unsafe fn load_ptr(self, ptr: *const f32) -> F32x8 {
-        unsafe { _mm256_loadu_ps(ptr) }.into()
-    }
-
-    #[inline]
-    fn select(self, x: F32x8, y: F32x8, mask: M32) -> F32x8 {
-        unsafe { _mm256_blendv_ps(y.0, x.0, mask.as_float()) }.into()
-    }
-
-    #[inline]
-    unsafe fn load_ptr_mask(self, ptr: *const f32, mask: M32) -> F32x8 {
-        unsafe { _mm256_maskload_ps(ptr, mask.0) }.into()
-    }
-
-    #[inline]
-    unsafe fn store_ptr_mask(self, x: F32x8, ptr: *mut f32, mask: M32) {
-        unsafe { _mm256_maskstore_ps(ptr, mask.0, x.0) }
-    }
-
-    #[inline]
-    unsafe fn store_ptr(self, x: F32x8, ptr: *mut f32) {
-        unsafe { _mm256_storeu_ps(ptr, x.0) }
     }
 
     #[inline]
@@ -336,7 +338,7 @@ impl FloatOps<f32> for Avx2Isa {
     }
 }
 
-unsafe impl NumOps<i32> for Avx2Isa {
+unsafe impl BitOps<i32> for Avx2Isa {
     simd_ops_common!(I32x8, M32);
     simd_int_ops_common!(I32x8);
 
@@ -347,38 +349,8 @@ unsafe impl NumOps<i32> for Avx2Isa {
     }
 
     #[inline]
-    fn add(self, x: I32x8, y: I32x8) -> I32x8 {
-        unsafe { _mm256_add_epi32(x.0, y.0) }.into()
-    }
-
-    #[inline]
-    fn sub(self, x: I32x8, y: I32x8) -> I32x8 {
-        unsafe { _mm256_sub_epi32(x.0, y.0) }.into()
-    }
-
-    #[inline]
-    fn mul(self, x: I32x8, y: I32x8) -> I32x8 {
-        unsafe { _mm256_mullo_epi32(x.0, y.0) }.into()
-    }
-
-    #[inline]
     fn splat(self, x: i32) -> I32x8 {
         unsafe { _mm256_set1_epi32(x) }.into()
-    }
-
-    #[inline]
-    fn eq(self, x: I32x8, y: I32x8) -> M32 {
-        M32(unsafe { _mm256_cmpeq_epi32(x.0, y.0) })
-    }
-
-    #[inline]
-    fn ge(self, x: I32x8, y: I32x8) -> M32 {
-        M32(unsafe { _mm256_or_si256(_mm256_cmpgt_epi32(x.0, y.0), _mm256_cmpeq_epi32(x.0, y.0)) })
-    }
-
-    #[inline]
-    fn gt(self, x: I32x8, y: I32x8) -> M32 {
-        M32(unsafe { _mm256_cmpgt_epi32(x.0, y.0) })
     }
 
     #[inline]
@@ -404,6 +376,38 @@ unsafe impl NumOps<i32> for Avx2Isa {
     #[inline]
     unsafe fn store_ptr_mask(self, x: I32x8, ptr: *mut i32, mask: M32) {
         unsafe { _mm256_maskstore_epi32(ptr, mask.0, x.0) }
+    }
+}
+
+unsafe impl NumOps<i32> for Avx2Isa {
+    #[inline]
+    fn add(self, x: I32x8, y: I32x8) -> I32x8 {
+        unsafe { _mm256_add_epi32(x.0, y.0) }.into()
+    }
+
+    #[inline]
+    fn sub(self, x: I32x8, y: I32x8) -> I32x8 {
+        unsafe { _mm256_sub_epi32(x.0, y.0) }.into()
+    }
+
+    #[inline]
+    fn mul(self, x: I32x8, y: I32x8) -> I32x8 {
+        unsafe { _mm256_mullo_epi32(x.0, y.0) }.into()
+    }
+
+    #[inline]
+    fn eq(self, x: I32x8, y: I32x8) -> M32 {
+        M32(unsafe { _mm256_cmpeq_epi32(x.0, y.0) })
+    }
+
+    #[inline]
+    fn ge(self, x: I32x8, y: I32x8) -> M32 {
+        M32(unsafe { _mm256_or_si256(_mm256_cmpgt_epi32(x.0, y.0), _mm256_cmpeq_epi32(x.0, y.0)) })
+    }
+
+    #[inline]
+    fn gt(self, x: I32x8, y: I32x8) -> M32 {
+        M32(unsafe { _mm256_cmpgt_epi32(x.0, y.0) })
     }
 }
 
@@ -479,7 +483,7 @@ impl ToFloat<i32> for Avx2Isa {
     }
 }
 
-unsafe impl NumOps<i16> for Avx2Isa {
+unsafe impl BitOps<i16> for Avx2Isa {
     simd_ops_common!(I16x16, M16);
     simd_int_ops_common!(I16x16);
 
@@ -490,38 +494,8 @@ unsafe impl NumOps<i16> for Avx2Isa {
     }
 
     #[inline]
-    fn add(self, x: I16x16, y: I16x16) -> I16x16 {
-        unsafe { _mm256_add_epi16(x.0, y.0) }.into()
-    }
-
-    #[inline]
-    fn sub(self, x: I16x16, y: I16x16) -> I16x16 {
-        unsafe { _mm256_sub_epi16(x.0, y.0) }.into()
-    }
-
-    #[inline]
-    fn mul(self, x: I16x16, y: I16x16) -> I16x16 {
-        unsafe { _mm256_mullo_epi16(x.0, y.0) }.into()
-    }
-
-    #[inline]
     fn splat(self, x: i16) -> I16x16 {
         unsafe { _mm256_set1_epi16(x) }.into()
-    }
-
-    #[inline]
-    fn eq(self, x: I16x16, y: I16x16) -> M16 {
-        M16(unsafe { _mm256_cmpeq_epi16(x.0, y.0) })
-    }
-
-    #[inline]
-    fn ge(self, x: I16x16, y: I16x16) -> M16 {
-        M16(unsafe { _mm256_or_si256(_mm256_cmpgt_epi16(x.0, y.0), _mm256_cmpeq_epi16(x.0, y.0)) })
-    }
-
-    #[inline]
-    fn gt(self, x: I16x16, y: I16x16) -> M16 {
-        M16(unsafe { _mm256_cmpgt_epi16(x.0, y.0) })
     }
 
     #[inline]
@@ -569,6 +543,38 @@ unsafe impl NumOps<i16> for Avx2Isa {
                 unsafe { *ptr.add(i) = xs[i] }
             }
         }
+    }
+}
+
+unsafe impl NumOps<i16> for Avx2Isa {
+    #[inline]
+    fn add(self, x: I16x16, y: I16x16) -> I16x16 {
+        unsafe { _mm256_add_epi16(x.0, y.0) }.into()
+    }
+
+    #[inline]
+    fn sub(self, x: I16x16, y: I16x16) -> I16x16 {
+        unsafe { _mm256_sub_epi16(x.0, y.0) }.into()
+    }
+
+    #[inline]
+    fn mul(self, x: I16x16, y: I16x16) -> I16x16 {
+        unsafe { _mm256_mullo_epi16(x.0, y.0) }.into()
+    }
+
+    #[inline]
+    fn eq(self, x: I16x16, y: I16x16) -> M16 {
+        M16(unsafe { _mm256_cmpeq_epi16(x.0, y.0) })
+    }
+
+    #[inline]
+    fn ge(self, x: I16x16, y: I16x16) -> M16 {
+        M16(unsafe { _mm256_or_si256(_mm256_cmpgt_epi16(x.0, y.0), _mm256_cmpeq_epi16(x.0, y.0)) })
+    }
+
+    #[inline]
+    fn gt(self, x: I16x16, y: I16x16) -> M16 {
+        M16(unsafe { _mm256_cmpgt_epi16(x.0, y.0) })
     }
 }
 
@@ -632,7 +638,7 @@ impl Interleave<i16> for Avx2Isa {
     }
 }
 
-unsafe impl NumOps<i8> for Avx2Isa {
+unsafe impl BitOps<i8> for Avx2Isa {
     simd_ops_common!(I8x32, M8);
     simd_int_ops_common!(I8x32);
 
@@ -643,45 +649,8 @@ unsafe impl NumOps<i8> for Avx2Isa {
     }
 
     #[inline]
-    fn add(self, x: I8x32, y: I8x32) -> I8x32 {
-        unsafe { _mm256_add_epi8(x.0, y.0) }.into()
-    }
-
-    #[inline]
-    fn sub(self, x: I8x32, y: I8x32) -> I8x32 {
-        unsafe { _mm256_sub_epi8(x.0, y.0) }.into()
-    }
-
-    #[inline]
-    fn mul(self, x: I8x32, y: I8x32) -> I8x32 {
-        let (x_lo, x_hi) = Extend::<i8>::extend(self, x);
-        let (y_lo, y_hi) = Extend::<i8>::extend(self, y);
-
-        let i16_ops = self.i16();
-        let prod_lo = i16_ops.mul(x_lo, y_lo);
-        let prod_hi = i16_ops.mul(x_hi, y_hi);
-
-        self.narrow_truncate(prod_lo, prod_hi)
-    }
-
-    #[inline]
     fn splat(self, x: i8) -> I8x32 {
         unsafe { _mm256_set1_epi8(x) }.into()
-    }
-
-    #[inline]
-    fn eq(self, x: I8x32, y: I8x32) -> M8 {
-        M8(unsafe { _mm256_cmpeq_epi8(x.0, y.0) })
-    }
-
-    #[inline]
-    fn ge(self, x: I8x32, y: I8x32) -> M8 {
-        M8(unsafe { _mm256_or_si256(_mm256_cmpgt_epi8(x.0, y.0), _mm256_cmpeq_epi8(x.0, y.0)) })
-    }
-
-    #[inline]
-    fn gt(self, x: I8x32, y: I8x32) -> M8 {
-        M8(unsafe { _mm256_cmpgt_epi8(x.0, y.0) })
     }
 
     #[inline]
@@ -729,6 +698,45 @@ unsafe impl NumOps<i8> for Avx2Isa {
                 unsafe { *ptr.add(i) = xs[i] }
             }
         }
+    }
+}
+
+unsafe impl NumOps<i8> for Avx2Isa {
+    #[inline]
+    fn add(self, x: I8x32, y: I8x32) -> I8x32 {
+        unsafe { _mm256_add_epi8(x.0, y.0) }.into()
+    }
+
+    #[inline]
+    fn sub(self, x: I8x32, y: I8x32) -> I8x32 {
+        unsafe { _mm256_sub_epi8(x.0, y.0) }.into()
+    }
+
+    #[inline]
+    fn mul(self, x: I8x32, y: I8x32) -> I8x32 {
+        let (x_lo, x_hi) = Extend::<i8>::extend(self, x);
+        let (y_lo, y_hi) = Extend::<i8>::extend(self, y);
+
+        let i16_ops = self.i16();
+        let prod_lo = i16_ops.mul(x_lo, y_lo);
+        let prod_hi = i16_ops.mul(x_hi, y_hi);
+
+        self.narrow_truncate(prod_lo, prod_hi)
+    }
+
+    #[inline]
+    fn eq(self, x: I8x32, y: I8x32) -> M8 {
+        M8(unsafe { _mm256_cmpeq_epi8(x.0, y.0) })
+    }
+
+    #[inline]
+    fn ge(self, x: I8x32, y: I8x32) -> M8 {
+        M8(unsafe { _mm256_or_si256(_mm256_cmpgt_epi8(x.0, y.0), _mm256_cmpeq_epi8(x.0, y.0)) })
+    }
+
+    #[inline]
+    fn gt(self, x: I8x32, y: I8x32) -> M8 {
+        M8(unsafe { _mm256_cmpgt_epi8(x.0, y.0) })
     }
 }
 
@@ -795,7 +803,7 @@ impl Interleave<i8> for Avx2Isa {
     }
 }
 
-unsafe impl NumOps<u8> for Avx2Isa {
+unsafe impl BitOps<u8> for Avx2Isa {
     simd_ops_common!(U8x32, M8);
     simd_int_ops_common!(U8x32);
 
@@ -806,53 +814,8 @@ unsafe impl NumOps<u8> for Avx2Isa {
     }
 
     #[inline]
-    fn add(self, x: U8x32, y: U8x32) -> U8x32 {
-        unsafe { _mm256_add_epi8(x.0, y.0) }.into()
-    }
-
-    #[inline]
-    fn sub(self, x: U8x32, y: U8x32) -> U8x32 {
-        unsafe { _mm256_sub_epi8(x.0, y.0) }.into()
-    }
-
-    #[inline]
-    fn mul(self, x: U8x32, y: U8x32) -> U8x32 {
-        let (x_lo, x_hi) = Extend::<u8>::extend(self, x);
-        let (y_lo, y_hi) = Extend::<u8>::extend(self, y);
-
-        let u16_ops = self.u16();
-        let prod_lo = u16_ops.mul(x_lo, y_lo);
-        let prod_hi = u16_ops.mul(x_hi, y_hi);
-
-        self.narrow_truncate(prod_lo, prod_hi)
-    }
-
-    #[inline]
     fn splat(self, x: u8) -> U8x32 {
         unsafe { _mm256_set1_epi8(x as i8) }.into()
-    }
-
-    #[inline]
-    fn eq(self, x: U8x32, y: U8x32) -> M8 {
-        M8(unsafe { _mm256_cmpeq_epi8(x.0, y.0) })
-    }
-
-    #[inline]
-    fn ge(self, x: U8x32, y: U8x32) -> M8 {
-        let xy_eq = <Self as NumOps<u8>>::eq(self, x, y);
-        let xy_gt = <Self as NumOps<u8>>::gt(self, x, y);
-        M8(unsafe { _mm256_or_si256(xy_eq.0, xy_gt.0) })
-    }
-
-    #[inline]
-    fn gt(self, x: U8x32, y: U8x32) -> M8 {
-        // AVX2 lacks u8 comparison. Shift both values to i8 and use signed compare.
-        M8(unsafe {
-            let mask = _mm256_set1_epi8(0x80u8 as i8);
-            let x_i8 = _mm256_xor_si256(x.0, mask);
-            let y_i8 = _mm256_xor_si256(y.0, mask);
-            _mm256_cmpgt_epi8(x_i8, y_i8)
-        })
     }
 
     #[inline]
@@ -903,7 +866,54 @@ unsafe impl NumOps<u8> for Avx2Isa {
     }
 }
 
-unsafe impl NumOps<u16> for Avx2Isa {
+unsafe impl NumOps<u8> for Avx2Isa {
+    #[inline]
+    fn add(self, x: U8x32, y: U8x32) -> U8x32 {
+        unsafe { _mm256_add_epi8(x.0, y.0) }.into()
+    }
+
+    #[inline]
+    fn sub(self, x: U8x32, y: U8x32) -> U8x32 {
+        unsafe { _mm256_sub_epi8(x.0, y.0) }.into()
+    }
+
+    #[inline]
+    fn mul(self, x: U8x32, y: U8x32) -> U8x32 {
+        let (x_lo, x_hi) = Extend::<u8>::extend(self, x);
+        let (y_lo, y_hi) = Extend::<u8>::extend(self, y);
+
+        let u16_ops = self.u16();
+        let prod_lo = u16_ops.mul(x_lo, y_lo);
+        let prod_hi = u16_ops.mul(x_hi, y_hi);
+
+        self.narrow_truncate(prod_lo, prod_hi)
+    }
+
+    #[inline]
+    fn eq(self, x: U8x32, y: U8x32) -> M8 {
+        M8(unsafe { _mm256_cmpeq_epi8(x.0, y.0) })
+    }
+
+    #[inline]
+    fn ge(self, x: U8x32, y: U8x32) -> M8 {
+        let xy_eq = <Self as NumOps<u8>>::eq(self, x, y);
+        let xy_gt = <Self as NumOps<u8>>::gt(self, x, y);
+        M8(unsafe { _mm256_or_si256(xy_eq.0, xy_gt.0) })
+    }
+
+    #[inline]
+    fn gt(self, x: U8x32, y: U8x32) -> M8 {
+        // AVX2 lacks u8 comparison. Shift both values to i8 and use signed compare.
+        M8(unsafe {
+            let mask = _mm256_set1_epi8(0x80u8 as i8);
+            let x_i8 = _mm256_xor_si256(x.0, mask);
+            let y_i8 = _mm256_xor_si256(y.0, mask);
+            _mm256_cmpgt_epi8(x_i8, y_i8)
+        })
+    }
+}
+
+unsafe impl BitOps<u16> for Avx2Isa {
     simd_ops_common!(U16x16, M16);
     simd_int_ops_common!(U16x16);
 
@@ -914,46 +924,8 @@ unsafe impl NumOps<u16> for Avx2Isa {
     }
 
     #[inline]
-    fn add(self, x: U16x16, y: U16x16) -> U16x16 {
-        unsafe { _mm256_add_epi16(x.0, y.0) }.into()
-    }
-
-    #[inline]
-    fn sub(self, x: U16x16, y: U16x16) -> U16x16 {
-        unsafe { _mm256_sub_epi16(x.0, y.0) }.into()
-    }
-
-    #[inline]
-    fn mul(self, x: U16x16, y: U16x16) -> U16x16 {
-        unsafe { _mm256_mullo_epi16(x.0, y.0) }.into()
-    }
-
-    #[inline]
     fn splat(self, x: u16) -> U16x16 {
         unsafe { _mm256_set1_epi16(x as i16) }.into()
-    }
-
-    #[inline]
-    fn eq(self, x: U16x16, y: U16x16) -> M16 {
-        M16(unsafe { _mm256_cmpeq_epi16(x.0, y.0) })
-    }
-
-    #[inline]
-    fn ge(self, x: U16x16, y: U16x16) -> M16 {
-        let xy_eq = <Self as NumOps<u16>>::eq(self, x, y);
-        let xy_gt = <Self as NumOps<u16>>::gt(self, x, y);
-        M16(unsafe { _mm256_or_si256(xy_eq.0, xy_gt.0) })
-    }
-
-    #[inline]
-    fn gt(self, x: U16x16, y: U16x16) -> M16 {
-        // AVX2 lacks u16 comparison. Shift both values to i16 and use signed compare.
-        M16(unsafe {
-            let mask = _mm256_set1_epi16(0x8000u16 as i16);
-            let x_i16 = _mm256_xor_si256(x.0, mask);
-            let y_i16 = _mm256_xor_si256(y.0, mask);
-            _mm256_cmpgt_epi16(x_i16, y_i16)
-        })
     }
 
     #[inline]
@@ -1001,6 +973,46 @@ unsafe impl NumOps<u16> for Avx2Isa {
                 unsafe { *ptr.add(i) = xs[i] }
             }
         }
+    }
+}
+
+unsafe impl NumOps<u16> for Avx2Isa {
+    #[inline]
+    fn add(self, x: U16x16, y: U16x16) -> U16x16 {
+        unsafe { _mm256_add_epi16(x.0, y.0) }.into()
+    }
+
+    #[inline]
+    fn sub(self, x: U16x16, y: U16x16) -> U16x16 {
+        unsafe { _mm256_sub_epi16(x.0, y.0) }.into()
+    }
+
+    #[inline]
+    fn mul(self, x: U16x16, y: U16x16) -> U16x16 {
+        unsafe { _mm256_mullo_epi16(x.0, y.0) }.into()
+    }
+
+    #[inline]
+    fn eq(self, x: U16x16, y: U16x16) -> M16 {
+        M16(unsafe { _mm256_cmpeq_epi16(x.0, y.0) })
+    }
+
+    #[inline]
+    fn ge(self, x: U16x16, y: U16x16) -> M16 {
+        let xy_eq = <Self as NumOps<u16>>::eq(self, x, y);
+        let xy_gt = <Self as NumOps<u16>>::gt(self, x, y);
+        M16(unsafe { _mm256_or_si256(xy_eq.0, xy_gt.0) })
+    }
+
+    #[inline]
+    fn gt(self, x: U16x16, y: U16x16) -> M16 {
+        // AVX2 lacks u16 comparison. Shift both values to i16 and use signed compare.
+        M16(unsafe {
+            let mask = _mm256_set1_epi16(0x8000u16 as i16);
+            let x_i16 = _mm256_xor_si256(x.0, mask);
+            let y_i16 = _mm256_xor_si256(y.0, mask);
+            _mm256_cmpgt_epi16(x_i16, y_i16)
+        })
     }
 }
 

--- a/rten-simd/src/arch/x86_64/avx512.rs
+++ b/rten-simd/src/arch/x86_64/avx512.rs
@@ -27,7 +27,7 @@ use std::mem::transmute;
 
 use super::super::{lanes, simd_type};
 use crate::ops::{
-    Concat, Extend, FloatOps, IntOps, Interleave, MaskOps, Narrow, NarrowSaturate, NumOps,
+    BitOps, Concat, Extend, FloatOps, IntOps, Interleave, MaskOps, Narrow, NarrowSaturate, NumOps,
     SignedIntOps, ToFloat,
 };
 use crate::{Isa, Mask, Simd};
@@ -175,9 +175,62 @@ macro_rules! simd_int_ops_common {
     };
 }
 
-unsafe impl NumOps<f32> for Avx512Isa {
+unsafe impl BitOps<f32> for Avx512Isa {
     simd_ops_common!(F32x16, __mmask16);
 
+    #[inline]
+    fn and(self, x: F32x16, y: F32x16) -> F32x16 {
+        unsafe { _mm512_and_ps(x.0, y.0) }.into()
+    }
+
+    #[inline]
+    fn not(self, x: F32x16) -> F32x16 {
+        let all_ones: F32x16 = self.splat(f32::from_bits(0xFFFFFFFF));
+        unsafe { _mm512_andnot_ps(x.0, all_ones.0) }.into()
+    }
+
+    #[inline]
+    fn or(self, x: F32x16, y: F32x16) -> F32x16 {
+        unsafe { _mm512_or_ps(x.0, y.0) }.into()
+    }
+
+    #[inline]
+    fn xor(self, x: F32x16, y: F32x16) -> F32x16 {
+        unsafe { _mm512_xor_ps(x.0, y.0) }.into()
+    }
+
+    #[inline]
+    fn splat(self, x: f32) -> F32x16 {
+        unsafe { _mm512_set1_ps(x) }.into()
+    }
+
+    #[inline]
+    unsafe fn load_ptr(self, ptr: *const f32) -> F32x16 {
+        unsafe { _mm512_loadu_ps(ptr) }.into()
+    }
+
+    #[inline]
+    fn select(self, x: F32x16, y: F32x16, mask: <F32x16 as Simd>::Mask) -> F32x16 {
+        unsafe { _mm512_mask_blend_ps(mask, y.0, x.0) }.into()
+    }
+
+    #[inline]
+    unsafe fn load_ptr_mask(self, ptr: *const f32, mask: __mmask16) -> F32x16 {
+        unsafe { _mm512_mask_loadu_ps(_mm512_set1_ps(0.), mask, ptr) }.into()
+    }
+
+    #[inline]
+    unsafe fn store_ptr_mask(self, x: F32x16, ptr: *mut f32, mask: __mmask16) {
+        unsafe { _mm512_mask_storeu_ps(ptr, mask, x.0) }
+    }
+
+    #[inline]
+    unsafe fn store_ptr(self, x: F32x16, ptr: *mut f32) {
+        unsafe { _mm512_storeu_ps(ptr, x.0) }
+    }
+}
+
+unsafe impl NumOps<f32> for Avx512Isa {
     #[inline]
     fn add(self, x: F32x16, y: F32x16) -> F32x16 {
         unsafe { _mm512_add_ps(x.0, y.0) }.into()
@@ -234,57 +287,6 @@ unsafe impl NumOps<f32> for Avx512Isa {
     }
 
     #[inline]
-    fn and(self, x: F32x16, y: F32x16) -> F32x16 {
-        unsafe { _mm512_and_ps(x.0, y.0) }.into()
-    }
-
-    #[inline]
-    fn not(self, x: F32x16) -> F32x16 {
-        let all_ones: F32x16 = self.splat(f32::from_bits(0xFFFFFFFF));
-        unsafe { _mm512_andnot_ps(x.0, all_ones.0) }.into()
-    }
-
-    #[inline]
-    fn or(self, x: F32x16, y: F32x16) -> F32x16 {
-        unsafe { _mm512_or_ps(x.0, y.0) }.into()
-    }
-
-    #[inline]
-    fn xor(self, x: F32x16, y: F32x16) -> F32x16 {
-        unsafe { _mm512_xor_ps(x.0, y.0) }.into()
-    }
-
-    #[inline]
-    fn splat(self, x: f32) -> F32x16 {
-        unsafe { _mm512_set1_ps(x) }.into()
-    }
-
-    #[inline]
-    unsafe fn load_ptr(self, ptr: *const f32) -> F32x16 {
-        unsafe { _mm512_loadu_ps(ptr) }.into()
-    }
-
-    #[inline]
-    fn select(self, x: F32x16, y: F32x16, mask: <F32x16 as Simd>::Mask) -> F32x16 {
-        unsafe { _mm512_mask_blend_ps(mask, y.0, x.0) }.into()
-    }
-
-    #[inline]
-    unsafe fn load_ptr_mask(self, ptr: *const f32, mask: __mmask16) -> F32x16 {
-        unsafe { _mm512_mask_loadu_ps(_mm512_set1_ps(0.), mask, ptr) }.into()
-    }
-
-    #[inline]
-    unsafe fn store_ptr_mask(self, x: F32x16, ptr: *mut f32, mask: __mmask16) {
-        unsafe { _mm512_mask_storeu_ps(ptr, mask, x.0) }
-    }
-
-    #[inline]
-    unsafe fn store_ptr(self, x: F32x16, ptr: *mut f32) {
-        unsafe { _mm512_storeu_ps(ptr, x.0) }
-    }
-
-    #[inline]
     fn sum(self, x: F32x16) -> f32 {
         unsafe { _mm512_reduce_add_ps(x.0) }
     }
@@ -329,43 +331,13 @@ impl FloatOps<f32> for Avx512Isa {
     }
 }
 
-unsafe impl NumOps<i32> for Avx512Isa {
+unsafe impl BitOps<i32> for Avx512Isa {
     simd_ops_common!(I32x16, __mmask16);
     simd_int_ops_common!(I32x16);
 
     #[inline]
-    fn add(self, x: I32x16, y: I32x16) -> I32x16 {
-        unsafe { _mm512_add_epi32(x.0, y.0) }.into()
-    }
-
-    #[inline]
-    fn sub(self, x: I32x16, y: I32x16) -> I32x16 {
-        unsafe { _mm512_sub_epi32(x.0, y.0) }.into()
-    }
-
-    #[inline]
-    fn mul(self, x: I32x16, y: I32x16) -> I32x16 {
-        unsafe { _mm512_mullo_epi32(x.0, y.0) }.into()
-    }
-
-    #[inline]
     fn splat(self, x: i32) -> I32x16 {
         unsafe { _mm512_set1_epi32(x) }.into()
-    }
-
-    #[inline]
-    fn eq(self, x: I32x16, y: I32x16) -> __mmask16 {
-        unsafe { _mm512_cmp_epi32_mask(x.0, y.0, _MM_CMPINT_EQ) }
-    }
-
-    #[inline]
-    fn ge(self, x: I32x16, y: I32x16) -> __mmask16 {
-        unsafe { _mm512_cmp_epi32_mask(x.0, y.0, _MM_CMPINT_NLT) }
-    }
-
-    #[inline]
-    fn gt(self, x: I32x16, y: I32x16) -> __mmask16 {
-        unsafe { _mm512_cmp_epi32_mask(x.0, y.0, _MM_CMPINT_NLE) }
     }
 
     #[inline]
@@ -391,6 +363,38 @@ unsafe impl NumOps<i32> for Avx512Isa {
     #[inline]
     unsafe fn store_ptr_mask(self, x: I32x16, ptr: *mut i32, mask: __mmask16) {
         unsafe { _mm512_mask_storeu_epi32(ptr, mask, x.0) }
+    }
+}
+
+unsafe impl NumOps<i32> for Avx512Isa {
+    #[inline]
+    fn add(self, x: I32x16, y: I32x16) -> I32x16 {
+        unsafe { _mm512_add_epi32(x.0, y.0) }.into()
+    }
+
+    #[inline]
+    fn sub(self, x: I32x16, y: I32x16) -> I32x16 {
+        unsafe { _mm512_sub_epi32(x.0, y.0) }.into()
+    }
+
+    #[inline]
+    fn mul(self, x: I32x16, y: I32x16) -> I32x16 {
+        unsafe { _mm512_mullo_epi32(x.0, y.0) }.into()
+    }
+
+    #[inline]
+    fn eq(self, x: I32x16, y: I32x16) -> __mmask16 {
+        unsafe { _mm512_cmp_epi32_mask(x.0, y.0, _MM_CMPINT_EQ) }
+    }
+
+    #[inline]
+    fn ge(self, x: I32x16, y: I32x16) -> __mmask16 {
+        unsafe { _mm512_cmp_epi32_mask(x.0, y.0, _MM_CMPINT_NLT) }
+    }
+
+    #[inline]
+    fn gt(self, x: I32x16, y: I32x16) -> __mmask16 {
+        unsafe { _mm512_cmp_epi32_mask(x.0, y.0, _MM_CMPINT_NLE) }
     }
 }
 
@@ -464,43 +468,13 @@ impl ToFloat<i32> for Avx512Isa {
     }
 }
 
-unsafe impl NumOps<i16> for Avx512Isa {
+unsafe impl BitOps<i16> for Avx512Isa {
     simd_ops_common!(I16x32, __mmask32);
     simd_int_ops_common!(I16x32);
 
     #[inline]
-    fn add(self, x: I16x32, y: I16x32) -> I16x32 {
-        unsafe { _mm512_add_epi16(x.0, y.0) }.into()
-    }
-
-    #[inline]
-    fn sub(self, x: I16x32, y: I16x32) -> I16x32 {
-        unsafe { _mm512_sub_epi16(x.0, y.0) }.into()
-    }
-
-    #[inline]
-    fn mul(self, x: I16x32, y: I16x32) -> I16x32 {
-        unsafe { _mm512_mullo_epi16(x.0, y.0) }.into()
-    }
-
-    #[inline]
     fn splat(self, x: i16) -> I16x32 {
         unsafe { _mm512_set1_epi16(x) }.into()
-    }
-
-    #[inline]
-    fn eq(self, x: I16x32, y: I16x32) -> __mmask32 {
-        unsafe { _mm512_cmp_epi16_mask(x.0, y.0, _MM_CMPINT_EQ) }
-    }
-
-    #[inline]
-    fn ge(self, x: I16x32, y: I16x32) -> __mmask32 {
-        unsafe { _mm512_cmp_epi16_mask(x.0, y.0, _MM_CMPINT_NLT) }
-    }
-
-    #[inline]
-    fn gt(self, x: I16x32, y: I16x32) -> __mmask32 {
-        unsafe { _mm512_cmp_epi16_mask(x.0, y.0, _MM_CMPINT_NLE) }
     }
 
     #[inline]
@@ -526,6 +500,38 @@ unsafe impl NumOps<i16> for Avx512Isa {
     #[inline]
     unsafe fn store_ptr_mask(self, x: I16x32, ptr: *mut i16, mask: __mmask32) {
         unsafe { _mm512_mask_storeu_epi16(ptr, mask, x.0) }
+    }
+}
+
+unsafe impl NumOps<i16> for Avx512Isa {
+    #[inline]
+    fn add(self, x: I16x32, y: I16x32) -> I16x32 {
+        unsafe { _mm512_add_epi16(x.0, y.0) }.into()
+    }
+
+    #[inline]
+    fn sub(self, x: I16x32, y: I16x32) -> I16x32 {
+        unsafe { _mm512_sub_epi16(x.0, y.0) }.into()
+    }
+
+    #[inline]
+    fn mul(self, x: I16x32, y: I16x32) -> I16x32 {
+        unsafe { _mm512_mullo_epi16(x.0, y.0) }.into()
+    }
+
+    #[inline]
+    fn eq(self, x: I16x32, y: I16x32) -> __mmask32 {
+        unsafe { _mm512_cmp_epi16_mask(x.0, y.0, _MM_CMPINT_EQ) }
+    }
+
+    #[inline]
+    fn ge(self, x: I16x32, y: I16x32) -> __mmask32 {
+        unsafe { _mm512_cmp_epi16_mask(x.0, y.0, _MM_CMPINT_NLT) }
+    }
+
+    #[inline]
+    fn gt(self, x: I16x32, y: I16x32) -> __mmask32 {
+        unsafe { _mm512_cmp_epi16_mask(x.0, y.0, _MM_CMPINT_NLE) }
     }
 }
 
@@ -595,50 +601,13 @@ impl Interleave<i16> for Avx512Isa {
     }
 }
 
-unsafe impl NumOps<i8> for Avx512Isa {
+unsafe impl BitOps<i8> for Avx512Isa {
     simd_ops_common!(I8x64, __mmask64);
     simd_int_ops_common!(I8x64);
 
     #[inline]
-    fn add(self, x: I8x64, y: I8x64) -> I8x64 {
-        unsafe { _mm512_add_epi8(x.0, y.0) }.into()
-    }
-
-    #[inline]
-    fn sub(self, x: I8x64, y: I8x64) -> I8x64 {
-        unsafe { _mm512_sub_epi8(x.0, y.0) }.into()
-    }
-
-    #[inline]
-    fn mul(self, x: I8x64, y: I8x64) -> I8x64 {
-        let (x_lo, x_hi) = Extend::<i8>::extend(self, x);
-        let (y_lo, y_hi) = Extend::<i8>::extend(self, y);
-
-        let i16_ops = self.i16();
-        let prod_lo = i16_ops.mul(x_lo, y_lo);
-        let prod_hi = i16_ops.mul(x_hi, y_hi);
-
-        self.narrow_truncate(prod_lo, prod_hi)
-    }
-
-    #[inline]
     fn splat(self, x: i8) -> I8x64 {
         unsafe { _mm512_set1_epi8(x) }.into()
-    }
-
-    #[inline]
-    fn eq(self, x: I8x64, y: I8x64) -> __mmask64 {
-        unsafe { _mm512_cmpeq_epi8_mask(x.0, y.0) }
-    }
-
-    #[inline]
-    fn ge(self, x: I8x64, y: I8x64) -> __mmask64 {
-        unsafe { _mm512_cmpge_epi8_mask(x.0, y.0) }
-    }
-
-    #[inline]
-    fn gt(self, x: I8x64, y: I8x64) -> __mmask64 {
-        unsafe { _mm512_cmpgt_epi8_mask(x.0, y.0) }
     }
 
     #[inline]
@@ -664,6 +633,45 @@ unsafe impl NumOps<i8> for Avx512Isa {
     #[inline]
     unsafe fn store_ptr_mask(self, x: I8x64, ptr: *mut i8, mask: __mmask64) {
         unsafe { _mm512_mask_storeu_epi8(ptr, mask, x.0) }
+    }
+}
+
+unsafe impl NumOps<i8> for Avx512Isa {
+    #[inline]
+    fn add(self, x: I8x64, y: I8x64) -> I8x64 {
+        unsafe { _mm512_add_epi8(x.0, y.0) }.into()
+    }
+
+    #[inline]
+    fn sub(self, x: I8x64, y: I8x64) -> I8x64 {
+        unsafe { _mm512_sub_epi8(x.0, y.0) }.into()
+    }
+
+    #[inline]
+    fn mul(self, x: I8x64, y: I8x64) -> I8x64 {
+        let (x_lo, x_hi) = Extend::<i8>::extend(self, x);
+        let (y_lo, y_hi) = Extend::<i8>::extend(self, y);
+
+        let i16_ops = self.i16();
+        let prod_lo = i16_ops.mul(x_lo, y_lo);
+        let prod_hi = i16_ops.mul(x_hi, y_hi);
+
+        self.narrow_truncate(prod_lo, prod_hi)
+    }
+
+    #[inline]
+    fn eq(self, x: I8x64, y: I8x64) -> __mmask64 {
+        unsafe { _mm512_cmpeq_epi8_mask(x.0, y.0) }
+    }
+
+    #[inline]
+    fn ge(self, x: I8x64, y: I8x64) -> __mmask64 {
+        unsafe { _mm512_cmpge_epi8_mask(x.0, y.0) }
+    }
+
+    #[inline]
+    fn gt(self, x: I8x64, y: I8x64) -> __mmask64 {
+        unsafe { _mm512_cmpgt_epi8_mask(x.0, y.0) }
     }
 }
 
@@ -736,50 +744,13 @@ impl Interleave<i8> for Avx512Isa {
     }
 }
 
-unsafe impl NumOps<u8> for Avx512Isa {
+unsafe impl BitOps<u8> for Avx512Isa {
     simd_ops_common!(U8x64, __mmask64);
     simd_int_ops_common!(U8x64);
 
     #[inline]
-    fn add(self, x: U8x64, y: U8x64) -> U8x64 {
-        unsafe { _mm512_add_epi8(x.0, y.0) }.into()
-    }
-
-    #[inline]
-    fn sub(self, x: U8x64, y: U8x64) -> U8x64 {
-        unsafe { _mm512_sub_epi8(x.0, y.0) }.into()
-    }
-
-    #[inline]
-    fn mul(self, x: U8x64, y: U8x64) -> U8x64 {
-        let (x_lo, x_hi) = Extend::<u8>::extend(self, x);
-        let (y_lo, y_hi) = Extend::<u8>::extend(self, y);
-
-        let u16_ops = self.u16();
-        let prod_lo = u16_ops.mul(x_lo, y_lo);
-        let prod_hi = u16_ops.mul(x_hi, y_hi);
-
-        self.narrow_truncate(prod_lo, prod_hi)
-    }
-
-    #[inline]
     fn splat(self, x: u8) -> U8x64 {
         unsafe { _mm512_set1_epi8(x as i8) }.into()
-    }
-
-    #[inline]
-    fn eq(self, x: U8x64, y: U8x64) -> __mmask64 {
-        unsafe { _mm512_cmpeq_epu8_mask(x.0, y.0) }
-    }
-
-    #[inline]
-    fn ge(self, x: U8x64, y: U8x64) -> __mmask64 {
-        unsafe { _mm512_cmpge_epu8_mask(x.0, y.0) }
-    }
-
-    #[inline]
-    fn gt(self, x: U8x64, y: U8x64) -> __mmask64 {
-        unsafe { _mm512_cmpgt_epu8_mask(x.0, y.0) }
     }
 
     #[inline]
@@ -805,6 +776,45 @@ unsafe impl NumOps<u8> for Avx512Isa {
     #[inline]
     unsafe fn store_ptr_mask(self, x: U8x64, ptr: *mut u8, mask: __mmask64) {
         unsafe { _mm512_mask_storeu_epi8(ptr as *mut i8, mask, x.0) }
+    }
+}
+
+unsafe impl NumOps<u8> for Avx512Isa {
+    #[inline]
+    fn add(self, x: U8x64, y: U8x64) -> U8x64 {
+        unsafe { _mm512_add_epi8(x.0, y.0) }.into()
+    }
+
+    #[inline]
+    fn sub(self, x: U8x64, y: U8x64) -> U8x64 {
+        unsafe { _mm512_sub_epi8(x.0, y.0) }.into()
+    }
+
+    #[inline]
+    fn mul(self, x: U8x64, y: U8x64) -> U8x64 {
+        let (x_lo, x_hi) = Extend::<u8>::extend(self, x);
+        let (y_lo, y_hi) = Extend::<u8>::extend(self, y);
+
+        let u16_ops = self.u16();
+        let prod_lo = u16_ops.mul(x_lo, y_lo);
+        let prod_hi = u16_ops.mul(x_hi, y_hi);
+
+        self.narrow_truncate(prod_lo, prod_hi)
+    }
+
+    #[inline]
+    fn eq(self, x: U8x64, y: U8x64) -> __mmask64 {
+        unsafe { _mm512_cmpeq_epu8_mask(x.0, y.0) }
+    }
+
+    #[inline]
+    fn ge(self, x: U8x64, y: U8x64) -> __mmask64 {
+        unsafe { _mm512_cmpge_epu8_mask(x.0, y.0) }
+    }
+
+    #[inline]
+    fn gt(self, x: U8x64, y: U8x64) -> __mmask64 {
+        unsafe { _mm512_cmpgt_epu8_mask(x.0, y.0) }
     }
 }
 
@@ -939,43 +949,13 @@ impl Narrow<U16x32> for Avx512Isa {
     }
 }
 
-unsafe impl NumOps<u16> for Avx512Isa {
+unsafe impl BitOps<u16> for Avx512Isa {
     simd_ops_common!(U16x32, __mmask32);
     simd_int_ops_common!(U16x32);
 
     #[inline]
-    fn add(self, x: U16x32, y: U16x32) -> U16x32 {
-        unsafe { _mm512_add_epi16(x.0, y.0) }.into()
-    }
-
-    #[inline]
-    fn sub(self, x: U16x32, y: U16x32) -> U16x32 {
-        unsafe { _mm512_sub_epi16(x.0, y.0) }.into()
-    }
-
-    #[inline]
-    fn mul(self, x: U16x32, y: U16x32) -> U16x32 {
-        unsafe { _mm512_mullo_epi16(x.0, y.0) }.into()
-    }
-
-    #[inline]
     fn splat(self, x: u16) -> U16x32 {
         unsafe { _mm512_set1_epi16(x as i16) }.into()
-    }
-
-    #[inline]
-    fn eq(self, x: U16x32, y: U16x32) -> __mmask32 {
-        unsafe { _mm512_cmp_epu16_mask(x.0, y.0, _MM_CMPINT_EQ) }
-    }
-
-    #[inline]
-    fn ge(self, x: U16x32, y: U16x32) -> __mmask32 {
-        unsafe { _mm512_cmp_epu16_mask(x.0, y.0, _MM_CMPINT_NLT) }
-    }
-
-    #[inline]
-    fn gt(self, x: U16x32, y: U16x32) -> __mmask32 {
-        unsafe { _mm512_cmp_epu16_mask(x.0, y.0, _MM_CMPINT_NLE) }
     }
 
     #[inline]
@@ -1001,6 +981,38 @@ unsafe impl NumOps<u16> for Avx512Isa {
     #[inline]
     unsafe fn store_ptr_mask(self, x: U16x32, ptr: *mut u16, mask: __mmask32) {
         unsafe { _mm512_mask_storeu_epi16(ptr as *mut i16, mask, x.0) }
+    }
+}
+
+unsafe impl NumOps<u16> for Avx512Isa {
+    #[inline]
+    fn add(self, x: U16x32, y: U16x32) -> U16x32 {
+        unsafe { _mm512_add_epi16(x.0, y.0) }.into()
+    }
+
+    #[inline]
+    fn sub(self, x: U16x32, y: U16x32) -> U16x32 {
+        unsafe { _mm512_sub_epi16(x.0, y.0) }.into()
+    }
+
+    #[inline]
+    fn mul(self, x: U16x32, y: U16x32) -> U16x32 {
+        unsafe { _mm512_mullo_epi16(x.0, y.0) }.into()
+    }
+
+    #[inline]
+    fn eq(self, x: U16x32, y: U16x32) -> __mmask32 {
+        unsafe { _mm512_cmp_epu16_mask(x.0, y.0, _MM_CMPINT_EQ) }
+    }
+
+    #[inline]
+    fn ge(self, x: U16x32, y: U16x32) -> __mmask32 {
+        unsafe { _mm512_cmp_epu16_mask(x.0, y.0, _MM_CMPINT_NLT) }
+    }
+
+    #[inline]
+    fn gt(self, x: U16x32, y: U16x32) -> __mmask32 {
+        unsafe { _mm512_cmp_epu16_mask(x.0, y.0, _MM_CMPINT_NLE) }
     }
 }
 

--- a/rten-simd/src/iter.rs
+++ b/rten-simd/src/iter.rs
@@ -262,7 +262,7 @@ impl<T: Elem, O: NumOps<T>> std::iter::FusedIterator for IterPad<'_, T, O> {}
 mod tests {
     use super::SimdIterable;
     use crate::dispatch::test_simd_op;
-    use crate::ops::NumOps;
+    use crate::ops::{BitOps, NumOps};
     use crate::{Isa, Simd, SimdOp};
 
     // f32 vector length, chosen to exercise main and tail loops for all ISAs.

--- a/rten-simd/src/lib.rs
+++ b/rten-simd/src/lib.rs
@@ -187,7 +187,7 @@
 //! ```
 //! use std::iter::Sum;
 //! use rten_simd::{Isa, Simd, SimdIterable, SimdOp};
-//! use rten_simd::ops::{GetNumOps, NumOps};
+//! use rten_simd::ops::{BitOps, GetNumOps, NumOps};
 //!
 //! struct SimdSum<'a, T>(&'a [T]);
 //!

--- a/rten-simd/src/ops.rs
+++ b/rten-simd/src/ops.rs
@@ -5,11 +5,14 @@
 //! supported element types which returns the implementation of operations on
 //! SIMD vectors with that element type.
 //!
-//! The [`NumOps`] trait provides operations available on all element types. The
-//! sub-traits [`FloatOps`] and [`SignedIntOps`] provide additional operations
-//! on float and signed integer element types. Additionally there are traits for
-//! individual operations such as [`Extend`] or [`NarrowSaturate`] which are
-//! available on a subset of element types.
+//! The [`BitOps`] trait provides operations available on all element types
+//! which only require treating a value as a sequence of bits (load, store,
+//! splat, bitwise ops, select etc.). The [`NumOps`] sub-trait adds arithmetic
+//! operations (add, subtract, multiply, comparison) which require interpreting
+//! the bits as numbers. The sub-traits [`FloatOps`] and [`SignedIntOps`]
+//! provide additional operations on float and signed integer element types.
+//! Additionally there are traits for individual operations such as [`Extend`]
+//! or [`NarrowSaturate`] which are available on a subset of element types.
 
 use std::mem::MaybeUninit;
 
@@ -117,7 +120,7 @@ pub unsafe trait Isa: Copy {
 ///
 /// ```
 /// use rten_simd::{Isa, SimdIterable, SimdOp};
-/// use rten_simd::ops::{GetNumOps, NumOps};
+/// use rten_simd::ops::{BitOps, GetNumOps, NumOps};
 ///
 /// struct Sum<'a, T>(&'a [T]);
 ///
@@ -169,6 +172,26 @@ impl_get_ops!(GetNumOps, num_ops, NumOps, i32);
 impl_get_ops!(GetNumOps, num_ops, NumOps, i8);
 impl_get_ops!(GetNumOps, num_ops, NumOps, u16);
 impl_get_ops!(GetNumOps, num_ops, NumOps, u8);
+
+/// Get the [`BitOps`] implementation from an [`Isa`] for a given element type.
+///
+/// This is the bit-level counterpart of [`GetNumOps`]. It is implemented for
+/// all element types which support bit-level SIMD operations, which is a
+/// superset of the types that support arithmetic operations.
+pub trait GetBitOps
+where
+    Self: GetSimd + 'static,
+{
+    /// Return the [`BitOps`] implementation from a SIMD [`Isa`] that provides
+    /// operations on vectors containing elements of type `Self`.
+    fn bit_ops<I: Isa>(isa: I) -> impl BitOps<Self, Simd = Self::Simd<I>>;
+}
+impl_get_ops!(GetBitOps, bit_ops, BitOps, f32);
+impl_get_ops!(GetBitOps, bit_ops, BitOps, i16);
+impl_get_ops!(GetBitOps, bit_ops, BitOps, i32);
+impl_get_ops!(GetBitOps, bit_ops, BitOps, i8);
+impl_get_ops!(GetBitOps, bit_ops, BitOps, u16);
+impl_get_ops!(GetBitOps, bit_ops, BitOps, u8);
 
 /// Get the [`Simd`] implementation from an [`Isa`] for a given element type.
 ///
@@ -255,22 +278,28 @@ pub unsafe trait MaskOps<M: Mask>: Copy {
     fn all(self, x: M) -> bool;
 }
 
-/// Operations available on all SIMD vector types.
+/// Bit-level operations available on all SIMD vector types.
 ///
-/// This trait provides core operations available on all SIMD vector types.
+/// This trait provides operations which treat a SIMD vector as a sequence of
+/// bits, without interpreting those bits as numbers of a particular type:
 ///
 /// - Load from and store into memory
 /// - Creating a new vector filled with zeros or a specific value
 /// - Combining elements from two vectors according to a mask
-/// - Add, subtract and multiply
-/// - Comparison (equality, less than, greater than etc.)
+/// - Bitwise operations (and, or, xor, not)
+///
+/// Arithmetic operations which require interpreting the bits as numbers are
+/// provided by the [`NumOps`] sub-trait. Splitting these operations allows
+/// supporting data types for which only bit-level operations are available. For
+/// example many x86 and Arm CPUs support loading, storing and shuffling `f16`
+/// vectors, but not arithmetic on them.
 ///
 /// # Safety
 ///
 /// Implementations must ensure they can only be constructed if the
 /// instruction set is supported on the current system.
 #[allow(clippy::len_without_is_empty)]
-pub unsafe trait NumOps<T: Elem>: Copy {
+pub unsafe trait BitOps<T: Elem>: Copy {
     /// SIMD vector containing lanes of type `T`.
     type Simd: Simd<Elem = T>;
 
@@ -283,31 +312,9 @@ pub unsafe trait NumOps<T: Elem>: Copy {
     /// Return the number of elements in the vector.
     fn len(self) -> usize;
 
-    /// Compute `x + y`.
-    fn add(self, x: Self::Simd, y: Self::Simd) -> Self::Simd;
-
-    /// Compute `x - y`.
-    fn sub(self, x: Self::Simd, y: Self::Simd) -> Self::Simd;
-
-    /// Compute `x * y`.
-    fn mul(self, x: Self::Simd, y: Self::Simd) -> Self::Simd;
-
     /// Create a new vector with all lanes set to zero.
     fn zero(self) -> Self::Simd {
         self.splat(T::default())
-    }
-
-    /// Create a new vector with all lanes set to one.
-    fn one(self) -> Self::Simd {
-        self.splat(T::one())
-    }
-
-    /// Compute `a * b + c`.
-    ///
-    /// This will use fused multiply-add instructions if available. For float
-    /// element types, this may use one or two roundings.
-    fn mul_add(self, a: Self::Simd, b: Self::Simd, c: Self::Simd) -> Self::Simd {
-        self.add(self.mul(a, b), c)
     }
 
     /// Broadcast the element from one lane of a vector to all lanes of a new
@@ -315,55 +322,6 @@ pub unsafe trait NumOps<T: Elem>: Copy {
     fn broadcast_lane<const LANE: i32>(self, x: Self::Simd) -> Self::Simd {
         let val = x.to_array()[LANE as usize];
         self.splat(val)
-    }
-
-    /// Evaluate a polynomial using Horner's method.
-    ///
-    /// Computes `x * coeffs[0] + x^2 * coeffs[1] ... x^n * coeffs[N]`
-    #[inline]
-    fn poly_eval(self, x: Self::Simd, coeffs: &[Self::Simd]) -> Self::Simd {
-        let mut y = coeffs[coeffs.len() - 1];
-        for i in (0..coeffs.len() - 1).rev() {
-            y = self.mul_add(y, x, coeffs[i]);
-        }
-        self.mul(y, x)
-    }
-
-    /// Return a mask indicating whether elements in `x` are less than `y`.
-    #[inline]
-    fn lt(self, x: Self::Simd, y: Self::Simd) -> <Self::Simd as Simd>::Mask {
-        self.gt(y, x)
-    }
-
-    /// Return a mask indicating whether elements in `x` are less or equal to `y`.
-    #[inline]
-    fn le(self, x: Self::Simd, y: Self::Simd) -> <Self::Simd as Simd>::Mask {
-        self.ge(y, x)
-    }
-
-    /// Return a mask indicating whether elements in `x` are equal to `y`.
-    fn eq(self, x: Self::Simd, y: Self::Simd) -> <Self::Simd as Simd>::Mask;
-
-    /// Return a mask indicating whether elements in `x` are greater or equal to `y`.
-    fn ge(self, x: Self::Simd, y: Self::Simd) -> <Self::Simd as Simd>::Mask;
-
-    /// Return a mask indicating whether elements in `x` are greater than `y`.
-    fn gt(self, x: Self::Simd, y: Self::Simd) -> <Self::Simd as Simd>::Mask;
-
-    /// Return the minimum of `x` and `y` for each lane.
-    fn min(self, x: Self::Simd, y: Self::Simd) -> Self::Simd {
-        self.select(x, y, self.le(x, y))
-    }
-
-    /// Return the maximum of `x` and `y` for each lane.
-    fn max(self, x: Self::Simd, y: Self::Simd) -> Self::Simd {
-        self.select(x, y, self.ge(x, y))
-    }
-
-    /// Clamp values in `x` to minimum and maximum values from corresponding
-    /// lanes in `min` and `max`.
-    fn clamp(self, x: Self::Simd, min: Self::Simd, max: Self::Simd) -> Self::Simd {
-        self.min(self.max(x, min), max)
     }
 
     /// Return the bitwise AND of `x` and `y`.
@@ -482,7 +440,7 @@ pub unsafe trait NumOps<T: Elem>: Copy {
 
     /// Store `x` into the first `self.len()` elements of `xs`.
     ///
-    /// This is a variant of [`store`](NumOps::store) which takes an
+    /// This is a variant of [`store`](BitOps::store) which takes an
     /// uninitialized slice as input and returns the initialized portion of the
     /// slice.
     #[inline]
@@ -517,6 +475,91 @@ pub unsafe trait NumOps<T: Elem>: Copy {
     fn prefetch_write(self, ptr: *mut T) {
         // Default implementation does nothing
         let _ = ptr;
+    }
+}
+
+/// Arithmetic operations available on all numeric SIMD vector types.
+///
+/// This trait extends [`BitOps`] with operations which interpret the bits of a
+/// SIMD vector as numbers of type `T`:
+///
+/// - Add, subtract and multiply
+/// - Comparison (equality, less than, greater than etc.)
+///
+/// # Safety
+///
+/// Implementations must ensure they can only be constructed if the
+/// instruction set is supported on the current system.
+pub unsafe trait NumOps<T: Elem>: BitOps<T> {
+    /// Compute `x + y`.
+    fn add(self, x: Self::Simd, y: Self::Simd) -> Self::Simd;
+
+    /// Compute `x - y`.
+    fn sub(self, x: Self::Simd, y: Self::Simd) -> Self::Simd;
+
+    /// Compute `x * y`.
+    fn mul(self, x: Self::Simd, y: Self::Simd) -> Self::Simd;
+
+    /// Create a new vector with all lanes set to one.
+    fn one(self) -> Self::Simd {
+        self.splat(T::one())
+    }
+
+    /// Compute `a * b + c`.
+    ///
+    /// This will use fused multiply-add instructions if available. For float
+    /// element types, this may use one or two roundings.
+    fn mul_add(self, a: Self::Simd, b: Self::Simd, c: Self::Simd) -> Self::Simd {
+        self.add(self.mul(a, b), c)
+    }
+
+    /// Evaluate a polynomial using Horner's method.
+    ///
+    /// Computes `x * coeffs[0] + x^2 * coeffs[1] ... x^n * coeffs[N]`
+    #[inline]
+    fn poly_eval(self, x: Self::Simd, coeffs: &[Self::Simd]) -> Self::Simd {
+        let mut y = coeffs[coeffs.len() - 1];
+        for i in (0..coeffs.len() - 1).rev() {
+            y = self.mul_add(y, x, coeffs[i]);
+        }
+        self.mul(y, x)
+    }
+
+    /// Return a mask indicating whether elements in `x` are less than `y`.
+    #[inline]
+    fn lt(self, x: Self::Simd, y: Self::Simd) -> <Self::Simd as Simd>::Mask {
+        self.gt(y, x)
+    }
+
+    /// Return a mask indicating whether elements in `x` are less or equal to `y`.
+    #[inline]
+    fn le(self, x: Self::Simd, y: Self::Simd) -> <Self::Simd as Simd>::Mask {
+        self.ge(y, x)
+    }
+
+    /// Return a mask indicating whether elements in `x` are equal to `y`.
+    fn eq(self, x: Self::Simd, y: Self::Simd) -> <Self::Simd as Simd>::Mask;
+
+    /// Return a mask indicating whether elements in `x` are greater or equal to `y`.
+    fn ge(self, x: Self::Simd, y: Self::Simd) -> <Self::Simd as Simd>::Mask;
+
+    /// Return a mask indicating whether elements in `x` are greater than `y`.
+    fn gt(self, x: Self::Simd, y: Self::Simd) -> <Self::Simd as Simd>::Mask;
+
+    /// Return the minimum of `x` and `y` for each lane.
+    fn min(self, x: Self::Simd, y: Self::Simd) -> Self::Simd {
+        self.select(x, y, self.le(x, y))
+    }
+
+    /// Return the maximum of `x` and `y` for each lane.
+    fn max(self, x: Self::Simd, y: Self::Simd) -> Self::Simd {
+        self.select(x, y, self.ge(x, y))
+    }
+
+    /// Clamp values in `x` to minimum and maximum values from corresponding
+    /// lanes in `min` and `max`.
+    fn clamp(self, x: Self::Simd, min: Self::Simd, max: Self::Simd) -> Self::Simd {
+        self.min(self.max(x, min), max)
     }
 
     /// Horizontally sum the elements in a vector.
@@ -672,7 +715,7 @@ pub trait NarrowSaturate<T: Elem, U: Elem>: NumOps<T> {
 mod tests {
     use crate::elem::WrappingAdd;
     use crate::ops::{
-        Concat, Extend, FloatOps, IntOps, Interleave, MaskOps, NarrowSaturate, NumOps,
+        BitOps, Concat, Extend, FloatOps, IntOps, Interleave, MaskOps, NarrowSaturate, NumOps,
         SignedIntOps, ToFloat,
     };
     use crate::{Isa, Mask, Simd, SimdOp, assert_simd_eq, assert_simd_ne, test_simd_op};
@@ -682,7 +725,7 @@ mod tests {
         ($modname:ident, $elem:ident, $mask_elem:ident) => {
             mod $modname {
                 use super::{
-                    Isa, MaskOps, NumOps, Simd, SimdOp, WrappingAdd, assert_simd_eq,
+                    BitOps, Isa, MaskOps, NumOps, Simd, SimdOp, WrappingAdd, assert_simd_eq,
                     assert_simd_ne, test_simd_op,
                 };
 
@@ -1008,7 +1051,7 @@ mod tests {
     macro_rules! test_float_ops {
         ($modname:ident, $elem:ident, $int_elem:ident) => {
             mod $modname {
-                use super::{FloatOps, Isa, NumOps, Simd, SimdOp, assert_simd_eq, test_simd_op};
+                use super::{BitOps, FloatOps, Isa, Simd, SimdOp, assert_simd_eq, test_simd_op};
 
                 #[test]
                 fn test_div() {
@@ -1116,7 +1159,7 @@ mod tests {
     macro_rules! test_unsigned_int_ops {
         ($modname:ident, $elem:ident) => {
             mod $modname {
-                use super::{IntOps, Isa, NumOps, Simd, SimdOp, assert_simd_eq, test_simd_op};
+                use super::{BitOps, IntOps, Isa, Simd, SimdOp, assert_simd_eq, test_simd_op};
 
                 #[test]
                 fn test_shift_left() {
@@ -1152,7 +1195,8 @@ mod tests {
         ($modname:ident, $elem:ident) => {
             mod $modname {
                 use super::{
-                    IntOps, Isa, NumOps, SignedIntOps, Simd, SimdOp, assert_simd_eq, test_simd_op,
+                    BitOps, IntOps, Isa, NumOps, SignedIntOps, Simd, SimdOp, assert_simd_eq,
+                    test_simd_op,
                 };
 
                 #[test]

--- a/rten-simd/src/writer.rs
+++ b/rten-simd/src/writer.rs
@@ -46,7 +46,7 @@ impl<'a, T: Elem> SliceWriter<'a, T> {
 mod tests {
     use std::mem::MaybeUninit;
 
-    use crate::ops::NumOps;
+    use crate::ops::BitOps;
     use crate::{Isa, SimdOp, SliceWriter};
 
     #[test]

--- a/rten-vecmath/src/erf.rs
+++ b/rten-vecmath/src/erf.rs
@@ -4,7 +4,7 @@
 
 use std::f32::consts::SQRT_2;
 
-use rten_simd::ops::{FloatOps, NumOps};
+use rten_simd::ops::{BitOps, FloatOps, NumOps};
 use rten_simd::{Isa, SimdUnaryOp};
 
 use crate::exp::ReducedRangeExp;

--- a/rten-vecmath/src/exp.rs
+++ b/rten-vecmath/src/exp.rs
@@ -2,7 +2,7 @@
 
 #![allow(clippy::excessive_precision)]
 
-use rten_simd::ops::{FloatOps, IntOps, NumOps};
+use rten_simd::ops::{BitOps, FloatOps, IntOps, NumOps};
 use rten_simd::{Isa, Simd, SimdUnaryOp};
 
 const INV_LOG2: f32 = std::f32::consts::LOG2_E; // aka. 1 / ln2

--- a/rten-vecmath/src/min_max.rs
+++ b/rten-vecmath/src/min_max.rs
@@ -1,4 +1,4 @@
-use rten_simd::ops::NumOps;
+use rten_simd::ops::{BitOps, NumOps};
 use rten_simd::{Isa, Simd, SimdIterable, SimdOp};
 
 /// Compute the minimum and maximum values in a slice of floats.

--- a/rten-vecmath/src/normalize.rs
+++ b/rten-vecmath/src/normalize.rs
@@ -1,7 +1,7 @@
 use std::mem::MaybeUninit;
 
 use rten_simd::functional::simd_map;
-use rten_simd::ops::NumOps;
+use rten_simd::ops::{BitOps, NumOps};
 use rten_simd::span::SrcDest;
 use rten_simd::{Isa, SimdIterable, SimdOp};
 

--- a/rten-vecmath/src/quantize.rs
+++ b/rten-vecmath/src/quantize.rs
@@ -1,6 +1,6 @@
 use std::mem::MaybeUninit;
 
-use rten_simd::ops::{FloatOps, NarrowSaturate, NumOps};
+use rten_simd::ops::{BitOps, FloatOps, NarrowSaturate, NumOps};
 use rten_simd::{Isa, SimdOp, SliceWriter};
 
 /// Quantize a slice of `f32` elements to 8-bit integers using the formula:
@@ -78,7 +78,7 @@ impl<'d> SimdOp for Quantize<'_, 'd, u8> {
 
 #[cfg(test)]
 mod tests {
-    use rten_simd::ops::NumOps;
+    use rten_simd::ops::BitOps;
     use rten_simd::{Isa, SimdOp};
 
     use super::Quantize;

--- a/rten-vecmath/src/relu.rs
+++ b/rten-vecmath/src/relu.rs
@@ -4,7 +4,7 @@
 //! is just `x.max(0)` which is easy for compilers to auto-vectorize. Variants
 //! such as leaky ReLU however do benefit.
 
-use rten_simd::ops::NumOps;
+use rten_simd::ops::{BitOps, NumOps};
 use rten_simd::{Isa, SimdUnaryOp};
 
 /// Computes the leaky ReLU activation function.

--- a/rten-vecmath/src/sin_cos.rs
+++ b/rten-vecmath/src/sin_cos.rs
@@ -3,7 +3,7 @@
 #![allow(clippy::approx_constant)]
 
 use rten_base::hint::unlikely;
-use rten_simd::ops::{FloatOps, MaskOps, NumOps};
+use rten_simd::ops::{BitOps, FloatOps, MaskOps, NumOps};
 use rten_simd::{Isa, Simd, SimdUnaryOp};
 
 // Values taken from the XNNPACK vsin implementation that was used as a

--- a/rten-vecmath/src/softmax.rs
+++ b/rten-vecmath/src/softmax.rs
@@ -1,7 +1,7 @@
 use std::mem::MaybeUninit;
 
 use rten_simd::functional::{simd_apply, simd_map};
-use rten_simd::ops::{FloatOps, NumOps};
+use rten_simd::ops::{BitOps, FloatOps, NumOps};
 use rten_simd::span::SrcDest;
 use rten_simd::{Isa, Simd, SimdIterable, SimdOp, SimdUnaryOp};
 

--- a/rten-vecmath/src/sum.rs
+++ b/rten-vecmath/src/sum.rs
@@ -1,4 +1,4 @@
-use rten_simd::ops::{FloatOps, NumOps};
+use rten_simd::ops::{BitOps, FloatOps, NumOps};
 use rten_simd::{Isa, Simd, SimdIterable, SimdOp};
 
 /// Computes the sum of a sequence of numbers.

--- a/rten-vecmath/src/tanh.rs
+++ b/rten-vecmath/src/tanh.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::excessive_precision)]
 
-use rten_simd::ops::{FloatOps, NumOps};
+use rten_simd::ops::{BitOps, FloatOps, NumOps};
 use rten_simd::{Isa, SimdUnaryOp};
 
 use crate::Exp;


### PR DESCRIPTION
The `NumOps` trait in rten-simd combined operations which only require treating the lanes of a SIMD vector as a sequence of bits (load, store, splat, select etc.) and those which require specific instructions that understand their meaning (add, sub, comparison etc.). For some data types and architectures, such as f16 on older x86 and Arm CPUs, there are instructions we can use for the first category but not the second. This PR splits the `NumOps` trait into a `BitOps` base trait and `NumOps` sub trait along those lines.

A subsequent PR will add f16 support to rten-simd where f16 vectors support `BitOps` + `Extend<f32>`, which can be implemented efficiently on all x86 CPUs supporting F16C and all Arm v8 CPUs.

Part of https://github.com/robertknight/rten/issues/1344.