### PR TITLE
Add `--range` option in CLI to set range of generated input values

### DIFF
--- a/rten-cli/src/dim_size.rs
+++ b/rten-cli/src/dim_size.rs
@@ -1,5 +1,7 @@
 use std::cmp::Ordering;
 
+use crate::name_value::{self, ParseError, Token};
+
 /// Specifies the size for a dynamic input dimension.
 #[derive(Clone, Debug, PartialEq)]
 pub struct DimSize {
@@ -34,38 +36,27 @@ impl DimSize {
     /// Parse a dimension size specifier in the form `dim_name=size` or
     /// `input_name.dim_name=size`.
     pub fn parse(spec: &str) -> Result<DimSize, ParseError> {
-        let tokens = tokenize(spec);
-        let Some(eq_pos) = tokens.iter().position(|tok| matches!(tok, Token::Equals)) else {
+        let Some((name_tokens, size_str)) = name_value::split(spec) else {
             return Err(ParseError::new(
                 spec,
-                ParseErrorKind::InvalidFormat {
-                    message: "expected <name>=<size> but no '=' was found".into(),
-                },
+                "expected <name>=<size> but no '=' was found",
             ));
         };
 
-        let (name_spec, size_spec) = tokens.split_at(eq_pos);
-
-        let [Token::Equals, Token::Text(size_str)] = size_spec else {
-            return Err(ParseError::new(
-                spec,
-                ParseErrorKind::InvalidFormat {
-                    message: "expected specifier to end with '=<size>'".into(),
-                },
-            ));
-        };
-
-        let (input_name, dim_name) = match name_spec {
+        let (input_name, dim_name) = match name_tokens.as_slice() {
             [Token::Text(dim)] => (None, dim),
             [Token::Text(input), Token::Dot, Token::Text(dim)] => (Some(input), dim),
             _ => {
-                return Err(ParseError::new(spec, ParseErrorKind::InvalidName));
+                return Err(ParseError::new(spec, "invalid input or dimension name"));
             }
         };
 
-        let size: usize = size_str
-            .parse()
-            .map_err(|_| ParseError::new(spec, ParseErrorKind::InvalidSize))?;
+        let size: usize = size_str.parse().map_err(|_| {
+            ParseError::new(
+                spec,
+                "invalid dimension size. Must be a non-negative integer",
+            )
+        })?;
 
         Ok(DimSize {
             input_name: input_name.map(|s| s.to_string()),
@@ -99,93 +90,12 @@ impl DimSize {
     }
 }
 
-enum Token {
-    Equals,
-    Dot,
-    Text(String),
-}
-
-fn tokenize(spec: &str) -> Vec<Token> {
-    let mut tokens = Vec::new();
-    let mut in_quote = false;
-
-    for ch in spec.chars() {
-        match ch {
-            '=' if !in_quote => {
-                tokens.push(Token::Equals);
-            }
-            '.' if !in_quote => {
-                tokens.push(Token::Dot);
-            }
-            '"' => in_quote = !in_quote,
-            ch => {
-                if let Some(tok) = tokens.last_mut()
-                    && let Token::Text(text) = tok
-                {
-                    text.push(ch);
-                } else {
-                    tokens.push(Token::Text(ch.into()));
-                }
-            }
-        }
-    }
-
-    tokens
-}
-
-#[derive(Clone, Debug, PartialEq)]
-#[allow(clippy::enum_variant_names)] // Don't warn about all variants having "Invalid" prefix.
-enum ParseErrorKind {
-    /// Dimension size spec doesn't match "name=size"
-    InvalidFormat { message: String },
-    /// Dimension size spec has an invalid input or dimension name
-    InvalidName,
-    /// Dimension size spec has an invalid size
-    InvalidSize,
-}
-
-#[derive(Clone, Debug, PartialEq)]
-pub struct ParseError {
-    spec: String,
-    kind: ParseErrorKind,
-}
-
-impl ParseError {
-    fn new(spec: &str, kind: ParseErrorKind) -> ParseError {
-        ParseError {
-            spec: spec.to_string(),
-            kind,
-        }
-    }
-}
-
-impl std::fmt::Display for ParseError {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match &self.kind {
-            ParseErrorKind::InvalidFormat { message } => write!(
-                fmt,
-                "invalid format for dimension size spec \"{}\": {}",
-                self.spec, message
-            ),
-            ParseErrorKind::InvalidName => {
-                write!(fmt, "invalid name in dimension size spec \"{}\"", self.spec)
-            }
-            ParseErrorKind::InvalidSize => write!(
-                fmt,
-                "invalid dimension size in \"{}\". Must be a non-negative integer.",
-                self.spec
-            ),
-        }
-    }
-}
-
-impl std::error::Error for ParseError {}
-
 #[cfg(test)]
 mod tests {
     use rten_testing::TestCases;
 
-    use super::{DimSize, ParseError, ParseErrorKind};
+    use super::DimSize;
+    use crate::name_value::ParseError;
 
     #[test]
     fn test_parse() {
@@ -213,42 +123,37 @@ mod tests {
                 }),
             },
             Case {
-                spec: "x.\"dim.name\"=1",
-                expected: Ok(DimSize {
-                    input_name: Some("x".to_string()),
-                    dim_name: "dim.name".to_string(),
-                    size: 1,
-                }),
-            },
-            Case {
-                spec: "\"input.name\".dim=1",
-                expected: Ok(DimSize {
-                    input_name: Some("input.name".to_string()),
-                    dim_name: "dim".to_string(),
-                    size: 1,
-                }),
-            },
-            Case {
                 spec: "foobar",
                 expected: Err(ParseError::new(
                     "foobar",
-                    ParseErrorKind::InvalidFormat {
-                        message: "expected <name>=<size> but no '=' was found".into(),
-                    },
+                    "expected <name>=<size> but no '=' was found",
+                )),
+            },
+            Case {
+                spec: "a.b.c=1",
+                expected: Err(ParseError::new(
+                    "a.b.c=1",
+                    "invalid input or dimension name",
                 )),
             },
             Case {
                 spec: "foobar=g",
-                expected: Err(ParseError::new("foobar=g", ParseErrorKind::InvalidSize)),
+                expected: Err(ParseError::new(
+                    "foobar=g",
+                    "invalid dimension size. Must be a non-negative integer",
+                )),
             },
             Case {
                 spec: "foobar=-1",
-                expected: Err(ParseError::new("foobar=-1", ParseErrorKind::InvalidSize)),
+                expected: Err(ParseError::new(
+                    "foobar=-1",
+                    "invalid dimension size. Must be a non-negative integer",
+                )),
             },
         ];
 
         cases.test_each(|Case { spec, expected }| {
-            let dim_size = DimSize::parse(&spec);
+            let dim_size = DimSize::parse(spec);
             assert_eq!(dim_size, *expected);
         })
     }

--- a/rten-cli/src/input_generator.rs
+++ b/rten-cli/src/input_generator.rs
@@ -1,0 +1,312 @@
+//! Generation of random values for model inputs.
+
+use std::error::Error;
+
+use rten::{DataType, Dimension, Value, ValueType};
+use rten_tensor::Tensor;
+
+use crate::dim_size::DimSize;
+use crate::input_range::InputRange;
+
+#[derive(Debug)]
+pub enum GenerateError {
+    UnsupportedDataType(ValueType),
+}
+
+impl std::fmt::Display for GenerateError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnsupportedDataType(dtype) => {
+                write!(f, "generation of {dtype} inputs is not supported")
+            }
+        }
+    }
+}
+
+impl Error for GenerateError {}
+
+pub struct RandomInputGenerator {
+    rng: fastrand::Rng,
+}
+
+impl RandomInputGenerator {
+    pub fn new() -> Self {
+        RandomInputGenerator {
+            rng: fastrand::Rng::new(),
+        }
+    }
+
+    /// Generate a random value for an input using the name, shape and dtype
+    /// properties from the model as well as configuration provided when
+    /// running the CLI.
+    ///
+    /// `range` specifies the range of generated values, overriding the
+    /// defaults chosen based on the input's name and dtype.
+    ///
+    /// `on_resolve_size` is invoked for each dynamic dimension size that
+    /// is resolved, specifying the dimension name and index of the entry in
+    /// `dim_sizes` that was used, if any.
+    pub fn generate(
+        &mut self,
+        name: &str,
+        value_type: Option<ValueType>,
+        shape: &[Dimension],
+        dim_sizes: &[DimSize],
+        range: Option<&InputRange>,
+        mut on_resolve_size: impl FnMut(&str, Option<usize>),
+    ) -> Result<Value, GenerateError> {
+        let dtype = match value_type {
+            Some(ValueType::Tensor(dtype)) => Some(dtype),
+            Some(vtype) => {
+                return Err(GenerateError::UnsupportedDataType(vtype));
+            }
+            None => None,
+        };
+
+        let resolved_shape: Vec<usize> = shape
+            .iter()
+            .map(|dim| match dim {
+                Dimension::Symbolic(dim_name) => {
+                    if let Some((idx, dim_size)) = dim_sizes
+                        .iter()
+                        .enumerate()
+                        .find(|(_i, ds)| ds.matches(name, dim_name))
+                    {
+                        on_resolve_size(dim_name, Some(idx));
+                        dim_size.size
+                    } else {
+                        on_resolve_size(dim_name, None);
+                        1
+                    }
+                }
+                Dimension::Fixed(size) => *size,
+            })
+            .collect();
+
+        fn random_ints<T, F: FnMut() -> T>(shape: &[usize], generate: F) -> Value
+        where
+            Value: From<Tensor<T>>,
+        {
+            Tensor::from_simple_fn(shape, generate).into()
+        }
+
+        let range = range.map(|r| (r.min, r.max));
+
+        // Guess suitable content for the input based on its name. Name-based
+        // guesses are skipped if an explicit value range was specified.
+        let value = match name {
+            // If this is a mask, use all ones on the assumption that we
+            // don't want to mask anything out.
+            name if range.is_none()
+                && name.ends_with("_mask")
+                && matches!(dtype, Some(DataType::Int32) | None) =>
+            {
+                Value::from(Tensor::full(&resolved_shape, 1i32))
+            }
+
+            // Inputs such as `token_type_ids`, `position_ids`, `input_ids`.
+            // We use zero as a value that is likely to be valid for all
+            // of these.
+            name if range.is_none()
+                && name.ends_with("_ids")
+                && matches!(dtype, Some(DataType::Int32) | None) =>
+            {
+                Value::from(Tensor::<i32>::zeros(&resolved_shape))
+            }
+
+            // Optimum can export "merged" transformer models which have two
+            // branches. One accepts KV-cache inputs and the other does not.
+            // Set this to false as a "safer" value because we don't have
+            // cached outputs from a previous run.
+            "use_cache_branch"
+                if range.is_none() && matches!(dtype, Some(DataType::Int32) | None) =>
+            {
+                Value::from(Tensor::from(0i32))
+            }
+
+            // For anything else, random values. The default ranges are
+            // intended to be suitable for many models.
+            //
+            // For int types the float bounds are converted with saturating `as`
+            // casts, so a range which is wider than the dtype is narrowed to
+            // it.
+            _ => match dtype {
+                Some(DataType::Float) | None => {
+                    let (min, max) = range.unwrap_or((0., 1.));
+                    Value::from(Tensor::from_simple_fn(&resolved_shape, || {
+                        min + self.rng.f32() * (max - min)
+                    }))
+                }
+                Some(DataType::Int32) => {
+                    let (min, max) = range.map_or((0, 255), |(min, max)| (min as i32, max as i32));
+                    random_ints(&resolved_shape, || self.rng.i32(min..=max))
+                }
+                Some(DataType::Int8) => {
+                    let (min, max) = range.map_or((0, 127), |(min, max)| (min as i8, max as i8));
+                    random_ints(&resolved_shape, || self.rng.i8(min..=max))
+                }
+                Some(DataType::UInt8) => {
+                    let (min, max) = range.map_or((0, 255), |(min, max)| (min as u8, max as u8));
+                    random_ints(&resolved_shape, || self.rng.u8(min..=max))
+                }
+                Some(dtype) => {
+                    return Err(GenerateError::UnsupportedDataType(ValueType::Tensor(dtype)));
+                }
+            },
+        };
+
+        Ok(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rten_tensor::prelude::*;
+    use rten_testing::TestCases;
+
+    use super::*;
+
+    /// Generate a random input with a given name and dtype, using the value
+    /// range specified by `range`, if any.
+    fn generate(name: &str, dtype: DataType, range: Option<(f32, f32)>) -> Value {
+        let range = range.map(|(min, max)| InputRange {
+            input_name: name.to_string(),
+            min,
+            max,
+        });
+        let mut generator = RandomInputGenerator::new();
+        generator
+            .generate(
+                name,
+                Some(ValueType::Tensor(dtype)),
+                &[Dimension::Fixed(64)],
+                &[],
+                range.as_ref(),
+                |_dim_name, _dim_size_idx| {},
+            )
+            .unwrap()
+    }
+
+    /// Extract the elements of a tensor value as floats, so that values of
+    /// different dtypes can be compared in the same way.
+    fn elements(value: &Value) -> Vec<f32> {
+        match value {
+            Value::FloatTensor(tensor) => tensor.to_vec(),
+            Value::Int32Tensor(tensor) => tensor.map(|x| *x as f32).to_vec(),
+            Value::Int8Tensor(tensor) => tensor.map(|x| *x as f32).to_vec(),
+            Value::UInt8Tensor(tensor) => tensor.map(|x| *x as f32).to_vec(),
+            value => panic!("unexpected value type {:?}", value.dtype()),
+        }
+    }
+
+    #[test]
+    fn test_generate_value_range() {
+        #[derive(Debug)]
+        struct Case {
+            dtype: DataType,
+            range: Option<(f32, f32)>,
+
+            /// Bounds that all generated values are expected to fall within.
+            expected: (f32, f32),
+        }
+
+        let cases = [
+            // Default ranges, used when no range is specified.
+            Case {
+                dtype: DataType::Float,
+                range: None,
+                expected: (0., 1.),
+            },
+            Case {
+                dtype: DataType::Int32,
+                range: None,
+                expected: (0., 255.),
+            },
+            Case {
+                dtype: DataType::Int8,
+                range: None,
+                expected: (0., 127.),
+            },
+            Case {
+                dtype: DataType::UInt8,
+                range: None,
+                expected: (0., 255.),
+            },
+            // Explicitly specified ranges.
+            Case {
+                dtype: DataType::Float,
+                range: Some((-1.5, 2.5)),
+                expected: (-1.5, 2.5),
+            },
+            Case {
+                dtype: DataType::Int32,
+                range: Some((5., 7.)),
+                expected: (5., 7.),
+            },
+            Case {
+                dtype: DataType::Int8,
+                range: Some((-5., 5.)),
+                expected: (-5., 5.),
+            },
+            Case {
+                dtype: DataType::UInt8,
+                range: Some((200., 255.)),
+                expected: (200., 255.),
+            },
+            // Ranges which are wider than the dtype are narrowed to it.
+            Case {
+                dtype: DataType::Int8,
+                range: Some((-1000., 1000.)),
+                expected: (-128., 127.),
+            },
+            Case {
+                dtype: DataType::UInt8,
+                range: Some((-1000., 1000.)),
+                expected: (0., 255.),
+            },
+        ];
+
+        cases.test_each(
+            |Case {
+                 dtype,
+                 range,
+                 expected,
+             }| {
+                let (min, max) = *expected;
+                let value = generate("x", *dtype, *range);
+                let outside: Vec<f32> = elements(&value)
+                    .into_iter()
+                    .filter(|x| *x < min || *x > max)
+                    .collect();
+                assert!(
+                    outside.is_empty(),
+                    "values outside {min}:{max}: {outside:?}"
+                );
+            },
+        )
+    }
+
+    #[test]
+    fn test_generate_name_heuristics() {
+        // Inputs whose names match certain patterns get fixed values which are
+        // more likely to be valid than random ones.
+        assert_eq!(
+            elements(&generate("attention_mask", DataType::Int32, None)),
+            [1.; 64]
+        );
+        assert_eq!(
+            elements(&generate("input_ids", DataType::Int32, None)),
+            [0.; 64]
+        );
+        assert_eq!(
+            elements(&generate("use_cache_branch", DataType::Int32, None)),
+            [0.]
+        );
+
+        // An explicitly specified range overrides these heuristics.
+        assert_eq!(
+            elements(&generate("input_ids", DataType::Int32, Some((5., 5.)))),
+            [5.; 64]
+        );
+    }
+}

--- a/rten-cli/src/input_range.rs
+++ b/rten-cli/src/input_range.rs
@@ -1,0 +1,218 @@
+use crate::name_value::{self, ParseError, Token};
+
+/// Specifies the range of randomly generated values for a model input.
+#[derive(Clone, Debug, PartialEq)]
+pub struct InputRange {
+    /// Name of model input.
+    pub input_name: String,
+
+    /// Minimum generated value.
+    pub min: f32,
+
+    /// Maximum generated value.
+    pub max: f32,
+}
+
+impl InputRange {
+    /// Return true if `self` specifies the value range for a given input.
+    pub fn matches(&self, input_name: &str) -> bool {
+        self.input_name == input_name
+    }
+
+    /// Parse a value range specifier in the form `input_name=min:max`.
+    pub fn parse(spec: &str) -> Result<InputRange, ParseError> {
+        let Some((name_tokens, range_str)) = name_value::split(spec) else {
+            return Err(ParseError::new(
+                spec,
+                "expected <name>=<min>:<max> but no '=' was found",
+            ));
+        };
+
+        let input_name =
+            join_name(&name_tokens).ok_or_else(|| ParseError::new(spec, "invalid input name"))?;
+
+        let Some((min_str, max_str)) = range_str.split_once(':') else {
+            return Err(ParseError::new(
+                spec,
+                "expected <min>:<max> but no ':' was found",
+            ));
+        };
+
+        let parse_value = |value: &str| {
+            value
+                .parse::<f32>()
+                .map_err(|_| ParseError::new(spec, "invalid min or max value. Must be a number"))
+        };
+        let min = parse_value(min_str)?;
+        let max = parse_value(max_str)?;
+
+        if !min.is_finite() || !max.is_finite() || min > max {
+            return Err(ParseError::new(
+                spec,
+                "invalid value range. Must be finite with min <= max",
+            ));
+        }
+
+        Ok(InputRange {
+            input_name,
+            min,
+            max,
+        })
+    }
+
+    /// Sort and de-duplicate entries in `ranges`.
+    ///
+    /// Entries are sorted by input name.
+    pub fn sort_dedup(ranges: &mut Vec<InputRange>) {
+        // Sort entries to group duplicates.
+        ranges.sort_by(|a, b| a.input_name.cmp(&b.input_name));
+
+        // Remove duplicate entries, keeping only the last one.
+        // `dedup_by` keeps only the first entry, hence we reverse before and after.
+        ranges.reverse();
+        ranges.dedup_by(|a, b| a.input_name == b.input_name);
+        ranges.reverse();
+    }
+}
+
+/// Join the tokens of a name into a single string, or `None` if the name is
+/// empty.
+fn join_name(tokens: &[Token]) -> Option<String> {
+    if tokens.is_empty() {
+        return None;
+    }
+    let name = tokens.iter().fold(String::new(), |mut name, token| {
+        match token {
+            Token::Dot => name.push('.'),
+            Token::Text(text) => name.push_str(text),
+        }
+        name
+    });
+    Some(name)
+}
+
+#[cfg(test)]
+mod tests {
+    use rten_testing::TestCases;
+
+    use super::InputRange;
+    use crate::name_value::ParseError;
+
+    #[test]
+    fn test_parse() {
+        #[derive(Debug)]
+        struct Case<'a> {
+            spec: &'a str,
+            expected: Result<InputRange, ParseError>,
+        }
+
+        let cases = [
+            Case {
+                spec: "input_ids=0:1000",
+                expected: Ok(InputRange {
+                    input_name: "input_ids".to_string(),
+                    min: 0.,
+                    max: 1000.,
+                }),
+            },
+            // Non-integer and negative bounds.
+            Case {
+                spec: "x=-1.5:1.5",
+                expected: Ok(InputRange {
+                    input_name: "x".to_string(),
+                    min: -1.5,
+                    max: 1.5,
+                }),
+            },
+            // Input names containing periods, quoted and unquoted.
+            Case {
+                spec: "\"past.0.key\"=0:1",
+                expected: Ok(InputRange {
+                    input_name: "past.0.key".to_string(),
+                    min: 0.,
+                    max: 1.,
+                }),
+            },
+            Case {
+                spec: "past.0.key=0:1",
+                expected: Ok(InputRange {
+                    input_name: "past.0.key".to_string(),
+                    min: 0.,
+                    max: 1.,
+                }),
+            },
+            Case {
+                spec: "foobar",
+                expected: Err(ParseError::new(
+                    "foobar",
+                    "expected <name>=<min>:<max> but no '=' was found",
+                )),
+            },
+            Case {
+                spec: "x=5",
+                expected: Err(ParseError::new(
+                    "x=5",
+                    "expected <min>:<max> but no ':' was found",
+                )),
+            },
+            Case {
+                spec: "=0:1",
+                expected: Err(ParseError::new("=0:1", "invalid input name")),
+            },
+            Case {
+                spec: "x=a:b",
+                expected: Err(ParseError::new(
+                    "x=a:b",
+                    "invalid min or max value. Must be a number",
+                )),
+            },
+            Case {
+                spec: "x=10:0",
+                expected: Err(ParseError::new(
+                    "x=10:0",
+                    "invalid value range. Must be finite with min <= max",
+                )),
+            },
+            Case {
+                spec: "x=0:inf",
+                expected: Err(ParseError::new(
+                    "x=0:inf",
+                    "invalid value range. Must be finite with min <= max",
+                )),
+            },
+        ];
+
+        cases.test_each(|Case { spec, expected }| {
+            let range = InputRange::parse(spec);
+            assert_eq!(range, *expected);
+        })
+    }
+
+    #[test]
+    fn test_matches() {
+        let range = InputRange::parse("input_ids=0:1").unwrap();
+        assert!(range.matches("input_ids"));
+        assert!(!range.matches("other_input"));
+    }
+
+    #[test]
+    fn test_sort_dedup() {
+        let mut ranges: Vec<InputRange> = [
+            InputRange::parse("input_ids=0:1").unwrap(),
+            InputRange::parse("input_ids=0:2").unwrap(),
+            InputRange::parse("attention_mask=0:3").unwrap(),
+        ]
+        .into();
+
+        InputRange::sort_dedup(&mut ranges);
+
+        assert_eq!(
+            ranges,
+            [
+                InputRange::parse("attention_mask=0:3").unwrap(),
+                // When there are duplicates, the last entry should be kept.
+                InputRange::parse("input_ids=0:2").unwrap(),
+            ]
+        );
+    }
+}

--- a/rten-cli/src/main.rs
+++ b/rten-cli/src/main.rs
@@ -6,17 +6,21 @@ use std::str::FromStr;
 use std::time::Instant;
 
 use rten::{
-    DataType, Dimension, Model, ModelMetadata, ModelOptions, NodeId, RunOptions, ThreadPool, Value,
-    ValueOrView, ValueType,
+    Model, ModelMetadata, ModelOptions, NodeId, RunOptions, ThreadPool, Value, ValueOrView,
 };
 use rten_base::num::AsUsize;
+use rten_tensor::TensorView;
 use rten_tensor::prelude::*;
-use rten_tensor::{Tensor, TensorView};
 
 mod dim_size;
 use dim_size::DimSize;
+mod input_generator;
+use input_generator::RandomInputGenerator;
 mod input_info;
 use input_info::{print_input_output_list, print_input_shapes, print_output_shapes};
+mod input_range;
+use input_range::InputRange;
+mod name_value;
 
 #[derive(Clone, Copy, Default, PartialEq)]
 enum ProfileMode {
@@ -79,6 +83,11 @@ struct Args {
     /// run model and don't produce other output
     #[argh(switch, short = 'q')]
     quiet: bool,
+
+    /// specify the range of randomly generated values for an input in the form `input_name=min:max`. Can be specified multiple times.
+    /// Input names may be quoted (eg. `"input.one"=0:10`).
+    #[argh(option, short = 'r')]
+    range: Vec<String>,
 
     /// specify size for a dynamic dimension in the form `dim_name=size` or `input_name.dim_name=size`. Can be specified multiple times.
     /// Input and dimension names may be quoted (eg. `"input.one"."dim.two"=3`).
@@ -145,6 +154,9 @@ struct InputConfig {
     /// a dynamic size.
     dim_sizes: Vec<DimSize>,
 
+    /// Ranges of values to use when generating random inputs.
+    ranges: Vec<InputRange>,
+
     /// Map of input name to value.
     ///
     /// Inputs use values from this map if present, otherwise a random input is
@@ -172,6 +184,9 @@ fn run_model(
     // Indexes of entries in `dim_sizes` that didn't match any inputs.
     let mut unused_dim_sizes: HashSet<usize> = (0..input_config.dim_sizes.len()).collect();
 
+    // Indexes of entries in `ranges` that didn't match any inputs.
+    let mut unused_ranges: HashSet<usize> = (0..input_config.ranges.len()).collect();
+
     let mut input_generator = RandomInputGenerator::new();
 
     // Fetch or generate model inputs
@@ -188,11 +203,21 @@ fn run_model(
             let value_or_view = if let Some(value) = input_config.values.get(name) {
                 ValueOrView::View(value.as_view())
             } else {
+                let range = input_config
+                    .ranges
+                    .iter()
+                    .enumerate()
+                    .find(|(_i, range)| range.matches(name));
+                if let Some((idx, _)) = range {
+                    unused_ranges.remove(&idx);
+                }
+
                 let tensor = input_generator.generate(
                     name,
                     dtype,
                     &shape,
                     &input_config.dim_sizes,
+                    range.map(|(_i, range)| range),
                     |dim_name, dim_size_idx| {
                         if let Some(idx) = dim_size_idx {
                             unused_dim_sizes.remove(&idx);
@@ -239,6 +264,17 @@ fn run_model(
                 dim_size.dim_name
             )
         };
+        return Err(err.into());
+    }
+
+    // Error if specified value ranges were unused, as this likely indicates a
+    // typo in the input name.
+    if let Some(idx) = unused_ranges.into_iter().next() {
+        let range = &input_config.ranges[idx];
+        let err = format!(
+            "Input name \"{}\" in value range did not match any generated inputs",
+            range.input_name
+        );
         return Err(err.into());
     }
 
@@ -393,129 +429,6 @@ fn compare_tensors<T: Copy + Debug>(
     CompareMetrics { max_diff }
 }
 
-#[derive(Debug)]
-enum GenerateError {
-    UnsupportedDataType(ValueType),
-}
-
-impl std::fmt::Display for GenerateError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::UnsupportedDataType(dtype) => {
-                write!(f, "generation of {dtype} inputs is not supported")
-            }
-        }
-    }
-}
-
-impl Error for GenerateError {}
-
-struct RandomInputGenerator {
-    rng: fastrand::Rng,
-}
-
-impl RandomInputGenerator {
-    fn new() -> Self {
-        RandomInputGenerator {
-            rng: fastrand::Rng::new(),
-        }
-    }
-
-    /// Generate a random value for an input using the name, shape and dtype
-    /// properties from the model as well as configuration provided when
-    /// running the CLI.
-    ///
-    /// `on_resolve_size` is invoked for each dynamic dimension size that
-    /// is resolved, specifying the dimension name and index of the entry in
-    /// `dim_sizes` that was used, if any.
-    fn generate(
-        &mut self,
-        name: &str,
-        value_type: Option<ValueType>,
-        shape: &[Dimension],
-        dim_sizes: &[DimSize],
-        mut on_resolve_size: impl FnMut(&str, Option<usize>),
-    ) -> Result<Value, GenerateError> {
-        let dtype = match value_type {
-            Some(ValueType::Tensor(dtype)) => Some(dtype),
-            Some(vtype) => {
-                return Err(GenerateError::UnsupportedDataType(vtype));
-            }
-            None => None,
-        };
-
-        let resolved_shape: Vec<usize> = shape
-            .iter()
-            .map(|dim| match dim {
-                Dimension::Symbolic(dim_name) => {
-                    if let Some((idx, dim_size)) = dim_sizes
-                        .iter()
-                        .enumerate()
-                        .find(|(_i, ds)| ds.matches(name, dim_name))
-                    {
-                        on_resolve_size(dim_name, Some(idx));
-                        dim_size.size
-                    } else {
-                        on_resolve_size(dim_name, None);
-                        1
-                    }
-                }
-                Dimension::Fixed(size) => *size,
-            })
-            .collect();
-
-        fn random_ints<T, F: FnMut() -> T>(shape: &[usize], generate: F) -> Value
-        where
-            Value: From<Tensor<T>>,
-        {
-            Tensor::from_simple_fn(shape, generate).into()
-        }
-
-        // Guess suitable content for the input based on its name.
-        let value = match name {
-            // If this is a mask, use all ones on the assumption that we
-            // don't want to mask anything out.
-            name if name.ends_with("_mask") && matches!(dtype, Some(DataType::Int32) | None) => {
-                Value::from(Tensor::full(&resolved_shape, 1i32))
-            }
-
-            // Inputs such as `token_type_ids`, `position_ids`, `input_ids`.
-            // We use zero as a value that is likely to be valid for all
-            // of these.
-            name if name.ends_with("_ids") && matches!(dtype, Some(DataType::Int32) | None) => {
-                Value::from(Tensor::<i32>::zeros(&resolved_shape))
-            }
-
-            // Optimum can export "merged" transformer models which have two
-            // branches. One accepts KV-cache inputs and the other does not.
-            // Set this to false as a "safer" value because we don't have
-            // cached outputs from a previous run.
-            "use_cache_branch" if matches!(dtype, Some(DataType::Int32) | None) => {
-                Value::from(Tensor::from(0i32))
-            }
-
-            // For anything else, random values.
-            _ => match dtype {
-                // Generate floats in [0, 1]
-                Some(DataType::Float) | None => {
-                    Value::from(Tensor::from_simple_fn(&resolved_shape, || self.rng.f32()))
-                }
-                // Generate random values for int types. The default ranges
-                // are intended to be suitable for many models, but there
-                // ought to be a way to override them.
-                Some(DataType::Int32) => random_ints(&resolved_shape, || self.rng.i32(0..256)),
-                Some(DataType::Int8) => random_ints(&resolved_shape, || self.rng.i8(0..=127)),
-                Some(DataType::UInt8) => random_ints(&resolved_shape, || self.rng.u8(0..=255)),
-                Some(dtype) => {
-                    return Err(GenerateError::UnsupportedDataType(ValueType::Tensor(dtype)));
-                }
-            },
-        };
-
-        Ok(value)
-    }
-}
-
 /// Convert a tensor read from a Safetensors file into an rten [`Value`].
 fn rten_value(value: rten_serialize::Value) -> Result<Value, Box<dyn Error>> {
     use rten_serialize::Value as SV;
@@ -578,12 +491,25 @@ fn main() {
         match DimSize::parse(size_str) {
             Ok(size) => input_sizes.push(size),
             Err(err) => {
-                eprintln!("Invalid size specification '{}': {}", size_str, err);
+                eprintln!("Invalid --size argument: {}", err);
                 std::process::exit(1);
             }
         }
     }
     DimSize::sort_dedup(&mut input_sizes);
+
+    // Parse input value ranges from string arguments
+    let mut input_ranges = Vec::new();
+    for range_str in &args.range {
+        match InputRange::parse(range_str) {
+            Ok(range) => input_ranges.push(range),
+            Err(err) => {
+                eprintln!("Invalid --range argument: {}", err);
+                std::process::exit(1);
+            }
+        }
+    }
+    InputRange::sort_dedup(&mut input_ranges);
 
     // Parse profile mode from switch count
     let profile_mode = match args.profile {
@@ -673,6 +599,7 @@ fn main() {
 
     let inputs = InputConfig {
         dim_sizes: input_sizes,
+        ranges: input_ranges,
         values: input_values,
     };
 

--- a/rten-cli/src/name_value.rs
+++ b/rten-cli/src/name_value.rs
@@ -1,0 +1,136 @@
+//! Parsing helpers for command line specifiers in the form `<name>=<value>`.
+
+/// A token in the name part of a `<name>=<value>` specifier.
+#[derive(Debug, PartialEq)]
+pub enum Token {
+    /// A `.` separator between parts of a name.
+    Dot,
+    /// A run of literal characters, with any quoting removed.
+    Text(String),
+}
+
+/// Split a specifier in the form `<name>=<value>` into the tokenized name and
+/// the raw value.
+///
+/// Parts of the name may be quoted with `"` in order to include `.` or `=`
+/// characters (eg. `"input.name".dim=3`).
+///
+/// Returns `None` if the specifier contains no unquoted `=`.
+pub fn split(spec: &str) -> Option<(Vec<Token>, &str)> {
+    let mut tokens = Vec::new();
+    let mut in_quote = false;
+
+    for (pos, ch) in spec.char_indices() {
+        match ch {
+            '=' if !in_quote => {
+                return Some((tokens, &spec[pos + 1..]));
+            }
+            '.' if !in_quote => {
+                tokens.push(Token::Dot);
+            }
+            '"' => in_quote = !in_quote,
+            ch => {
+                if let Some(Token::Text(text)) = tokens.last_mut() {
+                    text.push(ch);
+                } else {
+                    tokens.push(Token::Text(ch.into()));
+                }
+            }
+        }
+    }
+
+    None
+}
+
+/// Error parsing a `<name>=<value>` specifier.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ParseError {
+    spec: String,
+    message: String,
+}
+
+impl ParseError {
+    pub fn new(spec: &str, message: impl Into<String>) -> ParseError {
+        ParseError {
+            spec: spec.to_string(),
+            message: message.into(),
+        }
+    }
+}
+
+impl std::fmt::Display for ParseError {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(fmt, "invalid specifier \"{}\": {}", self.spec, self.message)
+    }
+}
+
+impl std::error::Error for ParseError {}
+
+#[cfg(test)]
+mod tests {
+    use rten_testing::TestCases;
+
+    use super::{Token, split};
+
+    fn text(text: &str) -> Token {
+        Token::Text(text.to_string())
+    }
+
+    #[test]
+    fn test_split() {
+        #[derive(Debug)]
+        struct Case<'a> {
+            spec: &'a str,
+            expected: Option<(Vec<Token>, &'a str)>,
+        }
+
+        let cases = [
+            Case {
+                spec: "name=value",
+                expected: Some((vec![text("name")], "value")),
+            },
+            // Periods separate parts of the name.
+            Case {
+                spec: "a.b=1",
+                expected: Some((vec![text("a"), Token::Dot, text("b")], "1")),
+            },
+            // Quoting allows periods and `=` to be used in a name.
+            Case {
+                spec: "\"a.b\"=1",
+                expected: Some((vec![text("a.b")], "1")),
+            },
+            Case {
+                spec: "\"a=b\".c=1",
+                expected: Some((vec![text("a=b"), Token::Dot, text("c")], "1")),
+            },
+            // Only the first unquoted `=` separates the name and value. The
+            // value is returned unparsed.
+            Case {
+                spec: "name=1.5=2",
+                expected: Some((vec![text("name")], "1.5=2")),
+            },
+            // Empty names and values.
+            Case {
+                spec: "=1",
+                expected: Some((Vec::new(), "1")),
+            },
+            Case {
+                spec: "name=",
+                expected: Some((vec![text("name")], "")),
+            },
+            // Specifiers with no unquoted `=`.
+            Case {
+                spec: "name",
+                expected: None,
+            },
+            Case {
+                spec: "\"a=b\"",
+                expected: None,
+            },
+        ];
+
+        cases.test_each(|Case { spec, expected }| {
+            assert_eq!(split(spec), *expected);
+        })
+    }
+}


### PR DESCRIPTION
Add a `--range` option to the CLI to set the range of generated input values. The syntax follows the existing `--size` option. This is useful especially for models which have inputs that are used as indices (eg. for `Gather`) but don't match the existing `*_ids` name heuristic.

The syntax is `--range input_name=min:max`.

As part of this, the input value generation code has been split out of `rten-cli/src/main.rs` into a separate module.