### PR TITLE
Add vectorized LogSoftmax kernel

### DIFF
--- a/rten-vecmath/src/lib.rs
+++ b/rten-vecmath/src/lib.rs
@@ -125,7 +125,7 @@ pub use tanh::Tanh;
 // Normalization and reduction functions.
 pub use min_max::{MaxNum, MinMax, MinNum};
 pub use normalize::{Normalize, NormalizeOptions};
-pub use softmax::Softmax;
+pub use softmax::{LogSoftmax, Softmax};
 pub use sum::{Sum, SumAbs, SumSquare, SumSquareSub};
 
 // Conversion functions.

--- a/rten-vecmath/src/softmax.rs
+++ b/rten-vecmath/src/softmax.rs
@@ -65,17 +65,7 @@ impl<'dst> SimdOp for Softmax<'_, 'dst> {
     fn eval<I: Isa>(self, isa: I) -> Self::Output {
         let ops = isa.f32();
 
-        let max_val = self.src_dest.src().simd_iter(ops).fold_unroll::<4>(
-            ops.splat(f32::MIN),
-            #[inline(always)]
-            |max, x| ops.max(max, x),
-            #[inline(always)]
-            |max, x| ops.max(max, x),
-        );
-        let max_val = max_val
-            .to_array()
-            .into_iter()
-            .fold(f32::MIN, |max, x| max.max(x));
+        let max_val = max(ops, self.src_dest.src());
 
         // Compute `y = exp(x - max(x))` and `sum(y)`.
         let (dest, exp_sum) = exp_sum_minus_max(isa, self.src_dest, max_val);
@@ -108,6 +98,95 @@ impl<'dst> SimdOp for Softmax<'_, 'dst> {
 
         dest
     }
+}
+
+/// Computes the log softmax function over a slice of floats.
+///
+/// This is conceptually `log(softmax(x))` which can be rewritten as
+/// `log(exp(x) / sum(exp(x)))`.
+pub struct LogSoftmax<'src, 'dst> {
+    src_dest: SrcDest<'src, 'dst, f32>,
+}
+
+impl<'src, 'dst> LogSoftmax<'src, 'dst> {
+    /// Construct a log softmax operation which reads `input` and writes to
+    /// `output`.
+    pub fn new(input: &'src [f32], output: &'dst mut [MaybeUninit<f32>]) -> Self {
+        LogSoftmax {
+            src_dest: (input, output).into(),
+        }
+    }
+
+    /// Construct a log softmax operation which updates `input` in place.
+    pub fn new_mut(input: &'dst mut [f32]) -> Self
+    where
+        'dst: 'src,
+    {
+        LogSoftmax {
+            src_dest: input.into(),
+        }
+    }
+}
+
+impl<'dst> SimdOp for LogSoftmax<'_, 'dst> {
+    /// The normalized elements.
+    type Output = &'dst mut [f32];
+
+    #[inline(always)]
+    fn eval<I: Isa>(self, isa: I) -> Self::Output {
+        let ops = isa.f32();
+
+        // The maximum is subtracted from the input for numerical stability.
+        // Log identities are used to simplify the result:
+        //
+        // log(exp(xi - xmax) / sum(exp(x - xmax)))
+        //  = log(exp(xi - xmax)) - log(sum(exp(x - xmax)))
+        //  = xi - xmax - log(sum(exp(x - xmax)))
+        let max_val = max(ops, self.src_dest.src());
+
+        // Compute `sum(exp(x - max(x)))`.
+        let max_vec = ops.splat(max_val);
+        let exp_sum = self.src_dest.src().simd_iter(ops).fold(
+            ops.zero(),
+            #[inline(always)]
+            |exp_sum, x| {
+                // Use faster `exp(x)` since input is known to be <= 0.
+                let y = ReducedRangeExp::apply(isa, ops.sub(x, max_vec));
+                ops.add(exp_sum, y)
+            },
+        );
+        let exp_sum: f32 = exp_sum.to_array().into_iter().sum();
+
+        // Compute `y = (x - x_max) - log(exp_sum)`.
+        //
+        // We use two separate subtractions inside the loop instead of computing
+        // `x_max + log(exp_sum)` once and then using a single subtraction. This
+        // reduces rounding error when `|x_max|` is large and `log(exp_sum)` is
+        // small.
+        let log_exp_sum = ops.splat(exp_sum.ln());
+        simd_map(
+            ops,
+            self.src_dest,
+            #[inline(always)]
+            |x| ops.sub(ops.sub(x, max_vec), log_exp_sum),
+        )
+    }
+}
+
+/// Returns the maximum value in `xs`, or [`f32::MIN`] if `xs` is empty.
+#[inline(always)]
+fn max<O: FloatOps<f32>>(ops: O, xs: &[f32]) -> f32 {
+    let max_val = xs.simd_iter(ops).fold_unroll::<4>(
+        ops.splat(f32::MIN),
+        #[inline(always)]
+        |max, x| ops.max(max, x),
+        #[inline(always)]
+        |max, x| ops.max(max, x),
+    );
+    max_val
+        .to_array()
+        .into_iter()
+        .fold(f32::MIN, |max, x| max.max(x))
 }
 
 /// Computes `y = exp(x - max(x))` and `sum(y)` in a single pass.
