### PR TITLE
Match `x * 1/sqrt(2)` as Erf argument in Gelu fusion

### DIFF
--- a/src/optimize/fusions.rs
+++ b/src/optimize/fusions.rs
@@ -415,7 +415,9 @@ impl PatternFusion for GeluFusion {
 
     fn pattern(&self) -> Pattern {
         let x = Pattern::symbol("x");
-        x.clone() * (Pattern::unary_op("Erf", x.clone() / (2.0f32).sqrt()) + 1.0) * 0.5
+        let sqrt_2 = (2.0f32).sqrt();
+        let x_scaled = Pattern::any_of([x.clone() / sqrt_2, x.clone() * (1. / sqrt_2)].into());
+        x.clone() * (Pattern::unary_op("Erf", x_scaled) + 1.0) * 0.5
     }
 
     fn inputs(&self) -> &[&str] {

--- a/src/optimize/tests.rs
+++ b/src/optimize/tests.rs
@@ -539,6 +539,10 @@ fn test_fuse_gelu() {
         Case {
             build: |x| x.clone() * ((x / (2.0f32).sqrt()).erf() + 1.0) * 0.5,
         },
+        // Erf argument expressed as `x * 1/sqrt(2)` instead of `x / sqrt(2)`
+        Case {
+            build: |x| x.clone() * ((x * 1. / (2.0f32).sqrt()).erf() + 1.0) * 0.5,
+        },
         // Scale-first form: `(x * 0.5) * (1 + erf(x / sqrt(2)))`
         Case {
             build: |x| x.clone() * 0.5 * ((x / (2.0f32).sqrt()).erf() + 1.0),


### PR DESCRIPTION
Allow the argument to `Erf` to be expressed as `x * 1/sqrt(2)` in the Gelu fusion. This version was encountered in a tf2onnx-generated model.  Tested with a model from https://huggingface.co/ch8693327/wd-v1-4-convnextv2-tagger-v2.