### PR TITLE
Fix incorrect use of `Vec::set_len` in `TensorBase::append`

### DIFF
--- a/rten-tensor/src/tensor.rs
+++ b/rten-tensor/src/tensor.rs
@@ -1094,11 +1094,27 @@ impl<T, L: Clone + Layout> TensorBase<Vec<T>, L> {
         let new_data_len = new_layout.min_data_len();
         self.layout = new_layout;
 
-        // Safety: The `copy_from` call below will initialize all elements
-        // added to the tensor.
-        assert!(self.data.capacity() >= new_data_len);
-        unsafe {
-            self.data.set_len(new_data_len);
+        // Fast path for the case where we can avoid initializing new elements
+        // before copying the data.
+        if self.layout.is_contiguous() && self.data.len() + other.len() == new_data_len {
+            let added = new_data_len - self.data.len();
+            other.copy_into_slice(&mut self.data.spare_capacity_mut()[..added]);
+
+            // Safety: `copy_into_slice` initialized every element between the
+            // old and new lengths.
+            unsafe {
+                self.data.set_len(new_data_len);
+            }
+
+            return Ok(());
+        }
+
+        // Initialize new capacity if needed.
+        if self.data.len() < new_data_len {
+            // `other` must be non-empty here as otherwise the old/new layouts
+            // would be the same and the `min_data_len` would not have grown.
+            let fill = *other.iter().next().unwrap();
+            self.data.resize(new_data_len, fill);
         }
 
         self.slice_axis_mut(axis, old_size..new_size)

--- a/rten-tensor/src/tensor/tests.rs
+++ b/rten-tensor/src/tensor/tests.rs
@@ -38,6 +38,8 @@ impl Alloc for FakeAlloc {
 
 #[test]
 fn test_append() {
+    // Append along an inner axis. This uses the default path which must
+    // initialize new capacity before copying elements.
     let mut tensor = NdTensor::<i32, 2>::with_capacity([3, 3], 1);
     assert_eq!(tensor.shape(), [3, 0]);
 
@@ -60,6 +62,27 @@ fn test_append() {
         tensor.append(1, &NdTensor::from([[10], [11], [12]])),
         Err(ExpandError::InsufficientCapacity)
     );
+
+    // Append along the outermost axis, where the tensor stays contiguous as it
+    // grows. This uses the fast path that avoids initializing new storage
+    // before copying into it.
+    let mut tensor = NdTensor::<i32, 2>::with_capacity([3, 2], 0);
+    assert_eq!(tensor.shape(), [0, 2]);
+
+    tensor.append(0, &NdTensor::from([[1, 2], [3, 4]])).unwrap();
+    assert_eq!(tensor.shape(), [2, 2]);
+
+    tensor.append(0, &NdTensor::from([[5, 6]])).unwrap();
+    assert_eq!(tensor, NdTensor::from([[1, 2], [3, 4], [5, 6]]));
+
+    // Append along an inner axis where the preceding dims all have size one, so
+    // the tensor is still contiguous as it grows. This also uses the fast path.
+    let mut tensor = NdTensor::<i32, 3>::with_capacity([1, 3, 2], 1);
+    tensor
+        .append(1, &NdTensor::from([[[1, 2], [3, 4]]]))
+        .unwrap();
+    tensor.append(1, &NdTensor::from([[[5, 6]]])).unwrap();
+    assert_eq!(tensor, NdTensor::from([[[1, 2], [3, 4], [5, 6]]]));
 
     // Append to an empty tensor
     let mut empty = NdTensor::<i32, 2>::zeros([0, 3]);


### PR DESCRIPTION
When `TensorBase::append` was used to extend a tensor along an axis other than zero, it could incorrectly extend the storage length to include uninitialized elements. It was hard to trigger a crash due to this because the elements are all `Copy`, but this is nevertheless UB.

If a tensor was allocated with capacity for (2, 4) and initial shape (2, 0) and then a new column was appended, the storage length would be expanded to 5, but the initialization status of the elements would be:

```
I U U U
I
```

Where I = initialized, U = uninitialized.

Fix this by initializing all new elements with a valid value, with a fast path for the case where the tensor is contiguous and we are extending along axis 0. In that case we can avoid initializing the new elements before copying data.

This fix does mean that elements may be written multiple times. In order to address that it would be necessary to replace `Vec<T>` with a new storage type which permits initialized and uninitialized elements to be interleaved, or use a tensor with `MaybeUninit<T>` storage and defer marking storage as initialized until the tensor is fully grown.