### PR TITLE
Prevent arithmetic overflow when validating tensor shapes and strides

### DIFF
--- a/rten-tensor/src/layout.rs
+++ b/rten-tensor/src/layout.rs
@@ -242,17 +242,19 @@ pub trait Layout {
 
     /// Return the minimum length required for the element data buffer used
     /// with this layout.
+    ///
+    /// If the required length exceeds `usize::MAX` the result saturates.
     fn min_data_len(&self) -> usize {
         if self.shape().iter().any(|d| d == 0) {
             return 0;
         }
-        let max_offset: usize = self
-            .shape()
-            .iter()
-            .zip(self.strides().iter())
-            .map(|(size, stride)| (size - 1) * stride)
-            .sum();
-        max_offset + 1
+        let max_offset = self.shape().iter().zip(self.strides().iter()).fold(
+            0usize,
+            |max_offset, (size, stride)| {
+                max_offset.saturating_add((size - 1).saturating_mul(stride))
+            },
+        );
+        max_offset.saturating_add(1)
     }
 
     /// Return a new layout formed by reshaping this one to `shape`.
@@ -2177,6 +2179,78 @@ mod tests {
             layout.merge_axes();
             assert_eq!(layout.shape(), case.merged_shape);
             assert_eq!(layout.strides(), case.merged_strides);
+        })
+    }
+
+    #[test]
+    fn test_min_data_len() {
+        #[derive(Debug)]
+        struct Case<'a> {
+            shape: &'a [usize],
+            strides: &'a [usize],
+            expected: usize,
+        }
+
+        let cases = [
+            // Scalar
+            Case {
+                shape: &[],
+                strides: &[],
+                expected: 1,
+            },
+            // Contiguous layout
+            Case {
+                shape: &[2, 3],
+                strides: &[3, 1],
+                expected: 6,
+            },
+            // Broadcasting layout
+            Case {
+                shape: &[5, 5],
+                strides: &[0, 0],
+                expected: 1,
+            },
+            // Non-contiguous layout
+            Case {
+                shape: &[2, 2],
+                strides: &[4, 2],
+                expected: 7,
+            },
+            // Empty layout. Strides are ignored.
+            Case {
+                shape: &[0, 2],
+                strides: &[usize::MAX, usize::MAX],
+                expected: 0,
+            },
+            // `(size - 1) * stride` term overflows. Result saturates.
+            Case {
+                shape: &[3],
+                strides: &[usize::MAX / 2 + 1],
+                expected: usize::MAX,
+            },
+            // Sum of per-dimension terms overflows. Result saturates.
+            Case {
+                shape: &[2, 2],
+                strides: &[usize::MAX - 1, usize::MAX - 1],
+                expected: usize::MAX,
+            },
+            // Max offset is `usize::MAX`, so adding one for the final length
+            // overflows. Result saturates.
+            Case {
+                shape: &[2],
+                strides: &[usize::MAX],
+                expected: usize::MAX,
+            },
+        ];
+
+        cases.test_each(|case| {
+            let layout = DynLayout::from_shape_and_strides(
+                case.shape,
+                case.strides,
+                OverlapPolicy::AllowOverlap,
+            )
+            .unwrap();
+            assert_eq!(layout.min_data_len(), case.expected);
         })
     }
 }

--- a/rten-tensor/src/overlap.rs
+++ b/rten-tensor/src/overlap.rs
@@ -16,7 +16,7 @@ pub fn is_contiguous<S: SizeArray, Strides: SizeArray>(shape: &S, strides: &Stri
         if stride != product {
             return false;
         }
-        product *= size;
+        product = product.saturating_mul(size);
     }
     true
 }
@@ -61,12 +61,14 @@ pub fn may_have_internal_overlap(shape: impl SizeArray, strides: impl SizeArray)
 
     // Verify that the stride for each dimension fully "steps over" the
     // previous dimension.
-    let mut max_offset = 0;
+    let mut max_offset = 0usize;
     for (stride, shape) in stride_shape {
         if stride <= max_offset {
             return true;
         }
-        max_offset += (shape - 1) * stride;
+        // Saturate on overflow. This will cause the next iteration to return
+        // true.
+        max_offset = max_offset.saturating_add((shape - 1).saturating_mul(stride));
     }
     false
 }
