### PR TITLE
Support upper-case letters in Einsum equations

### DIFF
--- a/rten-shape-inference/src/einsum_parser.rs
+++ b/rten-shape-inference/src/einsum_parser.rs
@@ -7,11 +7,11 @@ use std::fmt;
 /// [`EinsumExpr::parse`].
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ParseError {
-    /// An input term contains characters other than lowercase ASCII letters
-    /// or more than one ellipsis (`...`).
+    /// An input term contains characters other than ASCII letters or more than
+    /// one ellipsis (`...`).
     InvalidInputTerm,
-    /// The output term contains characters other than lowercase ASCII letters
-    /// or more than one ellipsis (`...`).
+    /// The output term contains characters other than ASCII letters or more
+    /// than one ellipsis (`...`).
     InvalidOutputTerm,
     /// The output term contains a repeated label.
     RepeatedOutputLabels,
@@ -45,8 +45,12 @@ impl Error for ParseError {}
 /// A parsed equation for an Einsum operator.
 ///
 /// Einsum expressions have the form `abc,def,...->xyz` where the `->xyz` part
-/// is optional. If omitted, it is inferred as the alphabetically ordered set of
-/// letters from the left hand side that do not repeat.
+/// is optional. If omitted, it is inferred as the set of letters from the left
+/// hand side that do not repeat, ordered by ASCII code (ie. upper-case letters
+/// before lower-case ones).
+///
+/// Labels are ASCII letters and are case-sensitive, so `i` and `I` refer to
+/// different dimensions.
 ///
 /// See <https://onnx.ai/onnx/operators/onnx__Einsum.html>.
 #[derive(Clone, Debug, PartialEq)]
@@ -88,7 +92,7 @@ impl EinsumExpr {
         }
         if output
             .chars()
-            .any(|c| c.is_ascii_lowercase() && !inputs.iter().any(|term| term.contains(c)))
+            .any(|c| c.is_ascii_alphabetic() && !inputs.iter().any(|term| term.contains(c)))
         {
             return Err(ParseError::UnknownOutputLabel);
         }
@@ -177,41 +181,58 @@ pub enum ValidateError {
 /// Compute the default output term for an equation with no explicit `->` part.
 ///
 /// The default consists of (1) the broadcast (ellipsis) dimensions if any input
-/// has an ellipsis, followed by (2) the lowercase-letter labels which appear
-/// exactly once across all input terms, in alphabetical order.
+/// has an ellipsis, followed by (2) the letter labels which appear exactly once
+/// across all input terms, ordered by ASCII code. This matches `numpy.einsum`,
+/// where upper-case labels come before lower-case ones.
 fn default_output(inputs: &[String]) -> String {
-    const N_LETTERS: usize = 26;
+    const N_LETTERS: usize = 52;
 
-    // Count occurrences of each lowercase ASCII letter.
+    // Map between labels and indices in `char_count`.
+    let label_index = |c: char| -> usize {
+        if c.is_ascii_uppercase() {
+            (c as u8 - b'A') as usize
+        } else {
+            26 + (c as u8 - b'a') as usize
+        }
+    };
+    let index_label = |i: usize| -> char {
+        if i < 26 {
+            (b'A' + i as u8) as char
+        } else {
+            (b'a' + (i - 26) as u8) as char
+        }
+    };
+
+    // Count occurrences of each letter.
     let mut char_count = [0; N_LETTERS];
     for ch in inputs
         .iter()
-        .flat_map(|term| term.chars().filter(|c| c.is_ascii_lowercase()))
+        .flat_map(|term| term.chars().filter(|c| c.is_ascii_alphabetic()))
     {
-        char_count[(ch as u8 - b'a') as usize] += 1;
+        char_count[label_index(ch)] += 1;
     }
 
-    // Generate output as the ellipsis (if any) followed by alphabetically
-    // ordered letters which appear only once in the input.
+    // Generate output as the ellipsis (if any) followed by the letters which
+    // appear only once in the input, in ASCII order.
     let mut output = String::with_capacity(N_LETTERS);
     if inputs.iter().any(|term| term.contains("...")) {
         output.push_str("...");
     }
-    for i in 0..N_LETTERS as u8 {
-        if char_count[i as usize] == 1 {
-            output.push((b'a' + i) as char);
+    for (i, count) in char_count.iter().enumerate() {
+        if *count == 1 {
+            output.push(index_label(i));
         }
     }
     output
 }
 
-/// Return true if `term` is a valid sequence of dimension labels: lowercase
-/// ASCII letters with at most one ellipsis (`...`).
+/// Return true if `term` is a valid sequence of dimension labels: ASCII letters
+/// with at most one ellipsis (`...`).
 fn is_valid_term(term: &str) -> bool {
     if let Some((lhs, rhs)) = term.split_once("...") {
         is_valid_term(lhs) && !rhs.contains("...") && is_valid_term(rhs)
     } else {
-        term.chars().all(|c| c.is_ascii_lowercase())
+        term.chars().all(|c| c.is_ascii_alphabetic())
     }
 }
 
@@ -329,9 +350,34 @@ mod tests {
                 equation: "->",
                 expected: Ok(expr(&[""], "")),
             },
-            // Upper-case letters in an input term.
+            // Upper-case letters are valid labels. The ONNX spec allows only
+            // lower-case letters, but `numpy.einsum` and ONNX Runtime accept
+            // upper-case ones.
             Case {
-                equation: "IJ,JK",
+                equation: "IJ,JK->IK",
+                expected: Ok(expr(&["IJ", "JK"], "IK")),
+            },
+            // Labels are case-sensitive, so `i` and `I` are different
+            // dimensions.
+            Case {
+                equation: "iI->Ii",
+                expected: Ok(expr(&["iI"], "Ii")),
+            },
+            // Implicit output with mixed-case labels. Labels are ordered by
+            // ASCII code, so upper-case letters come first. This matches
+            // `numpy.einsum`.
+            Case {
+                equation: "aBc",
+                expected: Ok(expr(&["aBc"], "Bac")),
+            },
+            Case {
+                equation: "Ij,jK",
+                expected: Ok(expr(&["Ij", "jK"], "IK")),
+            },
+            // Digits are not valid labels. They are used internally as
+            // placeholders for ellipsis dimensions.
+            Case {
+                equation: "i1j",
                 expected: Err(ParseError::InvalidInputTerm),
             },
             // A period that is not part of an ellipsis.
@@ -346,8 +392,14 @@ mod tests {
             },
             // Invalid output term.
             Case {
-                equation: "ij,jk->IK",
+                equation: "ij,jk->i.k",
                 expected: Err(ParseError::InvalidOutputTerm),
+            },
+            // Output labels which differ only in case from the input labels
+            // refer to dimensions which are not in any input.
+            Case {
+                equation: "ij,jk->IK",
+                expected: Err(ParseError::UnknownOutputLabel),
             },
             // Repeated labels in the output term.
             Case {

--- a/rten-shape-inference/src/ops/einsum.rs
+++ b/rten-shape-inference/src/ops/einsum.rs
@@ -184,6 +184,19 @@ mod tests {
                 inputs: vec![sym_shape!(4), sym_shape!(5)],
                 expected: sym_shape!(4, 5),
             },
+            // Upper-case labels, which are case-sensitive.
+            Case {
+                equation: "iI->Ii",
+                inputs: vec![sym_shape!(2, 3)],
+                expected: sym_shape!(3, 2),
+            },
+            // Implicit output with mixed-case labels. Labels are ordered by
+            // ASCII code, so the output here is "Bac".
+            Case {
+                equation: "aBc",
+                inputs: vec![sym_shape!(2, 3, 4)],
+                expected: sym_shape!(3, 2, 4),
+            },
         ];
 
         cases.test_each(|case| {

--- a/src/ops/einsum.rs
+++ b/src/ops/einsum.rs
@@ -345,8 +345,7 @@ fn einsum_step(
 
         // Evaluate the equation with the simplified input shapes using a
         // matmul.
-        let reduced_dim = 'K'; // Upper-case to avoid conflict with equation
-        // terms.
+        let reduced_dim = MERGED_K;
         let term_simplified: String = step
             .output
             .chars()
@@ -364,15 +363,27 @@ fn einsum_step(
     }
 }
 
+/// Label for a 1-sized dimension inserted into a term to serve as the `M`
+/// dimension of a matmul.
+///
+/// Labels from the equation are ASCII letters or digits (standing in for
+/// ellipsis dimensions), so non-alphanumeric characters are used for labels
+/// generated internally.
+const INSERTED_M: char = '<';
+
+/// Label for a 1-sized dimension inserted into a term to serve as the `N`
+/// dimension of a matmul. See [`INSERTED_M`].
+const INSERTED_N: char = '>';
+
+/// Label for the single dimension formed by merging several reduced dimensions
+/// into one. See [`INSERTED_M`].
+const MERGED_K: char = '*';
+
 /// Return true if `c` denotes a 1-sized dimension which was inserted into a
 /// term to give an input the shape required by a matmul, rather than a
 /// dimension from the equation.
-///
-/// Dimensions from the equation are lower-case letters or digits (standing in
-/// for ellipsis dimensions), so upper-case letters are used for inserted
-/// dimensions.
 fn is_inserted_dim(c: char) -> bool {
-    c.is_ascii_uppercase()
+    matches!(c, INSERTED_M | INSERTED_N)
 }
 
 fn is_valid_permute_insert_spec(src: &str, dest: &str) -> bool {
@@ -449,9 +460,9 @@ fn einsum_matmul(
     // Find terms that can be used as the `N` and `M` dimensions of a matmul.
     // These must be dimensions which appear in only one of the two inputs.
     //
-    // If there aren't suitable dimensions, we'll insert them. Upper-case
-    // letters are used to denote inserted dimensions since these cannot
-    // conflict with dimensions in the equation.
+    // If there aren't suitable dimensions, we'll insert them. Non-alphanumeric
+    // labels are used to denote inserted dimensions since these cannot conflict
+    // with dimensions in the equation.
     //
     // The last candidate is chosen in each case because it requires the least
     // re-ordering of the input: `M` and `N` need to be the second-to-last and
@@ -463,12 +474,12 @@ fn einsum_matmul(
         .chars()
         .rev()
         .find(|c| !term1.contains(*c))
-        .unwrap_or('N');
+        .unwrap_or(INSERTED_N);
     let matmul_m = term1
         .chars()
         .rev()
         .find(|c| !term2.contains(*c))
-        .unwrap_or('M');
+        .unwrap_or(INSERTED_M);
 
     // Every remaining dimension becomes a matmul batch dimension. A dimension
     // which appears in only one input is handled by inserting a 1-sized
@@ -769,6 +780,16 @@ mod tests {
         .unwrap()
         .into_shape([2, 3, 5, 6].as_slice());
 
+        // Expected output for an equation which reduces over the first two
+        // dimensions of two 3D inputs.
+        let abf_sq_sum_ij = reduce_sum(
+            &pool,
+            mul(&pool, abf.view(), abf.view()).unwrap().view(),
+            Some(&[0, 1]),
+            false, /* keep_dims */
+        )
+        .unwrap();
+
         // Expected output for an equation where one reduced dimension appears
         // in both terms and another appears in only the second term.
         let abf_summed_b =
@@ -1064,10 +1085,51 @@ mod tests {
                 inputs: vec![scalar.view()],
                 expected: Ok(scalar.clone()),
             },
+            // Upper-case labels. These are not allowed by the ONNX spec, but
+            // are supported by `numpy.einsum` and ONNX Runtime.
+            //
+            // See https://github.com/robertknight/rten/issues/1386
+            Case {
+                equation: "C,MCN->MN",
+                inputs: vec![mat_a.slice(0), hck.as_dyn()],
+                expected: Ok(matmul(&pool, mat_a.slice((..1, ..)), mat_b.view(), None).unwrap()),
+            },
+            // Reduction over multiple dimensions with upper-case labels.
+            Case {
+                equation: "IJK,IJK->K",
+                inputs: vec![abf.view(), abf.view()],
+                expected: Ok(abf_sq_sum_ij.clone()),
+            },
+            // Labels are case-sensitive, so `i` and `I` are different
+            // dimensions.
+            Case {
+                equation: "iI->Ii",
+                inputs: vec![mat_a.view()],
+                expected: Ok(mat_a.transposed().to_tensor()),
+            },
+            // Repeated upper-case label takes the diagonal.
+            Case {
+                equation: "II->I",
+                inputs: vec![square_mat.view()],
+                expected: Ok(Tensor::from([1., 5., 9.])),
+            },
+            // Implicit output with mixed-case labels. Labels are ordered by
+            // ASCII code, so the output term here is "Bac".
+            Case {
+                equation: "aBc",
+                inputs: vec![abf.view()],
+                expected: Ok(abf.permuted(&[1, 0, 2]).to_tensor()),
+            },
+            // Upper-case labels combined with an ellipsis.
+            Case {
+                equation: "I...J->J...I",
+                inputs: vec![ijk.view()],
+                expected: Ok(ijk.transposed().to_tensor()),
+            },
             // Invalid input terms
             Case {
-                equation: "IJ,JK", // Upper-case letters
-                inputs: vec![mat_a.view(), mat_b.view()],
+                equation: "i1j", // Digits are used internally for ellipsis dims
+                inputs: vec![mat_a.view()],
                 expected: Err(OpError::InvalidValue("Input term is invalid")),
             },
             Case {
@@ -1107,9 +1169,18 @@ mod tests {
             },
             // Invalid output term
             Case {
-                equation: "ij,jk->IK",
+                equation: "ij,jk->i.k",
                 inputs: vec![mat_a.view(), mat_b.view()],
                 expected: Err(OpError::InvalidValue("Output term is invalid")),
+            },
+            // Output labels which differ only in case from the input labels
+            // refer to dimensions which are not in any input.
+            Case {
+                equation: "ij,jk->IK",
+                inputs: vec![mat_a.view(), mat_b.view()],
+                expected: Err(OpError::InvalidValue(
+                    "Einsum output term contains a label not present in any input term",
+                )),
             },
             // Repeated labels in output term
             Case {


### PR DESCRIPTION
`numpy.einsum` and ONNX Runtime both accept upper-case letters as dimension labels and treat them as distinct from lower-case ones, even though the ONNX spec says that labels must be lower-case. Some models use them.

Accept any ASCII letter as a label and order the implicit output term by ASCII code, so upper-case letters come before lower-case ones, matching `numpy.einsum`.

Labels which are generated internally, for 1-sized dimensions inserted to satisfy a matmul and for merged reduced dimensions, previously used upper-case letters to avoid conflicting with equation labels. These now use non-alphanumeric characters instead.

Fixes #1386