### PR TITLE
Add `ConvIntegerToFloat` fusion

### DIFF
--- a/src/operator.rs
+++ b/src/operator.rs
@@ -830,6 +830,20 @@ impl<
     }
 }
 
+impl<
+    'a,
+    I1: Into<ValueView<'a>>,
+    I2: Into<ValueView<'a>>,
+    I3: Into<ValueView<'a>>,
+    I4: Into<ValueView<'a>>,
+    I5: Into<ValueView<'a>>,
+> From<(I1, I2, I3, I4, I5)> for InputList<'a>
+{
+    fn from((a, b, c, d, e): (I1, I2, I3, I4, I5)) -> InputList<'a> {
+        InputList::from(&[a.into(), b.into(), c.into(), d.into(), e.into()])
+    }
+}
+
 impl<'a> Extend<ValueView<'a>> for InputList<'a> {
     fn extend<T>(&mut self, iter: T)
     where

--- a/src/ops/conv.rs
+++ b/src/ops/conv.rs
@@ -17,7 +17,7 @@ use crate::operator::{
     OutputTypesContext, check_eq, static_dims,
 };
 use crate::ops::Padding;
-use crate::ops::matmul::{shift_cast_gemm_lhs_to_u8, zero_point_to_vec};
+use crate::ops::matmul::{OutputScale, cast_scale, shift_cast_gemm_lhs_to_u8, zero_point_to_vec};
 use crate::ops::pooling::{RoundMode, calc_output_size_and_padding};
 use crate::shift_cast::ShiftCast;
 use crate::value::{DataType, ValueType, ValueView};
@@ -475,7 +475,7 @@ where
     )
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct ConvInteger {
     pub groups: usize,
     pub dilations: Vec<usize>,
@@ -544,6 +544,48 @@ impl_infer_shapes!(
     }
 );
 
