### PR TITLE
Fix GatherND panic when output is empty

### DIFF
--- a/rten-tensor/src/lib.rs
+++ b/rten-tensor/src/lib.rs
@@ -90,7 +90,7 @@ pub use layout::{DynLayout, InsertDim, Layout, MatrixLayout, NdLayout, SizeArray
 pub use slice_range::{SliceItem, SliceRange};
 pub use storage::Storage;
 pub use tensor::{
-    ArcNdTensor, ArcTensor, AsView, CowNdTensor, CowTensor, Matrix, MatrixMut, NdTensor,
+    ArcNdTensor, ArcTensor, AsView, CowNdTensor, CowTensor, InitEmpty, Matrix, MatrixMut, NdTensor,
     NdTensorView, NdTensorViewMut, Scalar, Tensor, TensorBase, TensorView, TensorViewMut,
     WeaklyCheckedView,
 };

--- a/rten-tensor/src/tensor.rs
+++ b/rten-tensor/src/tensor.rs
@@ -1583,6 +1583,14 @@ impl<'a, T, L: Layout> TensorBase<CowData<'a, T>, L> {
     }
 }
 
+/// Result of [`TensorBase::init_if_empty`].
+pub enum InitEmpty<Init: Storage, Uninit: Storage, L: Layout> {
+    /// Empty tensor with initialized storage.
+    Empty(TensorBase<Init, L>),
+    /// Non-empty tensor with uninitialized storage.
+    NotEmpty(TensorBase<Uninit, L>),
+}
+
 impl<T, S: Storage<Elem = MaybeUninit<T>> + AssumeInit, L: Layout + Clone> TensorBase<S, L>
 where
     <S as AssumeInit>::Output: Storage<Elem = T>,
@@ -1600,6 +1608,16 @@ where
         TensorBase {
             layout: self.layout,
             data: unsafe { self.data.assume_init() },
+        }
+    }
+
+    /// Convert `self` to an initialized tensor, if it has no elements.
+    pub fn init_if_empty(self) -> InitEmpty<<S as AssumeInit>::Output, S, L> {
+        if self.is_empty() {
+            // The tensor has no elements, and thus is initialized.
+            InitEmpty::Empty(unsafe { self.assume_init() })
+        } else {
+            InitEmpty::NotEmpty(self)
         }
     }
 

--- a/rten-tensor/src/tensor/tests.rs
+++ b/rten-tensor/src/tensor/tests.rs
@@ -5,7 +5,7 @@ use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
-use super::{AsView, NdTensor, NdTensorView, NdTensorViewMut, Tensor, TensorView};
+use super::{AsView, InitEmpty, NdTensor, NdTensorView, NdTensorViewMut, Tensor, TensorView};
 use crate::errors::{DimensionError, ExpandError, FromDataError};
 use crate::layout::{DynLayout, FromShape, MatrixLayout};
 use crate::prelude::*;
@@ -825,6 +825,15 @@ fn test_index_axis() {
     let mut slice = tensor.index_axis_mut(0, 3);
     assert_eq!(slice.shape(), [2]);
     assert_eq!(slice.data_mut().unwrap(), [6, 7]);
+}
+
+#[test]
+fn test_init_if_empty() {
+    let empty = NdTensor::<f32, 2>::uninit([2, 0]);
+    assert!(matches!(empty.init_if_empty(), InitEmpty::Empty(_)));
+
+    let not_empty = NdTensor::<f32, 2>::uninit([2, 2]);
+    assert!(matches!(not_empty.init_if_empty(), InitEmpty::NotEmpty(_)));
 }
 
 #[test]

--- a/src/ops/concat.rs
+++ b/src/ops/concat.rs
@@ -3,7 +3,7 @@ use std::mem::MaybeUninit;
 use rten_base::bit_set::BitSet;
 use rten_shape_inference::ops as shape_ops;
 use rten_tensor::prelude::*;
-use rten_tensor::{AssumeInit, NdTensorView, Tensor, TensorView};
+use rten_tensor::{AssumeInit, InitEmpty, NdTensorView, Tensor, TensorView};
 
 use smallvec::SmallVec;
 
