### PR TITLE
Generate `use_cache_branch` input with declared shape in CLI

### DIFF
--- a/rten-cli/src/input_generator.rs
+++ b/rten-cli/src/input_generator.rs
@@ -121,7 +121,7 @@ impl RandomInputGenerator {
             "use_cache_branch"
                 if range.is_none() && matches!(dtype, Some(DataType::Int32) | None) =>
             {
-                Value::from(Tensor::from(0i32))
+                Value::from(Tensor::<i32>::zeros(&resolved_shape))
             }
 
             // For anything else, random values. The default ranges are
@@ -300,7 +300,7 @@ mod tests {
         );
         assert_eq!(
             elements(&generate("use_cache_branch", DataType::Int32, None)),
-            [0.]
+            [0.; 64]
         );
 
         // An explicitly specified range overrides these heuristics.


### PR DESCRIPTION
The input generator has a special case for inputs named `use_cache_branch`, but this case did not respect the input's declared shape and always generated a scalar. Fix this by using the declared shape.

This fixes an issue with models that have a `use_cache_branch` input which is a single-element vector.