### PR TITLE
Support Einsum equations with an empty left-hand side

### DIFF
--- a/rten-shape-inference/src/einsum_parser.rs
+++ b/rten-shape-inference/src/einsum_parser.rs
@@ -7,8 +7,6 @@ use std::fmt;
 /// [`EinsumExpr::parse`].
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ParseError {
-    /// The equation has no input terms (the left-hand side is empty).
-    NoInputTerms,
     /// An input term contains characters other than lowercase ASCII letters
     /// or more than one ellipsis (`...`).
     InvalidInputTerm,
@@ -26,7 +24,6 @@ impl ParseError {
     /// Return a human-readable description of the error.
     pub fn as_str(&self) -> &'static str {
         match self {
-            ParseError::NoInputTerms => "Einsum equation must have at least one term",
             ParseError::InvalidInputTerm => "Input term is invalid",
             ParseError::InvalidOutputTerm => "Output term is invalid",
             ParseError::RepeatedOutputLabels => "Einsum output term contains repeated labels",
@@ -63,14 +60,12 @@ pub struct EinsumExpr {
 impl EinsumExpr {
     /// Parse an Einsum expression.
     ///
-    /// The expression must contain at least one input term.
+    /// An empty left-hand side (eg. in "" or "->") is treated as a single
+    /// empty term, corresponding to a scalar input.
     pub fn parse(expr: &str) -> Result<EinsumExpr, ParseError> {
         let mut parts = expr.trim().splitn(2, "->").map(|part| part.trim());
 
-        let lhs = match parts.next() {
-            Some(lhs) if !lhs.is_empty() => lhs,
-            _ => return Err(ParseError::NoInputTerms),
-        };
+        let lhs = parts.next().unwrap_or_default();
 
         let inputs: Vec<String> = lhs
             .split(',')
@@ -331,15 +326,21 @@ mod tests {
                 equation: "...ij->...ji",
                 expected: Ok(expr(&["...ij"], "...ji")),
             },
-            // Empty equation.
+            // Empty equation. The left-hand side is a single empty term,
+            // corresponding to a scalar input.
             Case {
                 equation: "",
-                expected: Err(ParseError::NoInputTerms),
+                expected: Ok(expr(&[""], "")),
             },
             // Whitespace-only equation.
             Case {
                 equation: "  ",
-                expected: Err(ParseError::NoInputTerms),
+                expected: Ok(expr(&[""], "")),
+            },
+            // Explicit form with a single empty (scalar) term.
+            Case {
+                equation: "->",
+                expected: Ok(expr(&[""], "")),
             },
             // Upper-case letters in an input term.
             Case {

--- a/rten-shape-inference/src/ops/einsum.rs
+++ b/rten-shape-inference/src/ops/einsum.rs
@@ -165,6 +165,19 @@ mod tests {
                 inputs: vec![sym_shape!(2, "I", "J")],
                 expected: sym_shape!(2, "I", "J"),
             },
+            // Empty equation. The left-hand side is a single empty term,
+            // corresponding to a scalar input.
+            Case {
+                equation: "",
+                inputs: vec![sym_shape!()],
+                expected: sym_shape!(),
+            },
+            // As above, in explicit form.
+            Case {
+                equation: "->",
+                inputs: vec![sym_shape!()],
+                expected: sym_shape!(),
+            },
             // Outer product.
             Case {
                 equation: "i,j->ij",

--- a/src/ops/einsum.rs
+++ b/src/ops/einsum.rs
@@ -643,6 +643,7 @@ mod tests {
         }
 
         let pool = BufferPool::new();
+        let scalar = Tensor::from(2.5);
         let vec_a = Tensor::arange(1., 10., None);
         let vec_b = Tensor::arange(1., 5., None);
 
@@ -959,13 +960,26 @@ mod tests {
                         .sum::<f32>(),
                 )),
             },
-            // Empty equation
+            // Empty equation with no inputs. The equation implies a single
+            // scalar input.
             Case {
                 equation: "",
                 inputs: vec![],
                 expected: Err(OpError::InvalidValue(
-                    "Einsum equation must have at least one term",
+                    "Number of terms in Einsum equation does not match input tensor count",
                 )),
+            },
+            // Empty equation with a scalar input.
+            Case {
+                equation: "",
+                inputs: vec![scalar.view()],
+                expected: Ok(scalar.clone()),
+            },
+            // As above, in explicit form.
+            Case {
+                equation: "->",
+                inputs: vec![scalar.view()],
+                expected: Ok(scalar.clone()),
             },
             // Invalid input terms
             Case {


### PR DESCRIPTION
Change the einsum equation parser to accept equations with an empty left-hand side ("" or "->"). This corresponds to a single term with a scalar input and numpy accepts this: `np.einsum("->", np.array(42))` returns 42.