### PR TITLE
Fix panic loading an external tensor with zero length

### DIFF
--- a/src/constant_storage.rs
+++ b/src/constant_storage.rs
@@ -52,7 +52,10 @@ impl ConstantStorage {
     }
 
     /// Return the byte offsets of a sub-slice of this storage as a range, or
-    /// `None` if any part of `data` lies outside storage.
+    /// `None` if any element of `data` lies outside storage.
+    ///
+    /// If the slice is empty, this returns an empty range with a start that
+    /// corresponds to `data.as_ptr()` if inside the storage, or zero otherwise.
     ///
     /// Note this always returns `None` if `T` is a zero-sized type.
     fn byte_range_of<T>(&self, data: &[T]) -> Option<Range<usize>> {
@@ -65,7 +68,7 @@ impl ConstantStorage {
         let data_range = slice_address_range(data);
 
         if !self_range.contains(&data_range.start) || self_range.end < data_range.end {
-            return None;
+            return data.is_empty().then_some(0..0);
         }
 
         let start = data_range.start - self_range.start;
@@ -226,6 +229,10 @@ mod tests {
         // Create a slice referencing data outside the storage.
         let slice_outside = &[1, 2, 3];
         assert!(ArcSlice::new(storage.clone(), slice_outside).is_none());
+
+        // Like above, but the storage is empty.
+        let empty: &[i32] = &[];
+        assert!(ArcSlice::new(storage.clone(), empty).is_some());
 
         // Try with a zero-sized type.
         let zst_slice = &[(), ()];

--- a/src/model/onnx_loader.rs
+++ b/src/model/onnx_loader.rs
@@ -1116,6 +1116,7 @@ fn add_operator(
 mod tests {
     use rten_onnx::onnx;
     use rten_simd::float16::{f16_to_f32, f32_to_f16};
+    use rten_tensor::prelude::*;
     use rten_tensor::{Tensor, TensorView};
     use rten_testing::TestCases;
 
@@ -1417,6 +1418,82 @@ mod tests {
 
         let tensor = model.get_tensor_by_name::<f32>("f64_tensor").unwrap();
         assert_eq!(tensor, Tensor::from(1.23));
+    }
+
+    #[test]
+    fn test_initializer_with_empty_external_data() {
+        #[derive(Debug)]
+        struct Case {
+            shape: Vec<usize>,
+            dtype: onnx::DataType,
+            expected: Result<Vec<usize>, String>,
+        }
+
+        let cases = [
+            // Data types for which external data can be used without copying.
+            Case {
+                shape: [0].into(),
+                dtype: onnx::DataType::FLOAT,
+                expected: Ok([0].into()),
+            },
+            Case {
+                shape: [2, 3].into(),
+                dtype: onnx::DataType::FLOAT,
+                expected: Err(
+                    "in node \"init\": graph error: length 0 does not match shape [2, 3]".into(),
+                ),
+            },
+            // Data types which require copying and converting external data.
+            Case {
+                shape: [0].into(),
+                dtype: onnx::DataType::INT64,
+                expected: Ok([0].into()),
+            },
+            Case {
+                shape: [2].into(),
+                dtype: onnx::DataType::INT64,
+                expected: Err(
+                    "in node \"init\": graph error: length 0 does not match shape [2]".into(),
+                ),
+            },
+        ];
+
+        cases.test_each(|case| {
+            let tensor = create_tensor(
+                "init",
+                &case.shape,
+                case.dtype,
+                TensorData::External(DataLocation {
+                    path: "test.onnx.data".to_string(),
+                    offset: 0,
+                    length: 0,
+                }),
+            );
+            let model_proto = onnx::GraphProto::default()
+                .with_initializer(tensor)
+                .into_model();
+            let loader = MemLoader::from_entries([("test.onnx.data".to_string(), Vec::new())]);
+
+            let result = load_model(model_proto, Some(&loader));
+
+            match (result, &case.expected) {
+                (Ok(model), Ok(expected_shape)) => {
+                    let shape = match case.dtype {
+                        onnx::DataType::FLOAT => model
+                            .get_tensor_by_name::<f32>("init")
+                            .map(|t| t.shape().to_vec()),
+                        _ => model
+                            .get_tensor_by_name::<i32>("init")
+                            .map(|t| t.shape().to_vec()),
+                    };
+                    assert_eq!(shape.as_ref(), Some(expected_shape));
+                }
+                (Err(err), Err(expected)) => assert_eq!(&err.to_string(), expected),
+                (result, expected) => {
+                    panic!("expected {:?} but got {:?}", expected, result.map(|_| ()))
+                }
+            }
+        })
     }
 
     #[test]


### PR DESCRIPTION
Fix a panic when loading a tensor from an external data file where the length is empty. https://github.com/robertknight/rten/pull/1383 made a change which caused `cast_slice` to return a slice whose start pointer is outside the range of the input slice if the input is empty. When such a slice was passed to `ArcSlice::new`, this caused it to return `None`, and an `unwrap` panicked.

Fix this by changing `ArcSlice::new` to add a special case for empty slices so the result is always `Some`. If the slice pointer lies outside storage, it uses zero as the storage offset.