### PR TITLE
Fix false-positive internal-overlap panic for size-1 dimensions

### DIFF
--- a/rten-tensor/src/overlap.rs
+++ b/rten-tensor/src/overlap.rs
@@ -55,8 +55,14 @@ pub fn may_have_internal_overlap(shape: impl SizeArray, strides: impl SizeArray)
     }
 
     // Sort dimensions in order of increasing stride.
-    let mut stride_shape: SmallVec<[(usize, usize); 8]> =
-        strides.iter().zip(shape.iter()).collect();
+    //
+    // Dimensions of size 1 are skipped since their only valid index is 0, so
+    // they can never contribute to overlap regardless of their stride.
+    let mut stride_shape: SmallVec<[(usize, usize); 8]> = strides
+        .iter()
+        .zip(shape.iter())
+        .filter(|(_, size)| *size != 1)
+        .collect();
     stride_shape.sort_unstable();
 
     // Verify that the stride for each dimension fully "steps over" the
@@ -75,7 +81,7 @@ pub fn may_have_internal_overlap(shape: impl SizeArray, strides: impl SizeArray)
 mod tests {
     use rten_testing::TestCases;
 
-    use super::is_contiguous;
+    use super::{is_contiguous, may_have_internal_overlap};
 
     #[test]
     fn test_is_contiguous() {
@@ -160,6 +166,40 @@ mod tests {
 
         cases.test_each(|case| {
             assert_eq!(is_contiguous(&case.shape, &case.strides), case.contiguous);
+        })
+    }
+
+    #[test]
+    fn test_may_have_internal_overlap() {
+        #[derive(Debug)]
+        struct Case<'a> {
+            shape: &'a [usize],
+            strides: &'a [usize],
+            overlap: bool,
+        }
+
+        let cases = [
+            // Broadcast layout (stride 0 over a dimension of size > 1).
+            Case {
+                shape: &[5, 5],
+                strides: &[0, 1],
+                overlap: true,
+            },
+            // A leading size-1 dimension with a stride that would otherwise
+            // collide with the inner dimensions must be ignored, since its
+            // only valid index is 0.
+            Case {
+                shape: &[1, 3],
+                strides: &[3, 2],
+                overlap: false,
+            },
+        ];
+
+        cases.test_each(|case| {
+            assert_eq!(
+                may_have_internal_overlap(&case.shape, &case.strides),
+                case.overlap
+            );
         })
     }
 }

--- a/rten-tensor/src/tensor/tests.rs
+++ b/rten-tensor/src/tensor/tests.rs
@@ -67,6 +67,31 @@ fn test_append() {
     assert_eq!(empty.shape(), [0, 5]);
 }
 
+// This reproduces an issue where a `may_have_internal_overlap` check could
+// incorrectly fail.
+#[test]
+fn test_append_then_inner_iter_mut() {
+    // Create a tensor which has a 1-sized leading dim with a stride that is
+    // smaller than the product of interior dims.
+    let mut data = Vec::with_capacity(16);
+    data.extend(0..8);
+    let mut tensor = Tensor::from_data(&[1, 2, 4], data);
+    tensor
+        .append(1, &Tensor::from([[[8, 9, 10, 11], [12, 13, 14, 15]]]))
+        .unwrap();
+    assert_eq!(tensor.shape(), &[1, 4, 4]);
+    assert_eq!(tensor.strides(), &[8, 4, 1]);
+
+    // Make tensor non-contiguous
+    let mut sliced = tensor.slice_mut((.., .., ..2));
+
+    // Trigger call to `may_have_internal_overlap`
+    for mut inner in sliced.inner_iter_mut::<3>() {
+        inner.apply(|x| x * 10);
+    }
+    assert_eq!(sliced.to_vec(), &[0, 10, 40, 50, 80, 90, 120, 130]);
+}
+
 #[test]
 fn test_concat() {
     // Concat along dim 0 (rows)


### PR DESCRIPTION
Fix an issue where `may_have_internal_overlap` could incorrectly return true if a non-contiguous tensor with a leading 1-sized dim with a stride that was smaller than the sum of `(size - 1) * stride)` of following dims. For a 1-sized dim the only valid index is 0 so the stride should be ignored. Such a tensor can be produced via `TensorBase::append` to expand a tensor's shape without altering its size, and then `TensorBase::slice_mut` to create a non-contiguous mutable view.

The issue was originally encountered when running the model from https://huggingface.co/sweetlhare/wedetect-tiny-onnx/blob/main/wedetect_tiny_vision_int8.onnx. In this model a combination of in-place Concat + Slice + Mul ops trigger this via `TensorBase::{append -> clip_dim -> inner_iter_mut}`.