### PR TITLE
Fix `MutLayout::index_axis` for empty tensors

### DIFF
--- a/rten-tensor/src/layout.rs
+++ b/rten-tensor/src/layout.rs
@@ -780,9 +780,15 @@ pub trait MutLayout: Layout + Clone {
         assert!(index < self.size(axis));
 
         let layout = self.remove_dim(axis);
-        let start_offset = self.stride(axis) * index;
 
-        (start_offset..start_offset + layout.min_data_len(), layout)
+        let range = if layout.is_empty() {
+            0..0
+        } else {
+            let start_offset = self.stride(axis) * index;
+            start_offset..start_offset + layout.min_data_len()
+        };
+
+        (range, layout)
     }
 
     /// Move the axis at position `from` to `to` by swapping their strides.
@@ -1658,6 +1664,20 @@ mod tests {
                 axis: 1,
                 index: 2,
                 expected: (2, layout_with_strides([3], [4])),
+            },
+            // Empty result. The tensor's storage is empty, so the offset must
+            // be zero.
+            Case {
+                layout: NdLayout::from_shape([0, 3]),
+                axis: 1,
+                index: 1,
+                expected: (0, layout_with_strides([0], [3])),
+            },
+            Case {
+                layout: layout_with_strides([3, 0], [1, 3]),
+                axis: 0,
+                index: 1,
+                expected: (0, layout_with_strides([0], [3])),
             },
         ];
 


### PR DESCRIPTION
Fix an issue where the default implementation of `MutLayout::index_axis` could return invalid storage offsets for empty tensors.

This bug is similar to https://github.com/robertknight/rten/pull/1364 and was found by asking Claude to search for similar issues.

This bug was reachable via `TensorBase::axis_iter` and several other methods.