### PR TITLE
Remove 64-output limit for operators

### DIFF
--- a/src/graph/node.rs
+++ b/src/graph/node.rs
@@ -8,7 +8,7 @@ use rten_tensor::{ArcTensor, DynLayout, TensorView};
 
 use super::NodeId;
 use crate::constant_storage::ArcTensorView;
-use crate::operator::Operator;
+use crate::operator::{Operator, OutputMask};
 use crate::value::{DataType, Scalar, ValueType, ValueView};
 
 #[derive(Debug)]
@@ -132,7 +132,7 @@ pub struct OperatorNode {
     outputs: Box<[Option<NodeId>]>,
 
     // Cached mask indicating which positions in `outputs` are set.
-    output_mask: BitSet<u64>,
+    output_mask: OutputMask,
 
     operator: Arc<dyn Operator + Send + Sync>,
 
@@ -157,13 +157,14 @@ impl OperatorNode {
         // Trim trailing empty IDs
         let output_ids = trim_none_suffix(output_ids);
 
-        // Pre-compute mask of used outputs.
-        let mut output_mask = BitSet::<u64>::ones(output_ids.len() as u32);
-        for (i, id) in output_ids.iter().enumerate() {
-            if id.is_none() {
-                output_mask.delete(i as u32);
-            }
-        }
+        // Pre-compute mask of used outputs. Only the first 32 outputs are
+        // tracked individually; outputs beyond that are always treated as used.
+        let used = output_ids
+            .iter()
+            .take(u32::BITS as usize)
+            .enumerate()
+            .filter_map(|(i, id)| id.is_some().then_some(i as u32));
+        let output_mask = OutputMask::new(BitSet::from_indices(used), output_ids.len() as u32);
 
         OperatorNode {
             name: name.map(|s| s.to_owned()),
@@ -188,7 +189,7 @@ impl OperatorNode {
     }
 
     /// Return a bit mask indicating which outputs are used.
-    pub fn output_mask(&self) -> BitSet<u64> {
+    pub fn output_mask(&self) -> OutputMask {
         self.output_mask
     }
 

--- a/src/graph/tests.rs
+++ b/src/graph/tests.rs
@@ -16,8 +16,8 @@ use crate::graph::{
 };
 use crate::infer_shapes::InferShapes;
 use crate::operator::{
-    InPlaceInputs, IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputTypeList,
-    OutputTypesContext, PrepackedInput, SubgraphOperator,
+    InPlaceInputs, IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputMask,
+    OutputTypeList, OutputTypesContext, PrepackedInput, SubgraphOperator,
 };
 use crate::ops::{Add, Concat, Conv, Identity, If, MatMul, Mul, Relu, Shape};
 use crate::timing::Profiler;
@@ -1989,7 +1989,10 @@ fn test_run_context_outputs() {
     g.add_op(
         Some("test_op"),
         Arc::new(RunFn::new(|ctx| {
-            assert_eq!(ctx.outputs(), BitSet::from_indices([0, 3]));
+            assert_eq!(
+                ctx.outputs(),
+                OutputMask::new(BitSet::from_indices([0, 3]), 4)
+            );
             Ok([
                 // Expected output.
                 Tensor::from(1.).into(),
@@ -2010,6 +2013,38 @@ fn test_run_context_outputs() {
     let input = Tensor::from([1, 2, 3]);
     g.run(vec![(input_id, input.into())], &[out_0, out_1], None, None)
         .unwrap();
+}
+
+#[test]
+fn test_operator_with_many_outputs() {
+    // Operators can have more outputs than the mask tracks individually. All
+    // outputs beyond the first 32 are treated as used.
+    let n_outputs = 65;
+
+    let mut g = Graph::new();
+    let input_id = g.add_value(Some("input"), None, None);
+    let output_ids: Vec<_> = (0..n_outputs)
+        .map(|i| Some(g.add_value(Some(&format!("out_{}", i)), None, None)))
+        .collect();
+    g.add_op(
+        Some("test_op"),
+        Arc::new(RunFn::new(move |ctx| {
+            assert_eq!(ctx.outputs(), OutputMask::all_used(n_outputs));
+            Ok((0..n_outputs)
+                .map(|i| Tensor::from(i as i32).into())
+                .collect())
+        })),
+        &[Some(input_id)],
+        &output_ids,
+    );
+
+    let input = Tensor::from([1, 2, 3]);
+    let last_out = output_ids.last().copied().flatten().unwrap();
+    let mut results = g
+        .run(vec![(input_id, input.into())], &[last_out], None, None)
+        .unwrap();
+    let result: Tensor<i32> = results.remove(0).try_into().unwrap();
+    assert_eq!(result, Tensor::from(n_outputs as i32 - 1));
 }
 
 #[test]

--- a/src/model/onnx_loader.rs
+++ b/src/model/onnx_loader.rs
@@ -1080,13 +1080,9 @@ fn add_operator(
         ));
     }
 
-    // We set a limit of 64 outputs per operator so we can represent the used
-    // positions conveniently in a u64 mask.
-    const MAX_OUTPUTS: usize = u64::BITS as usize;
-
-    let max_outputs = op.max_outputs().unwrap_or(MAX_OUTPUTS).min(MAX_OUTPUTS);
-
-    if outputs.len() > max_outputs {
+    if let Some(max_outputs) = op.max_outputs()
+        && outputs.len() > max_outputs
+    {
         return Err(load_error!(
             OperatorInvalid,
             onnx_op.name.as_deref(),
@@ -1650,7 +1646,7 @@ mod tests {
             "in node \"relu_op\": operator error: operator has 2 outputs but maximum is 1"
         );
 
-        // Test RTen's implementation limit that applies to all op types.
+        // Operators without a limit can have many outputs.
         let mut node = create_node("Split").with_input("x").with_name("split_op");
 
         for i in 0..65 {
@@ -1660,11 +1656,7 @@ mod tests {
         let graph = onnx::GraphProto::default()
             .with_input(create_value_info("x"))
             .with_node(node);
-        let err = load_model(graph.into_model(), None).err().unwrap();
-        assert_eq!(
-            err.to_string(),
-            "in node \"split_op\": operator error: operator has 65 outputs but maximum is 64"
-        );
+        load_model(graph.into_model(), None).unwrap();
     }
 
     #[test]

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -258,12 +258,57 @@ macro_rules! check_eq {
 }
 pub(crate) use check_eq;
 
+/// The number of outputs an operator has and which are used.
+///
+/// This contains a mask that tracks which of the first 32 outputs are used,
+/// plus the total number. Outputs beyond the first 32 are always treated as
+/// used.
+#[derive(Copy, Clone, Debug, Default, PartialEq)]
+pub struct OutputMask {
+    /// Mask tracking which of the first 32 outputs are used.
+    mask: BitSet<u32>,
+    /// Total number of outputs.
+    len: u32,
+}
+
+impl OutputMask {
+    /// Return a mask with `len` outputs, where `mask` specifies which of the
+    /// first 32 are used.
+    pub fn new(mask: BitSet<u32>, len: u32) -> Self {
+        Self { mask, len }
+    }
+
+    /// Return a mask with `len` outputs, all used.
+    pub fn all_used(len: usize) -> Self {
+        Self {
+            mask: BitSet::ones(len.min(u32::BITS as usize) as u32),
+            len: len as u32,
+        }
+    }
+
+    /// Return the total number of outputs.
+    pub fn len(&self) -> usize {
+        self.len as usize
+    }
+
+    /// Return true if the output at position `idx` is used.
+    ///
+    /// Returns false if `idx` is out of bounds.
+    pub fn is_used(&self, idx: usize) -> bool {
+        if idx < u32::BITS as usize {
+            self.mask.get(idx as u32)
+        } else {
+            idx < self.len as usize
+        }
+    }
+}
+
 /// Context passed to [`Operator::run`] containing the information needed for
 /// the operator to execute.
 pub struct OpRunContext<'a, 'i> {
     pool: &'a BufferPool,
     inputs: &'a InputList<'i>,
-    outputs: BitSet<u64>,
+    outputs: OutputMask,
     name: Option<&'a str>,
 }
 
@@ -272,7 +317,7 @@ impl<'a, 'i> OpRunContext<'a, 'i> {
     ///
     /// `outputs` is a mask indicating which of the operator's outputs are
     /// requested.
-    pub fn new(pool: &'a BufferPool, inputs: &'a InputList<'i>, outputs: BitSet<u64>) -> Self {
+    pub fn new(pool: &'a BufferPool, inputs: &'a InputList<'i>, outputs: OutputMask) -> Self {
         OpRunContext {
             pool,
             inputs,
@@ -309,7 +354,7 @@ impl<'a, 'i> OpRunContext<'a, 'i> {
     /// This can be used to skip generating outputs that are unused, or in
     /// the rare cases that the output count cannot be determined from the
     /// operator's inputs and attributes alone.
-    pub fn outputs(&self) -> BitSet<u64> {
+    pub fn outputs(&self) -> OutputMask {
         self.outputs
     }
 
@@ -597,7 +642,7 @@ pub trait OperatorExt: Operator {
     {
         let pool = BufferPool::new();
         let inputs = inputs.into();
-        let ctx = OpRunContext::new(&pool, &inputs, BitSet::ones(1));
+        let ctx = OpRunContext::new(&pool, &inputs, OutputMask::all_used(1));
         let mut outputs = self.run(&ctx)?;
         Ok(outputs.remove(0).try_into()?)
     }
@@ -613,7 +658,7 @@ pub trait OperatorExt: Operator {
     {
         let pool = BufferPool::new();
         let inputs = inputs.into();
-        let ctx = OpRunContext::new(&pool, &inputs, BitSet::ones(1));
+        let ctx = OpRunContext::new(&pool, &inputs, OutputMask::all_used(1));
         let in_place = InPlaceInputs::from((0, mut_input.into()));
         let mut outputs = self.run_in_place(in_place, &ctx)?;
         let typed_output = outputs.remove(0).try_into()?;
@@ -882,11 +927,31 @@ where
 
 #[cfg(test)]
 mod tests {
+    use rten_base::bit_set::BitSet;
     use rten_tensor::prelude::*;
     use rten_tensor::{Tensor, TensorView};
 
-    use crate::operator::{InputList, OpError, Operator};
+    use crate::operator::{InputList, OpError, Operator, OutputMask};
     use crate::ops::{Add, Sub};
+
+    #[test]
+    fn test_output_mask() {
+        // Lengths below, at and above the number of tracked outputs.
+        for len in [5, 32, 33, 100] {
+            let mask = OutputMask::all_used(len);
+            assert_eq!(mask.len(), len);
+            for i in 0..len + 10 {
+                assert_eq!(mask.is_used(i), i < len);
+            }
+        }
+
+        // Positions beyond the first 32 are always treated as used, even if
+        // not marked as used in the mask.
+        let mask = OutputMask::new(BitSet::from_indices([0, 3]), 100);
+        for i in 0..100 {
+            assert_eq!(mask.is_used(i), i == 0 || i == 3 || i >= 32);
+        }
+    }
 
     #[test]
     fn test_input_list_require_as_error_index() {

--- a/src/ops/attention.rs
+++ b/src/ops/attention.rs
@@ -675,7 +675,7 @@ impl Attention {
         // key/value inputs are right-padded.
         let nonpad_kv_seqlen: Option<NdTensorView<i32, 1>> = inputs.get_as(6)?;
 
-        if ctx.outputs().get(3) {
+        if ctx.outputs().is_used(3) {
             return Err(OpError::UnsupportedValue(
                 "qk_matmul_output output is not supported",
             ));
@@ -894,10 +894,10 @@ impl Attention {
         };
 
         let mut outputs: OutputList = [output].into();
-        if ctx.outputs().get(1) || ctx.outputs().get(2) {
+        if ctx.outputs().is_used(1) || ctx.outputs().is_used(2) {
             outputs.push(key.take().into_owned_in(pool).into());
         }
-        if ctx.outputs().get(2) {
+        if ctx.outputs().is_used(2) {
             outputs.push(value.take().into_owned_in(pool).into());
         }
         Ok(outputs)
@@ -980,7 +980,6 @@ mod contrib;
 
 #[cfg(test)]
 mod tests {
-    use rten_base::bit_set::BitSet;
     use rten_gemm::GemmExecutor;
     use rten_simd::SimdOp;
     use rten_tensor::prelude::*;
@@ -995,7 +994,9 @@ mod tests {
         RepeatInterleave, apply_softcap, sdpa_head,
     };
     use crate::buffer_pool::BufferPool;
-    use crate::operator::{InPlaceInputs, InputList, OpError, OpRunContext, Operator, OperatorExt};
+    use crate::operator::{
+        InPlaceInputs, InputList, OpError, OpRunContext, Operator, OperatorExt, OutputMask,
+    };
     use crate::ops::{Add, Softmax};
     use crate::value::{Value, ValueView};
 
@@ -1324,7 +1325,7 @@ mod tests {
     fn run_attention(op: &Attention, inputs: &[Option<ValueView>]) -> Result<Vec<Tensor>, OpError> {
         let input_list = InputList::from_optional(inputs);
         let pool = BufferPool::new();
-        let ctx = OpRunContext::new(&pool, &input_list, BitSet::ones(3));
+        let ctx = OpRunContext::new(&pool, &input_list, OutputMask::all_used(3));
         op.run(&ctx)
             .map(|outputs| outputs.into_iter().map(|o| o.try_into().unwrap()).collect())
     }
@@ -1904,7 +1905,7 @@ mod tests {
 
         // Reference outputs from a normal run with the caches passed as views.
         let input_list = InputList::from_optional(inputs);
-        let ctx = OpRunContext::new(&pool, &input_list, BitSet::ones(3));
+        let ctx = OpRunContext::new(&pool, &input_list, OutputMask::all_used(3));
         let expected: Vec<Tensor> = op
             .run(&ctx)
             .unwrap()
@@ -1937,7 +1938,7 @@ mod tests {
         inputs[past_key_index] = None;
         inputs[past_value_index] = None;
         let input_list = InputList::from_optional(&inputs);
-        let ctx = OpRunContext::new(&pool, &input_list, BitSet::ones(3));
+        let ctx = OpRunContext::new(&pool, &input_list, OutputMask::all_used(3));
         let in_place = InPlaceInputs::from_iter([
             (past_key_index, Value::from(past_key)),
             (past_value_index, Value::from(past_value)),

--- a/src/ops/attention/contrib.rs
+++ b/src/ops/attention/contrib.rs
@@ -289,10 +289,10 @@ impl MultiHeadAttention {
         let output = merge_attention_heads(pool, attn_out);
 
         let mut outputs: OutputList = [output.into()].into();
-        if ctx.outputs().get(1) || ctx.outputs().get(2) {
+        if ctx.outputs().is_used(1) || ctx.outputs().is_used(2) {
             outputs.push(key.take().into_owned_in(pool).into());
         }
-        if ctx.outputs().get(2) {
+        if ctx.outputs().is_used(2) {
             outputs.push(value.take().into_owned_in(pool).into());
         }
         Ok(outputs)
@@ -744,7 +744,7 @@ impl GroupQueryAttention {
         let output = merge_attention_heads(ctx.pool(), attn_out);
 
         let mut outputs: OutputList = [output.into()].into();
-        if ctx.outputs().get(1) || ctx.outputs().get(2) {
+        if ctx.outputs().is_used(1) || ctx.outputs().is_used(2) {
             outputs.push(present_key.into());
             outputs.push(present_value.into());
         }
@@ -834,7 +834,7 @@ mod tests {
     use super::super::tests::check_in_place_kv_cache;
     use super::{GroupQueryAttention, MultiHeadAttention};
     use crate::buffer_pool::BufferPool;
-    use crate::operator::{InputList, OpError, OpRunContext, Operator, OperatorExt};
+    use crate::operator::{InputList, OpError, OpRunContext, Operator, OperatorExt, OutputMask};
     use crate::value::ValueView;
 
     /// Reference implementation of causal grouped-query attention.
@@ -923,7 +923,7 @@ mod tests {
         ];
         let input_list = InputList::from_optional(&inputs);
         let pool = BufferPool::new();
-        let ctx = OpRunContext::new(&pool, &input_list, BitSet::ones(3));
+        let ctx = OpRunContext::new(&pool, &input_list, OutputMask::all_used(3));
         op.run(&ctx)
             .map(|outputs| outputs.into_iter().map(|o| o.try_into().unwrap()).collect())
     }
@@ -1214,12 +1214,20 @@ mod tests {
 
         // When only the first output is requested, the present KV caches are not
         // materialized as outputs.
-        let ctx = OpRunContext::new(&pool, &input_list, BitSet::from_indices([0]));
+        let ctx = OpRunContext::new(
+            &pool,
+            &input_list,
+            OutputMask::new(BitSet::from_indices([0]), 3),
+        );
         let outputs = op.run(&ctx).unwrap();
         assert_eq!(outputs.len(), 1);
 
         // When a KV-cache output is requested, all three outputs are returned.
-        let ctx = OpRunContext::new(&pool, &input_list, BitSet::from_indices([0, 1]));
+        let ctx = OpRunContext::new(
+            &pool,
+            &input_list,
+            OutputMask::new(BitSet::from_indices([0, 1]), 3),
+        );
         let outputs = op.run(&ctx).unwrap();
         assert_eq!(outputs.len(), 3);
     }
@@ -1249,7 +1257,7 @@ mod tests {
             ];
             let input_list = InputList::from_optional(&inputs);
             let pool = BufferPool::new();
-            let ctx = OpRunContext::new(&pool, &input_list, BitSet::ones(3));
+            let ctx = OpRunContext::new(&pool, &input_list, OutputMask::all_used(3));
             op.run(&ctx)
                 .map(|outputs| outputs.into_iter().map(|o| o.try_into().unwrap()).collect())
         };
@@ -1358,7 +1366,7 @@ mod tests {
         ];
         let input_list = InputList::from_optional(&inputs);
         let pool = BufferPool::new();
-        let ctx = OpRunContext::new(&pool, &input_list, BitSet::ones(1));
+        let ctx = OpRunContext::new(&pool, &input_list, OutputMask::all_used(1));
 
         let mut outputs = op.run(&ctx).unwrap();
         let result: Tensor = outputs.remove(0).try_into().unwrap();
@@ -1442,7 +1450,7 @@ mod tests {
             ];
             let input_list = InputList::from_optional(&inputs);
             let pool = BufferPool::new();
-            let ctx = OpRunContext::new(&pool, &input_list, BitSet::ones(1));
+            let ctx = OpRunContext::new(&pool, &input_list, OutputMask::all_used(1));
             let mut outputs = op.run(&ctx).unwrap();
             outputs.remove(0).try_into().unwrap()
         };

--- a/src/ops/binary_elementwise.rs
+++ b/src/ops/binary_elementwise.rs
@@ -1283,7 +1283,6 @@ impl Operator for Where {
 mod tests {
     use std::error::Error;
 
-    use rten_base::bit_set::BitSet;
     use rten_tensor::prelude::*;
     use rten_tensor::test_util::{eq_with_nans, expect_equal};
     use rten_tensor::{Scalar, Tensor};
@@ -1296,7 +1295,7 @@ mod tests {
         where_op, xor,
     };
     use crate::buffer_pool::BufferPool;
-    use crate::operator::{InputList, OpError, OpRunContext, Operator, OperatorExt};
+    use crate::operator::{InputList, OpError, OpRunContext, Operator, OperatorExt, OutputMask};
     use crate::value::Value;
 
     #[test]
@@ -1437,7 +1436,7 @@ mod tests {
         // Run `Add` operator in place with inputs that support in-place addition.
         let op = Add {};
         let inputs: InputList = (&b).into();
-        let ctx = OpRunContext::new(&pool, &inputs, BitSet::ones(1));
+        let ctx = OpRunContext::new(&pool, &inputs, OutputMask::all_used(1));
         let result = op
             .run_in_place((0, Value::FloatTensor(a_copy)).into(), &ctx)
             .unwrap();

--- a/src/ops/control_flow.rs
+++ b/src/ops/control_flow.rs
@@ -320,13 +320,12 @@ where
 
 #[cfg(test)]
 mod tests {
-    use rten_base::bit_set::BitSet;
     use rten_tensor::Tensor;
 
     use crate::buffer_pool::BufferPool;
     use crate::graph::builder::Expr;
     use crate::graph::{CaptureEnv, Graph, RunError, RunErrorKind};
-    use crate::operator::{InputList, OpRunContext, SubgraphOperator};
+    use crate::operator::{InputList, OpRunContext, OutputMask, SubgraphOperator};
     use crate::value::{Scalar, Value, ValueView};
 
     use super::Loop;
@@ -362,8 +361,8 @@ mod tests {
             let pool = BufferPool::new();
             // A `Loop` produces one output per body output, except the first
             // body output which is the loop condition.
-            let num_outputs = self.op.body.output_ids().len().saturating_sub(1) as u32;
-            let ctx = OpRunContext::new(&pool, &input_list, BitSet::ones(num_outputs));
+            let num_outputs = self.op.body.output_ids().len().saturating_sub(1);
+            let ctx = OpRunContext::new(&pool, &input_list, OutputMask::all_used(num_outputs));
             let captures = CaptureEnv::empty();
             let weight_caches = None;
             let profiler = None;

--- a/src/ops/embedding.rs
+++ b/src/ops/embedding.rs
@@ -251,7 +251,7 @@ mod contrib;
 
 #[cfg(test)]
 mod tests {
-    use rten_base::bit_set::BitSet;
+    use crate::operator::OutputMask;
     use rten_tensor::{Tensor, test_util::expect_equal_with_tolerance};
     use rten_testing::TestCases;
 
@@ -572,7 +572,7 @@ mod tests {
         input_list.push(sin_cache.view());
 
         let pool = BufferPool::new();
-        let ctx = OpRunContext::new(&pool, &input_list, BitSet::ones(1));
+        let ctx = OpRunContext::new(&pool, &input_list, OutputMask::all_used(1));
 
         assert!(op.run(&ctx).is_err());
     }

--- a/src/ops/matmul.rs
+++ b/src/ops/matmul.rs
@@ -820,7 +820,6 @@ mod contrib;
 mod tests {
     use std::error::Error;
 
-    use rten_base::bit_set::BitSet;
     use rten_bench::run_bench;
     use rten_gemm::{
         BiasVector, GemmExecutor, GemmInT, GemmInputA, GemmInputB, GemmOptions, GemmOutT,
@@ -834,7 +833,7 @@ mod tests {
 
     use crate::buffer_pool::AutoReturn;
     use crate::buffer_pool::BufferPool;
-    use crate::operator::{InputList, Operator};
+    use crate::operator::{InputList, Operator, OutputMask};
     use crate::ops::binary_elementwise::broadcast_shapes;
 
     use super::{
@@ -1229,7 +1228,7 @@ mod tests {
                 inputs.push(bias.view());
             }
 
-            let ctx = OpRunContext::new(&pool, &inputs, BitSet::ones(1));
+            let ctx = OpRunContext::new(&pool, &inputs, OutputMask::all_used(1));
             let mut result = op.run(&ctx).unwrap();
             let result: Tensor<f32> = result.remove(0).try_into().unwrap();
 
@@ -1561,7 +1560,7 @@ mod tests {
         };
         let inputs =
             InputList::from(&[a.view().into(), b.view().into()]).with_prepacked(&get_prepacked);
-        let ctx = OpRunContext::new(&pool, &inputs, BitSet::ones(1));
+        let ctx = OpRunContext::new(&pool, &inputs, OutputMask::all_used(1));
         let mut result = op.run(&ctx).unwrap();
         let result: Tensor<i32> = result.remove(0).try_into().unwrap();
 

--- a/src/ops/norm/contrib.rs
+++ b/src/ops/norm/contrib.rs
@@ -65,7 +65,7 @@ fn skip_layer_normalization(
     )?;
 
     let mut outputs: OutputList = [output.into()].into();
-    if ctx.outputs().get(3) {
+    if ctx.outputs().is_used(3) {
         // `mean` and `inv_std_var` are used for training. Here we push
         // dummy values.
         outputs.push(Tensor::from(0.).into()); // mean
@@ -248,7 +248,7 @@ mod tests {
 
     use super::{SkipLayerNormalization, SkipSimplifiedLayerNormalization};
     use crate::buffer_pool::BufferPool;
-    use crate::operator::{InputList, OpError, OpRunContext, Operator, OutputList};
+    use crate::operator::{InputList, OpError, OpRunContext, Operator, OutputList, OutputMask};
     use crate::ops::tests::expect_eq_1e4;
 
     /// Wrapper around `SkipLayerNormalization` and
@@ -277,7 +277,7 @@ mod tests {
             beta: Option<TensorView>,
             bias: Option<TensorView>,
             epsilon: f32,
-            outputs: BitSet<u64>,
+            outputs: OutputMask,
         ) -> Result<OutputList, OpError> {
             let mut inputs = InputList::new();
             inputs.push(input);
@@ -412,7 +412,7 @@ mod tests {
                     case.beta.as_ref().map(|b| b.view()),
                     case.bias.as_ref().map(|b| b.view()),
                     epsilon,
-                    BitSet::from_indices([0]),
+                    OutputMask::new(BitSet::from_indices([0]), 4),
                 )
                 .unwrap();
             let result: Tensor = outputs.remove(0).try_into().unwrap();
@@ -468,7 +468,7 @@ mod tests {
                     case.beta.as_ref().map(|b| b.view()),
                     Some(bias.view()),
                     epsilon,
-                    BitSet::from_indices([0, 3]),
+                    OutputMask::new(BitSet::from_indices([0, 3]), 4),
                 )
                 .unwrap();
             assert_eq!(outputs.len(), 4);
@@ -544,7 +544,7 @@ mod tests {
                 None,
                 None,
                 1e-5,
-                BitSet::from_indices([0]),
+                OutputMask::new(BitSet::from_indices([0]), 4),
             );
             let err = result.err().expect("expected an error");
             assert_eq!(&err, &case.expected);

--- a/src/ops/random.rs
+++ b/src/ops/random.rs
@@ -395,13 +395,12 @@ impl_infer_shapes!(Dropout, _op, shape_ops::Dropout);
 
 #[cfg(test)]
 mod tests {
-    use rten_base::bit_set::BitSet;
     use rten_tensor::Tensor;
     use rten_tensor::prelude::*;
     use rten_testing::TestCases;
 
     use crate::buffer_pool::BufferPool;
-    use crate::operator::{InputList, OpError, OpRunContext, Operator, OperatorExt};
+    use crate::operator::{InputList, OpError, OpRunContext, Operator, OperatorExt, OutputMask};
     use crate::ops::operators::{FloatOperators, Operators};
 
     use super::{
@@ -783,7 +782,7 @@ mod tests {
                 training_mode_input.as_ref().map(|tm| tm.view().into()),
             ]);
             let pool = BufferPool::new();
-            let ctx = OpRunContext::new(&pool, &inputs, BitSet::ones(2));
+            let ctx = OpRunContext::new(&pool, &inputs, OutputMask::all_used(2));
             let mut outputs = op.run(&ctx).unwrap();
             let output: Tensor<f32> = outputs.remove(0).try_into().unwrap();
             assert_eq!(output, data);
@@ -832,7 +831,7 @@ mod tests {
                 Some(training_mode_input.view().into()),
             ]);
             let pool = BufferPool::new();
-            let ctx = OpRunContext::new(&pool, &inputs, BitSet::ones(2));
+            let ctx = OpRunContext::new(&pool, &inputs, OutputMask::all_used(2));
 
             let mut outputs = op.run(&ctx).unwrap();
             let output: Tensor<f32> = outputs.remove(0).try_into().unwrap();

--- a/src/ops/resize.rs
+++ b/src/ops/resize.rs
@@ -603,7 +603,6 @@ impl_infer_shapes!(Upsample, _op, shape_ops::Upsample);
 
 #[cfg(test)]
 mod tests {
-    use rten_base::bit_set::BitSet;
     use rten_tensor::prelude::*;
     use rten_tensor::test_util::expect_equal;
     use rten_tensor::{NdTensor, NdTensorView, Tensor};
@@ -611,7 +610,7 @@ mod tests {
 
     use crate::buffer_pool::BufferPool;
     use crate::operator::OperatorExt;
-    use crate::operator::{InputList, OpError, OpRunContext, Operator};
+    use crate::operator::{InputList, OpError, OpRunContext, Operator, OutputMask};
     use crate::ops::tests::expect_eq_1e4;
     use crate::ops::{
         CoordTransformMode, NearestMode, Resize, ResizeMode, ResizeTarget, Upsample, resize,
@@ -1048,7 +1047,7 @@ mod tests {
                 case.sizes.as_ref().map(|t| t.into()),
             ];
             let inputs = InputList::from_optional(&inputs);
-            let ctx = OpRunContext::new(&pool, &inputs, BitSet::ones(1));
+            let ctx = OpRunContext::new(&pool, &inputs, OutputMask::all_used(1));
             let result = op.run(&ctx);
             match (&case.expected, result) {
                 (CaseOutput::Shape(shape), Ok(out)) => {

--- a/src/ops/split.rs
+++ b/src/ops/split.rs
@@ -125,7 +125,7 @@ impl Operator for Split {
         } else {
             SplitSizes::NumSplits(
                 self.num_outputs
-                    .unwrap_or_else(|| ctx.outputs().count_true()),
+                    .unwrap_or_else(|| ctx.outputs().len() as u32),
             )
         };
 
@@ -158,13 +158,12 @@ impl_infer_shapes!(
 
 #[cfg(test)]
 mod tests {
-    use rten_base::bit_set::BitSet;
     use rten_tensor::prelude::*;
     use rten_tensor::{NdTensor, Tensor};
     use rten_testing::TestCases;
 
     use crate::buffer_pool::BufferPool;
-    use crate::operator::{InputList, OpError, OpRunContext, Operator};
+    use crate::operator::{InputList, OpError, OpRunContext, Operator, OutputMask};
 
     use super::{Split, SplitSizes, split};
 
@@ -247,7 +246,10 @@ mod tests {
                 case.splits.as_ref().map(|s| s.view().into()),
             ]);
             let pool = BufferPool::new();
-            let output_mask = case.graph_outputs.map(BitSet::ones).unwrap_or_default();
+            let output_mask = case
+                .graph_outputs
+                .map(|n| OutputMask::all_used(n as usize))
+                .unwrap_or_default();
             let ctx = OpRunContext::new(&pool, &inputs, output_mask);
             let results = split_op.run(&ctx).unwrap();
             let results: Vec<Tensor> = results.into_iter().map(|o| o.try_into().unwrap()).collect();

--- a/src/ops/variadic_elementwise.rs
+++ b/src/ops/variadic_elementwise.rs
@@ -208,14 +208,13 @@ impl Operator for Sum {
 
 #[cfg(test)]
 mod tests {
-    use rten_base::bit_set::BitSet;
     use rten_tensor::prelude::*;
     use rten_tensor::test_util::eq_with_nans;
     use rten_tensor::{Tensor, TensorView};
     use rten_testing::TestCases;
 
     use crate::buffer_pool::BufferPool;
-    use crate::operator::{InputList, OpError, OpRunContext, Operator};
+    use crate::operator::{InputList, OpError, OpRunContext, Operator, OutputMask};
     use crate::ops::{Max, Min, Sum, max, mean, min, sum};
     use crate::value::ValueView;
 
@@ -223,7 +222,7 @@ mod tests {
         let inputs: Vec<ValueView> = inputs.iter().cloned().map(|i| i.into()).collect();
         let inputs = InputList::from(inputs.as_slice());
         let pool = BufferPool::new();
-        let ctx = OpRunContext::new(&pool, &inputs, BitSet::ones(1));
+        let ctx = OpRunContext::new(&pool, &inputs, OutputMask::all_used(1));
         let mut outputs = op.run(&ctx).unwrap();
         outputs.remove(0).try_into().unwrap()
     }


### PR DESCRIPTION
A [32-output limit](https://github.com/robertknight/rten/pull/1281) for operators was introduced, then [increased to 64](https://github.com/robertknight/rten/pull/1322), as part of a change to expose a bit-mask to operators indicating which outputs are needed, so they can skip generating unused outputs. The limit of 64 came from the fact that a `u64` was used as the mask.

This PR removes the limit by changing `Operator::outputs` to return a new `OutputMask` type which tracks both the total number of outputs and which of the first 32 are used. The rationale is that for operators which return more than 32 outputs, we can just assume that any beyond the first 32 are always used. This keeps the mask data structure small and cheap to create and copy.