### PR TITLE
Split `Extend::extend` into `extend_low` and `extend_high`

### DIFF
--- a/rten-gemm/src/block_quant.rs
+++ b/rten-gemm/src/block_quant.rs
@@ -239,12 +239,18 @@ impl<'a> VecDotMatrix<'a> {
                 let hi = i8_ops.sub(hi, zero_point);
 
                 // Widen to i32
-                let (a_i16, b_i16) = i8_ops.extend(lo);
-                let (c_i16, d_i16) = i8_ops.extend(hi);
-                let (a_i32, b_i32) = i16_ops.extend(a_i16);
-                let (c_i32, d_i32) = i16_ops.extend(b_i16);
-                let (e_i32, f_i32) = i16_ops.extend(c_i16);
-                let (g_i32, h_i32) = i16_ops.extend(d_i16);
+                let a_i16 = i8_ops.extend_low(lo);
+                let b_i16 = i8_ops.extend_high(lo);
+                let c_i16 = i8_ops.extend_low(hi);
+                let d_i16 = i8_ops.extend_high(hi);
+                let a_i32 = i16_ops.extend_low(a_i16);
+                let b_i32 = i16_ops.extend_high(a_i16);
+                let c_i32 = i16_ops.extend_low(b_i16);
+                let d_i32 = i16_ops.extend_high(b_i16);
+                let e_i32 = i16_ops.extend_low(c_i16);
+                let f_i32 = i16_ops.extend_high(c_i16);
+                let g_i32 = i16_ops.extend_low(d_i16);
+                let h_i32 = i16_ops.extend_high(d_i16);
                 let rhs_i32 = [a_i32, b_i32, c_i32, d_i32, e_i32, f_i32, g_i32, h_i32];
 
                 // Convert to f32, apply scale and multiply with LHS.

--- a/rten-gemm/src/kernels/aarch64.rs
+++ b/rten-gemm/src/kernels/aarch64.rs
@@ -535,10 +535,12 @@ unsafe impl Kernel<u8, i8, i32> for ArmInt8MlalKernel {
 
         for k_block in 0..depth_blocks {
             let a_vec = u8_ops.load_ptr(a_data.as_ptr().add(k_block * u8_ops.len()));
-            let (a_lo, a_hi) = u8_ops.extend(a_vec);
+            let a_lo = u8_ops.extend_low(a_vec);
+            let a_hi = u8_ops.extend_high(a_vec);
 
             let b_vec = u8_ops.load_ptr(b.as_ptr().add(k_block * u8_ops.len()));
-            let (b_lo, b_hi) = u8_ops.extend(b_vec);
+            let b_lo = u8_ops.extend_low(b_vec);
+            let b_hi = u8_ops.extend_high(b_vec);
 
             // Compute first outer product update of this block.
             compute_row!(0, a_lo, b_lo);
@@ -581,10 +583,12 @@ unsafe impl Kernel<u8, i8, i32> for ArmInt8MlalKernel {
             });
 
             let a_vec = u8_ops.load_ptr(a_buf.as_ptr());
-            let (a_lo, _a_hi) = u8_ops.extend(a_vec);
+            let a_lo = u8_ops.extend_low(a_vec);
+            let _a_hi = u8_ops.extend_high(a_vec);
 
             let b_vec = u8_ops.load_ptr(b_buf.as_ptr());
-            let (b_lo, _b_hi) = u8_ops.extend(b_vec);
+            let b_lo = u8_ops.extend_low(b_vec);
+            let _b_hi = u8_ops.extend_high(b_vec);
 
             compute_row!(0, a_lo, b_lo);
             compute_row!(1, a_lo, b_lo);

--- a/rten-gemm/src/kernels/simd_generic.rs
+++ b/rten-gemm/src/kernels/simd_generic.rs
@@ -912,9 +912,12 @@ pub fn simd_int8_gemv<I: Isa, const CAST_B_U8: bool>(
 
             // Load one `i8` vec, sign-extend each quarter to give 4 `i32` vecs.
             let b = unsafe { i8_ops.load_ptr(b_ptr.add(k * b_row_stride)) };
-            let (b01, b23) = i8_ops.extend(b);
-            let (b0, b1) = i16_ops.extend(b01);
-            let (b2, b3) = i16_ops.extend(b23);
+            let b01 = i8_ops.extend_low(b);
+            let b23 = i8_ops.extend_high(b);
+            let b0 = i16_ops.extend_low(b01);
+            let b1 = i16_ops.extend_high(b01);
+            let b2 = i16_ops.extend_low(b23);
+            let b3 = i16_ops.extend_high(b23);
             let b_rows = [b0, b1, b2, b3];
 
             for i in 0..4 {
@@ -941,9 +944,12 @@ pub fn simd_int8_gemv<I: Isa, const CAST_B_U8: bool>(
         let b_zero_vec = if let Some(b_zero) = b_zero_points {
             // Load one `i8` vec, sign-extend each quarter to give 4 `i32` vecs.
             let b = unsafe { i8_ops.load_ptr(b_zero.as_ptr().add(col_tile.start)) };
-            let (b01, b23) = i8_ops.extend(b);
-            let (b0, b1) = i16_ops.extend(b01);
-            let (b2, b3) = i16_ops.extend(b23);
+            let b01 = i8_ops.extend_low(b);
+            let b23 = i8_ops.extend_high(b);
+            let b0 = i16_ops.extend_low(b01);
+            let b1 = i16_ops.extend_high(b01);
+            let b2 = i16_ops.extend_low(b23);
+            let b3 = i16_ops.extend_high(b23);
             [b0, b1, b2, b3]
         } else {
             [ops.zero(); 4]

--- a/rten-simd/src/arch/aarch64.rs
+++ b/rten-simd/src/arch/aarch64.rs
@@ -571,12 +571,13 @@ impl Extend<i16> for ArmNeonIsa {
     type Output = int32x4_t;
 
     #[inline]
-    fn extend(self, x: int16x8_t) -> (int32x4_t, int32x4_t) {
-        unsafe {
-            let low = vmovl_s16(vget_low_s16(x));
-            let high = vmovl_high_s16(x);
-            (low, high)
-        }
+    fn extend_low(self, x: int16x8_t) -> int32x4_t {
+        unsafe { vmovl_s16(vget_low_s16(x)) }
+    }
+
+    #[inline]
+    fn extend_high(self, x: int16x8_t) -> int32x4_t {
+        unsafe { vmovl_high_s16(x) }
     }
 }
 
@@ -687,12 +688,13 @@ impl Extend<i8> for ArmNeonIsa {
     type Output = int16x8_t;
 
     #[inline]
-    fn extend(self, x: int8x16_t) -> (int16x8_t, int16x8_t) {
-        unsafe {
-            let low = vmovl_s8(vget_low_s8(x));
-            let high = vmovl_high_s8(x);
-            (low, high)
-        }
+    fn extend_low(self, x: int8x16_t) -> int16x8_t {
+        unsafe { vmovl_s8(vget_low_s8(x)) }
+    }
+
+    #[inline]
+    fn extend_high(self, x: int8x16_t) -> int16x8_t {
+        unsafe { vmovl_high_s8(x) }
     }
 }
 
@@ -784,12 +786,13 @@ impl Extend<u8> for ArmNeonIsa {
     type Output = uint16x8_t;
 
     #[inline]
-    fn extend(self, x: uint8x16_t) -> (uint16x8_t, uint16x8_t) {
-        unsafe {
-            let low = vmovl_u8(vget_low_u8(x));
-            let high = vmovl_high_u8(x);
-            (low, high)
-        }
+    fn extend_low(self, x: uint8x16_t) -> uint16x8_t {
+        unsafe { vmovl_u8(vget_low_u8(x)) }
+    }
+
+    #[inline]
+    fn extend_high(self, x: uint8x16_t) -> uint16x8_t {
+        unsafe { vmovl_high_u8(x) }
     }
 }
 
@@ -1042,12 +1045,13 @@ impl Extend<f16> for ArmNeonIsa {
     type Output = float32x4_t;
 
     #[inline]
-    fn extend(self, x: float16x8_t) -> (float32x4_t, float32x4_t) {
-        unsafe {
-            let low = vcvt_f32_f16(vget_low_f16(x));
-            let high = vcvt_high_f32_f16(x);
-            (low, high)
-        }
+    fn extend_low(self, x: float16x8_t) -> float32x4_t {
+        unsafe { vcvt_f32_f16(vget_low_f16(x)) }
+    }
+
+    #[inline]
+    fn extend_high(self, x: float16x8_t) -> float32x4_t {
+        unsafe { vcvt_high_f32_f16(x) }
     }
 }
 

--- a/rten-simd/src/arch/generic.rs
+++ b/rten-simd/src/arch/generic.rs
@@ -411,11 +411,16 @@ macro_rules! impl_extend {
         impl Extend<$elem> for GenericIsa {
             type Output = $dst;
 
-            fn extend(self, x: $src) -> ($dst, $dst) {
+            fn extend_low(self, x: $src) -> $dst {
                 let extended = x.0.map(|x| x as <$dst as Simd>::Elem);
                 let low = array::from_fn(|i| extended[i]);
+                low.into()
+            }
+
+            fn extend_high(self, x: $src) -> $dst {
+                let extended = x.0.map(|x| x as <$dst as Simd>::Elem);
                 let high = array::from_fn(|i| extended[i + extended.len() / 2]);
-                (low.into(), high.into())
+                high.into()
             }
         }
     };
@@ -556,12 +561,17 @@ unsafe impl BitOps<f16> for GenericIsa {
 impl Extend<f16> for GenericIsa {
     type Output = F32x4;
 
-    fn extend(self, x: F16x8) -> (F32x4, F32x4) {
+    fn extend_low(self, x: F16x8) -> F32x4 {
+        let vals = x.0.map(|v| v.to_f32());
+        let low = array::from_fn(|i| vals[i]);
+        low.into()
+    }
+
+    fn extend_high(self, x: F16x8) -> F32x4 {
         let vals = x.0.map(|v| v.to_f32());
         let mid = vals.len() / 2;
-        let low = array::from_fn(|i| vals[i]);
         let high = array::from_fn(|i| vals[i + mid]);
-        (low.into(), high.into())
+        high.into()
     }
 }
 

--- a/rten-simd/src/arch/wasm32.rs
+++ b/rten-simd/src/arch/wasm32.rs
@@ -491,10 +491,13 @@ impl Extend<i16> for Wasm32Isa {
     type Output = I32x4;
 
     #[inline]
-    fn extend(self, x: I16x8) -> (I32x4, I32x4) {
-        let low = i32x4_extend_low_i16x8(x.0);
-        let high = i32x4_extend_high_i16x8(x.0);
-        (low.into(), high.into())
+    fn extend_low(self, x: I16x8) -> I32x4 {
+        i32x4_extend_low_i16x8(x.0).into()
+    }
+
+    #[inline]
+    fn extend_high(self, x: I16x8) -> I32x4 {
+        i32x4_extend_high_i16x8(x.0).into()
     }
 }
 
@@ -592,10 +595,13 @@ impl Extend<i8> for Wasm32Isa {
     type Output = I16x8;
 
     #[inline]
-    fn extend(self, x: I8x16) -> (I16x8, I16x8) {
-        let low = i16x8_extend_low_i8x16(x.0);
-        let high = i16x8_extend_high_i8x16(x.0);
-        (low.into(), high.into())
+    fn extend_low(self, x: I8x16) -> I16x8 {
+        i16x8_extend_low_i8x16(x.0).into()
+    }
+
+    #[inline]
+    fn extend_high(self, x: I8x16) -> I16x8 {
+        i16x8_extend_high_i8x16(x.0).into()
     }
 }
 
@@ -719,10 +725,13 @@ impl Extend<u8> for Wasm32Isa {
     type Output = U16x8;
 
     #[inline]
-    fn extend(self, x: U8x16) -> (U16x8, U16x8) {
-        let low = u16x8_extend_low_u8x16(x.0);
-        let high = u16x8_extend_high_u8x16(x.0);
-        (low.into(), high.into())
+    fn extend_low(self, x: U8x16) -> U16x8 {
+        u16x8_extend_low_u8x16(x.0).into()
+    }
+
+    #[inline]
+    fn extend_high(self, x: U8x16) -> U16x8 {
+        u16x8_extend_high_u8x16(x.0).into()
     }
 }
 
@@ -766,21 +775,25 @@ impl Extend<f16> for Wasm32Isa {
     type Output = F32x4;
 
     #[inline]
-    fn extend(self, x: F16x8) -> (F32x4, F32x4) {
+    fn extend_low(self, x: F16x8) -> F32x4 {
         let lanes = x.to_array();
-        let low = F32x4(f32x4(
+        F32x4(f32x4(
             lanes[0].to_f32(),
             lanes[1].to_f32(),
             lanes[2].to_f32(),
             lanes[3].to_f32(),
-        ));
-        let high = F32x4(f32x4(
+        ))
+    }
+
+    #[inline]
+    fn extend_high(self, x: F16x8) -> F32x4 {
+        let lanes = x.to_array();
+        F32x4(f32x4(
             lanes[4].to_f32(),
             lanes[5].to_f32(),
             lanes[6].to_f32(),
             lanes[7].to_f32(),
-        ));
-        (low, high)
+        ))
     }
 }
 

--- a/rten-simd/src/arch/x86_64/avx2.rs
+++ b/rten-simd/src/arch/x86_64/avx2.rs
@@ -728,8 +728,10 @@ unsafe impl NumOps<i8> for Avx2Isa {
 
     #[inline]
     fn mul(self, x: I8x32, y: I8x32) -> I8x32 {
-        let (x_lo, x_hi) = Extend::<i8>::extend(self, x);
-        let (y_lo, y_hi) = Extend::<i8>::extend(self, y);
+        let x_lo = Extend::<i8>::extend_low(self, x);
+        let x_hi = Extend::<i8>::extend_high(self, x);
+        let y_lo = Extend::<i8>::extend_low(self, y);
+        let y_hi = Extend::<i8>::extend_high(self, y);
 
         let i16_ops = self.i16();
         let prod_lo = i16_ops.mul(x_lo, y_lo);
@@ -757,7 +759,8 @@ unsafe impl NumOps<i8> for Avx2Isa {
 impl IntOps<i8> for Avx2Isa {
     #[inline]
     fn shift_left<const SHIFT: i32>(self, x: I8x32) -> I8x32 {
-        let (x_lo, x_hi) = Extend::<i8>::extend(self, x);
+        let x_lo = Extend::<i8>::extend_low(self, x);
+        let x_hi = Extend::<i8>::extend_high(self, x);
 
         let i16_ops = self.i16();
         let y_lo = i16_ops.shift_left::<SHIFT>(x_lo);
@@ -768,7 +771,8 @@ impl IntOps<i8> for Avx2Isa {
 
     #[inline]
     fn shift_right<const SHIFT: i32>(self, x: I8x32) -> I8x32 {
-        let (x_lo, x_hi) = Extend::<i8>::extend(self, x);
+        let x_lo = Extend::<i8>::extend_low(self, x);
+        let x_hi = Extend::<i8>::extend_high(self, x);
 
         let i16_ops = self.i16();
         let y_lo = i16_ops.shift_right::<SHIFT>(x_lo);
@@ -893,8 +897,10 @@ unsafe impl NumOps<u8> for Avx2Isa {
 
     #[inline]
     fn mul(self, x: U8x32, y: U8x32) -> U8x32 {
-        let (x_lo, x_hi) = Extend::<u8>::extend(self, x);
-        let (y_lo, y_hi) = Extend::<u8>::extend(self, y);
+        let x_lo = Extend::<u8>::extend_low(self, x);
+        let x_hi = Extend::<u8>::extend_high(self, x);
+        let y_lo = Extend::<u8>::extend_low(self, y);
+        let y_hi = Extend::<u8>::extend_high(self, y);
 
         let u16_ops = self.u16();
         let prod_lo = u16_ops.mul(x_lo, y_lo);
@@ -1109,12 +1115,13 @@ impl Extend<f16> for Avx2Isa {
     type Output = F32x8;
 
     #[inline]
-    fn extend(self, x: F16x16) -> (F32x8, F32x8) {
-        unsafe {
-            let low = _mm256_castsi256_si128(x.0);
-            let high = _mm256_extracti128_si256(x.0, 1);
-            (_mm256_cvtph_ps(low).into(), _mm256_cvtph_ps(high).into())
-        }
+    fn extend_low(self, x: F16x16) -> F32x8 {
+        unsafe { _mm256_cvtph_ps(_mm256_castsi256_si128(x.0)).into() }
+    }
+
+    #[inline]
+    fn extend_high(self, x: F16x16) -> F32x8 {
+        unsafe { _mm256_cvtph_ps(_mm256_extracti128_si256(x.0, 1)).into() }
     }
 }
 
@@ -1195,15 +1202,13 @@ impl Extend<i16> for Avx2Isa {
     type Output = I32x8;
 
     #[inline]
-    fn extend(self, x: I16x16) -> (Self::Output, Self::Output) {
-        unsafe {
-            let low = _mm256_castsi256_si128(x.0);
-            let high = _mm256_extracti128_si256(x.0, 1);
-            (
-                _mm256_cvtepi16_epi32(low).into(),
-                _mm256_cvtepi16_epi32(high).into(),
-            )
-        }
+    fn extend_low(self, x: I16x16) -> Self::Output {
+        unsafe { _mm256_cvtepi16_epi32(_mm256_castsi256_si128(x.0)).into() }
+    }
+
+    #[inline]
+    fn extend_high(self, x: I16x16) -> Self::Output {
+        unsafe { _mm256_cvtepi16_epi32(_mm256_extracti128_si256(x.0, 1)).into() }
     }
 }
 
@@ -1211,15 +1216,13 @@ impl Extend<i8> for Avx2Isa {
     type Output = I16x16;
 
     #[inline]
-    fn extend(self, x: I8x32) -> (Self::Output, Self::Output) {
-        unsafe {
-            let low = _mm256_castsi256_si128(x.0);
-            let high = _mm256_extracti128_si256(x.0, 1);
-            (
-                _mm256_cvtepi8_epi16(low).into(),
-                _mm256_cvtepi8_epi16(high).into(),
-            )
-        }
+    fn extend_low(self, x: I8x32) -> Self::Output {
+        unsafe { _mm256_cvtepi8_epi16(_mm256_castsi256_si128(x.0)).into() }
+    }
+
+    #[inline]
+    fn extend_high(self, x: I8x32) -> Self::Output {
+        unsafe { _mm256_cvtepi8_epi16(_mm256_extracti128_si256(x.0, 1)).into() }
     }
 }
 
@@ -1227,22 +1230,21 @@ impl Extend<u8> for Avx2Isa {
     type Output = U16x16;
 
     #[inline]
-    fn extend(self, x: U8x32) -> (Self::Output, Self::Output) {
-        unsafe {
-            let low = _mm256_castsi256_si128(x.0);
-            let high = _mm256_extracti128_si256(x.0, 1);
-            (
-                _mm256_cvtepu8_epi16(low).into(),
-                _mm256_cvtepu8_epi16(high).into(),
-            )
-        }
+    fn extend_low(self, x: U8x32) -> Self::Output {
+        unsafe { _mm256_cvtepu8_epi16(_mm256_castsi256_si128(x.0)).into() }
+    }
+
+    #[inline]
+    fn extend_high(self, x: U8x32) -> Self::Output {
+        unsafe { _mm256_cvtepu8_epi16(_mm256_extracti128_si256(x.0, 1)).into() }
     }
 }
 
 impl IntOps<u8> for Avx2Isa {
     #[inline(always)]
     fn shift_left<const SHIFT: i32>(self, x: U8x32) -> U8x32 {
-        let (x_lo, x_hi) = Extend::<u8>::extend(self, x);
+        let x_lo = Extend::<u8>::extend_low(self, x);
+        let x_hi = Extend::<u8>::extend_high(self, x);
 
         let u16_ops = self.u16();
         let y_lo = u16_ops.shift_left::<SHIFT>(x_lo);
@@ -1253,7 +1255,8 @@ impl IntOps<u8> for Avx2Isa {
 
     #[inline(always)]
     fn shift_right<const SHIFT: i32>(self, x: U8x32) -> U8x32 {
-        let (x_lo, x_hi) = Extend::<u8>::extend(self, x);
+        let x_lo = Extend::<u8>::extend_low(self, x);
+        let x_hi = Extend::<u8>::extend_high(self, x);
 
         let u16_ops = self.u16();
         let y_lo = u16_ops.shift_right::<SHIFT>(x_lo);

--- a/rten-simd/src/arch/x86_64/avx512.rs
+++ b/rten-simd/src/arch/x86_64/avx512.rs
@@ -659,8 +659,10 @@ unsafe impl NumOps<i8> for Avx512Isa {
 
     #[inline]
     fn mul(self, x: I8x64, y: I8x64) -> I8x64 {
-        let (x_lo, x_hi) = Extend::<i8>::extend(self, x);
-        let (y_lo, y_hi) = Extend::<i8>::extend(self, y);
+        let x_lo = Extend::<i8>::extend_low(self, x);
+        let x_hi = Extend::<i8>::extend_high(self, x);
+        let y_lo = Extend::<i8>::extend_low(self, y);
+        let y_hi = Extend::<i8>::extend_high(self, y);
 
         let i16_ops = self.i16();
         let prod_lo = i16_ops.mul(x_lo, y_lo);
@@ -688,7 +690,8 @@ unsafe impl NumOps<i8> for Avx512Isa {
 impl IntOps<i8> for Avx512Isa {
     #[inline]
     fn shift_left<const SHIFT: i32>(self, x: I8x64) -> I8x64 {
-        let (x_lo, x_hi) = Extend::<i8>::extend(self, x);
+        let x_lo = Extend::<i8>::extend_low(self, x);
+        let x_hi = Extend::<i8>::extend_high(self, x);
 
         let i16_ops = self.i16();
         let (y_lo, y_hi) = (
@@ -701,7 +704,8 @@ impl IntOps<i8> for Avx512Isa {
 
     #[inline]
     fn shift_right<const SHIFT: i32>(self, x: I8x64) -> I8x64 {
-        let (x_lo, x_hi) = Extend::<i8>::extend(self, x);
+        let x_lo = Extend::<i8>::extend_low(self, x);
+        let x_hi = Extend::<i8>::extend_high(self, x);
 
         let i16_ops = self.i16();
         let (y_lo, y_hi) = (
@@ -802,8 +806,10 @@ unsafe impl NumOps<u8> for Avx512Isa {
 
     #[inline]
     fn mul(self, x: U8x64, y: U8x64) -> U8x64 {
-        let (x_lo, x_hi) = Extend::<u8>::extend(self, x);
-        let (y_lo, y_hi) = Extend::<u8>::extend(self, y);
+        let x_lo = Extend::<u8>::extend_low(self, x);
+        let x_hi = Extend::<u8>::extend_high(self, x);
+        let y_lo = Extend::<u8>::extend_low(self, y);
+        let y_hi = Extend::<u8>::extend_high(self, y);
 
         let u16_ops = self.u16();
         let prod_lo = u16_ops.mul(x_lo, y_lo);
@@ -832,15 +838,13 @@ impl Extend<i16> for Avx512Isa {
     type Output = I32x16;
 
     #[inline]
-    fn extend(self, x: I16x32) -> (Self::Output, Self::Output) {
-        unsafe {
-            let lo = _mm512_extracti64x4_epi64(x.0, 0);
-            let lo = _mm512_cvtepi16_epi32(lo);
+    fn extend_low(self, x: I16x32) -> Self::Output {
+        unsafe { _mm512_cvtepi16_epi32(_mm512_extracti64x4_epi64(x.0, 0)).into() }
+    }
 
-            let hi = _mm512_extracti64x4_epi64(x.0, 1);
-            let hi = _mm512_cvtepi16_epi32(hi);
-            (lo.into(), hi.into())
-        }
+    #[inline]
+    fn extend_high(self, x: I16x32) -> Self::Output {
+        unsafe { _mm512_cvtepi16_epi32(_mm512_extracti64x4_epi64(x.0, 1)).into() }
     }
 }
 
@@ -848,15 +852,13 @@ impl Extend<i8> for Avx512Isa {
     type Output = I16x32;
 
     #[inline]
-    fn extend(self, x: I8x64) -> (I16x32, I16x32) {
-        unsafe {
-            let lo = _mm512_extracti64x4_epi64(x.0, 0);
-            let lo = _mm512_cvtepi8_epi16(lo);
+    fn extend_low(self, x: I8x64) -> I16x32 {
+        unsafe { _mm512_cvtepi8_epi16(_mm512_extracti64x4_epi64(x.0, 0)).into() }
+    }
 
-            let hi = _mm512_extracti64x4_epi64(x.0, 1);
-            let hi = _mm512_cvtepi8_epi16(hi);
-            (lo.into(), hi.into())
-        }
+    #[inline]
+    fn extend_high(self, x: I8x64) -> I16x32 {
+        unsafe { _mm512_cvtepi8_epi16(_mm512_extracti64x4_epi64(x.0, 1)).into() }
     }
 }
 
@@ -864,22 +866,21 @@ impl Extend<u8> for Avx512Isa {
     type Output = U16x32;
 
     #[inline]
-    fn extend(self, x: U8x64) -> (U16x32, U16x32) {
-        unsafe {
-            let lo = _mm512_extracti64x4_epi64(x.0, 0);
-            let lo = _mm512_cvtepu8_epi16(lo);
+    fn extend_low(self, x: U8x64) -> U16x32 {
+        unsafe { _mm512_cvtepu8_epi16(_mm512_extracti64x4_epi64(x.0, 0)).into() }
+    }
 
-            let hi = _mm512_extracti64x4_epi64(x.0, 1);
-            let hi = _mm512_cvtepu8_epi16(hi);
-            (lo.into(), hi.into())
-        }
+    #[inline]
+    fn extend_high(self, x: U8x64) -> U16x32 {
+        unsafe { _mm512_cvtepu8_epi16(_mm512_extracti64x4_epi64(x.0, 1)).into() }
     }
 }
 
 impl IntOps<u8> for Avx512Isa {
     #[inline]
     fn shift_left<const SHIFT: i32>(self, x: U8x64) -> U8x64 {
-        let (x_lo, x_hi) = Extend::<u8>::extend(self, x);
+        let x_lo = Extend::<u8>::extend_low(self, x);
+        let x_hi = Extend::<u8>::extend_high(self, x);
 
         let u16_ops = self.u16();
         let (y_lo, y_hi) = (
@@ -892,7 +893,8 @@ impl IntOps<u8> for Avx512Isa {
 
     #[inline]
     fn shift_right<const SHIFT: i32>(self, x: U8x64) -> U8x64 {
-        let (x_lo, x_hi) = Extend::<u8>::extend(self, x);
+        let x_lo = Extend::<u8>::extend_low(self, x);
+        let x_hi = Extend::<u8>::extend_high(self, x);
 
         let u16_ops = self.u16();
         let (y_lo, y_hi) = (
@@ -1079,12 +1081,13 @@ impl Extend<f16> for Avx512Isa {
     type Output = F32x16;
 
     #[inline]
-    fn extend(self, x: F16x32) -> (F32x16, F32x16) {
-        unsafe {
-            let low = _mm512_castsi512_si256(x.0);
-            let high = _mm512_extracti64x4_epi64(x.0, 1);
-            (_mm512_cvtph_ps(low).into(), _mm512_cvtph_ps(high).into())
-        }
+    fn extend_low(self, x: F16x32) -> F32x16 {
+        unsafe { _mm512_cvtph_ps(_mm512_castsi512_si256(x.0)).into() }
+    }
+
+    #[inline]
+    fn extend_high(self, x: F16x32) -> F32x16 {
+        unsafe { _mm512_cvtph_ps(_mm512_extracti64x4_epi64(x.0, 1)).into() }
     }
 }
 

--- a/rten-simd/src/ops.rs
+++ b/rten-simd/src/ops.rs
@@ -702,10 +702,13 @@ pub trait Extend<T: Elem>: BitOps<T> {
     /// those in `Self::SIMD`.
     type Output;
 
-    /// Extend each lane to a type with twice the width.
-    ///
-    /// Returns a tuple containing the extended low and high half of the input.
-    fn extend(self, x: Self::Simd) -> (Self::Output, Self::Output);
+    /// Extend each lane in the low half of the input to a type with twice the
+    /// width.
+    fn extend_low(self, x: Self::Simd) -> Self::Output;
+
+    /// Extend each lane in the high half of the input to a type with twice the
+    /// width.
+    fn extend_high(self, x: Self::Simd) -> Self::Output;
 }
 
 /// Interleave elements from the low or high halves of two vectors to form a
@@ -1478,7 +1481,8 @@ mod tests {
                     let expected: Vec<$dest> = src.iter().map(|&x| x as $dest).collect();
 
                     let x = ops.load(&src);
-                    let (y_low, y_high) = ops.extend(x);
+                    let y_low = ops.extend_low(x);
+                    let y_high = ops.extend_high(x);
                     assert_eq!(y_low.to_array().as_ref(), &expected[..dst_ops.len()]);
                     assert_eq!(y_high.to_array().as_ref(), &expected[dst_ops.len()..]);
                 });
@@ -1641,7 +1645,8 @@ mod tests {
             assert_eq!(half.to_array().as_ref(), expected.as_slice());
 
             // f16 -> f32
-            let (back_lo, back_hi) = f16_ops.extend(half);
+            let back_lo = f16_ops.extend_low(half);
+            let back_hi = f16_ops.extend_high(half);
             let expected_lo: Vec<f32> = expected[..f32_ops.len()]
                 .iter()
                 .map(|h| h.to_f32())

--- a/rten-vecmath/src/convert.rs
+++ b/rten-vecmath/src/convert.rs
@@ -35,8 +35,10 @@ impl<'d> SimdOp for F16ToF32<'_, 'd> {
         let mut chunks = self.src.chunks_exact(f16_v_len * 2);
         for chunk in chunks.by_ref() {
             let xs = f16_ops.load_many::<2>(chunk);
-            let (lo0, hi0) = f16_ops.extend(xs[0]);
-            let (lo1, hi1) = f16_ops.extend(xs[1]);
+            let lo0 = f16_ops.extend_low(xs[0]);
+            let hi0 = f16_ops.extend_high(xs[0]);
+            let lo1 = f16_ops.extend_low(xs[1]);
+            let hi1 = f16_ops.extend_high(xs[1]);
             // Store all four f32 vectors with a single bounds check.
             dest_writer.write_vecs(f32_ops, [lo0, hi0, lo1, hi1]);
         }
@@ -45,7 +47,8 @@ impl<'d> SimdOp for F16ToF32<'_, 'd> {
         let mut chunks = chunks.remainder().chunks_exact(f16_v_len);
         for chunk in chunks.by_ref() {
             let x = f16_ops.load(chunk);
-            let (low, high) = f16_ops.extend(x);
+            let low = f16_ops.extend_low(x);
+            let high = f16_ops.extend_high(x);
             dest_writer.write_vec(f32_ops, low);
             dest_writer.write_vec(f32_ops, high);
         }


### PR DESCRIPTION
This method returned a tuple of SIMD vectors. Scalable vectors cannot be tuple fields, so this won't work on ISAs such as Arm SVE. Split this into two methods which each return a single SIMD vector.

Part of https://github.com/robertknight/rten/issues/1396.