### PR TITLE
Support all tensor data types in ConstantOfShape `value` attribute

### DIFF
--- a/src/graph/node.rs
+++ b/src/graph/node.rs
@@ -9,7 +9,7 @@ use rten_tensor::{ArcTensor, DynLayout, TensorView};
 use super::NodeId;
 use crate::constant_storage::ArcTensorView;
 use crate::operator::Operator;
-use crate::value::{DataType, ValueType, ValueView};
+use crate::value::{DataType, Scalar, ValueType, ValueView};
 
 #[derive(Debug)]
 pub enum Node {
@@ -321,6 +321,16 @@ impl Constant {
             Constant::Int32(i) => i.layout(),
             Constant::Int8(i) => i.layout(),
             Constant::UInt8(i) => i.layout(),
+        }
+    }
+
+    /// Return this constant's value as a scalar, if it has exactly one element.
+    pub fn item(&self) -> Option<Scalar> {
+        match self {
+            Constant::Float(f) => f.view().item().copied().map(Scalar::Float),
+            Constant::Int32(i) => i.view().item().copied().map(Scalar::Int32),
+            Constant::Int8(i) => i.view().item().copied().map(Scalar::Int8),
+            Constant::UInt8(i) => i.view().item().copied().map(Scalar::UInt8),
         }
     }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -27,7 +27,7 @@ mod load_error;
 mod metadata;
 
 #[cfg(feature = "onnx_format")]
-mod onnx_loader;
+pub(crate) mod onnx_loader;
 
 #[cfg(feature = "rten_format")]
 mod rten_loader;