@@ -152,8 +231,19 @@ fn exp_sum_minus_max<'dst, I: Isa>(
 mod tests {
     use rten_simd::SimdOp;
 
-    use super::Softmax;
+    use super::{LogSoftmax, Softmax};
     use crate::testing::{AsUninit, benchmark_op, check_f32s_are_equal_ulps, triples};
+
+    fn reference_log_softmax(xs: &[f32], ys: &mut [f32]) {
+        let max = xs.iter().copied().fold(f32::MIN, |max, x| max.max(x));
+        let log_exp_sum = xs
+            .iter()
+            .fold(0., |exp_sum: f32, x| exp_sum + (x - max).exp())
+            .ln();
+        for (x, y) in xs.iter().zip(ys.iter_mut()) {
+            *y = (*x - max) - log_exp_sum;
+        }
+    }
 
     fn reference_softmax(xs: &[f32], ys: &mut [f32]) {
         let max = xs.iter().copied().fold(f32::MIN, |max, x| max.max(x));
@@ -208,10 +298,59 @@ mod tests {
     }
 
     #[test]
+    fn test_log_softmax() {
+        // Test against reference implementation for various lengths.
+        for len in 1..20 {
+            let input: Vec<f32> = (0..len).map(|x| x as f32 + 0.1).collect();
+            let mut expected = vec![0.; input.len()];
+            reference_log_softmax(&input, &mut expected);
+
+            let mut actual = vec![0.; input.len()];
+            LogSoftmax::new(&input, actual.as_mut_slice().as_uninit()).dispatch();
+
+            check_f32s_are_equal_ulps(triples(&input, &actual, &expected), 3. /* max ULPs */);
+        }
+    }
+
+    #[test]
+    fn test_log_softmax_in_place() {
+        let input: Vec<f32> = (0..32).map(|x| x as f32 * 0.5 - 8.).collect();
+        let mut expected = vec![0.; input.len()];
+        reference_log_softmax(&input, &mut expected);
+
+        let mut actual = input.clone();
+        LogSoftmax::new_mut(&mut actual).dispatch();
+
+        check_f32s_are_equal_ulps(triples(&input, &actual, &expected), 3. /* max ULPs */);
+    }
+
+    #[test]
+    fn test_log_softmax_sums_to_one() {
+        // `exp(log_softmax(x))` is a probability distribution, so it must sum
+        // to one regardless of the input scale.
+        for scale in [1e-3, 1., 10., 100.] {
+            let input: Vec<f32> = (0..64).map(|x| (x as f32 - 32.) * scale).collect();
+            let mut actual = input.clone();
+            LogSoftmax::new_mut(&mut actual).dispatch();
+
+            let sum: f32 = actual.iter().map(|x| x.exp()).sum();
+            assert!((sum - 1.).abs() < 1e-4, "scale {scale} sum {sum}");
+        }
+    }
+
+    #[test]
     #[ignore]
     fn bench_softmax() {
         benchmark_op(reference_softmax, |src, dest| {
             Softmax::new(src, dest).dispatch();
+        });
+    }
+
+    #[test]
+    #[ignore]
+    fn bench_log_softmax() {
+        benchmark_op(reference_log_softmax, |src, dest| {
+            LogSoftmax::new(src, dest).dispatch();
         });
     }
 }

--- a/src/ops/norm.rs
+++ b/src/ops/norm.rs
@@ -15,7 +15,6 @@ use crate::operator::{
     OutputTypeList, OutputTypesContext, check_eq,
 };
 use crate::ops::resolve_axis;
-use crate::slice_reductions::slice_max;
 
 /// Specifies how to normalize the mean and variance.
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -657,28 +656,7 @@ fn normalize_lanes<T: Clone + Send, F: Fn(&mut [T]) + Send + Sync>(
 
 pub fn log_softmax_in_place(output: &mut Tensor, axis: isize) -> Result<(), OpError> {
     normalize_lanes(output, axis, |lane| {
-        // This operator computes:
-        //
-        //   log(exp(xi) / sum(exp(x)))
-        //
-        // Improve numerical stability by first subtracting max value, as we do
-        // for the softmax op:
-        //
-        //   log(exp(xi - xmax) / sum(exp(x - xmax)))
-        //
-        // Then using log identities to simplify:
-        //
-        //   = log(exp(xi - xmax)) - log(sum(exp(x - xmax)))
-        //   = xi - xmax - log(sum(exp(x - xmax)))
-
-        let max_val = slice_max(lane);
-        let log_exp_sum = lane
-            .iter()
-            .fold(0., |exp_sum, x| exp_sum + (x - max_val).exp())
-            .ln();
-        for el in lane.iter_mut() {
-            *el = (*el - max_val) - log_exp_sum
-        }
+        vecmath::LogSoftmax::new_mut(lane).dispatch();
     })
 }
 

--- a/src/slice_reductions.rs
+++ b/src/slice_reductions.rs
@@ -10,8 +10,6 @@
 //!
 //! - <https://blog.zachbjornson.com/2019/08/11/fast-float-summation.html>
 
-use rten_base::num::MinMax;
-
 /// Fold the contents of a slice under the assumption that the fold operation
 /// is associative.
 ///
@@ -41,11 +39,6 @@ pub fn slice_fold_assoc<T: Copy, F: Fn(T, T) -> T>(xs: &[T], init: T, f: F) -> T
     tail.iter().copied().fold(acc, &f)
 }
 
-/// Return the maximum of a slice of numbers.
-pub fn slice_max<T: Copy + MinMax>(xs: &[T]) -> T {
-    slice_fold_assoc(xs, T::min_val(), |acc, x| acc.max(x))
-}
-
 /// Return the sum of a slice of numbers.
 pub fn slice_sum<T: Copy + Default + std::ops::Add<Output = T>>(xs: &[T]) -> T {
     slice_fold_assoc(xs, T::default(), |acc, x| acc + x)
@@ -56,18 +49,7 @@ mod tests {
     use rten_tensor::rng::XorShiftRng;
     use rten_tensor::test_util::ApproxEq;
 
-    use super::{slice_max, slice_sum};
-
-    #[test]
-    fn test_slice_max() {
-        let mut rng = XorShiftRng::new(1234);
-        let xs: Vec<_> = std::iter::from_fn(|| Some(rng.next_f32()))
-            .take(256)
-            .collect();
-        let expected = xs.iter().fold(f32::NEG_INFINITY, |x, y| x.max(*y));
-        let actual = slice_max(&xs);
-        assert_eq!(actual, expected);
-    }
+    use super::slice_sum;
 
     #[test]
     fn test_slice_sum() {


### PR DESCRIPTION
Replace the scalar loop used by the LogSoftmax operator with a vectorized kernel. The `bench_log_softmax` microbenchmark shows ~3.2x improvement vs the previous implementation.