### PR TITLE
Remove 64-output limit for operators

### DIFF
--- a/rten-base/src/bit_set.rs
+++ b/rten-base/src/bit_set.rs
@@ -3,6 +3,8 @@
 pub struct BitSet<B: BitOps = u32>(B);
 
 impl<B: BitOps> BitSet<B> {
+    const BITS: u32 = B::BITS;
+
     /// Return a bit set with all positions cleared.
     pub fn new() -> Self {
         Self(B::ZERO)
@@ -106,7 +108,7 @@ macro_rules! impl_bitops {
             }
 
             fn nth(idx: u32) -> Self {
-                (1 << idx) as Self
+                (1 as $ty) << idx
             }
         }
     };
@@ -119,9 +121,157 @@ impl_bitops!(u64);
 impl_bitops!(u128);
 impl_bitops!(usize);
 
+type Block = BitSet<u64>;
+
+#[derive(Clone, Debug, PartialEq)]
+enum BitVecData {
+    Inline { bits: Block, len: usize },
+    Heap { blocks: Box<[Block]>, len: usize },
+}
+
+/// A set of bit flags with a length chosen at runtime.
+///
+/// Vectors of 64 bits or less are stored inline without allocating.
+#[derive(Clone, Debug, PartialEq)]
+pub struct BitVec(BitVecData);
+
+impl BitVec {
+    /// Return a bit vector of length `len` with all positions cleared.
+    pub fn new(len: usize) -> Self {
+        let blocks = len.div_ceil(Block::BITS as usize);
+        if blocks <= 1 {
+            Self(BitVecData::Inline {
+                bits: BitSet::new(),
+                len,
+            })
+        } else {
+            Self(BitVecData::Heap {
+                blocks: std::iter::repeat_n(BitSet::new(), blocks).collect(),
+                len,
+            })
+        }
+    }
+
+    /// Return a bit vector of length `len` with all positions set.
+    pub fn ones(len: usize) -> Self {
+        let mut vec = Self::new(len);
+        match &mut vec.0 {
+            BitVecData::Inline { bits, len } => *bits = Block::ones(*len as u32),
+            BitVecData::Heap { blocks, len } => {
+                let mut remaining = *len;
+                for block in blocks {
+                    *block = Block::ones(remaining.min(Block::BITS as usize) as u32);
+                    remaining = remaining.saturating_sub(Block::BITS as usize);
+                }
+            }
+        }
+        vec
+    }
+
+    /// Return a bit vector of length `len` with given indices set.
+    pub fn from_indices<I: IntoIterator<Item = u32>>(len: usize, indices: I) -> Self {
+        let mut bits = Self::new(len);
+        for pos in indices {
+            bits.set(pos);
+        }
+        bits
+    }
+
+    /// Return the number of bits in this vector.
+    pub fn len(&self) -> usize {
+        match &self.0 {
+            BitVecData::Inline { bits: _, len } => *len,
+            BitVecData::Heap { blocks: _, len } => *len,
+        }
+    }
+
+    /// Return the block containing bit `pos` and the offset within it.
+    ///
+    /// `pos` must be less than `self.len()`.
+    fn block(&self, pos: u32) -> (&Block, u32) {
+        match &self.0 {
+            BitVecData::Inline { bits, len: _ } => (bits, pos),
+            BitVecData::Heap { blocks, len: _ } => {
+                let (block_idx, block_off) = (pos / Block::BITS, pos % Block::BITS);
+                (&blocks[block_idx as usize], block_off)
+            }
+        }
+    }
+
+    /// Return the block containing bit `pos` and the offset within it.
+    ///
+    /// `pos` must be less than `self.len()`.
+    fn block_mut(&mut self, pos: u32) -> (&mut Block, u32) {
+        match &mut self.0 {
+            BitVecData::Inline { bits, len: _ } => (bits, pos),
+            BitVecData::Heap { blocks, len: _ } => {
+                let (block_idx, block_off) = (pos / Block::BITS, pos % Block::BITS);
+                (&mut blocks[block_idx as usize], block_off)
+            }
+        }
+    }
+
+    fn blocks(&self) -> &[Block] {
+        match &self.0 {
+            BitVecData::Inline { bits, len: _ } => std::slice::from_ref(bits),
+            BitVecData::Heap { blocks, len: _ } => blocks,
+        }
+    }
+
+    /// Set the bit at position `pos`.
+    ///
+    /// Panics if `pos` is out of bounds.
+    pub fn set(&mut self, pos: u32) {
+        assert!((pos as usize) < self.len(), "position out of bounds");
+        let (blk, blk_off) = self.block_mut(pos);
+        blk.set(blk_off);
+    }
+
+    /// Unset the bit at position `pos`.
+    ///
+    /// Panics if `pos` is out of bounds.
+    pub fn delete(&mut self, pos: u32) {
+        assert!((pos as usize) < self.len(), "position out of bounds");
+        let (blk, blk_off) = self.block_mut(pos);
+        blk.delete(blk_off);
+    }
+
+    /// Return true if position `pos` is set.
+    ///
+    /// Returns false if `pos` is out of bounds.
+    pub fn get(&self, pos: u32) -> bool {
+        if pos as usize >= self.len() {
+            return false;
+        }
+        let (blk, blk_off) = self.block(pos);
+        blk.get(blk_off)
+    }
+
+    /// Return the number of bits set.
+    pub fn count_true(&self) -> u32 {
+        self.blocks().iter().map(|blk| blk.count_true()).sum()
+    }
+
+    /// Return true if no bits are set.
+    pub fn is_empty(&self) -> bool {
+        self.blocks().iter().all(|blk| blk.is_empty())
+    }
+
+    /// Return an iterator over the indices of set positions.
+    pub fn iter(&self) -> impl Iterator<Item = usize> {
+        (0..self.len()).filter(|pos| self.get(*pos as u32))
+    }
+}
+
+impl Default for BitVec {
+    fn default() -> Self {
+        BitVec::new(0)
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::BitSet;
+    use super::{BitSet, BitVec};
 
     #[test]
     fn test_bit_set() {
@@ -164,6 +314,72 @@ mod tests {
         let set = BitSet::<u32>::from_indices([0, 3]);
         for i in 0..u32::BITS {
             assert_eq!(set.get(i), i == 0 || i == 3);
+        }
+    }
+
+    // Lengths which use the inline and heap-allocated representations
+    // respectively.
+    const BIT_VEC_LENS: [usize; 2] = [5, 100];
+
+    #[test]
+    fn test_bit_vec_new() {
+        for len in BIT_VEC_LENS {
+            let vec = BitVec::new(len);
+            assert_eq!(vec.len(), len);
+            assert_eq!(vec.count_true(), 0);
+            assert!(vec.is_empty());
+            assert_eq!(vec, BitVec::new(len));
+            assert_ne!(vec, BitVec::ones(len));
+        }
+        assert_eq!(BitVec::default(), BitVec::new(0));
+    }
+
+    #[test]
+    fn test_bit_vec_ones() {
+        for len in BIT_VEC_LENS {
+            let vec = BitVec::ones(len);
+            assert_eq!(vec.len(), len);
+            assert_eq!(vec.count_true(), len as u32);
+            for i in 0..len + 10 {
+                assert_eq!(vec.get(i as u32), i < len);
+            }
+        }
+    }
+
+    #[test]
+    fn test_bit_vec_set_get_delete() {
+        for len in BIT_VEC_LENS {
+            let mut vec = BitVec::new(len);
+            for i in 0..len as u32 {
+                assert!(!vec.get(i));
+                vec.set(i);
+                assert!(vec.get(i));
+            }
+            assert_eq!(vec.count_true(), len as u32);
+            assert!(!vec.is_empty());
+
+            for i in 0..len as u32 {
+                vec.delete(i);
+                assert!(!vec.get(i));
+            }
+            assert!(vec.is_empty());
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "position out of bounds")]
+    fn test_bit_vec_set_out_of_bounds() {
+        let mut vec = BitVec::new(5);
+        vec.set(5);
+    }
+
+    #[test]
+    fn test_bit_vec_iter() {
+        for len in BIT_VEC_LENS {
+            let last = len as u32 - 1;
+            let vec = BitVec::from_indices(len, [0, 3, last]);
+            let positions: Vec<_> = vec.iter().collect();
+            assert_eq!(positions, [0, 3, last as usize]);
         }
     }
 }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1136,7 +1136,7 @@ impl Graph {
                     .and_then(|node_id| weight_cache.and_then(|wc| wc.get(node_id)))
             };
             let inputs = InputList::from_optional(&op_inputs).with_prepacked(&get_prepacked);
-            let mut ctx = OpRunContext::new(pool, &inputs, op_node.output_mask());
+            let mut ctx = OpRunContext::new(pool, &inputs, op_node.output_mask().clone());
             ctx.set_name(op_node.name());
 
             let op_result = if !in_place_taken.is_empty() {

--- a/src/graph/node.rs
+++ b/src/graph/node.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 use std::fmt;
 use std::sync::Arc;
 
-use rten_base::bit_set::BitSet;
+use rten_base::bit_set::BitVec;
 use rten_tensor::prelude::*;
 use rten_tensor::{ArcTensor, DynLayout, TensorView};
 
@@ -132,7 +132,7 @@ pub struct OperatorNode {
     outputs: Box<[Option<NodeId>]>,
 
     // Cached mask indicating which positions in `outputs` are set.
-    output_mask: BitSet<u64>,
+    output_mask: BitVec,
 
     operator: Arc<dyn Operator + Send + Sync>,
 
@@ -158,7 +158,7 @@ impl OperatorNode {
         let output_ids = trim_none_suffix(output_ids);
 
         // Pre-compute mask of used outputs.
-        let mut output_mask = BitSet::<u64>::ones(output_ids.len() as u32);
+        let mut output_mask = BitVec::ones(output_ids.len());
         for (i, id) in output_ids.iter().enumerate() {
             if id.is_none() {
                 output_mask.delete(i as u32);
@@ -188,8 +188,8 @@ impl OperatorNode {
     }
 
     /// Return a bit mask indicating which outputs are used.
-    pub fn output_mask(&self) -> BitSet<u64> {
-        self.output_mask
+    pub fn output_mask(&self) -> &BitVec {
+        &self.output_mask
     }
 
     /// Return the names of nodes captured by this operator's subgraphs.

--- a/src/graph/tests.rs
+++ b/src/graph/tests.rs
@@ -2,7 +2,7 @@ use std::error::Error;
 use std::sync::atomic::{AtomicI32, Ordering};
 use std::sync::{Arc, Mutex};
 
-use rten_base::bit_set::BitSet;
+use rten_base::bit_set::{BitSet, BitVec};
 use rten_tensor::prelude::*;
 use rten_tensor::test_util::{expect_equal, expect_equal_with_tolerance};
 use rten_tensor::{Tensor, TensorView};
@@ -1989,7 +1989,7 @@ fn test_run_context_outputs() {
     g.add_op(
         Some("test_op"),
         Arc::new(RunFn::new(|ctx| {
-            assert_eq!(ctx.outputs(), BitSet::from_indices([0, 3]));
+            assert_eq!(ctx.outputs(), &BitVec::from_indices(4, [0, 3]));
             Ok([
                 // Expected output.
                 Tensor::from(1.).into(),
@@ -2010,6 +2010,38 @@ fn test_run_context_outputs() {
     let input = Tensor::from([1, 2, 3]);
     g.run(vec![(input_id, input.into())], &[out_0, out_1], None, None)
         .unwrap();
+}
+
+#[test]
+fn test_operator_with_many_outputs() {
+    // Operators can have more than 64 outputs, so the output mask does not
+    // fit in a `u64`.
+    let n_outputs = 65;
+
+    let mut g = Graph::new();
+    let input_id = g.add_value(Some("input"), None, None);
+    let output_ids: Vec<_> = (0..n_outputs)
+        .map(|i| Some(g.add_value(Some(&format!("out_{}", i)), None, None)))
+        .collect();
+    g.add_op(
+        Some("test_op"),
+        Arc::new(RunFn::new(move |ctx| {
+            assert_eq!(ctx.outputs(), &BitVec::ones(n_outputs));
+            Ok((0..n_outputs)
+                .map(|i| Tensor::from(i as i32).into())
+                .collect())
+        })),
+        &[Some(input_id)],
+        &output_ids,
+    );
+
+    let input = Tensor::from([1, 2, 3]);
+    let last_out = output_ids.last().copied().flatten().unwrap();
+    let mut results = g
+        .run(vec![(input_id, input.into())], &[last_out], None, None)
+        .unwrap();
+    let result: Tensor<i32> = results.remove(0).try_into().unwrap();
+    assert_eq!(result, Tensor::from(n_outputs as i32 - 1));
 }
 
 #[test]

--- a/src/model/onnx_loader.rs
+++ b/src/model/onnx_loader.rs
@@ -1080,13 +1080,9 @@ fn add_operator(
         ));
     }
 
-    // We set a limit of 64 outputs per operator so we can represent the used
-    // positions conveniently in a u64 mask.
-    const MAX_OUTPUTS: usize = u64::BITS as usize;
-
-    let max_outputs = op.max_outputs().unwrap_or(MAX_OUTPUTS).min(MAX_OUTPUTS);
-
-    if outputs.len() > max_outputs {
+    if let Some(max_outputs) = op.max_outputs()
+        && outputs.len() > max_outputs
+    {
         return Err(load_error!(
             OperatorInvalid,
             onnx_op.name.as_deref(),
@@ -1650,7 +1646,7 @@ mod tests {
             "in node \"relu_op\": operator error: operator has 2 outputs but maximum is 1"
         );
 
-        // Test RTen's implementation limit that applies to all op types.
+        // Operators without a limit can have many outputs.
         let mut node = create_node("Split").with_input("x").with_name("split_op");
 
         for i in 0..65 {
@@ -1660,11 +1656,7 @@ mod tests {
         let graph = onnx::GraphProto::default()
             .with_input(create_value_info("x"))
             .with_node(node);
-        let err = load_model(graph.into_model(), None).err().unwrap();
-        assert_eq!(
-            err.to_string(),
-            "in node \"split_op\": operator error: operator has 65 outputs but maximum is 64"
-        );
+        load_model(graph.into_model(), None).unwrap();
     }
 
     #[test]

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -7,7 +7,7 @@ use std::error::Error;
 use std::fmt;
 use std::fmt::{Debug, Display};
 
-use rten_base::bit_set::BitSet;
+use rten_base::bit_set::{BitSet, BitVec};
 use rten_gemm::PackedBMatrix;
 use rten_tensor::errors::DimensionError;
 use rten_tensor::{Layout, Storage, TensorBase};
@@ -263,7 +263,7 @@ pub(crate) use check_eq;
 pub struct OpRunContext<'a, 'i> {
     pool: &'a BufferPool,
     inputs: &'a InputList<'i>,
-    outputs: BitSet<u64>,
+    outputs: BitVec,
     name: Option<&'a str>,
 }
 
@@ -272,7 +272,7 @@ impl<'a, 'i> OpRunContext<'a, 'i> {
     ///
     /// `outputs` is a mask indicating which of the operator's outputs are
     /// requested.
-    pub fn new(pool: &'a BufferPool, inputs: &'a InputList<'i>, outputs: BitSet<u64>) -> Self {
+    pub fn new(pool: &'a BufferPool, inputs: &'a InputList<'i>, outputs: BitVec) -> Self {
         OpRunContext {
             pool,
             inputs,
@@ -288,7 +288,12 @@ impl<'a, 'i> OpRunContext<'a, 'i> {
     where
         'a: 'b,
     {
-        OpRunContext { inputs, ..*self }
+        OpRunContext {
+            inputs,
+            pool: self.pool,
+            outputs: self.outputs.clone(),
+            name: self.name,
+        }
     }
 
     /// The pool which should be used to allocate large buffers.
@@ -309,8 +314,8 @@ impl<'a, 'i> OpRunContext<'a, 'i> {
     /// This can be used to skip generating outputs that are unused, or in
     /// the rare cases that the output count cannot be determined from the
     /// operator's inputs and attributes alone.
-    pub fn outputs(&self) -> BitSet<u64> {
-        self.outputs
+    pub fn outputs(&self) -> &BitVec {
+        &self.outputs
     }
 
     /// Set the name of the current node in the graph.
@@ -597,7 +602,7 @@ pub trait OperatorExt: Operator {
     {
         let pool = BufferPool::new();
         let inputs = inputs.into();
-        let ctx = OpRunContext::new(&pool, &inputs, BitSet::ones(1));
+        let ctx = OpRunContext::new(&pool, &inputs, BitVec::ones(1));
         let mut outputs = self.run(&ctx)?;
         Ok(outputs.remove(0).try_into()?)
     }
@@ -613,7 +618,7 @@ pub trait OperatorExt: Operator {
     {
         let pool = BufferPool::new();
         let inputs = inputs.into();
-        let ctx = OpRunContext::new(&pool, &inputs, BitSet::ones(1));
+        let ctx = OpRunContext::new(&pool, &inputs, BitVec::ones(1));
         let in_place = InPlaceInputs::from((0, mut_input.into()));
         let mut outputs = self.run_in_place(in_place, &ctx)?;
         let typed_output = outputs.remove(0).try_into()?;

--- a/src/ops/attention.rs
+++ b/src/ops/attention.rs
@@ -980,7 +980,7 @@ mod contrib;
 
 #[cfg(test)]
 mod tests {
-    use rten_base::bit_set::BitSet;
+    use rten_base::bit_set::BitVec;
     use rten_gemm::GemmExecutor;
     use rten_simd::SimdOp;
     use rten_tensor::prelude::*;
@@ -1324,7 +1324,7 @@ mod tests {
     fn run_attention(op: &Attention, inputs: &[Option<ValueView>]) -> Result<Vec<Tensor>, OpError> {
         let input_list = InputList::from_optional(inputs);
         let pool = BufferPool::new();
-        let ctx = OpRunContext::new(&pool, &input_list, BitSet::ones(3));
+        let ctx = OpRunContext::new(&pool, &input_list, BitVec::ones(3));
         op.run(&ctx)
             .map(|outputs| outputs.into_iter().map(|o| o.try_into().unwrap()).collect())
     }
@@ -1904,7 +1904,7 @@ mod tests {
 
         // Reference outputs from a normal run with the caches passed as views.
         let input_list = InputList::from_optional(inputs);
-        let ctx = OpRunContext::new(&pool, &input_list, BitSet::ones(3));
+        let ctx = OpRunContext::new(&pool, &input_list, BitVec::ones(3));
         let expected: Vec<Tensor> = op
             .run(&ctx)
             .unwrap()
@@ -1937,7 +1937,7 @@ mod tests {
         inputs[past_key_index] = None;
         inputs[past_value_index] = None;
         let input_list = InputList::from_optional(&inputs);
-        let ctx = OpRunContext::new(&pool, &input_list, BitSet::ones(3));
+        let ctx = OpRunContext::new(&pool, &input_list, BitVec::ones(3));
         let in_place = InPlaceInputs::from_iter([
             (past_key_index, Value::from(past_key)),
             (past_value_index, Value::from(past_value)),

--- a/src/ops/attention/contrib.rs
+++ b/src/ops/attention/contrib.rs
@@ -822,7 +822,7 @@ impl_infer_shapes!(
 
 #[cfg(test)]
 mod tests {
-    use rten_base::bit_set::BitSet;
+    use rten_base::bit_set::BitVec;
     use rten_simd::SimdOp;
     use rten_tensor::prelude::*;
     use rten_tensor::rng::XorShiftRng;
@@ -923,7 +923,7 @@ mod tests {
         ];
         let input_list = InputList::from_optional(&inputs);
         let pool = BufferPool::new();
-        let ctx = OpRunContext::new(&pool, &input_list, BitSet::ones(3));
+        let ctx = OpRunContext::new(&pool, &input_list, BitVec::ones(3));
         op.run(&ctx)
             .map(|outputs| outputs.into_iter().map(|o| o.try_into().unwrap()).collect())
     }
@@ -1214,12 +1214,12 @@ mod tests {
 
         // When only the first output is requested, the present KV caches are not
         // materialized as outputs.
-        let ctx = OpRunContext::new(&pool, &input_list, BitSet::from_indices([0]));
+        let ctx = OpRunContext::new(&pool, &input_list, BitVec::from_indices(3, [0]));
         let outputs = op.run(&ctx).unwrap();
         assert_eq!(outputs.len(), 1);
 
         // When a KV-cache output is requested, all three outputs are returned.
-        let ctx = OpRunContext::new(&pool, &input_list, BitSet::from_indices([0, 1]));
+        let ctx = OpRunContext::new(&pool, &input_list, BitVec::from_indices(3, [0, 1]));
         let outputs = op.run(&ctx).unwrap();
         assert_eq!(outputs.len(), 3);
     }
@@ -1249,7 +1249,7 @@ mod tests {
             ];
             let input_list = InputList::from_optional(&inputs);
             let pool = BufferPool::new();
-            let ctx = OpRunContext::new(&pool, &input_list, BitSet::ones(3));
+            let ctx = OpRunContext::new(&pool, &input_list, BitVec::ones(3));
             op.run(&ctx)
                 .map(|outputs| outputs.into_iter().map(|o| o.try_into().unwrap()).collect())
         };
@@ -1358,7 +1358,7 @@ mod tests {
         ];
         let input_list = InputList::from_optional(&inputs);
         let pool = BufferPool::new();
-        let ctx = OpRunContext::new(&pool, &input_list, BitSet::ones(1));
+        let ctx = OpRunContext::new(&pool, &input_list, BitVec::ones(1));
 
         let mut outputs = op.run(&ctx).unwrap();
         let result: Tensor = outputs.remove(0).try_into().unwrap();
@@ -1442,7 +1442,7 @@ mod tests {
             ];
             let input_list = InputList::from_optional(&inputs);
             let pool = BufferPool::new();
-            let ctx = OpRunContext::new(&pool, &input_list, BitSet::ones(1));
+            let ctx = OpRunContext::new(&pool, &input_list, BitVec::ones(1));
             let mut outputs = op.run(&ctx).unwrap();
             outputs.remove(0).try_into().unwrap()
         };

--- a/src/ops/binary_elementwise.rs
+++ b/src/ops/binary_elementwise.rs
@@ -1283,7 +1283,7 @@ impl Operator for Where {
 mod tests {
     use std::error::Error;
 
-    use rten_base::bit_set::BitSet;
+    use rten_base::bit_set::BitVec;
     use rten_tensor::prelude::*;
     use rten_tensor::test_util::{eq_with_nans, expect_equal};
     use rten_tensor::{Scalar, Tensor};
@@ -1437,7 +1437,7 @@ mod tests {
         // Run `Add` operator in place with inputs that support in-place addition.
         let op = Add {};
         let inputs: InputList = (&b).into();
-        let ctx = OpRunContext::new(&pool, &inputs, BitSet::ones(1));
+        let ctx = OpRunContext::new(&pool, &inputs, BitVec::ones(1));
         let result = op
             .run_in_place((0, Value::FloatTensor(a_copy)).into(), &ctx)
             .unwrap();

--- a/src/ops/control_flow.rs
+++ b/src/ops/control_flow.rs
@@ -320,7 +320,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use rten_base::bit_set::BitSet;
+    use rten_base::bit_set::BitVec;
     use rten_tensor::Tensor;
 
     use crate::buffer_pool::BufferPool;
@@ -362,8 +362,8 @@ mod tests {
             let pool = BufferPool::new();
             // A `Loop` produces one output per body output, except the first
             // body output which is the loop condition.
-            let num_outputs = self.op.body.output_ids().len().saturating_sub(1) as u32;
-            let ctx = OpRunContext::new(&pool, &input_list, BitSet::ones(num_outputs));
+            let num_outputs = self.op.body.output_ids().len().saturating_sub(1);
+            let ctx = OpRunContext::new(&pool, &input_list, BitVec::ones(num_outputs));
             let captures = CaptureEnv::empty();
             let weight_caches = None;
             let profiler = None;

--- a/src/ops/embedding.rs
+++ b/src/ops/embedding.rs
@@ -251,7 +251,7 @@ mod contrib;
 
 #[cfg(test)]
 mod tests {
-    use rten_base::bit_set::BitSet;
+    use rten_base::bit_set::BitVec;
     use rten_tensor::{Tensor, test_util::expect_equal_with_tolerance};
     use rten_testing::TestCases;
 
@@ -572,7 +572,7 @@ mod tests {
         input_list.push(sin_cache.view());
 
         let pool = BufferPool::new();
-        let ctx = OpRunContext::new(&pool, &input_list, BitSet::ones(1));
+        let ctx = OpRunContext::new(&pool, &input_list, BitVec::ones(1));
 
         assert!(op.run(&ctx).is_err());
     }

--- a/src/ops/matmul.rs
+++ b/src/ops/matmul.rs
@@ -820,7 +820,7 @@ mod contrib;
 mod tests {
     use std::error::Error;
 
-    use rten_base::bit_set::BitSet;
+    use rten_base::bit_set::BitVec;
     use rten_bench::run_bench;
     use rten_gemm::{
         BiasVector, GemmExecutor, GemmInT, GemmInputA, GemmInputB, GemmOptions, GemmOutT,
@@ -1229,7 +1229,7 @@ mod tests {
                 inputs.push(bias.view());
             }
 
-            let ctx = OpRunContext::new(&pool, &inputs, BitSet::ones(1));
+            let ctx = OpRunContext::new(&pool, &inputs, BitVec::ones(1));
             let mut result = op.run(&ctx).unwrap();
             let result: Tensor<f32> = result.remove(0).try_into().unwrap();
 
@@ -1561,7 +1561,7 @@ mod tests {
         };
         let inputs =
             InputList::from(&[a.view().into(), b.view().into()]).with_prepacked(&get_prepacked);
-        let ctx = OpRunContext::new(&pool, &inputs, BitSet::ones(1));
+        let ctx = OpRunContext::new(&pool, &inputs, BitVec::ones(1));
         let mut result = op.run(&ctx).unwrap();
         let result: Tensor<i32> = result.remove(0).try_into().unwrap();
 

--- a/src/ops/norm/contrib.rs
+++ b/src/ops/norm/contrib.rs
@@ -239,7 +239,7 @@ impl Operator for SkipSimplifiedLayerNormalization {
 
 #[cfg(test)]
 mod tests {
-    use rten_base::bit_set::BitSet;
+    use rten_base::bit_set::BitVec;
     use rten_tensor::prelude::*;
     use rten_tensor::rng::XorShiftRng;
     use rten_tensor::test_util::expect_equal;
@@ -277,7 +277,7 @@ mod tests {
             beta: Option<TensorView>,
             bias: Option<TensorView>,
             epsilon: f32,
-            outputs: BitSet<u64>,
+            outputs: BitVec,
         ) -> Result<OutputList, OpError> {
             let mut inputs = InputList::new();
             inputs.push(input);
@@ -412,7 +412,7 @@ mod tests {
                     case.beta.as_ref().map(|b| b.view()),
                     case.bias.as_ref().map(|b| b.view()),
                     epsilon,
-                    BitSet::from_indices([0]),
+                    BitVec::from_indices(4, [0]),
                 )
                 .unwrap();
             let result: Tensor = outputs.remove(0).try_into().unwrap();
@@ -468,7 +468,7 @@ mod tests {
                     case.beta.as_ref().map(|b| b.view()),
                     Some(bias.view()),
                     epsilon,
-                    BitSet::from_indices([0, 3]),
+                    BitVec::from_indices(4, [0, 3]),
                 )
                 .unwrap();
             assert_eq!(outputs.len(), 4);
@@ -544,7 +544,7 @@ mod tests {
                 None,
                 None,
                 1e-5,
-                BitSet::from_indices([0]),
+                BitVec::from_indices(4, [0]),
             );
             let err = result.err().expect("expected an error");
             assert_eq!(&err, &case.expected);

--- a/src/ops/random.rs
+++ b/src/ops/random.rs
@@ -395,7 +395,7 @@ impl_infer_shapes!(Dropout, _op, shape_ops::Dropout);
 
 #[cfg(test)]
 mod tests {
-    use rten_base::bit_set::BitSet;
+    use rten_base::bit_set::BitVec;
     use rten_tensor::Tensor;
     use rten_tensor::prelude::*;
     use rten_testing::TestCases;
@@ -783,7 +783,7 @@ mod tests {
                 training_mode_input.as_ref().map(|tm| tm.view().into()),
             ]);
             let pool = BufferPool::new();
-            let ctx = OpRunContext::new(&pool, &inputs, BitSet::ones(2));
+            let ctx = OpRunContext::new(&pool, &inputs, BitVec::ones(2));
             let mut outputs = op.run(&ctx).unwrap();
             let output: Tensor<f32> = outputs.remove(0).try_into().unwrap();
             assert_eq!(output, data);
@@ -832,7 +832,7 @@ mod tests {
                 Some(training_mode_input.view().into()),
             ]);
             let pool = BufferPool::new();
-            let ctx = OpRunContext::new(&pool, &inputs, BitSet::ones(2));
+            let ctx = OpRunContext::new(&pool, &inputs, BitVec::ones(2));
 
             let mut outputs = op.run(&ctx).unwrap();
             let output: Tensor<f32> = outputs.remove(0).try_into().unwrap();

--- a/src/ops/resize.rs
+++ b/src/ops/resize.rs
@@ -603,7 +603,7 @@ impl_infer_shapes!(Upsample, _op, shape_ops::Upsample);
 
 #[cfg(test)]
 mod tests {
-    use rten_base::bit_set::BitSet;
+    use rten_base::bit_set::BitVec;
     use rten_tensor::prelude::*;
     use rten_tensor::test_util::expect_equal;
     use rten_tensor::{NdTensor, NdTensorView, Tensor};
@@ -1048,7 +1048,7 @@ mod tests {
                 case.sizes.as_ref().map(|t| t.into()),
             ];
             let inputs = InputList::from_optional(&inputs);
-            let ctx = OpRunContext::new(&pool, &inputs, BitSet::ones(1));
+            let ctx = OpRunContext::new(&pool, &inputs, BitVec::ones(1));
             let result = op.run(&ctx);
             match (&case.expected, result) {
                 (CaseOutput::Shape(shape), Ok(out)) => {

--- a/src/ops/slice.rs
+++ b/src/ops/slice.rs
@@ -173,7 +173,7 @@ impl Operator for Slice {
             }
 
             let input_list = InputList::from(&inputs);
-            let ctx = OpRunContext::new(ctx.pool(), &input_list, ctx.outputs());
+            let ctx = OpRunContext::new(ctx.pool(), &input_list, ctx.outputs().clone());
             return self.run(&ctx);
         }
 

--- a/src/ops/split.rs
+++ b/src/ops/split.rs
@@ -158,7 +158,7 @@ impl_infer_shapes!(
 
 #[cfg(test)]
 mod tests {
-    use rten_base::bit_set::BitSet;
+    use rten_base::bit_set::BitVec;
     use rten_tensor::prelude::*;
     use rten_tensor::{NdTensor, Tensor};
     use rten_testing::TestCases;
@@ -247,7 +247,10 @@ mod tests {
                 case.splits.as_ref().map(|s| s.view().into()),
             ]);
             let pool = BufferPool::new();
-            let output_mask = case.graph_outputs.map(BitSet::ones).unwrap_or_default();
+            let output_mask = case
+                .graph_outputs
+                .map(|n| BitVec::ones(n as usize))
+                .unwrap_or_default();
             let ctx = OpRunContext::new(&pool, &inputs, output_mask);
             let results = split_op.run(&ctx).unwrap();
             let results: Vec<Tensor> = results.into_iter().map(|o| o.try_into().unwrap()).collect();

--- a/src/ops/transform_inputs.rs
+++ b/src/ops/transform_inputs.rs
@@ -116,7 +116,7 @@ impl Operator for TransformInputs {
             };
             transform.transform(input)?;
         }
-        let inner_ctx = OpRunContext::new(ctx.pool(), &inputs, ctx.outputs());
+        let inner_ctx = OpRunContext::new(ctx.pool(), &inputs, ctx.outputs().clone());
         self.inner.run(&inner_ctx)
     }
 
@@ -151,7 +151,7 @@ impl Operator for TransformInputs {
             };
             transform.transform(input)?;
         }
-        let inner_ctx = OpRunContext::new(ctx.pool(), &inputs, ctx.outputs());
+        let inner_ctx = OpRunContext::new(ctx.pool(), &inputs, ctx.outputs().clone());
         self.inner.run_in_place(in_place, &inner_ctx)
     }
 

--- a/src/ops/variadic_elementwise.rs
+++ b/src/ops/variadic_elementwise.rs
@@ -208,7 +208,7 @@ impl Operator for Sum {
 
 #[cfg(test)]
 mod tests {
-    use rten_base::bit_set::BitSet;
+    use rten_base::bit_set::BitVec;
     use rten_tensor::prelude::*;
     use rten_tensor::test_util::eq_with_nans;
     use rten_tensor::{Tensor, TensorView};
@@ -223,7 +223,7 @@ mod tests {
         let inputs: Vec<ValueView> = inputs.iter().cloned().map(|i| i.into()).collect();
         let inputs = InputList::from(inputs.as_slice());
         let pool = BufferPool::new();
-        let ctx = OpRunContext::new(&pool, &inputs, BitSet::ones(1));
+        let ctx = OpRunContext::new(&pool, &inputs, BitVec::ones(1));
         let mut outputs = op.run(&ctx).unwrap();
         outputs.remove(0).try_into().unwrap()
     }


### PR DESCRIPTION
Earlier PRs added a [64-output limit](https://github.com/robertknight/rten/pull/1322) for operators but it turns out there are real models with more outputs than this.

Remove the 64-output limit on operators by replacing the `BitSet<u64>` type used to represent the output mask with a `BitVec` which is a `SmallVec`-like type for bits. For up to 64 bits the values are stored inline without allocation, for larger lengths a heap allocation is used.