### PR TITLE
Optimize f16 to f32 conversion at model load time using native SIMD instructions

### DIFF
--- a/rten-simd/src/ops.rs
+++ b/rten-simd/src/ops.rs
@@ -472,6 +472,43 @@ pub unsafe trait BitOps<T: Elem>: Copy {
         }
     }
 
+    /// Store `N` vectors into consecutive sub-slices of `xs`, returning the
+    /// initialized portion.
+    ///
+    /// This is the batched counterpart of [`store_uninit`](Self::store_uninit),
+    /// storing several vectors after a single length check. The destination is
+    /// uninitialized, as with `store_uninit`, since stores initialize memory.
+    ///
+    /// Panics if `xs.len() < self.len() * N`.
+    #[inline(always)]
+    fn store_many_uninit<const N: usize>(
+        self,
+        vecs: [Self::Simd; N],
+        xs: &mut [MaybeUninit<T>],
+    ) -> &mut [T] {
+        let v_len = self.len();
+        let total = v_len * N;
+
+        // Bounds-check the whole batch up front. The panic message is a static
+        // string with no arguments. A formatted message was observed to spill
+        // its arguments to the stack for the (cold) panic path on each call,
+        // pessimizing tight loops.
+        assert!(
+            xs.len() >= total,
+            "slice length too short for SIMD vector array"
+        );
+        let dest_ptr = xs.as_mut_ptr() as *mut T;
+
+        for (i, vec) in vecs.into_iter().enumerate() {
+            // Safety: `xs` holds at least `total = N * v_len` elements, so the
+            // store of `v_len` elements at offset `i * v_len` (i in `0..N`)
+            // stays in bounds.
+            unsafe { self.store_ptr(vec, dest_ptr.add(i * v_len)) };
+        }
+        // Safety: the loop initialized `total` elements of `xs`.
+        unsafe { std::slice::from_raw_parts_mut(dest_ptr, total) }
+    }
+
     /// Store the values in this vector to a memory location, where the
     /// corresponding mask element is set.
     ///
@@ -791,6 +828,20 @@ mod tests {
                         let xs = ops.load_many::<2>(&src);
                         assert_simd_eq!(xs[0], ops.load(&src));
                         assert_simd_eq!(xs[1], ops.load(&src[ops.len()..]));
+                    })
+                }
+
+                #[test]
+                fn test_store_many_uninit() {
+                    test_simd_op!(isa, {
+                        let ops = isa.$elem();
+
+                        let src: Vec<_> = (0..ops.len() * 2).map(|x| x as $elem).collect();
+                        let xs = ops.load_many::<2>(&src);
+
+                        let mut dest = Vec::with_capacity(src.len());
+                        let init = ops.store_many_uninit(xs, dest.spare_capacity_mut());
+                        assert_eq!(init, &src[..]);
                     })
                 }
 