+/// Fusion of [`ConvInteger`] with the cast and scaling of its output to float.
+///
+/// This computes `Cast(ConvInteger(x, w, x_zero_point, w_zero_point)) * scale`,
+/// where `scale` is a scalar.
+#[derive(Debug)]
+pub struct ConvIntegerToFloat {
+    conv: ConvInteger,
+}
+
+impl ConvIntegerToFloat {
+    pub fn new(conv: ConvInteger) -> Self {
+        ConvIntegerToFloat { conv }
+    }
+}
+
+impl Operator for ConvIntegerToFloat {
+    fn name(&self) -> &str {
+        "ConvIntegerToFloat"
+    }
+
+    fn max_inputs(&self) -> Option<usize> {
+        Some(5)
+    }
+
+    fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+        let scale: TensorView<f32> = ctx.inputs().require_as(4)?;
+        let Some(&scale) = scale.item() else {
+            return Err(OpError::InvalidValue("scale should be a scalar"));
+        };
+        let output: Tensor<i32> = self.conv.run(ctx)?.remove(0).try_into().unwrap();
+        cast_scale(ctx.pool(), output, OutputScale::Scalar(scale)).into_op_result()
+    }
+
+    fn output_types(&self, _ctx: &OutputTypesContext) -> Option<OutputTypeList> {
+        Some([OutputType::Fixed(ValueType::Tensor(DataType::Float))].into())
+    }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        Some(&self.conv)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::error::Error;
@@ -560,7 +602,7 @@ mod tests {
     use crate::operator::{OpError, OperatorExt};
     use crate::ops::pooling::{RoundMode, calc_output_size_and_padding};
     use crate::ops::tests::expect_eq_1e4;
-    use crate::ops::{Conv, Padding, conv, conv_integer};
+    use crate::ops::{Conv, ConvInteger, ConvIntegerToFloat, Padding, conv, conv_integer};
 
     trait ReferenceConvKernel<X, W> {
         /// Update a single output element (`self`) with a given input and weight value.
@@ -1471,6 +1513,83 @@ mod tests {
     impl_conv_integer_test!(test_conv_integer_u8_i8, u8, i8);
     impl_conv_integer_test!(test_conv_integer_i8_u8, i8, u8);
     impl_conv_integer_test!(test_conv_integer_i8_i8, i8, i8);
+
+    #[test]
+    fn test_conv_integer_to_float() {
+        #[derive(Debug)]
+        struct Case {
+            scale: Tensor<f32>,
+            expected: Result<Tensor<f32>, OpError>,
+        }
+
+        let mut rng = XorShiftRng::new(1234);
+        let mut kernel_rng = ReducedRangeRng::new(true /* reduce_range */, 1234);
+        let input = Tensor::<u8>::rand(&[1, 2, 5, 5], &mut rng);
+        let kernel = Tensor::<i8>::rand(&[3, 2, 3, 3], &mut kernel_rng);
+        let input_zero = Tensor::from(12u8);
+        let kernel_zero = Tensor::from([1i8, 2, 3]);
+
+        let conv = ConvInteger {
+            groups: 1,
+            dilations: vec![1, 1],
+            padding: Padding::zero::<2>(),
+            strides: vec![1, 1],
+        };
+
+        // Unscaled output.
+        let int_output: Tensor<i32> = conv
+            .run_simple((
+                input.view(),
+                kernel.view(),
+                input_zero.view(),
+                kernel_zero.view(),
+            ))
+            .unwrap();
+
+        let scale_by = |scale: f32| {
+            Tensor::from_data(
+                int_output.shape(),
+                int_output
+                    .iter()
+                    .map(|x| *x as f32 * scale)
+                    .collect::<Vec<_>>(),
+            )
+        };
+
+        let cases = [
+            // Scalar scale.
+            Case {
+                scale: Tensor::from(0.1),
+                expected: Ok(scale_by(0.1)),
+            },
+            // Single-element vector scale, which is equivalent to a scalar.
+            Case {
+                scale: Tensor::from([0.1]),
+                expected: Ok(scale_by(0.1)),
+            },
+            // Non-scalar scale.
+            Case {
+                scale: Tensor::from([0.1, 0.2, 0.3]),
+                expected: Err(OpError::InvalidValue("scale should be a scalar")),
+            },
+        ];
+
+        let op = ConvIntegerToFloat::new(conv);
+
+        cases.test_each(|case| {
+            let result: Result<Tensor<f32>, _> = op.run_simple((
+                input.view(),
+                kernel.view(),
+                input_zero.view(),
+                kernel_zero.view(),
+                case.scale.view(),
+            ));
+            match (&result, &case.expected) {
+                (Ok(result), Ok(expected)) => expect_equal(result, expected).unwrap(),
+                _ => assert_eq!(&result, &case.expected),
+            }
+        })
+    }
 
     #[ignore]
     #[test]

--- a/src/ops/matmul.rs
+++ b/src/ops/matmul.rs
@@ -705,14 +705,33 @@ impl Operator for MatMulInteger {
     }
 }
 
+/// Scale factor applied to the integer output of a quantized operator when
+/// converting it to float.
 #[derive(Clone, Debug)]
-enum OutputScale<'a> {
+pub enum OutputScale<'a> {
+    /// Scale which is applied to every element.
     Scalar(f32),
+    /// Scale which is applied per-column (ie. along the last axis).
     Vector(NdTensorView<'a, f32, 1>),
 }
 
+impl<'a> OutputScale<'a> {
+    /// Extract the scale from an operator input.
+    ///
+    /// The input must be a scalar or vector. A vector with a single element is
+    /// treated as a scalar, since it broadcasts against all columns.
+    fn from_view(scale: TensorView<'a, f32>) -> Result<Self, OpError> {
+        match scale.ndim() {
+            0 => Ok(OutputScale::Scalar(scale.item().copied().unwrap())),
+            1 if scale.size(0) == 1 => Ok(OutputScale::Scalar(scale.item().copied().unwrap())),
+            1 => Ok(OutputScale::Vector(scale.into_rank().unwrap())),
+            _ => Err(OpError::InvalidValue("scale should have rank 0 or 1")),
+        }
+    }
+}
+
 /// Cast elements in `data` to f32 and scale by the per-column scales in `scale`.
-fn cast_scale(
+pub fn cast_scale(
     pool: &BufferPool,
     mut data: Tensor<i32>,
     scale: OutputScale,
@@ -769,13 +788,7 @@ impl Operator for MatMulIntegerToFloat {
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let scale: TensorView<f32> = ctx.inputs().require_as(4)?;
-        let scale = match scale.ndim() {
-            0 => OutputScale::Scalar(scale.item().copied().unwrap()),
-            1 => OutputScale::Vector(scale.into_rank().unwrap()),
-            _ => {
-                return Err(OpError::InvalidValue("scale should have rank 0 or 1"));
-            }
-        };
+        let scale = OutputScale::from_view(scale)?;
         let output: Tensor<i32> = self.matmul.run(ctx)?.remove(0).try_into().unwrap();
         cast_scale(ctx.pool(), output, scale).into_op_result()
     }

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -76,7 +76,7 @@ pub(crate) use {
     compute_shape::{ComputeShape, SymbolInfo},
     concat::{Concat, Tile},
     control_flow::{If, Loop},
-    conv::{Conv, ConvInteger},
+    conv::{Conv, ConvInteger, ConvIntegerToFloat},
     conv_transpose::ConvTranspose,
     convert::{Cast, CastLike},
     einsum::Einsum,

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -24,12 +24,12 @@ mod pattern_matcher;
 use diagnostics::{DiagnosticLevel, Diagnostics};
 
 use fusions::{
-    AddSoftmaxFusion, ApproxGeluFusion, CastElimination, ComputeShapeFusion, ConvAddFusion, Fusion,
-    FusionError, FusionVisitor, GeluFusion, GroupedQueryAttentionMatMulFusion, IdentityFusion,
-    LayerNormalizationFusion, MatMulAddFusion, MatMulIntegerToFloatFusion, MatMulScaleFusion,
-    PatternFusion, RMSNormalizationFusion, ReciprocalFusion, ReduceMeanAxesFusion,
-    RepeatInterleaveFusion, SafeSoftmaxFusion, ShapeSliceToConstant, SiluFusion, SwishFusion,
-    TransposeFusion,
+    AddSoftmaxFusion, ApproxGeluFusion, CastElimination, ComputeShapeFusion, ConvAddFusion,
+    ConvIntegerToFloatFusion, Fusion, FusionError, FusionVisitor, GeluFusion,
+    GroupedQueryAttentionMatMulFusion, IdentityFusion, LayerNormalizationFusion, MatMulAddFusion,
+    MatMulIntegerToFloatFusion, MatMulScaleFusion, PatternFusion, RMSNormalizationFusion,
+    ReciprocalFusion, ReduceMeanAxesFusion, RepeatInterleaveFusion, SafeSoftmaxFusion,
+    ShapeSliceToConstant, SiluFusion, SwishFusion, TransposeFusion,
 };
 
 /// Errors that occur while applying graph optimizations.
@@ -577,6 +577,7 @@ impl GraphOptimizer {
 
         // Convolution fusions
         fusions.push(ConvAddFusion {});
+        fusions.push(ConvIntegerToFloatFusion {}.into_visitor());
 
         // Attention fusions.
         //

--- a/src/optimize/fusions.rs
+++ b/src/optimize/fusions.rs
@@ -14,9 +14,9 @@ use crate::graph::{
 use crate::operator::Operator;
 use crate::ops::transform_inputs::TransformInputsBuilder;
 use crate::ops::{
-    AddSoftmax, Cast, ComputeShape, Conv, FusedMatMul, Gelu, GroupedQueryAttentionMatMul,
-    LayerNormalization, MatMulIntegerToFloat, RMSNormalization, Reciprocal, ReduceMean,
-    RepeatInterleave, Shape, Silu, Softmax, Swish, SymbolInfo, Transpose,
+    AddSoftmax, Cast, ComputeShape, Conv, ConvInteger, ConvIntegerToFloat, FusedMatMul, Gelu,
+    GroupedQueryAttentionMatMul, LayerNormalization, MatMulIntegerToFloat, RMSNormalization,
+    Reciprocal, ReduceMean, RepeatInterleave, Shape, Silu, Softmax, Swish, SymbolInfo, Transpose,
 };
 use crate::optimize::pattern_matcher::{Match, Pattern};
 use crate::value::ValueType;
@@ -1006,6 +1006,54 @@ impl PatternFusion for MatMulIntegerToFloatFusion {
         }
 
         Ok(MatMulIntegerToFloat::default())
+    }
+}
+
+pub struct ConvIntegerToFloatFusion {}
+
+impl PatternFusion for ConvIntegerToFloatFusion {
+    type Operator = ConvIntegerToFloat;
+
+    fn name(&self) -> &str {
+        "ConvIntegerToFloatFusion"
+    }
+
+    fn pattern(&self) -> Pattern {
+        let scale = Pattern::symbol("scale");
+        let x = Pattern::symbol("x");
+        let w = Pattern::symbol("w");
+        let x_zero = Pattern::symbol("x_zero");
+        let w_zero = Pattern::symbol("w_zero");
+
+        Pattern::unary_op(
+            "Cast",
+            Pattern::operator("ConvInteger", [x, w, x_zero, w_zero]).with_name("conv"),
+        ) * scale
+    }
+
+    fn inputs(&self) -> &[&str] {
+        &["x", "w", "x_zero", "w_zero", "scale"]
+    }
+
+    fn maybe_fuse(&self, pat_match: &Match, graph: &Graph) -> Result<Self::Operator, FusionError> {
+        let scale = pat_match.node_id("scale").unwrap();
+        let scale_shape = graph
+            .get_node(scale)
+            .ok_or(FusionError::NoMatch)?
+            .shape()
+            .ok_or(FusionError::CheckFailed("unknown scale shape"))?;
+
+        let is_scalar = matches!(scale_shape.as_ref(), [] | [Dimension::Fixed(1)]);
+        if !is_scalar {
+            return Err(FusionError::NoMatch);
+        }
+
+        let conv_id = pat_match.node_id("conv").unwrap();
+        let conv: &ConvInteger = graph
+            .get_operator(conv_id)
+            .ok_or(FusionError::CheckFailed("expected ConvInteger operator"))?;
+
+        Ok(ConvIntegerToFloat::new(conv.clone()))
     }
 }
 

--- a/src/optimize/tests.rs
+++ b/src/optimize/tests.rs
@@ -15,10 +15,10 @@ use crate::graph::{
 };
 use crate::infer_shapes::InferShapeOptions;
 use crate::ops::{
-    Add, Cast, ComputeShape, Conv, DynamicQuantizeLinear, Erf, Expand, FusedMatMul, Gather, Gelu,
-    GroupedQueryAttentionMatMul, Identity, If, IsNaN, LayerNormalization, MatMul, MatMulInteger,
-    Neg, Padding, Pow, RMSNormalization, ReduceMean, RepeatInterleave, Reshape, Shape, Sigmoid,
-    Slice, Softmax, Sqrt, Swish, Tanh, Transpose, Unsqueeze, Where,
+    Add, Cast, ComputeShape, Conv, ConvInteger, DynamicQuantizeLinear, Erf, Expand, FusedMatMul,
+    Gather, Gelu, GroupedQueryAttentionMatMul, Identity, If, IsNaN, LayerNormalization, MatMul,
+    MatMulInteger, Neg, Padding, Pow, RMSNormalization, ReduceMean, RepeatInterleave, Reshape,
+    Shape, Sigmoid, Slice, Softmax, Sqrt, Swish, Tanh, Transpose, Unsqueeze, Where,
 };
 use crate::value::{DataType, Value, ValueType};
 
@@ -973,6 +973,76 @@ fn test_fuse_matmulinteger_cast_scale() {
     let (_, op) = graph.get_source_node(graph.output_ids()[0]).unwrap();
 
     assert_eq!(op.operator().name(), "MatMulIntegerToFloat");
+}
+
+#[test]
+fn test_fuse_convinteger_cast_scale() {
+    #[derive(Debug)]
+    struct Case {
+        scale: Tensor<f32>,
+        expected_op: &'static str,
+    }
+
+    let cases = [
+        // Scalar scale
+        Case {
+            scale: Tensor::from(0.1),
+            expected_op: "ConvIntegerToFloat",
+        },
+        // Unsupported scale shapes
+        Case {
+            scale: Tensor::from([0.1, 0.2, 0.3]),
+            expected_op: "Mul",
+        },
+        Case {
+            scale: Tensor::from_data(&[1, 1, 1, 1, 1], vec![0.1]),
+            expected_op: "Mul",
+        },
+    ];
+
+    cases.test_each(|case| {
+        let graph = {
+            let x = Expr::value("x");
+            let weights = Expr::constant(Tensor::<i8>::zeros(&[3, 2, 3, 3]));
+            let weights_zero = Expr::constant(Tensor::<i8>::zeros(&[3]));
+
+            let quant = x.apply(
+                DynamicQuantizeLinear {},
+                &[],
+                &[
+                    OutputMeta::NoMeta,
+                    OutputMeta::Meta((DataType::Float, vec![])),
+                    OutputMeta::NoMeta,
+                ],
+            );
+            let quant_x = quant.output(0);
+            let quant_scale = quant.output(1);
+            let quant_zero = quant.output(2);
+            let weight_scale = Expr::constant(case.scale.clone());
+
+            let expr = quant_x
+                .apply(
+                    ConvInteger {
+                        groups: 1,
+                        dilations: vec![1, 1],
+                        padding: Padding::zero::<2>(),
+                        strides: vec![1, 1],
+                    },
+                    &[weights, quant_zero, weights_zero],
+                    &[OutputMeta::NoMeta],
+                )
+                .unary(Cast {
+                    to: DataType::Float,
+                })
+                * (quant_scale * weight_scale);
+            expr.build_graph(["x"])
+        };
+
+        let graph = optimize_graph_infer_shapes(graph).unwrap();
+        let (_, op) = graph.get_source_node(graph.output_ids()[0]).unwrap();
+
+        assert_eq!(op.operator().name(), case.expected_op);
+    })
 }
 
 #[test]


### PR DESCRIPTION
Quantized models produced by dynamic quantization convert the output of `ConvInteger` back to float via `Cast` followed by a `Mul` with the product of the input and weight scales. Fuse the `ConvInteger`, `Cast` and final `Mul` into a single `ConvIntegerToFloat` operator, mirroring the existing `MatMulIntegerToFloat` fusion.

The scale must be a scalar, ie. per-tensor quantization. This is what the quantized models produced by `onnxruntime.quantization` currently use.

The `cast_scale` helper is shared with `MatMulIntegerToFloat`. Its scale parsing is factored out into `OutputScale::from_view`, which now treats a single-element vector scale as a scalar. Previously such a scale took the per-column path and failed unless the output's last dimension also had a size of one.