### PR TITLE
Prevent optimizer removing values captured by subgraphs

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -300,6 +300,22 @@ impl Graph {
         &self.captures
     }
 
+    /// Return the IDs of value nodes in this graph that are captured by name
+    /// by a nested subgraph (eg. the body of an `If` or `Loop` operator).
+    pub(crate) fn subgraph_capture_value_ids(&self) -> FxHashSet<NodeId> {
+        let mut ids = FxHashSet::default();
+        for node in self.nodes.values() {
+            if let Node::Operator(op) = node {
+                for name in op.capture_names() {
+                    if let Some(id) = self.get_node_id(name) {
+                        ids.insert(id);
+                    }
+                }
+            }
+        }
+        ids
+    }
+
     /// Remove nodes from the graph.
     ///
     /// This method accepts a list of node IDs as it is more efficient to

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -126,6 +126,8 @@ impl GraphMutator {
 
         let mut ops_pending_removal = FxHashSet::default();
 
+        let captured_values = self.graph.subgraph_capture_value_ids();
+
         // Get all operators, in the order they will be run.
         let Ok(mut operators) = self.graph.execution_plan(
             self.graph.input_ids(),
@@ -210,6 +212,28 @@ impl GraphMutator {
                                 "skipping {} fusion because output is reused by {}",
                                 fusion.name(),
                                 consumer_name
+                            ),
+                        );
+                    }
+                    return None;
+                }
+
+                // Skip fusion if it would remove a value captured by a subgraph.
+                //
+                // Ideally we would replace references to the value in the
+                // subgraph instead of skipping the fusion.
+                // See https://github.com/robertknight/rten/issues/1359.
+                if let Some(captured) =
+                    find_operator_output_captured_by_subgraph(&self.graph, &captured_values, &unfused_ops, &fusion)
+                {
+                    if diag.enabled(DiagnosticLevel::Warn) {
+                        diag.warn(
+                            &self.graph,
+                            op_node_id,
+                            std::format_args!(
+                                "skipping {} fusion because output \"{}\" is captured by a subgraph",
+                                fusion.name(),
+                                self.graph.node_name(captured)
                             ),
                         );
                     }
@@ -335,6 +359,36 @@ struct ConsumerInfo {
     #[expect(unused)]
     output: NodeId,
     consumer: ConsumerKind,
+}
+
+/// Check for an operator output ID that would be removed by a fusion and is
+/// captured by a subgraph.
+fn find_operator_output_captured_by_subgraph(
+    graph: &Graph,
+    captured_values: &FxHashSet<NodeId>,
+    unfused_ops: &[NodeId],
+    fusion: &Fusion,
+) -> Option<NodeId> {
+    if captured_values.is_empty() {
+        return None;
+    }
+
+    let preserved: &[Option<NodeId>] = match fusion {
+        Fusion::Op(op) => &op.output_ids,
+        Fusion::Identity { .. } | Fusion::Constant { .. } => &[],
+    };
+
+    for &op_id in unfused_ops {
+        let Some(op) = graph.get_node(op_id).and_then(|n| n.as_operator()) else {
+            continue;
+        };
+        for &output in op.output_ids().iter().flatten() {
+            if captured_values.contains(&output) && !preserved.contains(&Some(output)) {
+                return Some(output);
+            }
+        }
+    }
+    None
 }
 
 /// Find an operator output in a subgraph which is used outside the subgraph,

--- a/src/optimize/tests.rs
+++ b/src/optimize/tests.rs
@@ -16,9 +16,9 @@ use crate::graph::{
 use crate::infer_shapes::InferShapeOptions;
 use crate::ops::{
     Add, Cast, ComputeShape, Conv, DynamicQuantizeLinear, Erf, Expand, FusedMatMul, Gather, Gelu,
-    GroupedQueryAttentionMatMul, Identity, IsNaN, LayerNormalization, MatMul, MatMulInteger, Neg,
-    Padding, Pow, RMSNormalization, ReduceMean, RepeatInterleave, Reshape, Shape, Sigmoid, Slice,
-    Softmax, Sqrt, Swish, Tanh, Transpose, Unsqueeze, Where,
+    GroupedQueryAttentionMatMul, Identity, If, IsNaN, LayerNormalization, MatMul, MatMulInteger,
+    Neg, Padding, Pow, RMSNormalization, ReduceMean, RepeatInterleave, Reshape, Shape, Sigmoid,
+    Slice, Softmax, Sqrt, Swish, Tanh, Transpose, Unsqueeze, Where,
 };
 use crate::value::{DataType, Value, ValueType};
 
@@ -885,6 +885,54 @@ fn test_eliminate_noop_cast() {
         graph.get_consuming_op(input_id).unwrap().operator().name(),
         "Erf"
     );
+}
+
+#[test]
+fn test_no_eliminate_value_captured_by_subgraph() {
+    let mut graph = Graph::new();
+    let input = graph.add_value(Some("x"), None, Some(ValueType::Tensor(DataType::Float)));
+    let cond = graph.add_value(Some("cond"), None, Some(ValueType::Tensor(DataType::Int32)));
+    graph.set_input_ids(&[input, cond]);
+
+    // No-op cast
+    let (_cast_op, _cast_out) = graph.add_simple_op(
+        "cast",
+        Cast {
+            to: DataType::Float,
+        },
+        &[input],
+    );
+
+    // Build then/else branches which each capture "cast_out" and return it.
+    let make_branch = || {
+        let mut sg = Graph::new();
+        let cap = sg.add_value(Some("cast_out"), None, None);
+        sg.set_captures(&[cap]);
+        sg.set_output_ids(&[cap]);
+        sg
+    };
+
+    let if_out = graph.add_value(Some("if_out"), None, None);
+    graph.add_op(
+        Some("If"),
+        Arc::new(If {
+            then_branch: make_branch(),
+            else_branch: make_branch(),
+        }),
+        &[Some(cond)],
+        &[Some(if_out)],
+    );
+    graph.set_output_ids(&[if_out]);
+
+    let graph = optimize_graph(graph).unwrap();
+
+    let cast_out = graph
+        .get_node_id("cast_out")
+        .expect("captured value should still exist");
+    let (_, op) = graph
+        .get_source_node(cast_out)
+        .expect("captured value should still have a producer");
+    assert_eq!(op.operator().name(), "Cast");
 }
 
 #[test]


### PR DESCRIPTION
Fix an issue where fusions like `CastElimination` could remove values that were still referenced by subgraphs. Identity fusions like this one replace references to an operator's output with an operator's input in the current graph, but failed to check for subgraphs referencing the removed operator's output value by name.

The ideal fix would be to update references to the captured value in subgraphs as well, but that is slightly tricky because it involves modifying a graph after it has been loaded and optimized and embedded in an operator in the parent graph. The solution in this commit is just to detect when a fusion would remove a captured value and skip it.

Fixes https://github.com/robertknight/rten/issues/1359