--- a/rten-simd/src/ops.rs
+++ b/rten-simd/src/ops.rs
@@ -475,9 +475,8 @@ pub unsafe trait BitOps<T: Elem>: Copy {
     /// Store `N` vectors into consecutive sub-slices of `xs`, returning the
     /// initialized portion.
     ///
-    /// This is the batched counterpart of [`store_uninit`](Self::store_uninit),
-    /// storing several vectors after a single length check. The destination is
-    /// uninitialized, as with `store_uninit`, since stores initialize memory.
+    /// This can be faster than [`store_uninit`](Self::store_uninit) when
+    /// storing several vectors as it only performs a single bounds check.
     ///
     /// Panics if `xs.len() < self.len() * N`.
     #[inline(always)]
@@ -489,10 +488,9 @@ pub unsafe trait BitOps<T: Elem>: Copy {
         let v_len = self.len();
         let total = v_len * N;
 
-        // Bounds-check the whole batch up front. The panic message is a static
-        // string with no arguments. A formatted message was observed to spill
-        // its arguments to the stack for the (cold) panic path on each call,
-        // pessimizing tight loops.
+        // Bounds-check the whole batch up front. The panic message is kept
+        // simple with no arguments. Adding arguments was observed to cause
+        // stack writes, slowing down calls to this function in hot loops.
         assert!(
             xs.len() >= total,
             "slice length too short for SIMD vector array"

--- a/rten-simd/src/writer.rs
+++ b/rten-simd/src/writer.rs
@@ -25,6 +25,19 @@ impl<'a, T: Elem> SliceWriter<'a, T> {
         self.n_init += written.len();
     }
 
+    /// Initialize the next `N * ops.len()` elements of the slice from the
+    /// contents of the SIMD vectors `xs`.
+    ///
+    /// This is equivalent to calling [`write_vec`](Self::write_vec) for each
+    /// vector, but performs a single bounds check for the whole batch, which is
+    /// useful when writing several vectors per loop iteration.
+    ///
+    /// Panics if the slice does not have space for `N * ops.len()` elements.
+    pub fn write_vecs<O: BitOps<T>, const N: usize>(&mut self, ops: O, xs: [O::Simd; N]) {
+        let written = ops.store_many_uninit(xs, &mut self.buf[self.n_init..]);
+        self.n_init += written.len();
+    }
+
     /// Initialize the next element of the slice from `x`.
     ///
     /// Panics if the slice does not have space for writing any more elements.

--- a/rten-simd/src/writer.rs
+++ b/rten-simd/src/writer.rs
@@ -1,7 +1,7 @@
 use std::mem::{MaybeUninit, transmute};
 
 use crate::Elem;
-use crate::ops::NumOps;
+use crate::ops::BitOps;
 
 /// Utility for incrementally filling an uninitialized slice, one SIMD vector
 /// at a time.
@@ -20,7 +20,7 @@ impl<'a, T: Elem> SliceWriter<'a, T> {
     /// of SIMD vector `xs`.
     ///
     /// Panics if the slice does not have space for `ops.len()` elements.
-    pub fn write_vec<O: NumOps<T>>(&mut self, ops: O, xs: O::Simd) {
+    pub fn write_vec<O: BitOps<T>>(&mut self, ops: O, xs: O::Simd) {
         let written = ops.store_uninit(xs, &mut self.buf[self.n_init..]);
         self.n_init += written.len();
     }

--- a/rten-vecmath/src/convert.rs
+++ b/rten-vecmath/src/convert.rs
@@ -1,0 +1,191 @@
+use std::mem::MaybeUninit;
+
+use rten_simd::ops::{BitOps, Extend, NarrowSaturate};
+use rten_simd::{Isa, SimdOp, SliceWriter, f16};
+
+/// Convert a slice of `f16` values to `f32`.
+pub struct F16ToF32<'s, 'd> {
+    src: &'s [f16],
+    dest: &'d mut [MaybeUninit<f32>],
+}
+
+impl<'s, 'd> F16ToF32<'s, 'd> {
+    /// Create a conversion operation which reads from `src` and writes the
+    /// converted values to `dest`.
+    ///
+    /// Panics if `src` and `dest` have different lengths.
+    pub fn new(src: &'s [f16], dest: &'d mut [MaybeUninit<f32>]) -> Self {
+        assert_eq!(src.len(), dest.len());
+        F16ToF32 { src, dest }
+    }
+}
+
+impl<'d> SimdOp for F16ToF32<'_, 'd> {
+    type Output = &'d mut [f32];
+
+    #[inline(always)]
+    fn eval<I: Isa>(self, isa: I) -> Self::Output {
+        let f16_ops = isa.f16();
+        let f32_ops = isa.f32();
+        let f16_v_len = f16_ops.len();
+
+        let mut dest_writer = SliceWriter::new(self.dest);
+
+        // Main loop, unrolled by two.
+        let mut chunks = self.src.chunks_exact(f16_v_len * 2);
+        for chunk in chunks.by_ref() {
+            let xs = f16_ops.load_many::<2>(chunk);
+            let (lo0, hi0) = f16_ops.extend(xs[0]);
+            let (lo1, hi1) = f16_ops.extend(xs[1]);
+            // Store all four f32 vectors with a single bounds check.
+            dest_writer.write_vecs(f32_ops, [lo0, hi0, lo1, hi1]);
+        }
+
+        // Convert a remaining whole `f16` vector, if any.
+        let mut chunks = chunks.remainder().chunks_exact(f16_v_len);
+        for chunk in chunks.by_ref() {
+            let x = f16_ops.load(chunk);
+            let (low, high) = f16_ops.extend(x);
+            dest_writer.write_vec(f32_ops, low);
+            dest_writer.write_vec(f32_ops, high);
+        }
+
+        // Convert tail elements which don't fill a whole vector.
+        for &x in chunks.remainder() {
+            dest_writer.write_scalar(x.to_f32());
+        }
+
+        dest_writer.into_mut_slice()
+    }
+}
+
+/// Convert a slice of `f32` values to `f16`.
+///
+/// Values are rounded to the nearest `f16`, with ties to even. Values whose
+/// magnitude exceeds the `f16` range are rounded to infinity.
+pub struct F32ToF16<'s, 'd> {
+    src: &'s [f32],
+    dest: &'d mut [MaybeUninit<f16>],
+}
+
+impl<'s, 'd> F32ToF16<'s, 'd> {
+    /// Create a conversion operation which reads from `src` and writes the
+    /// converted values to `dest`.
+    ///
+    /// Panics if `src` and `dest` have different lengths.
+    pub fn new(src: &'s [f32], dest: &'d mut [MaybeUninit<f16>]) -> Self {
+        assert_eq!(src.len(), dest.len());
+        F32ToF16 { src, dest }
+    }
+}
+
+impl<'d> SimdOp for F32ToF16<'_, 'd> {
+    type Output = &'d mut [f16];
+
+    #[inline(always)]
+    fn eval<I: Isa>(self, isa: I) -> Self::Output {
+        let f32_ops = isa.f32();
+        let f16_ops = isa.f16();
+        let f32_v_len = f32_ops.len();
+
+        let mut src_chunks = self.src.chunks_exact(f32_v_len * 2);
+        let mut dest_writer = SliceWriter::new(self.dest);
+
+        for src_chunk in src_chunks.by_ref() {
+            let xs = f32_ops.load_many::<2>(src_chunk);
+            let half = f32_ops.narrow_saturate(xs[0], xs[1]);
+            dest_writer.write_vec(f16_ops, half);
+        }
+
+        for &x in src_chunks.remainder() {
+            dest_writer.write_scalar(f16::from_f32(x));
+        }
+
+        dest_writer.into_mut_slice()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rten_simd::ops::BitOps;
+    use rten_simd::{Isa, SimdOp, f16};
+
+    use super::{F16ToF32, F32ToF16};
+
+    /// Return the number of `f16` lanes in a SIMD vector.
+    fn f16_vec_len() -> usize {
+        struct F16VecLen {}
+        impl SimdOp for F16VecLen {
+            type Output = usize;
+            fn eval<I: Isa>(self, isa: I) -> usize {
+                isa.f16().len()
+            }
+        }
+        F16VecLen {}.dispatch()
+    }
+
+    #[test]
+    fn test_f16_to_f32() {
+        // Length chosen to exercise all three code paths: the main loop
+        // (unrolled by two, so it needs at least two whole vectors), the
+        // single-vector cleanup loop, and the scalar tail.
+        let len = f16_vec_len() * 3 + 1;
+        let src: Vec<f16> = (0..len)
+            .map(|i| f16::from_f32(i as f32 * 0.5 - 3.0))
+            .collect();
+        let expected: Vec<f32> = src.iter().map(|x| x.to_f32()).collect();
+
+        let mut buf = Vec::with_capacity(src.len());
+        let actual = F16ToF32::new(&src, buf.spare_capacity_mut()).dispatch();
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_f16_to_f32_empty() {
+        let src: Vec<f16> = Vec::new();
+        let mut buf: Vec<f32> = Vec::new();
+        let actual = F16ToF32::new(&src, buf.spare_capacity_mut()).dispatch();
+        assert!(actual.is_empty());
+    }
+
+    #[test]
+    fn test_f32_to_f16() {
+        // Length larger than the max `f16` vector width, and not an exact
+        // multiple, so we exercise both the vectorized body and the scalar
+        // tail.
+        let len = f16_vec_len() + 1;
+        let src: Vec<f32> = (0..len).map(|i| i as f32 * 0.5 - 3.0).collect();
+        let expected: Vec<f16> = src.iter().map(|&x| f16::from_f32(x)).collect();
+
+        let mut buf = Vec::with_capacity(src.len());
+        let actual = F32ToF16::new(&src, buf.spare_capacity_mut()).dispatch();
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_f32_to_f16_empty() {
+        let src: Vec<f32> = Vec::new();
+        let mut buf: Vec<f16> = Vec::new();
+        let actual = F32ToF16::new(&src, buf.spare_capacity_mut()).dispatch();
+        assert!(actual.is_empty());
+    }
+
+    // Round-trip f32 -> f16 -> f32 for values exactly representable in f16.
+    #[test]
+    fn test_roundtrip() {
+        let len = f16_vec_len() * 2 + 3;
+        let src: Vec<f32> = (0..len).map(|i| i as f32 * 0.25 - 5.0).collect();
+
+        let mut half_buf = Vec::with_capacity(len);
+        let half = F32ToF16::new(&src, half_buf.spare_capacity_mut()).dispatch();
+        let half: Vec<f16> = half.to_vec();
+
+        let mut back_buf = Vec::with_capacity(len);
+        let back = F16ToF32::new(&half, back_buf.spare_capacity_mut()).dispatch();
+
+        let expected: Vec<f32> = src.iter().map(|&x| f16::from_f32(x).to_f32()).collect();
+        assert_eq!(back, expected);
+    }
+}

--- a/rten-vecmath/src/lib.rs
+++ b/rten-vecmath/src/lib.rs
@@ -94,6 +94,7 @@
 //! let sum = Sum::new(&data).dispatch();
 //! ```
 
+mod convert;
 mod erf;
 mod exp;
 mod min_max;
@@ -126,6 +127,9 @@ pub use min_max::{MaxNum, MinMax, MinNum};
 pub use normalize::{Normalize, NormalizeOptions};
 pub use softmax::Softmax;
 pub use sum::{Sum, SumAbs, SumSquare, SumSquareSub};
+
+// Conversion functions.
+pub use convert::{F16ToF32, F32ToF16};
 
 // Utilities
 pub use extend_init::ExtendInit;

--- a/src/model/onnx_loader.rs
+++ b/src/model/onnx_loader.rs
@@ -1,11 +1,13 @@
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fs::File;
 use std::path::Path;
 
 use rten_base::byte_cast::{FromByteArray, cast_slice};
 use rten_onnx::onnx;
-use rten_simd::float16::f16_to_f32;
+use rten_simd::{SimdOp, f16};
 use rten_tensor::{ArcTensor, Storage, Tensor};
+use rten_vecmath::{ExtendInit, F16ToF32};
 
 use super::external_data::{DataLoader, DataLocation, DataSlice};
 use super::load_error::{LoadError, LoadErrorImpl, load_error};
@@ -502,18 +504,13 @@ fn load_constant(
             )?
         }
 
-        Some(onnx::DataType::FLOAT16) => {
-            let f16_bytes_to_f32 = |bytes: [u8; 2]| f16_to_f32(u16::from_le_bytes(bytes));
-            convert_constant(
-                name,
-                &shape,
-                raw_data.as_deref(),
-                external_data,
-                &initializer.int32_data,
-                |x| f16_to_f32(x as u16),
-                f16_bytes_to_f32,
-            )?
-        }
+        Some(onnx::DataType::FLOAT16) => convert_f16_constant(
+            name,
+            &shape,
+            raw_data.as_deref(),
+            external_data,
+            &initializer.int32_data,
+        )?,
 
         Some(dtype) => {
             return Err(load_error!(
@@ -644,6 +641,56 @@ where
     } else {
         typed_data.iter().copied().map(convert).collect()
     };
+    let tensor = tensor_from_elements(shape, data, name)?;
+    Ok(Constant::new(name, tensor))
+}
+
+/// View a little-endian byte buffer as a slice of `f16` values without copying.
+///
+/// Returns `None` if the bytes are not `u16`-aligned, have a length that is not
+/// a multiple of 2, or the host is big-endian.
+fn f16_slice_from_le_bytes(bytes: &[u8]) -> Option<&[f16]> {
+    if cfg!(target_endian = "big") {
+        // The reinterpret assumes the bytes are little-endian `f16` bit patterns.
+        return None;
+    }
+    // `cast_slice` checks alignment and length. `f16` is not `FromByteArray`
+    // (it lives in another crate), so cast to `u16` first.
+    let u16s: &[u16] = cast_slice(bytes)?;
+    // Safety: `f16` is `repr(transparent)` over `u16`, so `&[u16]` and `&[f16]`
+    // have identical layout and alignment.
+    Some(unsafe { std::slice::from_raw_parts(u16s.as_ptr() as *const f16, u16s.len()) })
+}
+
+/// Load an f16 constant, converting the elements to f32.
+fn convert_f16_constant(
+    name: Option<&str>,
+    shape: &[usize],
+    raw_data: Option<&[u8]>,
+    external_data: Option<DataSlice>,
+    int32_data: &[i32],
+) -> Result<Constant, LoadError> {
+    let ext_bytes = external_data.as_ref().map(|data| data.data());
+
+    // Obtain the f16 values. Byte buffers are reinterpreted in place, which
+    // requires them to be 2-byte aligned.
+    let f16s: Cow<[f16]> = if let Some(bytes) = raw_data.or(ext_bytes) {
+        let halfs = f16_slice_from_le_bytes(bytes).ok_or_else(|| {
+            load_error!(GraphError, name, "f16 tensor data is not 2-byte aligned")
+        })?;
+        Cow::Borrowed(halfs)
+    } else {
+        int32_data
+            .iter()
+            .map(|&x| f16::from_bits(x as u16))
+            .collect()
+    };
+
+    // Convert f16 -> f32 using SIMD.
+    let n = f16s.len();
+    let mut data: Vec<f32> = Vec::with_capacity(n);
+    data.extend_init(|spare_capacity| F16ToF32::new(&f16s, &mut spare_capacity[..n]).dispatch());
+
     let tensor = tensor_from_elements(shape, data, name)?;
     Ok(Constant::new(name, tensor))
 }
@@ -1318,8 +1365,10 @@ mod tests {
 
         let i64_tensor = external_tensor("i64_tensor", onnx::DataType::INT64, 8, 8);
         let f32_tensor = external_tensor("f32_tensor", onnx::DataType::FLOAT, 16, 4);
-        let bool_tensor = external_tensor("bool_tensor", onnx::DataType::BOOL, 20, 1);
-        let f16_tensor = external_tensor("f16_tensor", onnx::DataType::FLOAT16, 21, 2);
+        // The f16 data must be 2-byte aligned, so place it at an even offset
+        // ahead of the single-byte bool.
+        let f16_tensor = external_tensor("f16_tensor", onnx::DataType::FLOAT16, 20, 2);
+        let bool_tensor = external_tensor("bool_tensor", onnx::DataType::BOOL, 22, 1);
         let f64_tensor = external_tensor("f64_tensor", onnx::DataType::DOUBLE, 23, 8);
 
         let model_proto = onnx::GraphProto::default()
@@ -1331,12 +1380,12 @@ mod tests {
             .into_model();
 
         let mut buf = Vec::new();
-        buf.extend(0i64.to_le_bytes());
-        buf.extend(1i64.to_le_bytes());
-        buf.extend((3.14f32).to_le_bytes());
-        buf.push(1u8);
-        buf.extend([0x00, 0x3C]); // 1.0 in f16
-        buf.extend((1.23f64).to_le_bytes());
+        buf.extend(0i64.to_le_bytes()); // offset 0
+        buf.extend(1i64.to_le_bytes()); // offset 8
+        buf.extend((3.14f32).to_le_bytes()); // offset 16
+        buf.extend([0x00, 0x3C]); // offset 20: 1.0 in f16
+        buf.push(1u8); // offset 22: bool
+        buf.extend((1.23f64).to_le_bytes()); // offset 23
         let loader = MemLoader::from_entries([("test.onnx.data".to_string(), buf)]);
 
         let model = load_model(model_proto, Some(&loader)).unwrap();


### PR DESCRIPTION
Building on the f16 support added to rten-simd in https://github.com/robertknight/rten/pull/1350, add vectorized operations for f16 <-> f32 conversion in rten-vecmath and use these when loading ONNX models to up-convert f16 weights to f32. New functionality has been added to rten-simd for storing multiple SIMD vectors to a slice at once, amortizing bounds checking overhead.

One assumption I have made to save an unnecessary copy is that the `u8` byte vectors / slices created by loading data from the `TensorProto.raw_data` field in ONNX protobufs or external data files will in practice always have an alignment that allows for a transmuting to `[u16]`. The code does a checked transmute for safety, but if it fails, the model will simply fail to load rather than falling back to a copy.

Tested with a ~400MB fp16 transformer model this reduced load times as reported by `rten -n 0 model.onnx` from ~220ms to ~120ms on an M3 Pro (~29ms reading f16 weights, ~84ms converting to f32, ~8ms freeing memory). This could be improved in future by fusing the read from disk/file cache and widening. Of course, if f16 was supported directly, the conversion would not be needed at all.

Fixes https://github.com/robertknight/rten/issues/1344.