### PR TITLE
Support packed QKV format in `GroupQueryAttention` operator

### DIFF
--- a/rten-shape-inference/src/ops/attention.rs
+++ b/rten-shape-inference/src/ops/attention.rs
@@ -140,6 +140,7 @@ impl InferShapes for GroupQueryAttention {
         // Inputs: query (0), key (1), value (2), past_key (3), past_value (4),
         // seqlens_k (5), total_sequence_length (6), ...
         let query = inputs.require(0)?;
+        let key = inputs.get(1);
         let past_key = inputs.get(3);
 
         let Some(query_ndim) = query.ndim() else {
@@ -156,16 +157,23 @@ impl InferShapes for GroupQueryAttention {
             return Ok(unknown_outputs());
         };
 
-        // `q_hidden = num_heads * head_size`, so the per-head size follows from
-        // the query hidden size.
-        let head_size = q_hidden.clone() / num_heads;
+        // If the `key` input is absent, `query` contains Q, K and V packed
+        // along the hidden axis. Otherwise `q_hidden = num_heads * head_size`.
+        // Either way the per-head size follows from the query hidden size.
+        let (head_size, out_hidden) = if key.is_some() {
+            (q_hidden.clone() / num_heads, q_hidden)
+        } else {
+            let head_size = q_hidden / (num_heads.clone() + kv_num_heads.clone() * 2.into());
+            let out_hidden = num_heads * head_size.clone();
+            (head_size, out_hidden)
+        };
 
         // The present KV cache holds the past cache plus the new key/value
         // tokens. New KV length equals the query sequence length.
         let total_seq = total_kv_seq(past_key, seq.clone(), sym_gen);
 
-        // Output 0: attention output `[batch, seq, q_hidden]`.
-        let output = SymTensor::from_shape(vec![batch.clone(), seq, q_hidden]);
+        // Output 0: attention output `[batch, seq, out_hidden]`.
+        let output = SymTensor::from_shape(vec![batch.clone(), seq, out_hidden]);
 
         // Outputs 1 & 2: present key/value
         // `[batch, kv_num_heads, past_seq + seq, head_size]`.
@@ -459,6 +467,29 @@ mod tests {
         let value = sym_shape!("batch", "seq", 256);
         let result = infer_gqa(16, 4, &[query, key, value]);
         assert_eq!(result.len(), 3);
+        assert_eq!(result[0], sym_shape!("batch", "seq", 1024));
+        assert_eq!(result[1], sym_shape!("batch", 4, "seq", 64));
+        assert_eq!(result[2], sym_shape!("batch", 4, "seq", 64));
+    }
+
+    #[test]
+    fn test_gqa_packed_qkv() {
+        // Packed QKV: the key and value inputs are absent and the query holds
+        // 16 + 2 * 4 heads, so the per-head size is 1536 / 24 = 64 and the
+        // output hidden size is 16 * 64 = 1024.
+        let mut sym_gen = SymbolGen::new();
+        let query = sym_shape!("batch", "seq", 1536);
+        let inputs = vec![Some(query), None, None];
+        let op = GroupQueryAttention {
+            num_heads: 16,
+            kv_num_heads: 4,
+        };
+        let result: Vec<_> = op
+            .infer_shapes(inputs.into(), &mut sym_gen)
+            .unwrap()
+            .into_iter()
+            .map(SymTensor::simplify)
+            .collect();
         assert_eq!(result[0], sym_shape!("batch", "seq", 1024));
         assert_eq!(result[1], sym_shape!("batch", 4, "seq", 64));
         assert_eq!(result[2], sym_shape!("batch", 4, "seq", 64));

--- a/src/ops/attention/contrib.rs
+++ b/src/ops/attention/contrib.rs
@@ -445,9 +445,10 @@ impl GroupQueryAttention {
 
         // (batch, seq, q_hidden)
         let query: NdTensorView<f32, 3> = inputs.require_as(0)?;
-        // (batch, seq, kv_hidden). Packed QKV (key absent) is not supported.
-        let key: NdTensorView<f32, 3> = inputs.require_as(1)?;
-        let value: NdTensorView<f32, 3> = inputs.require_as(2)?;
+        // (batch, seq, kv_hidden). Absent if Q, K and V are packed into
+        // `query`.
+        let key: Option<NdTensorView<f32, 3>> = inputs.get_as(1)?;
+        let value: Option<NdTensorView<f32, 3>> = inputs.get_as(2)?;
 
         // (batch,). Equal to total_sequence_lengths - 1.
         //
@@ -490,6 +491,45 @@ impl GroupQueryAttention {
                 "num_heads must be a multiple of kv_num_heads",
             ));
         }
+
+        // In the packed QKV format, `query` contains the Q, K and V heads
+        // concatenated along the hidden axis and the `key` and `value` inputs
+        // are absent. Unpack them into separate tensors.
+        let packed_qkv = match (key, value) {
+            (None, None) => {
+                let [batch, seq, packed_hidden] = query.shape();
+                let total_heads = num_heads + 2 * kv_num_heads;
+                if !packed_hidden.is_multiple_of(total_heads) {
+                    return Err(OpError::IncompatibleInputShapes(
+                        "packed query hidden size must be divisible by num_heads + 2 * kv_num_heads",
+                    ));
+                }
+                let head_size = packed_hidden / total_heads;
+                let heads = query.reshaped([batch, seq, total_heads, head_size]);
+                let unpack = |start: usize, n_heads: usize| {
+                    heads
+                        .slice((.., .., start..start + n_heads))
+                        .to_tensor_in(ctx.pool())
+                        .into_shape([batch, seq, n_heads * head_size])
+                };
+                Some((
+                    unpack(0, num_heads),
+                    unpack(num_heads, kv_num_heads),
+                    unpack(num_heads + kv_num_heads, kv_num_heads),
+                ))
+            }
+            (Some(_), Some(_)) => None,
+            _ => {
+                return Err(OpError::InvalidValue(
+                    "key and value must both be present or both absent",
+                ));
+            }
+        };
+        let (query, key, value) = match &packed_qkv {
+            Some((query, key, value)) => (query.view(), key.view(), value.view()),
+            // `key` and `value` are set whenever the query is not packed.
+            None => (query, key.unwrap(), value.unwrap()),
+        };
 
         let [batch, seq, q_hidden] = query.shape();
         if !q_hidden.is_multiple_of(num_heads) {
@@ -1106,6 +1146,59 @@ mod tests {
             present_key.slice((0, 0, 2)).to_vec(),
             vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]
         );
+    }
+
+    #[test]
+    fn test_group_query_attention_packed_qkv() {
+        let (num_heads, kv_num_heads, head_size) = (4u32, 2u32, 8);
+        let (batch, seq) = (1, 3);
+        let q_hidden = num_heads as usize * head_size;
+        let kv_hidden = kv_num_heads as usize * head_size;
+
+        let mut rng = XorShiftRng::new(1234);
+        let packed = NdTensor::<f32, 3>::rand([batch, seq, q_hidden + 2 * kv_hidden], &mut rng);
+
+        // Q, K and V occupy consecutive slices of the hidden axis.
+        let query = packed.slice((.., .., ..q_hidden)).to_tensor();
+        let key = packed
+            .slice((.., .., q_hidden..q_hidden + kv_hidden))
+            .to_tensor();
+        let value = packed.slice((.., .., q_hidden + kv_hidden..)).to_tensor();
+
+        let op = default_gqa(num_heads, kv_num_heads, None);
+        let seqlens_k = NdTensor::<i32, 1>::full([batch], seq as i32 - 1);
+        let total = NdTensor::from_scalar(seq as i32);
+
+        let inputs = [
+            Some(ValueView::from(packed.view())),
+            None, // key
+            None, // value
+            None, // past_key
+            None, // past_value
+            Some(ValueView::from(seqlens_k.view())),
+            Some(ValueView::from(total.view())),
+        ];
+        let input_list = InputList::from_optional(&inputs);
+        let pool = BufferPool::new();
+        let ctx = OpRunContext::new(&pool, &input_list, OutputMask::all_used(3));
+        let packed_outputs: Vec<Tensor> = op
+            .run(&ctx)
+            .unwrap()
+            .into_iter()
+            .map(|o| o.try_into().unwrap())
+            .collect();
+
+        // The packed inputs must produce the same result as the equivalent
+        // separate Q, K and V inputs.
+        let outputs = run_gqa(
+            &op, &query, &key, &value, None, None, &seqlens_k, seq as i32,
+        )
+        .unwrap();
+
+        assert_eq!(packed_outputs[0].shape(), [batch, seq, q_hidden]);
+        for (packed, separate) in packed_outputs.iter().zip(&outputs) {
+            expect_equal(&packed.view(), &separate.view()).unwrap();
+        }
     }
 
     #[test]

--- a/src/ops/attention/contrib.rs
+++ b/src/ops/attention/contrib.rs
@@ -492,10 +492,57 @@ impl GroupQueryAttention {
             ));
         }
 
