### PR TITLE
Fix panic in int8 GEMV if LHS is not 4-byte aligned

### DIFF
--- a/rten-gemm/src/kernels/simd_generic.rs
+++ b/rten-gemm/src/kernels/simd_generic.rs
@@ -809,9 +809,6 @@ pub fn simd_int8_gemv<I: Isa, const CAST_B_U8: bool>(
         b.cols()
     );
 
-    // Inner loop loads 4x u8 values at a time as an i32.
-    assert_eq!(a.as_ptr() as usize % align_of::<i32>(), 0);
-
     if b.row_stride() == 1 {
         // Safety: Input and output dimensions are compatible.
         unsafe {
@@ -859,7 +856,7 @@ pub fn simd_int8_gemv<I: Isa, const CAST_B_U8: bool>(
         let mut k = 0;
         while k + 4 <= depth {
             // Broadcast 4 values from A.
-            let a_block = unsafe { *(a_ptr.add(k) as *const i32) };
+            let a_block = unsafe { (a_ptr.add(k) as *const i32).read_unaligned() };
             let a = ops.splat(a_block).reinterpret_cast::<I::I8>();
 
             // Load 4 rows of int8 elements from B and interleave to give 4


### PR DESCRIPTION
When testing a quantized model [^1] I encountered a panic in a MatMulInteger where the LHS input passed to rten_gemm had a data pointer that was not 4-byte aligned, causing a precondition assert to fail. Fix this by relaxing the alignment constraint using `read_unaligned`.

In the test model the `MatMulInteger` input operands had shape `[1, 16, 1, 1]` and `[1, 16, 1, 64]`. Although the LHS input as a whole had at least 16-byte alignment (the system allocator's minimum), individual batch items did not.

[^1]: https://huggingface.co/baby2008/nllb-200-distilled-1.3B-onnx/blob/main/encoder_model_quantized.onnx