### PR TITLE
Fix Einsum errors when equations with 3+ terms contain repeated labels or ellipses

### DIFF
--- a/rten-shape-inference/src/einsum_parser.rs
+++ b/rten-shape-inference/src/einsum_parser.rs
@@ -96,19 +96,6 @@ impl EinsumExpr {
         Ok(EinsumExpr { inputs, output })
     }
 
-    /// Return the dimensions in the expression which are summed over.
-    pub fn reduced_dims(&self) -> Vec<char> {
-        let mut terms = Vec::new();
-        for in_term in &self.inputs {
-            for in_ch in in_term.chars() {
-                if !terms.contains(&in_ch) && !self.output.contains(in_ch) {
-                    terms.push(in_ch);
-                }
-            }
-        }
-        terms
-    }
-
     /// Check operator inputs are compatible with the parsed equation and
     /// calculate the number of dimensions represented by `...` in input terms.
     ///
@@ -376,43 +363,6 @@ mod tests {
 
         cases.test_each(|case| {
             assert_eq!(EinsumExpr::parse(case.equation), case.expected);
-        });
-    }
-
-    #[test]
-    fn test_reduced_dims() {
-        #[derive(Debug)]
-        struct Case<'a> {
-            equation: &'a str,
-            reduced: Vec<char>,
-        }
-
-        let cases = [
-            // Matmul reduces the shared `j` label.
-            Case {
-                equation: "ij,jk->ik",
-                reduced: vec!['j'],
-            },
-            // Nothing is reduced for a transpose.
-            Case {
-                equation: "ij->ji",
-                reduced: vec![],
-            },
-            // All labels are reduced for a full reduction.
-            Case {
-                equation: "ij->",
-                reduced: vec!['i', 'j'],
-            },
-            // Labels only count once even if they appear in multiple inputs.
-            Case {
-                equation: "ij,ij->",
-                reduced: vec!['i', 'j'],
-            },
-        ];
-
-        cases.test_each(|case| {
-            let expr = EinsumExpr::parse(case.equation).unwrap();
-            assert_eq!(expr.reduced_dims(), case.reduced);
         });
     }
 

--- a/src/ops/einsum.rs
+++ b/src/ops/einsum.rs
@@ -509,6 +509,45 @@ struct EinsumStep {
     output: String,
 }
 
+/// Iterate over the unique labels of a term, in order of first occurrence.
+fn unique_dims(term: &str) -> impl Iterator<Item = char> + '_ {
+    term.chars()
+        .enumerate()
+        .filter_map(|(i, dim)| (!term.chars().take(i).any(|c| c == dim)).then_some(dim))
+}
+
+/// Decrement the count of terms which have yet to use each label in `term`.
+fn subtract_term_dims(reduced_dims: &mut HashMap<char, usize>, term: &str) {
+    for dim in unique_dims(term) {
+        if let Some(count) = reduced_dims.get_mut(&dim) {
+            *count -= 1;
+        }
+    }
+}
+
+/// Return the output term for an intermediate step in a multi-step einsum
+/// path.
+///
+/// This contains the unique labels of the step's input terms which either
+/// appear in the final output or are reduced dimensions used by subsequent
+/// steps.
+fn step_output(
+    term_a: &str,
+    term_b: &str,
+    final_output: &str,
+    reduced_dims: &HashMap<char, usize>,
+) -> String {
+    let mut output = String::new();
+    for dim in term_a.chars().chain(term_b.chars()) {
+        if !output.contains(dim)
+            && (final_output.contains(dim) || reduced_dims.get(&dim).copied().unwrap_or(0) > 0)
+        {
+            output.push(dim);
+        }
+    }
+    output
+}
+
 /// Convert an Einsum expression with many inputs into a sequence of steps which
 /// each processes one or two inputs.
 ///