-        // In the packed QKV format, `query` contains the Q, K and V heads
-        // concatenated along the hidden axis and the `key` and `value` inputs
-        // are absent. Unpack them into separate tensors.
-        let packed_qkv = match (key, value) {
+        // Reshape of `query` used by the packed QKV path. Declared outside the
+        // match so that views of it outlive the arm that creates it.
+        let packed_heads;
+
+        // Split Q, K and V into per-head views of shape
+        // (batch, seq, heads, head_size).
+        let (query, key, value) = match (key, value) {
+            (Some(key), Some(value)) => {
+                let [batch, seq, q_hidden] = query.shape();
+                if !q_hidden.is_multiple_of(num_heads) {
+                    return Err(OpError::IncompatibleInputShapes(
+                        "query hidden size must be divisible by num_heads",
+                    ));
+                }
+                let head_size = q_hidden / num_heads;
+
+                let [key_batch, kv_seq, kv_hidden] = key.shape();
+                let [value_batch, value_seq, value_hidden] = value.shape();
+                if key_batch != batch || value_batch != batch {
+                    return Err(OpError::IncompatibleInputShapes(
+                        "key and value batch size must match query",
+                    ));
+                }
+                if kv_seq != value_seq || kv_hidden != value_hidden {
+                    return Err(OpError::IncompatibleInputShapes(
+                        "key and value must have the same shape",
+                    ));
+                }
+                if kv_hidden != kv_num_heads * head_size {
+                    return Err(OpError::IncompatibleInputShapes(
+                        "key hidden size must equal kv_num_heads * head_size",
+                    ));
+                }
+                // Shared KV buffer mode (kv_seq == 0) and cross attention are
+                // not supported. New key/value sequence length must match the
+                // query.
+                if kv_seq != seq {
+                    return Err(OpError::UnsupportedValue(
+                        "key sequence length must match query sequence length",
+                    ));
+                }
+
+                (
+                    query.reshaped([batch, seq, num_heads, head_size]),
+                    key.reshaped([batch, seq, kv_num_heads, head_size]),
+                    value.reshaped([batch, seq, kv_num_heads, head_size]),
+                )
+            }
+            // In the packed QKV format the `key` and `value` inputs are absent
+            // and `query` contains the Q, K and V heads concatenated along the
+            // hidden axis.
             (None, None) => {
                 let [batch, seq, packed_hidden] = query.shape();
                 let total_heads = num_heads + 2 * kv_num_heads;
@@ -505,64 +552,24 @@ impl GroupQueryAttention {
                     ));
                 }
                 let head_size = packed_hidden / total_heads;
-                let heads = query.reshaped([batch, seq, total_heads, head_size]);
-                let unpack = |start: usize, n_heads: usize| {
-                    heads
-                        .slice((.., .., start..start + n_heads))
-                        .to_tensor_in(ctx.pool())
-                        .into_shape([batch, seq, n_heads * head_size])
-                };
-                Some((
-                    unpack(0, num_heads),
-                    unpack(num_heads, kv_num_heads),
-                    unpack(num_heads + kv_num_heads, kv_num_heads),
-                ))
+                packed_heads = query.reshaped([batch, seq, total_heads, head_size]);
+                (
+                    packed_heads.slice((.., .., ..num_heads)).as_cow(),
+                    packed_heads
+                        .slice((.., .., num_heads..num_heads + kv_num_heads))
+                        .as_cow(),
+                    packed_heads
+                        .slice((.., .., num_heads + kv_num_heads..))
+                        .as_cow(),
+                )
             }