@@ -252,19 +252,20 @@ pub fn tile<T: Copy>(
         .zip(repeats.iter())
         .map(|(size, repeat)| size * repeat)
         .collect();
-    let mut output = Tensor::uninit_in(pool, &out_shape);
+    let output = Tensor::uninit_in(pool, &out_shape);
+    let mut output = match output.init_if_empty() {
+        InitEmpty::Empty(e) => return Ok(e),
+        InitEmpty::NotEmpty(ne) => ne,
+    };
 
-    if !output.is_empty() {
-        tile_inner(
-            input.to_contiguous_in(pool).auto_return(pool).data(),
-            output.data_mut().unwrap(),
-            input.shape(),
-            &repeats,
-        );
-    }
+    tile_inner(
+        input.to_contiguous_in(pool).auto_return(pool).data(),
+        output.data_mut().unwrap(),
+        input.shape(),
+        &repeats,
+    );
 
-    // Safety - `tile_inner` initialized all output elements, or the tensor
-    // is empty.
+    // Safety - `tile_inner` initialized all output elements.
     let output = unsafe { output.assume_init() };
 
     Ok(output)

--- a/src/ops/gather.rs
+++ b/src/ops/gather.rs
@@ -6,7 +6,7 @@ use rten_shape_inference::UnaryOp;
 use rten_shape_inference::ops as shape_ops;
 use rten_tensor::prelude::*;
 use rten_tensor::slice_range::to_slice_items;
-use rten_tensor::{NdTensorView, SliceItem, Tensor, TensorBase, TensorView};
+use rten_tensor::{InitEmpty, NdTensorView, SliceItem, Tensor, TensorBase, TensorView};
 use smallvec::SmallVec;
 
 use crate::buffer_pool::{AutoReturn, BufferPool};
@@ -360,7 +360,12 @@ pub fn gather_nd<T: Clone + Default>(
     let out_slice_len = out_shape[out_shape.len() - out_slice_ndim..]
         .iter()
         .product();
-    let mut output = Tensor::<T>::uninit_in(pool, &out_shape);
+
+    let output = Tensor::<T>::uninit_in(pool, &out_shape);
+    let mut output = match output.init_if_empty() {
+        InitEmpty::Empty(e) => return Ok(e),
+        InitEmpty::NotEmpty(ne) => ne,
+    };
 
     let output_non_batch_dims = output.ndim() - batch_dims;
     let input_non_batch_dims = input.ndim() - batch_dims;
@@ -1184,6 +1189,30 @@ mod tests {
                 transpose: false,
                 indices: [[0, 0], [1, 2]].into(),
                 expected: Err(OpError::InvalidValue("Invalid index")),
+            },
+            // Input with a zero-size dimension in the gathered slice.
+            Case {
+                batch_dims: 0,
+                data: Tensor::zeros(&[2, 0]),
+                transpose: false,
+                indices: [[0]].into(),
+                expected: Ok(Tensor::zeros(&[1, 0])),
+            },
+            // Empty `indices` combined with a zero-size input dimension.
+            Case {
+                batch_dims: 0,
+                data: Tensor::zeros(&[8, 0]),
+                transpose: false,
+                indices: Tensor::zeros(&[0, 1]),
+                expected: Ok(Tensor::zeros(&[0, 0])),
+            },
+            // Empty `indices` with a non-empty gathered slice.
+            Case {
+                batch_dims: 0,
+                data: [[0, 1], [2, 3]].into(),
+                transpose: false,
+                indices: Tensor::zeros(&[0, 1]),
+                expected: Ok(Tensor::zeros(&[0, 2])),
             },
             // Transposed input
             Case {

--- a/src/ops/gather.rs
+++ b/src/ops/gather.rs
@@ -248,11 +248,11 @@ pub fn gather_elements<T: Copy + Default + Send + Sync + std::fmt::Debug>(
         Ok(())
     }
 
-    let mut output = Tensor::uninit_in(pool, indices.shape());
-    if output.is_empty() {
-        // Safety: Output has zero elements, so is fully "initialized".
-        return Ok(unsafe { output.assume_init() });
-    }
+    let output = Tensor::uninit_in(pool, indices.shape());
+    let mut output = match output.init_if_empty() {
+        InitEmpty::Empty(e) => return Ok(e),
+        InitEmpty::NotEmpty(ne) => ne,
+    };
 
     // When gathering from a stride-1 axis in a contiguous tensor, we can get
     // the 1D lanes by just splitting the data into chunks.

--- a/src/ops/resize.rs
+++ b/src/ops/resize.rs
@@ -7,7 +7,7 @@ use rten_base::iter::range_chunks;
 use rten_parallel::par_iter::ParIter;
 use rten_shape_inference::ops as shape_ops;
 use rten_tensor::prelude::*;
-use rten_tensor::{NdTensor, NdTensorView, NdTensorViewMut, Tensor, TensorView};
+use rten_tensor::{InitEmpty, NdTensor, NdTensorView, NdTensorViewMut, Tensor, TensorView};
 
 use crate::buffer_pool::{AutoReturn, BufferPool};
 use crate::infer_shapes::{InferShapes, impl_infer_shapes};
@@ -380,13 +380,11 @@ fn resize_4d(
 
     let [batch, _chans, _height, _width] = input.shape();
 
-    let mut output = NdTensor::uninit_in(pool, output_size);
-
-    if output.is_empty() {
-        // Safety: Empty output is already initialized.
-        let output = unsafe { output.assume_init() };
-        return Ok(output);
-    }
+    let output = NdTensor::uninit_in(pool, output_size);
+    let mut output = match output.init_if_empty() {
+        InitEmpty::Empty(e) => return Ok(e),
+        InitEmpty::NotEmpty(ne) => ne,
+    };
 
     let n_init = AtomicUsize::new(0);
     for n in 0..batch {


### PR DESCRIPTION
`gather_nd` computes `out_slice_len` as the product of input dimensions that are not indexed, then splits the output buffer with `chunks_mut(out_slice_len)`. This panics if `out_slice_len` is empty.

Fix this with an early exit if the output is empty. As part of this I added a `TensorBase::init_if_empty` helper to avoid the need for `unsafe` and refactored existing early-exits in other operators to use it.