@@ -75,7 +77,7 @@ pub fn may_have_internal_overlap(shape: impl SizeArray, strides: impl SizeArray)
 mod tests {
     use rten_testing::TestCases;
 
-    use super::is_contiguous;
+    use super::{is_contiguous, may_have_internal_overlap};
 
     #[test]
     fn test_is_contiguous() {
@@ -156,10 +158,92 @@ mod tests {
                 strides: &[100, 25, 1, 5],
                 contiguous: false,
             },
+            // Contiguous layout where element count overflows usize.
+            Case {
+                shape: &[4, usize::MAX / 2 + 1],
+                strides: &[usize::MAX / 2 + 1, 1],
+                contiguous: true,
+            },
+            // Element count product overflows mid-loop, then a stride
+            // mismatch is found.
+            Case {
+                shape: &[2, 2, usize::MAX / 2 + 1],
+                strides: &[5, usize::MAX / 2 + 1, 1],
+                contiguous: false,
+            },
         ];
 
         cases.test_each(|case| {
             assert_eq!(is_contiguous(&case.shape, &case.strides), case.contiguous);
+        })
+    }
+
+    #[test]
+    fn test_may_have_internal_overlap() {
+        #[derive(Debug)]
+        struct Case<'a> {
+            shape: &'a [usize],
+            strides: &'a [usize],
+            may_overlap: bool,
+        }
+
+        let cases = [
+            // Empty
+            Case {
+                shape: &[0, 2],
+                strides: &[2, 1],
+                may_overlap: false,
+            },
+            // Contiguous layout
+            Case {
+                shape: &[2, 3],
+                strides: &[3, 1],
+                may_overlap: false,
+            },
+            // Transposed layout
+            Case {
+                shape: &[2, 3],
+                strides: &[1, 2],
+                may_overlap: false,
+            },
+            // Non-contiguous layout produced by slicing
+            Case {
+                shape: &[2, 2],
+                strides: &[4, 2],
+                may_overlap: false,
+            },
+            // Broadcasting layout
+            Case {
+                shape: &[5, 5],
+                strides: &[0, 1],
+                may_overlap: true,
+            },
+            // Overlapping strides
+            Case {
+                shape: &[2, 2],
+                strides: &[1, 1],
+                may_overlap: true,
+            },
+            // Second-largest stride causes overflow. Conservatively returns
+            // true.
+            Case {
+                shape: &[2, 2, 2],
+                strides: &[2, usize::MAX - 1, usize::MAX],
+                may_overlap: true,
+            },
+            // Largest stride only causes overflow.
+            Case {
+                shape: &[2, 2],
+                strides: &[usize::MAX - 1, 2],
+                may_overlap: false,
+            },
+        ];
+
+        cases.test_each(|case| {
+            assert_eq!(
+                may_have_internal_overlap(case.shape, case.strides),
+                case.may_overlap
+            );
         })
     }
 }

--- a/rten-tensor/src/tensor/tests.rs
+++ b/rten-tensor/src/tensor/tests.rs
@@ -558,6 +558,46 @@ fn test_from_data_with_strides() {
 }
 
 #[test]
+fn test_from_data_with_strides_overflow() {
+    // Shape and stride combinations for which computing the required storage
+    // length overflows `usize`. These must be rejected rather than wrapping,
+    // as a wrapped length can match the storage length and pass validation.
+    // The strides in the first case are chosen so that the wrapped minimum
+    // storage length would be exactly 4, the actual storage length.
+
+    // Sum of per-dimension max offsets overflows.
+    let x = Tensor::from_data_with_strides(&[2, 2], vec![0; 4], &[usize::MAX - 1, 5]);
+    assert_eq!(x, Err(FromDataError::StorageTooShort));
+
+    // Single dimension's `(size - 1) * stride` term overflows.
+    let x = Tensor::from_data_with_strides(&[3], vec![0; 3], &[usize::MAX / 2 + 1]);
+    assert_eq!(x, Err(FromDataError::StorageTooShort));
+
+    // Stride-consistent (row-major "contiguous") layout whose element count
+    // overflows.
+    let x = Tensor::from_data_with_strides(
+        &[4, usize::MAX / 2 + 1],
+        vec![0; 4],
+        &[usize::MAX / 2 + 1, 1],
+    );
+    assert_eq!(x, Err(FromDataError::StorageTooShort));
+
+    // Same cases via `NdTensor`, which uses a different layout type.
+    let x = NdTensor::from_data_with_strides([2, 2], vec![0; 4], [usize::MAX - 1, 5]);
+    assert_eq!(x, Err(FromDataError::StorageTooShort));
+
+    let x = NdTensor::from_data_with_strides([3], vec![0; 3], [usize::MAX / 2 + 1]);
+    assert_eq!(x, Err(FromDataError::StorageTooShort));
+
+    let x = NdTensor::from_data_with_strides(
+        [4, usize::MAX / 2 + 1],
+        vec![0; 4],
+        [usize::MAX / 2 + 1, 1],
+    );
+    assert_eq!(x, Err(FromDataError::StorageTooShort));
+}
+
+#[test]
 fn test_from_slice_with_strides() {
     // The strides here are overlapping, but `from_slice_with_strides`
     // allows this since it is a read-only view.


### PR DESCRIPTION
Fix an issue where it was possible to create tensors with invalid shape/stride combinations using `TensorBase::from_data_with_strides` if arithmetic overflow happened during validation.

`Layout::min_data_len`, `may_have_internal_overlap` and `is_contiguous` used unchecked arithmetic on shape and stride values. This could cause `from_data_with_strides` to panic (in debug builds) or incorrectly accept invalid shape/strides in release builds, if the required storage length calculation wrapped and the result was less than the actual storage length.

Use saturating arithmetic in all three functions. Saturation preserves the result of the comparisons these values are used in, since a saturated value always exceeds the length of any real buffer (<= `isize::MAX`).

There is still a hazard where a custom `Layout` could override `min_data_len` with an incorrect implementation. That needs to be fixed in future. Also using saturating arithmetic does have a small cost, and these functions are called a lot. Maybe the requirement that element count or offset computations cannot overflow could be moved to layout construction time?

Claude noticed the issue with `min_data_len` while auditing for issues similar to https://github.com/robertknight/rten/pull/1364.