-            (Some(_), Some(_)) => None,
             _ => {
                 return Err(OpError::InvalidValue(
                     "key and value must both be present or both absent",
                 ));
             }
         };
-        let (query, key, value) = match &packed_qkv {
-            Some((query, key, value)) => (query.view(), key.view(), value.view()),
-            // `key` and `value` are set whenever the query is not packed.
-            None => (query, key.unwrap(), value.unwrap()),
-        };
-
-        let [batch, seq, q_hidden] = query.shape();
-        if !q_hidden.is_multiple_of(num_heads) {
-            return Err(OpError::IncompatibleInputShapes(
-                "query hidden size must be divisible by num_heads",
-            ));
-        }
-        let head_size = q_hidden / num_heads;
-
-        let [key_batch, kv_seq, kv_hidden] = key.shape();
-        let [value_batch, value_seq, value_hidden] = value.shape();
-        if key_batch != batch || value_batch != batch {
-            return Err(OpError::IncompatibleInputShapes(
-                "key and value batch size must match query",
-            ));
-        }
-        if kv_seq != value_seq || kv_hidden != value_hidden {
-            return Err(OpError::IncompatibleInputShapes(
-                "key and value must have the same shape",
-            ));
-        }
-        if kv_hidden != kv_num_heads * head_size {
-            return Err(OpError::IncompatibleInputShapes(
-                "key hidden size must equal kv_num_heads * head_size",
-            ));
-        }
-        // Shared KV buffer mode (kv_seq == 0) and cross attention are not
-        // supported. New key/value sequence length must match the query.
-        if kv_seq != seq {
-            return Err(OpError::UnsupportedValue(
-                "key sequence length must match query sequence length",
-            ));
-        }
+        let [batch, seq, _, head_size] = query.shape();
 
         // Resolve per-batch sequence lengths.
         if seqlens_k.len() != batch {
@@ -673,11 +680,15 @@ impl GroupQueryAttention {
                 NdTensor::from_fn([batch, seq], |[b, s]| (past_len(b) + s) as i32).into_cow()
             };
 
+            // `rotary_embedding` takes a (batch, heads, seq, head_size) input
+            // when given a 4D tensor, and returns the result in that layout.
+            //
             // TODO - These two calls each gather the cos/sin caches with the
             // same `pos_ids`. Gather once and reuse.
             let q = rotary_embedding(
                 ctx.pool(),
-                query.as_dyn(),
+                // (batch, seq, heads, head_size) => (batch, heads, seq, head_size)
+                query.permuted([0, 2, 1, 3]).as_dyn(),
                 cos.as_dyn(),
                 sin.as_dyn(),
                 Some(pos_ids.view()),
@@ -687,7 +698,8 @@ impl GroupQueryAttention {
             )?;
             let k = rotary_embedding(
                 ctx.pool(),
-                key.as_dyn(),
+                // (batch, seq, heads, head_size) => (batch, heads, seq, head_size)
+                key.permuted([0, 2, 1, 3]).as_dyn(),
                 cos.as_dyn(),
                 sin.as_dyn(),
                 Some(pos_ids.view()),
@@ -700,20 +712,25 @@ impl GroupQueryAttention {
             (None, None)
         };
 
-        // `rotary_q` and `rotary_k` have same rank as `query` and `key`
-        // respectively (ie. 3).
-        let query = rotary_q.as_ref().map(|q| q.nd_view::<3>()).unwrap_or(query);
-        let key = rotary_k.as_ref().map(|k| k.nd_view::<3>()).unwrap_or(key);
+        // Restore the (batch, seq, heads, head_size) layout of the rotated
+        // tensors.
+        let query = rotary_q
+            .as_ref()
+            // (batch, heads, seq, head_size) => (batch, seq, heads, head_size)
+            .map(|q| q.nd_view::<4>().permuted([0, 2, 1, 3]))
+            .unwrap_or(query.view());
+        let key = rotary_k
+            .as_ref()
+            // (batch, heads, seq, head_size) => (batch, seq, heads, head_size)
+            .map(|k| k.nd_view::<4>().permuted([0, 2, 1, 3]))
+            .unwrap_or(key.view());
 
-        // Reshape Q to (batch, num_heads, seq, head_size).
-        let query = query.reshaped([batch, seq, num_heads, head_size]);
+        // (batch, seq, num_heads, head_size) => (batch, num_heads, seq, head_size)
         let query = query.permuted([0, 2, 1, 3]);
 
         // Build the present key/value caches in BNSH layout by concatenating the
         // past cache with the new key/value tokens. When the past caches are
         // owned and have spare capacity, they are extended in place.
-        let key = key.reshaped([batch, seq, kv_num_heads, head_size]);
-        let value = value.reshaped([batch, seq, kv_num_heads, head_size]);
 
         let present_key =
             gqa_present_cache(ctx.pool(), past_key, key.view(), past_len, present_seq);

--- a/src/ops/embedding.rs
+++ b/src/ops/embedding.rs
@@ -124,12 +124,16 @@ pub(crate) fn rotary_embedding(
         "Last dimension of sin cache does not match rotary_embedding_dim/2",
     )?;
 
-    // Make the inputs contiguous so each head vector and cache row is a
-    // contiguous slice that the kernel can index directly.
-    let input_contig = reshaped_input.to_contiguous_in(pool).auto_return(pool);
+    let head_dim = reshaped_input.ndim() - 1;
+    let input_contig = if reshaped_input.stride(head_dim) != 1 {
+        reshaped_input.to_contiguous_in(pool).into_inner()
+    } else {
+        reshaped_input.as_cow()
+    }
+    .auto_return(pool);
+
     let cos_contig = cos_cache.to_contiguous_in(pool).auto_return(pool);
     let sin_contig = sin_cache.to_contiguous_in(pool).auto_return(pool);
-    let in_data = input_contig.data();
     let cos_data = cos_contig.data();
     let sin_data = sin_contig.data();
 
@@ -140,11 +144,15 @@ pub(crate) fn rotary_embedding(
     // For each `(batch, seq, head)` row, apply the rotation to the first
     // `rotary_embedding_dim` elements and copy the remainder.
     let out_uninit = &mut out_data.spare_capacity_mut()[..out_len];
-    in_data
-        .par_chunks(head_size)
+    input_contig
+        .lanes(head_dim)
+        .into_par_iter()
         .zip(out_uninit.par_chunks_mut(head_size))
         .enumerate()
         .for_each(|(row, (x, y))| {
+            // OK because the lanes are contiguous.
+            let x = x.as_slice().unwrap();
+
             let bs = row / num_heads;
             let b = bs / seq_len;
             let s = bs % seq_len;


### PR DESCRIPTION
The contrib `GroupQueryAttention` operator can take the Q, K and V inputs either as three separate tensors of shape `(batch, seq, heads, size)` or a single _packed_ tensor of shape `(batch, seq, (num_heads + 2 * kv_num_heads) * head_size)` (see [spec](https://github.com/microsoft/onnxruntime/blob/main/docs/ContribOperators.md#commicrosoftgroupqueryattention)). Previously only the un-packed layout was supported. This PR adds support for the packed layout.

Since `head_size` is no longer its own dimension in the packed layout, it is computed as `head_size = q_hidden / (num_heads + 2 * kv_num_heads)`.

As part of this, `RotaryEmbedding` was refactored so that it only copies the input before rotating if the rows are not contiguous. Previously it would copy if the entire tensor was not contiguous. This change is needed to avoid an extra copy when applying rotary embedding within the GQA op when QKV is packed.