@@ -1471,7 +1471,7 @@ mod tests {
         add_operator!(Concat, [input_node, input_node], { axis: 0 });
 
         let shape = graph_builder.add_constant(Tensor::from([1, 5, 10]).view());
-        add_operator!(ConstantOfShape, [shape], { value: Scalar::Int(42) });
+        add_operator!(ConstantOfShape, [shape], { value: Scalar::Int32(42) });
 
         add_operator!(Conv, [input_node, kernel], {
             dilations: vec![1, 1],

--- a/src/model/onnx_loader.rs
+++ b/src/model/onnx_loader.rs
@@ -372,7 +372,7 @@ fn load_value_info(
 /// Create a constant graph node from an ONNX tensor.
 ///
 /// If `name` is provided, it overrides the name from `initializer.name`.
-fn load_constant(
+pub(crate) fn load_constant(
     initializer: &onnx::TensorProto,
     loader: Option<&dyn DataLoader>,
     name: Option<&str>,
@@ -965,6 +965,9 @@ fn add_operator(
         load_graph: &'a dyn Fn(&onnx::GraphProto) -> Result<Graph, LoadError>,
         opset_versions: OpsetVersions<'a>,
 
+        /// Source for tensor data stored outside the model file.
+        loader: Option<&'a dyn DataLoader>,
+
         /// Domain of the operator being loaded.
         domain: &'a str,
     }
@@ -978,11 +981,21 @@ fn add_operator(
             // Resolved on demand since most deserializers don't need it.
             self.opset_versions.version(self.domain)
         }
+
+        fn load_tensor(
+            &self,
+            attr_name: &str,
+            tensor: &onnx::TensorProto,
+        ) -> Result<Constant, ReadOpError> {
+            load_constant(tensor, self.loader, None)
+                .map_err(|err| ReadOpError::attr_error(attr_name, err.to_string()))
+        }
     }
 
     let ctx = LoadContext {
         load_graph: &load_subgraph,
         opset_versions: subgraph_opts.opset_versions,
+        loader: subgraph_opts.loader,
         domain: onnx_op.domain.as_deref().unwrap_or_default(),
     };
 

--- a/src/model/rten_builder.rs
+++ b/src/model/rten_builder.rs
@@ -503,7 +503,7 @@ impl<'mb, 'a> GraphBuilder<'mb, 'a> {
             OpType::ConstantOfShape(args) => {
                 op_with_attrs!(ConstantOfShape, ConstantOfShapeAttrs, {
                     match args.value {
-                        Scalar::Int(int_value) => sg::ConstantOfShapeAttrsArgs {
+                        Scalar::Int32(int_value) => sg::ConstantOfShapeAttrsArgs {
                             value_type: sg::Scalar::IntScalar,
                             value: Some(
                                 sg::IntScalar::create(
@@ -523,6 +523,9 @@ impl<'mb, 'a> GraphBuilder<'mb, 'a> {
                                 .as_union_value(),
                             ),
                         },
+                        Scalar::Int8(_) | Scalar::UInt8(_) => unimplemented!(
+                            "serializing int8/uint8 ConstantOfShape values requires a schema change"
+                        ),
                     }
                 })
             }

--- a/src/op_registry.rs
+++ b/src/op_registry.rs
@@ -113,7 +113,7 @@ pub enum ReadOpError {
 }
 
 impl ReadOpError {
-    fn attr_error(attr: impl AsRef<str>, error: impl AsRef<str>) -> Self {
+    pub(crate) fn attr_error(attr: impl AsRef<str>, error: impl AsRef<str>) -> Self {
         Self::AttrError {
             attr: attr.as_ref().to_string(),
             error: error.as_ref().to_string(),

--- a/src/op_registry/onnx_registry.rs
+++ b/src/op_registry/onnx_registry.rs
@@ -7,13 +7,13 @@ use std::fmt;
 use std::sync::Arc;
 
 use rten_base::bit_set::BitSet;
-use rten_base::num::{AsUsize, LeBytes};
+use rten_base::num::AsUsize;
 use rten_onnx::onnx;
 use rustc_hash::FxHashMap;
 use smallvec::SmallVec;
 
 use super::ReadOpError;
-use crate::graph::Graph;
+use crate::graph::{Constant, Graph};
 use crate::operator::Operator;
 use crate::ops;
 #[cfg(feature = "contrib")]
@@ -342,6 +342,16 @@ pub trait OpLoadContext {
     /// Return the opset version that the operator uses, or `None` if
     /// unspecified or invalid.
     fn opset_version(&self) -> Option<u16>;
+
+    /// Deserialize a tensor from the operator attribute named `attr_name`.
+    ///
+    /// Tensor data stored in the `raw_data` field is moved out of `tensor`
+    /// rather than copied, so this must be called at most once per tensor.
+    fn load_tensor(
+        &self,
+        attr_name: &str,
+        tensor: &onnx::TensorProto,
+    ) -> Result<Constant, ReadOpError>;
 }
 
 /// Value for an operator input created from an attribute (`onnx::AttributeProto`).
@@ -958,69 +968,31 @@ impl_read_op!(ConvInteger, |attrs: &Attrs| {
     })
 });
 
-/// Helper for extracting scalar values from a `TensorProto`.
-///
-/// The data may be stored either as little-endian bytes in the `raw_data` field
-/// or in one of the repeated numeric fields (`float_data`, `int32_data` etc.)
-/// The numeric field may have a wider type than the tensor's data type (eg.
-/// int8 values are stored in the int32_data field).
-fn extract_scalar<T: Copy + LeBytes, U: Copy + TryInto<T>>(
-    raw_data: Option<&[u8]>,
-    typed_data: &[U],
-) -> Result<T, ReadOpError> {
-    if let Some(data) = raw_data
-        && let Ok(bytes) = data.try_into()
-    {
-        Ok(T::from_le_bytes(bytes))
-    } else if typed_data.len() == 1
-        && let Ok(value) = typed_data[0].try_into()
-    {
-        Ok(value)
-    } else {
-        Err(ReadOpError::attr_error("value", "invalid scalar value"))
+impl ReadOp for ops::ConstantOfShape {
+    fn id() -> OpId<'static> {
+        OpId::new("ConstantOfShape")
+    }
+
+    fn read(op: &onnx::NodeProto, ctx: &dyn OpLoadContext) -> Result<ParsedOp<Self>, ReadOpError> {
+        let attrs = Attrs::new(&op.attribute, ctx.opset_version());
+
+        let value = attrs
+            .get("value")
+            .map(|attr| {
+                let Some(tensor) = attr.attr.t.as_ref() else {
+                    return Err(ReadOpError::attr_error("value", "missing tensor value"));
+                };
+                let constant = ctx.load_tensor("value", tensor)?;
+                constant
+                    .item()
+                    .ok_or_else(|| ReadOpError::attr_error("value", "expected a single element"))
+            })
+            .transpose()?
+            .unwrap_or(Scalar::Float(0.));
+
+        Ok(ParsedOp::from(ops::ConstantOfShape { value }).with_unused_attrs(attrs.unused_attrs()))
     }
 }
-
-impl_read_op!(ConstantOfShape, |attrs: &Attrs| {
-    let value = attrs
-        .get("value")
-        .map(|attr| {
-            let Some(tensor) = attr.attr.t.as_ref() else {
-                return Err(ReadOpError::attr_error("value", "missing tensor value"));
-            };
-
-            let raw_data = tensor.raw_data.as_ref().map(|data| data.take());
-
-            match tensor.data_type {
-                Some(onnx::DataType::FLOAT) => {
-                    let value = extract_scalar(raw_data.as_deref(), &tensor.float_data)?;
-                    Ok(Scalar::Float(value))
-                }
-                Some(onnx::DataType::INT64) => {
-                    let value: i64 = extract_scalar(raw_data.as_deref(), &tensor.int64_data)?;
-                    #[allow(clippy::as_conversions)]
-                    Ok(Scalar::Int(value as i32))
-                }
-                Some(onnx::DataType::INT32) => {
-                    let value: i32 = extract_scalar(raw_data.as_deref(), &tensor.int32_data)?;
-                    Ok(Scalar::Int(value))
-                }
-                Some(onnx::DataType::BOOL) => {
-                    let value: u8 = extract_scalar(raw_data.as_deref(), &tensor.int32_data)?;
-                    let value = if value != 0 { 1 } else { 0 };
-                    Ok(Scalar::Int(value))
-                }
-                _ => Err(ReadOpError::attr_error(
-                    "value",
-                    "unsupported data type for ConstantOfShape",
-                )),
-            }
-        })
-        .transpose()?
-        .unwrap_or(Scalar::Float(0.));
-
-    Ok(ops::ConstantOfShape { value })
-});
 
 impl_read_op!(ConvTranspose, |attrs: &Attrs| {
     let ConvAttrs {
@@ -1943,11 +1915,13 @@ impl_read_op!(Xor);
 #[cfg(test)]
 mod tests {
     use rten_onnx::onnx;
+    use rten_simd::f16;
     use rten_testing::TestCases;
 
     use super::{ConstInput, OnnxOpRegistry, OpLoadContext, ReadOpError};
-    use crate::graph::Graph;
+    use crate::graph::{Constant, Graph};
     use crate::model::onnx_builder::{NodeProtoExt, TensorData, create_node, create_tensor};
+    use crate::model::onnx_loader::load_constant;
     #[cfg(feature = "contrib")]
     use crate::operator::Operator;
     use crate::ops::{
@@ -1969,6 +1943,15 @@ mod tests {
 
         fn opset_version(&self) -> Option<u16> {
             self.opset_version
+        }
+
+        fn load_tensor(
+            &self,
+            attr_name: &str,
+            tensor: &onnx::TensorProto,
+        ) -> Result<Constant, ReadOpError> {
+            load_constant(tensor, None, None)
+                .map_err(|err| ReadOpError::attr_error(attr_name, err.to_string()))
         }
     }
 
@@ -2272,59 +2255,138 @@ mod tests {
     #[test]
     fn test_constant_of_shape_dtypes() {
         #[derive(Debug)]
-        struct Case {
+        struct Case<'a> {
             dtype: onnx::DataType,
+            shape: &'a [usize],
             data: TensorData,
-            expected: ConstantOfShape,
+            expected: Result<ConstantOfShape, &'a str>,
         }
 
         let cases = [
             // Conversions that don't alter the dtype.
             Case {
                 dtype: onnx::DataType::FLOAT,
+                shape: &[],
                 data: TensorData::Raw(1.0f32.to_le_bytes().into()),
-                expected: ConstantOfShape {
+                expected: Ok(ConstantOfShape {
                     value: Scalar::Float(1.0),
-                },
+                }),
             },
             Case {
                 dtype: onnx::DataType::INT32,
+                shape: &[],
                 data: TensorData::Raw(2i32.to_le_bytes().into()),
-                expected: ConstantOfShape {
-                    value: Scalar::Int(2),
-                },
+                expected: Ok(ConstantOfShape {
+                    value: Scalar::Int32(2),
+                }),
+            },
+            Case {
+                dtype: onnx::DataType::INT8,
+                shape: &[],
+                data: TensorData::Raw((-3i8).to_le_bytes().into()),
+                expected: Ok(ConstantOfShape {
+                    value: Scalar::Int8(-3),
+                }),
+            },
+            Case {
+                dtype: onnx::DataType::UINT8,
+                shape: &[],
+                data: TensorData::Raw(200u8.to_le_bytes().into()),
+                expected: Ok(ConstantOfShape {
+                    value: Scalar::UInt8(200),
+                }),
             },
             // Test conversions that alter the dtype.
             Case {
                 dtype: onnx::DataType::BOOL,
+                shape: &[],
                 data: TensorData::Int([1].into()),
-                expected: ConstantOfShape {
-                    value: Scalar::Int(1),
-                },
+                expected: Ok(ConstantOfShape {
+                    value: Scalar::Int32(1),
+                }),
             },
             Case {
                 dtype: onnx::DataType::BOOL,
+                shape: &[],
                 data: TensorData::Raw([0].into()),
-                expected: ConstantOfShape {
-                    value: Scalar::Int(0),
-                },
+                expected: Ok(ConstantOfShape {
+                    value: Scalar::Int32(0),
+                }),
             },
             Case {
                 dtype: onnx::DataType::INT64,
+                shape: &[],
                 data: TensorData::Raw(42i64.to_le_bytes().into()),
-                expected: ConstantOfShape {
-                    value: Scalar::Int(42),
-                },
+                expected: Ok(ConstantOfShape {
+                    value: Scalar::Int32(42),
+                }),
+            },
+            Case {
+                dtype: onnx::DataType::DOUBLE,
+                shape: &[],
+                data: TensorData::Double([2.5].into()),
+                expected: Ok(ConstantOfShape {
+                    value: Scalar::Float(2.5),
+                }),
+            },
+            // f16 values are converted to f32.
+            Case {
+                dtype: onnx::DataType::FLOAT16,
+                shape: &[],
+                data: TensorData::Raw(f16::from_f32(2.5).to_bits().to_le_bytes().into()),
+                expected: Ok(ConstantOfShape {
+                    value: Scalar::Float(2.5),
+                }),
+            },
+            // The ONNX spec describes `value` as a 1-element 1D tensor, but any
+            // shape with a single element is accepted.
+            Case {
+                dtype: onnx::DataType::FLOAT,
+                shape: &[1],
+                data: TensorData::Raw(3.0f32.to_le_bytes().into()),
+                expected: Ok(ConstantOfShape {
+                    value: Scalar::Float(3.0),
+                }),
+            },
+            Case {
+                dtype: onnx::DataType::FLOAT,
+                shape: &[1, 1],
+                data: TensorData::Raw(3.0f32.to_le_bytes().into()),
+                expected: Ok(ConstantOfShape {
+                    value: Scalar::Float(3.0),
+                }),
+            },
+            // Tensors with more than one element are rejected.
+            Case {
+                dtype: onnx::DataType::INT32,
+                shape: &[2],
+                data: TensorData::Int([1, 2].into()),
+                expected: Err("expected a single element"),
             },
         ];
 
         cases.test_each(|case| {
             let reg = OnnxOpRegistry::with_all_ops();
-            let tensor = create_tensor("test", &[], case.dtype, case.data.clone());
+            let tensor = create_tensor("test", case.shape, case.dtype, case.data.clone());
             let node = create_node("ConstantOfShape").with_attr("value", tensor);
-            let op = reg.read_op(&node, &FakeOpLoadContext::default()).unwrap();
-            let cos_op = op.op.downcast_ref::<ConstantOfShape>().unwrap();
-            assert_eq!(cos_op, &case.expected);
+
+            match (
+                reg.read_op(&node, &FakeOpLoadContext::default()),
+                &case.expected,
+            ) {
+                (Ok(op), Ok(expected)) => {
+                    let cos_op = op.op.downcast_ref::<ConstantOfShape>().unwrap();
+                    assert_eq!(cos_op, expected);
+                }
+                (Err(err), Err(expected)) => {
+                    assert!(
+                        err.to_string().contains(expected),
+                        "expected error containing {expected:?}, got {err}"
+                    );
+                }
+                (Ok(_), Err(expected)) => panic!("expected error containing {expected:?}"),
+                (Err(err), Ok(_)) => panic!("unexpected error {err}"),
+            }
         });
     }
 

--- a/src/op_registry/rten_registry.rs
+++ b/src/op_registry/rten_registry.rs
@@ -513,11 +513,11 @@ impl_read_op!(
     attrs_as_constant_of_shape_attrs,
     |attrs: sg::ConstantOfShapeAttrs| {
         let value = if let Some(int_val) = attrs.value_as_int_scalar() {
-            Scalar::Int(int_val.value())
+            Scalar::Int32(int_val.value())
         } else if let Some(float_val) = attrs.value_as_float_scalar() {
             Scalar::Float(float_val.value())
         } else {
-            Scalar::Int(0)
+            Scalar::Int32(0)
         };
         Ok(ops::ConstantOfShape { value })
     }

--- a/src/ops/control_flow.rs
+++ b/src/ops/control_flow.rs
@@ -522,7 +522,7 @@ mod tests {
                     // the iteration index.
                     let iter_vec = iter.clone() + Expr::constant(Tensor::from([0]));
                     let output = iter_vec.unary(crate::ops::ConstantOfShape {
-                        value: Scalar::Int(1),
+                        value: Scalar::Int32(1),
                     });
 
                     Expr::make_graph([iter, cond.clone()], [cond, output])

--- a/src/ops/generate.rs
+++ b/src/ops/generate.rs
@@ -47,8 +47,10 @@ impl Operator for ConstantOfShape {
         let shape = ctx.inputs().require_as(0)?;
 
         match self.value {
-            Scalar::Int(value) => constant_of_shape(pool, value, &shape).into_op_result(),
             Scalar::Float(value) => constant_of_shape(pool, value, &shape).into_op_result(),
+            Scalar::Int32(value) => constant_of_shape(pool, value, &shape).into_op_result(),
+            Scalar::Int8(value) => constant_of_shape(pool, value, &shape).into_op_result(),
+            Scalar::UInt8(value) => constant_of_shape(pool, value, &shape).into_op_result(),
         }
     }
 
@@ -66,7 +68,9 @@ impl_infer_shapes!(
     op,
     shape_ops::ConstantOfShape {
         value: match op.value {
-            Scalar::Int(val) => Some(val),
+            Scalar::Int32(val) => Some(val),
+            Scalar::Int8(val) => Some(val.into()),
+            Scalar::UInt8(val) => Some(val.into()),
             Scalar::Float(_) => None,
         },
     }
@@ -307,7 +311,7 @@ mod tests {
     #[test]
     fn test_constant_of_shape() {
         let op = ConstantOfShape {
-            value: Scalar::Int(42),
+            value: Scalar::Int32(42),
         };
         let shape = Tensor::from([1, 5, 10]);
         let result: Tensor<i32> = op.run_simple(&shape).unwrap();

--- a/src/value.rs
+++ b/src/value.rs
@@ -847,15 +847,19 @@ impl ExtractBuffer for ValueOrView<'_> {
 /// A scalar value with runtime-determined type.
 #[derive(Debug, PartialEq)]
 pub enum Scalar {
-    Int(i32),
     Float(f32),
+    Int32(i32),
+    Int8(i8),
+    UInt8(u8),
 }
 
 impl Scalar {
     pub fn dtype(&self) -> DataType {
         match self {
-            Self::Int(_) => DataType::Int32,
             Self::Float(_) => DataType::Float,
+            Self::Int32(_) => DataType::Int32,
+            Self::Int8(_) => DataType::Int8,
+            Self::UInt8(_) => DataType::UInt8,
         }
     }
 }


### PR DESCRIPTION
The ONNX deserializer for `ConstantOfShape` parsed this attribute with a bespoke helper which only supported float, int32, int64 and bool tensors, rejecting anything else with an error. It also only supported `TensorProto` initializers where the data was stored in the `raw_data` field. This prevented loading f16 models with `ConstantOfShape` nodes that used an f16 dtype.

Fix this by making the existing logic for loading ONNX initializers (`load_constant`) accessible to operator deserializers and using that. This allows `ConstantOfShape` to support all the same dtypes and data sources (`TensorProto.raw_data`, other fields on `TensorProto`, external data) that are supported for model weights.