### PR TITLE
Use correct associated types in `from_shape_and_strides` impl

### DIFF
--- a/rten-tensor/src/layout.rs
+++ b/rten-tensor/src/layout.rs
@@ -941,8 +941,8 @@ impl<const N: usize> FromShape for NdLayout<N> {
 
 impl<const N: usize> MutLayout for NdLayout<N> {
     fn from_shape_and_strides(
-        shape: Self::Index<'_>,
-        strides: Self::Index<'_>,
+        shape: Self::Shape<'_>,
+        strides: Self::Strides<'_>,
         overlap: OverlapPolicy,
     ) -> Result<Self, FromDataError> {
         let layout = NdLayout { shape, strides };


### PR DESCRIPTION
Use `Shape`/`Strides` associated types instead of `Index` in `<NdLayout as MutLayout>::from_shape_and_strides`.

This fixes an oversight in https://github.com/robertknight/rten/pull/1340.