### PR TITLE
Fix constant propagation error when a graph output is also a graph input

### DIFF
--- a/src/graph/planner.rs
+++ b/src/graph/planner.rs
@@ -412,6 +412,11 @@ impl<'a> PlanBuilder<'a> {
 
             if let Some((op_node_id, op_node)) = self.graph.get_source_node(*output_id) {
                 self.visit(op_node_id, op_node, &mut active_set)?;
+            } else if self.options.allow_missing_inputs {
+                // The output has no producing operator, so it must be a value
+                // that is supplied at runtime (eg. a graph input which is
+                // passed through directly to the outputs).
+                continue;
             } else {
                 let output_name = self.graph.node_name(*output_id);
                 let msg = format!("Source node not found for output \"{}\"", output_name);

--- a/src/graph/tests.rs
+++ b/src/graph/tests.rs
@@ -721,6 +721,25 @@ fn test_no_source_for_output() {
 }
 
 #[test]
+fn test_graph_input_as_output() -> Result<(), Box<dyn Error>> {
+    // Graph with a value that is both an input and an output.
+    let mut g = Graph::new();
+    let val = g.add_value(Some("x"), None, None);
+
+    // A partial run with no inputs, as used for constant propagation, should
+    // succeed and produce no values for the pass-through output.
+    let partial_outs = g.partial_run(vec![], &[val], None)?;
+    assert_eq!(partial_outs.len(), 0);
+
+    // A full run providing the input should pass the value through.
+    let input = Tensor::from([1., 2.]);
+    let result = g.run(vec![(val, input.view().into())], &[val], None, None)?;
+    assert_eq!(result, [Value::FloatTensor(input)]);
+
+    Ok(())
+}
+
+#[test]
 fn test_invalid_input_id() {
     let mut g = Graph::new();
 


### PR DESCRIPTION
The constant propagation optimization pass failed with a planning error when a model had a graph output that is also a graph input. During this pass `Graph::partial_run` is called with no inputs provided, which runs the planner with `allow_missing_inputs` set. The planner already allows for operator inputs being unavailable when this flag is set, but was missing a check when handling graph outputs that are not produced by an operator.

Fix the issue by changing the planner to skip outputs that are not available when `allow_missing_inputs` is set.

The issue was found while testing fp16 chunk models from https://huggingface.co/safetype/blackbar-nano/tree/main/onnx.