@@ -557,27 +596,10 @@ fn einsum_path(expr: &EinsumExpr, broadcast_ndim: u8) -> Vec<EinsumStep> {
                 .collect();
 
             // Add step for first two terms.
-            for dim in term_a.chars() {
-                if let Some(count) = reduced_dims.get_mut(&dim) {
-                    *count -= 1;
-                }
-            }
-            for dim in term_b.chars() {
-                if let Some(count) = reduced_dims.get_mut(&dim) {
-                    *count -= 1;
-                }
-            }
+            subtract_term_dims(&mut reduced_dims, term_a);
+            subtract_term_dims(&mut reduced_dims, term_b);
 
-            // The output for each step consists of the unique input dim labels
-            // which either appear in the final output, or are reduced
-            // dimensions that appear in subsequent steps.
-            let mut next_output: String = term_a
-                .chars()
-                .chain(term_b.chars().filter(|c| !term_a.contains(*c)))
-                .filter(|dim| {
-                    expr.output.contains(*dim) || reduced_dims.get(dim).copied().unwrap_or(0) > 0
-                })
-                .collect();
+            let mut next_output = step_output(term_a, term_b, &expr.output, &reduced_dims);
 
             steps.push(EinsumStep {
                 lhs: input_term(term_a, 0),
@@ -587,22 +609,12 @@ fn einsum_path(expr: &EinsumExpr, broadcast_ndim: u8) -> Vec<EinsumStep> {
 
             // Add a step for each remaining term.
             for (term_idx, term) in rest.iter().enumerate() {
-                for dim in term.chars() {
-                    if let Some(count) = reduced_dims.get_mut(&dim) {
-                        *count -= 1;
-                    }
-                }
+                subtract_term_dims(&mut reduced_dims, term);
                 let prev_output = next_output;
                 if term_idx == rest.len() - 1 {
                     next_output = output.clone();
                 } else {
-                    next_output = prev_output
-                        .chars()
-                        .chain(term.chars().filter(|c| !prev_output.contains(*c)))
-                        .filter(|dim| {
-                            output.contains(*dim) || reduced_dims.get(dim).copied().unwrap_or(0) > 0
-                        })
-                        .collect();
+                    next_output = step_output(&prev_output, term, &output, &reduced_dims);
                 }
                 steps.push(EinsumStep {
                     lhs: EinsumTerm {
@@ -1237,6 +1249,68 @@ mod tests {
                         lhs: new_term("abcd", None),
                         rhs: Some(new_term("ef", Some(2))),
                         output: "abcdef".to_string(),
+                    },
+                ]
+                .into(),
+            },
+            // 3+ input terms where a term contains repeated labels.
+            //
+            // The repeated label must be counted once when determining whether
+            // later steps still need it, and appear only once in a step's
+            // output term.
+            Case {
+                equation: "ii,j,i->",
+                broadcast_ndim: 0,
+                path: [
+                    EinsumStep {
+                        lhs: new_term("ii", Some(0)),
+                        rhs: Some(new_term("j", Some(1))),
+                        // `i` is retained because the final term needs it.
+                        output: "i".to_string(),
+                    },
+                    EinsumStep {
+                        lhs: new_term("i", None),
+                        rhs: Some(new_term("i", Some(2))),
+                        output: "".to_string(),
+                    },
+                ]
+                .into(),
+            },
+            // As above, but with the terms reordered so that the other use of
+            // the repeated label is consumed by the first step of the path
+            // rather than a later one.
+            Case {
+                equation: "ii,i,j->",
+                broadcast_ndim: 0,
+                path: [
+                    EinsumStep {
+                        lhs: new_term("ii", Some(0)),
+                        rhs: Some(new_term("i", Some(1))),
+                        // `i` is dropped because no later term uses it.
+                        output: "".to_string(),
+                    },
+                    EinsumStep {
+                        lhs: new_term("", None),
+                        rhs: Some(new_term("j", Some(2))),
+                        output: "".to_string(),
+                    },
+                ]
+                .into(),
+            },
+            // 3+ input terms with repeated labels which are kept in the output.
+            Case {
+                equation: "ii,i,i->i",
+                broadcast_ndim: 0,
+                path: [
+                    EinsumStep {
+                        lhs: new_term("ii", Some(0)),
+                        rhs: Some(new_term("i", Some(1))),
+                        output: "i".to_string(),
+                    },
+                    EinsumStep {
+                        lhs: new_term("i", None),
+                        rhs: Some(new_term("i", Some(2))),
+                        output: "i".to_string(),
                     },
                 ]
                 .into(),

--- a/src/ops/einsum.rs
+++ b/src/ops/einsum.rs
@@ -555,12 +555,17 @@ fn step_output(
 /// terms stand for. The ellipses are replaced with digit labels in the path.
 fn einsum_path(expr: &EinsumExpr, broadcast_ndim: u8) -> Vec<EinsumStep> {
     let output = expand_ellipsis(&expr.output, broadcast_ndim as usize);
+    let in_terms: Vec<String> = expr
+        .inputs
+        .iter()
+        .map(|term| expand_ellipsis(term, broadcast_ndim as usize))
+        .collect();
     let input_term = |term: &str, index: u32| EinsumTerm {
-        term: expand_ellipsis(term, broadcast_ndim as usize),
+        term: term.to_string(),
         input: EinsumInput::Index(index),
     };
 
-    match &expr.inputs[..] {
+    match &in_terms[..] {
         // This case shouldn't happen since Einsum equations must have at least
         // one input term.
         [] => Vec::new(),
@@ -584,22 +589,20 @@ fn einsum_path(expr: &EinsumExpr, broadcast_ndim: u8) -> Vec<EinsumStep> {
             let mut steps = Vec::with_capacity(all_terms.len() - 1);
 
             // Count how many terms use each reduced dimension.
-            let mut reduced_dims: HashMap<char, usize> = expr
-                .reduced_dims()
-                .into_iter()
-                .map(|dim| {
-                    (
-                        dim,
-                        all_terms.iter().filter(|term| term.contains(dim)).count(),
-                    )
-                })
-                .collect();
+            let mut reduced_dims: HashMap<char, usize> = HashMap::new();
+            for term in all_terms {
+                for dim in unique_dims(term) {
+                    if !output.contains(dim) {
+                        *reduced_dims.entry(dim).or_insert(0) += 1;
+                    }
+                }
+            }
 
             // Add step for first two terms.
             subtract_term_dims(&mut reduced_dims, term_a);
             subtract_term_dims(&mut reduced_dims, term_b);
 
-            let mut next_output = step_output(term_a, term_b, &expr.output, &reduced_dims);
+            let mut next_output = step_output(term_a, term_b, &output, &reduced_dims);
 
             steps.push(EinsumStep {
                 lhs: input_term(term_a, 0),
@@ -1324,6 +1327,27 @@ mod tests {
                     rhs: None,
                     output: "j012i".to_string(),
                 }]
+                .into(),
+            },
+            // 3+ input terms with ellipses.
+            //
+            // Ellipses must be expanded before intermediate step outputs are
+            // built, otherwise the ellipsis is treated as an ordinary label.
+            Case {
+                equation: "...i,...j,...k->...ijk",
+                broadcast_ndim: 2,
+                path: [
+                    EinsumStep {
+                        lhs: new_term("01i", Some(0)),
+                        rhs: Some(new_term("01j", Some(1))),
+                        output: "01ij".to_string(),
+                    },
+                    EinsumStep {
+                        lhs: new_term("01ij", None),
+                        rhs: Some(new_term("01k", Some(2))),
+                        output: "01ijk".to_string(),
+                    },
+                ]
                 .into(),
             },
         ];


### PR DESCRIPTION
Fix two issues when planning einsum execution with multiple steps, which happens when equations have 3+ terms.

1. The planner keeps track of how many terms have yet to use each reduced dimension. When updating these counts, the logic decremented once per _occurrence_ of each dimension instead of once per _term_. This could result in underflow with repeated labels, causing a panic or incorrect behavior.
2. The planner incorrectly used versions of the terms where ellipses had not been expanded in some places. Expansion of ellipses now happens once at the top of `einsum_path`.