### PR TITLE
Support `exclusive` and `reverse` attributes in CumSum operator

### DIFF
--- a/rten-convert/rten_convert/converter.py
+++ b/rten-convert/rten_convert/converter.py
@@ -469,7 +469,7 @@ def op_node_from_onnx_operator(
         case "CumSum":
             attrs = sg.CumSumAttrsT()
             attrs.exclusive = attr_reader.get_bool_attr("exclusive", False)
-            attr_reader.check_attr("reverse", "int", 0)
+            attrs.reverse = attr_reader.get_bool_attr("reverse", False)
 
         case "DFT":
             attrs = sg.DFTAttrsT()

--- a/rten-convert/rten_convert/converter.py
+++ b/rten-convert/rten_convert/converter.py
@@ -467,7 +467,8 @@ def op_node_from_onnx_operator(
             read_pads(attr_reader, attrs)
 
         case "CumSum":
-            attr_reader.check_attr("exclusive", "int", 0)
+            attrs = sg.CumSumAttrsT()
+            attrs.exclusive = attr_reader.get_bool_attr("exclusive", False)
             attr_reader.check_attr("reverse", "int", 0)
 
         case "DFT":

--- a/rten-convert/rten_convert/schema_generated.py
+++ b/rten-convert/rten_convert/schema_generated.py
@@ -250,6 +250,7 @@ class OperatorAttrs(object):
     UpsampleAttrs = 58
     RotaryEmbeddingAttrs = 59
     AttentionAttrs = 60
+    CumSumAttrs = 61
 
 def OperatorAttrsCreator(unionType, table):
     from flatbuffers.table import Table
@@ -375,6 +376,8 @@ def OperatorAttrsCreator(unionType, table):
         return RotaryEmbeddingAttrsT.InitFromBuf(table.Bytes, table.Pos)
     if unionType == OperatorAttrs.AttentionAttrs:
         return AttentionAttrsT.InitFromBuf(table.Bytes, table.Pos)
+    if unionType == OperatorAttrs.CumSumAttrs:
+        return CumSumAttrsT.InitFromBuf(table.Bytes, table.Pos)
     return None
 
 
@@ -2400,6 +2403,86 @@ class ConvTransposeAttrsT(object):
             ConvTransposeAttrsAddDilations(builder, dilations)
         convTransposeAttrs = ConvTransposeAttrsEnd(builder)
         return convTransposeAttrs
+
+
+class CumSumAttrs(object):
+    __slots__ = ['_tab']
+
+    @classmethod
+    def GetRootAs(cls, buf, offset=0):
+        n = flatbuffers.encode.Get(flatbuffers.packer.uoffset, buf, offset)
+        x = CumSumAttrs()
+        x.Init(buf, n + offset)
+        return x
+
+    @classmethod
+    def GetRootAsCumSumAttrs(cls, buf, offset=0):
+        """This method is deprecated. Please switch to GetRootAs."""
+        return cls.GetRootAs(buf, offset)
+    @classmethod
+    def CumSumAttrsBufferHasIdentifier(cls, buf, offset, size_prefixed=False):
+        return flatbuffers.util.BufferHasIdentifier(buf, offset, b"\x52\x54\x45\x4E", size_prefixed=size_prefixed)
+
+    # CumSumAttrs
+    def Init(self, buf, pos):
+        self._tab = flatbuffers.table.Table(buf, pos)
+
+    # CumSumAttrs
+    def Exclusive(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
+        if o != 0:
+            return bool(self._tab.Get(flatbuffers.number_types.BoolFlags, o + self._tab.Pos))
+        return False
+
+def CumSumAttrsStart(builder):
+    builder.StartObject(1)
+
+def CumSumAttrsAddExclusive(builder, exclusive):
+    builder.PrependBoolSlot(0, exclusive, 0)
+
+def CumSumAttrsEnd(builder):
+    return builder.EndObject()
+
+
+
+class CumSumAttrsT(object):
+
+    # CumSumAttrsT
+    def __init__(
+        self,
+        exclusive = False,
+    ):
+        self.exclusive = exclusive  # type: bool
+
+    @classmethod
+    def InitFromBuf(cls, buf, pos):
+        cumSumAttrs = CumSumAttrs()
+        cumSumAttrs.Init(buf, pos)
+        return cls.InitFromObj(cumSumAttrs)
+
+    @classmethod
+    def InitFromPackedBuf(cls, buf, pos=0):
+        n = flatbuffers.encode.Get(flatbuffers.packer.uoffset, buf, pos)
+        return cls.InitFromBuf(buf, pos+n)
+
+    @classmethod
+    def InitFromObj(cls, cumSumAttrs):
+        x = CumSumAttrsT()
+        x._UnPack(cumSumAttrs)
+        return x
+
+    # CumSumAttrsT
+    def _UnPack(self, cumSumAttrs):
+        if cumSumAttrs is None:
+            return
+        self.exclusive = cumSumAttrs.Exclusive()
+
+    # CumSumAttrsT
+    def Pack(self, builder):
+        CumSumAttrsStart(builder)
+        CumSumAttrsAddExclusive(builder, self.exclusive)
+        cumSumAttrs = CumSumAttrsEnd(builder)
+        return cumSumAttrs
 
 
 class DequantizeLinearAttrs(object):
@@ -7180,7 +7263,7 @@ class OperatorNodeT(object):
     ):
         self.type = type  # type: int
         self.attrsType = attrsType  # type: int
-        self.attrs = attrs  # type: Union[None, 'ArgMaxAttrsT', 'AveragePoolAttrsT', 'BatchNormalizationAttrsT', 'CastAttrsT', 'ConcatAttrsT', 'ConstantOfShapeAttrsT', 'ConvAttrsT', 'ConvTransposeAttrsT', 'FlattenAttrsT', 'GatherAttrsT', 'GemmAttrsT', 'GRUAttrsT', 'LeakyReluAttrsT', 'LSTMAttrsT', 'MaxPoolAttrsT', 'ReduceMeanAttrsT', 'ReshapeAttrsT', 'ResizeAttrsT', 'SplitAttrsT', 'SoftmaxAttrsT', 'TransposeAttrsT', 'ModAttrsT', 'ScatterElementsAttrsT', 'OneHotAttrsT', 'TopKAttrsT', 'HardSigmoidAttrsT', 'TriluAttrsT', 'ScatterNDAttrsT', 'NonMaxSuppressionAttrsT', 'LayerNormalizationAttrsT', 'RandomUniformAttrsT', 'EluAttrsT', 'RandomUniformLikeAttrsT', 'RandomNormalAttrsT', 'RandomNormalLikeAttrsT', 'GatherNDAttrsT', 'GeluAttrsT', 'EinsumAttrsT', 'IfAttrsT', 'PadAttrsT', 'DequantizeLinearAttrsT', 'QuantizeLinearAttrsT', 'DepthToSpaceAttrsT', 'CastLikeAttrsT', 'ShapeAttrsT', 'DropoutAttrsT', 'EyeLikeAttrsT', 'IsInfAttrsT', 'LoopAttrsT', 'SequenceEmptyAttrsT', 'ConcatFromSequenceAttrsT', 'SplitToSequenceAttrsT', 'GridSampleAttrsT', 'STFTAttrsT', 'MultinomialAttrsT', 'ReverseSequenceAttrsT', 'DFTAttrsT', 'UpsampleAttrsT', 'RotaryEmbeddingAttrsT', 'AttentionAttrsT']
+        self.attrs = attrs  # type: Union[None, 'ArgMaxAttrsT', 'AveragePoolAttrsT', 'BatchNormalizationAttrsT', 'CastAttrsT', 'ConcatAttrsT', 'ConstantOfShapeAttrsT', 'ConvAttrsT', 'ConvTransposeAttrsT', 'FlattenAttrsT', 'GatherAttrsT', 'GemmAttrsT', 'GRUAttrsT', 'LeakyReluAttrsT', 'LSTMAttrsT', 'MaxPoolAttrsT', 'ReduceMeanAttrsT', 'ReshapeAttrsT', 'ResizeAttrsT', 'SplitAttrsT', 'SoftmaxAttrsT', 'TransposeAttrsT', 'ModAttrsT', 'ScatterElementsAttrsT', 'OneHotAttrsT', 'TopKAttrsT', 'HardSigmoidAttrsT', 'TriluAttrsT', 'ScatterNDAttrsT', 'NonMaxSuppressionAttrsT', 'LayerNormalizationAttrsT', 'RandomUniformAttrsT', 'EluAttrsT', 'RandomUniformLikeAttrsT', 'RandomNormalAttrsT', 'RandomNormalLikeAttrsT', 'GatherNDAttrsT', 'GeluAttrsT', 'EinsumAttrsT', 'IfAttrsT', 'PadAttrsT', 'DequantizeLinearAttrsT', 'QuantizeLinearAttrsT', 'DepthToSpaceAttrsT', 'CastLikeAttrsT', 'ShapeAttrsT', 'DropoutAttrsT', 'EyeLikeAttrsT', 'IsInfAttrsT', 'LoopAttrsT', 'SequenceEmptyAttrsT', 'ConcatFromSequenceAttrsT', 'SplitToSequenceAttrsT', 'GridSampleAttrsT', 'STFTAttrsT', 'MultinomialAttrsT', 'ReverseSequenceAttrsT', 'DFTAttrsT', 'UpsampleAttrsT', 'RotaryEmbeddingAttrsT', 'AttentionAttrsT', 'CumSumAttrsT']
         self.inputs = inputs  # type: Optional[List[int]]
         self.outputs = outputs  # type: Optional[List[int]]
 

--- a/rten-convert/rten_convert/schema_generated.py
+++ b/rten-convert/rten_convert/schema_generated.py
@@ -2434,11 +2434,21 @@ class CumSumAttrs(object):
             return bool(self._tab.Get(flatbuffers.number_types.BoolFlags, o + self._tab.Pos))
         return False
 
+    # CumSumAttrs
+    def Reverse(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(6))
+        if o != 0:
+            return bool(self._tab.Get(flatbuffers.number_types.BoolFlags, o + self._tab.Pos))
+        return False
+
 def CumSumAttrsStart(builder):
-    builder.StartObject(1)
+    builder.StartObject(2)
 
 def CumSumAttrsAddExclusive(builder, exclusive):
     builder.PrependBoolSlot(0, exclusive, 0)
+
+def CumSumAttrsAddReverse(builder, reverse):
+    builder.PrependBoolSlot(1, reverse, 0)
 
 def CumSumAttrsEnd(builder):
     return builder.EndObject()
@@ -2451,8 +2461,10 @@ class CumSumAttrsT(object):
     def __init__(
         self,
         exclusive = False,
+        reverse = False,
     ):
         self.exclusive = exclusive  # type: bool
+        self.reverse = reverse  # type: bool
 
     @classmethod
     def InitFromBuf(cls, buf, pos):
@@ -2476,11 +2488,13 @@ class CumSumAttrsT(object):
         if cumSumAttrs is None:
             return
         self.exclusive = cumSumAttrs.Exclusive()
+        self.reverse = cumSumAttrs.Reverse()
 
     # CumSumAttrsT
     def Pack(self, builder):
         CumSumAttrsStart(builder)
         CumSumAttrsAddExclusive(builder, self.exclusive)
+        CumSumAttrsAddReverse(builder, self.reverse)
         cumSumAttrs = CumSumAttrsEnd(builder)
         return cumSumAttrs
 

--- a/rten-model-file/src/schema.fbs
+++ b/rten-model-file/src/schema.fbs
@@ -267,6 +267,7 @@ union OperatorAttrs {
   UpsampleAttrs,
   RotaryEmbeddingAttrs,
   AttentionAttrs,
+  CumSumAttrs,
 }
 
 table ArgMaxAttrs {
@@ -371,6 +372,11 @@ table ConvTransposeAttrs {
 
   output_padding:[uint];
   dilations:[uint];
+}
+
+// Attributes are optional for backwards compatibility.
+table CumSumAttrs {
+  exclusive:bool;
 }
 
 table DequantizeLinearAttrs {

--- a/rten-model-file/src/schema.fbs
+++ b/rten-model-file/src/schema.fbs
@@ -377,6 +377,7 @@ table ConvTransposeAttrs {
 // Attributes are optional for backwards compatibility.
 table CumSumAttrs {
   exclusive:bool;
+  reverse:bool;
 }
 
 table DequantizeLinearAttrs {

--- a/rten-model-file/src/schema_generated.rs
+++ b/rten-model-file/src/schema_generated.rs
@@ -4731,6 +4731,7 @@ impl<'a> ::flatbuffers::Follow<'a> for CumSumAttrs<'a> {
 
 impl<'a> CumSumAttrs<'a> {
     pub const VT_EXCLUSIVE: ::flatbuffers::VOffsetT = 4;
+    pub const VT_REVERSE: ::flatbuffers::VOffsetT = 6;
 
     #[inline]
     pub unsafe fn init_from_table(table: ::flatbuffers::Table<'a>) -> Self {
@@ -4747,6 +4748,7 @@ impl<'a> CumSumAttrs<'a> {
         args: &'args CumSumAttrsArgs,
     ) -> ::flatbuffers::WIPOffset<CumSumAttrs<'bldr>> {
         let mut builder = CumSumAttrsBuilder::new(_fbb);
+        builder.add_reverse(args.reverse);
         builder.add_exclusive(args.exclusive);
         builder.finish()
     }
@@ -4762,6 +4764,17 @@ impl<'a> CumSumAttrs<'a> {
                 .unwrap()
         }
     }
+    #[inline]
+    pub fn reverse(&self) -> bool {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab
+                .get::<bool>(CumSumAttrs::VT_REVERSE, Some(false))
+                .unwrap()
+        }
+    }
 }
 
 impl ::flatbuffers::Verifiable for CumSumAttrs<'_> {
@@ -4772,17 +4785,22 @@ impl ::flatbuffers::Verifiable for CumSumAttrs<'_> {
     ) -> Result<(), ::flatbuffers::InvalidFlatbuffer> {
         v.visit_table(pos)?
             .visit_field::<bool>("exclusive", Self::VT_EXCLUSIVE, false)?
+            .visit_field::<bool>("reverse", Self::VT_REVERSE, false)?
             .finish();
         Ok(())
     }
 }
 pub struct CumSumAttrsArgs {
     pub exclusive: bool,
+    pub reverse: bool,
 }
 impl<'a> Default for CumSumAttrsArgs {
     #[inline]
     fn default() -> Self {
-        CumSumAttrsArgs { exclusive: false }
+        CumSumAttrsArgs {
+            exclusive: false,
+            reverse: false,
+        }
     }
 }
 
@@ -4795,6 +4813,11 @@ impl<'a: 'b, 'b, A: ::flatbuffers::Allocator + 'a> CumSumAttrsBuilder<'a, 'b, A>
     pub fn add_exclusive(&mut self, exclusive: bool) {
         self.fbb_
             .push_slot::<bool>(CumSumAttrs::VT_EXCLUSIVE, exclusive, false);
+    }
+    #[inline]
+    pub fn add_reverse(&mut self, reverse: bool) {
+        self.fbb_
+            .push_slot::<bool>(CumSumAttrs::VT_REVERSE, reverse, false);
     }
     #[inline]
     pub fn new(
@@ -4817,6 +4840,7 @@ impl ::core::fmt::Debug for CumSumAttrs<'_> {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         let mut ds = f.debug_struct("CumSumAttrs");
         ds.field("exclusive", &self.exclusive());
+        ds.field("reverse", &self.reverse());
         ds.finish()
     }
 }

--- a/rten-model-file/src/schema_generated.rs
+++ b/rten-model-file/src/schema_generated.rs
@@ -1236,13 +1236,13 @@ pub const ENUM_MIN_OPERATOR_ATTRS: u8 = 0;
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
-pub const ENUM_MAX_OPERATOR_ATTRS: u8 = 60;
+pub const ENUM_MAX_OPERATOR_ATTRS: u8 = 61;
 #[deprecated(
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_OPERATOR_ATTRS: [OperatorAttrs; 61] = [
+pub const ENUM_VALUES_OPERATOR_ATTRS: [OperatorAttrs; 62] = [
     OperatorAttrs::NONE,
     OperatorAttrs::ArgMaxAttrs,
     OperatorAttrs::AveragePoolAttrs,
@@ -1304,6 +1304,7 @@ pub const ENUM_VALUES_OPERATOR_ATTRS: [OperatorAttrs; 61] = [
     OperatorAttrs::UpsampleAttrs,
     OperatorAttrs::RotaryEmbeddingAttrs,
     OperatorAttrs::AttentionAttrs,
+    OperatorAttrs::CumSumAttrs,
 ];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -1372,9 +1373,10 @@ impl OperatorAttrs {
     pub const UpsampleAttrs: Self = Self(58);
     pub const RotaryEmbeddingAttrs: Self = Self(59);
     pub const AttentionAttrs: Self = Self(60);
+    pub const CumSumAttrs: Self = Self(61);
 
     pub const ENUM_MIN: u8 = 0;
-    pub const ENUM_MAX: u8 = 60;
+    pub const ENUM_MAX: u8 = 61;
     pub const ENUM_VALUES: &'static [Self] = &[
         Self::NONE,
         Self::ArgMaxAttrs,
@@ -1437,6 +1439,7 @@ impl OperatorAttrs {
         Self::UpsampleAttrs,
         Self::RotaryEmbeddingAttrs,
         Self::AttentionAttrs,
+        Self::CumSumAttrs,
     ];
     /// Returns the variant's name or "" if unknown.
     pub fn variant_name(self) -> Option<&'static str> {
@@ -1502,6 +1505,7 @@ impl OperatorAttrs {
             Self::UpsampleAttrs => Some("UpsampleAttrs"),
             Self::RotaryEmbeddingAttrs => Some("RotaryEmbeddingAttrs"),
             Self::AttentionAttrs => Some("AttentionAttrs"),
+            Self::CumSumAttrs => Some("CumSumAttrs"),
             _ => None,
         }
     }
@@ -4705,6 +4709,114 @@ impl ::core::fmt::Debug for ConvTransposeAttrs<'_> {
         ds.field("groups", &self.groups());
         ds.field("output_padding", &self.output_padding());
         ds.field("dilations", &self.dilations());
+        ds.finish()
+    }
+}
+pub enum CumSumAttrsOffset {}
+#[derive(Copy, Clone, PartialEq)]
+
+pub struct CumSumAttrs<'a> {
+    pub _tab: ::flatbuffers::Table<'a>,
+}
+
+impl<'a> ::flatbuffers::Follow<'a> for CumSumAttrs<'a> {
+    type Inner = CumSumAttrs<'a>;
+    #[inline]
+    unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self {
+            _tab: unsafe { ::flatbuffers::Table::new(buf, loc) },
+        }
+    }
+}
+
+impl<'a> CumSumAttrs<'a> {
+    pub const VT_EXCLUSIVE: ::flatbuffers::VOffsetT = 4;
+
+    #[inline]
+    pub unsafe fn init_from_table(table: ::flatbuffers::Table<'a>) -> Self {
+        CumSumAttrs { _tab: table }
+    }
+    #[allow(unused_mut)]
+    pub fn create<
+        'bldr: 'args,
+        'args: 'mut_bldr,
+        'mut_bldr,
+        A: ::flatbuffers::Allocator + 'bldr,
+    >(
+        _fbb: &'mut_bldr mut ::flatbuffers::FlatBufferBuilder<'bldr, A>,
+        args: &'args CumSumAttrsArgs,
+    ) -> ::flatbuffers::WIPOffset<CumSumAttrs<'bldr>> {
+        let mut builder = CumSumAttrsBuilder::new(_fbb);
+        builder.add_exclusive(args.exclusive);
+        builder.finish()
+    }
+
+    #[inline]
+    pub fn exclusive(&self) -> bool {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab
+                .get::<bool>(CumSumAttrs::VT_EXCLUSIVE, Some(false))
+                .unwrap()
+        }
+    }
+}
+
+impl ::flatbuffers::Verifiable for CumSumAttrs<'_> {
+    #[inline]
+    fn run_verifier(
+        v: &mut ::flatbuffers::Verifier,
+        pos: usize,
+    ) -> Result<(), ::flatbuffers::InvalidFlatbuffer> {
+        v.visit_table(pos)?
+            .visit_field::<bool>("exclusive", Self::VT_EXCLUSIVE, false)?
+            .finish();
+        Ok(())
+    }
+}
+pub struct CumSumAttrsArgs {
+    pub exclusive: bool,
+}
+impl<'a> Default for CumSumAttrsArgs {
+    #[inline]
+    fn default() -> Self {
+        CumSumAttrsArgs { exclusive: false }
+    }
+}
+
+pub struct CumSumAttrsBuilder<'a: 'b, 'b, A: ::flatbuffers::Allocator + 'a> {
+    fbb_: &'b mut ::flatbuffers::FlatBufferBuilder<'a, A>,
+    start_: ::flatbuffers::WIPOffset<::flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b, A: ::flatbuffers::Allocator + 'a> CumSumAttrsBuilder<'a, 'b, A> {
+    #[inline]
+    pub fn add_exclusive(&mut self, exclusive: bool) {
+        self.fbb_
+            .push_slot::<bool>(CumSumAttrs::VT_EXCLUSIVE, exclusive, false);
+    }
+    #[inline]
+    pub fn new(
+        _fbb: &'b mut ::flatbuffers::FlatBufferBuilder<'a, A>,
+    ) -> CumSumAttrsBuilder<'a, 'b, A> {
+        let start = _fbb.start_table();
+        CumSumAttrsBuilder {
+            fbb_: _fbb,
+            start_: start,
+        }
+    }
+    #[inline]
+    pub fn finish(self) -> ::flatbuffers::WIPOffset<CumSumAttrs<'a>> {
+        let o = self.fbb_.end_table(self.start_);
+        ::flatbuffers::WIPOffset::new(o.value())
+    }
+}
+
+impl ::core::fmt::Debug for CumSumAttrs<'_> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+        let mut ds = f.debug_struct("CumSumAttrs");
+        ds.field("exclusive", &self.exclusive());
         ds.finish()
     }
 }
@@ -11766,6 +11878,21 @@ impl<'a> OperatorNode<'a> {
             None
         }
     }
+
+    #[inline]
+    #[allow(non_snake_case)]
+    pub fn attrs_as_cum_sum_attrs(&self) -> Option<CumSumAttrs<'a>> {
+        if self.attrs_type() == OperatorAttrs::CumSumAttrs {
+            self.attrs().map(|t| {
+                // Safety:
+                // Created from a valid Table for this object
+                // Which contains a valid union in this slot
+                unsafe { CumSumAttrs::init_from_table(t) }
+            })
+        } else {
+            None
+        }
+    }
 }
 
 impl ::flatbuffers::Verifiable for OperatorNode<'_> {
@@ -11838,6 +11965,7 @@ impl ::flatbuffers::Verifiable for OperatorNode<'_> {
           OperatorAttrs::UpsampleAttrs => v.verify_union_variant::<::flatbuffers::ForwardsUOffset<UpsampleAttrs>>("OperatorAttrs::UpsampleAttrs", pos),
           OperatorAttrs::RotaryEmbeddingAttrs => v.verify_union_variant::<::flatbuffers::ForwardsUOffset<RotaryEmbeddingAttrs>>("OperatorAttrs::RotaryEmbeddingAttrs", pos),
           OperatorAttrs::AttentionAttrs => v.verify_union_variant::<::flatbuffers::ForwardsUOffset<AttentionAttrs>>("OperatorAttrs::AttentionAttrs", pos),
+          OperatorAttrs::CumSumAttrs => v.verify_union_variant::<::flatbuffers::ForwardsUOffset<CumSumAttrs>>("OperatorAttrs::CumSumAttrs", pos),
           _ => Ok(()),
         }
      })?
@@ -12518,6 +12646,16 @@ impl ::core::fmt::Debug for OperatorNode<'_> {
             }
             OperatorAttrs::AttentionAttrs => {
                 if let Some(x) = self.attrs_as_attention_attrs() {
+                    ds.field("attrs", &x)
+                } else {
+                    ds.field(
+                        "attrs",
+                        &"InvalidFlatbuffer: Union discriminant does not match value.",
+                    )
+                }
+            }
+            OperatorAttrs::CumSumAttrs => {
+                if let Some(x) = self.attrs_as_cum_sum_attrs() {
                     ds.field("attrs", &x)
                 } else {
                     ds.field(

--- a/src/model.rs
+++ b/src/model.rs
@@ -1495,6 +1495,9 @@ mod tests {
         add_operator!(Cos, [input_node]);
         add_operator!(Cosh, [input_node]);
 
+        let cum_sum_axis = graph_builder.add_constant(Tensor::from(0).view());
+        add_operator!(CumSum, [input_node, cum_sum_axis], { exclusive: true });
+
         let const_u8_val = Tensor::from([0u8, 1, 2, 3, 4]);
         let const_u8 = graph_builder.add_constant(const_u8_val.view());
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -1496,7 +1496,7 @@ mod tests {
         add_operator!(Cosh, [input_node]);
 
         let cum_sum_axis = graph_builder.add_constant(Tensor::from(0).view());
-        add_operator!(CumSum, [input_node, cum_sum_axis], { exclusive: true });
+        add_operator!(CumSum, [input_node, cum_sum_axis], { exclusive: true, reverse: true });
 
         let const_u8_val = Tensor::from([0u8, 1, 2, 3, 4]);
         let const_u8 = graph_builder.add_constant(const_u8_val.view());

--- a/src/model/rten_builder.rs
+++ b/src/model/rten_builder.rs
@@ -8,7 +8,7 @@ use rten_tensor::prelude::*;
 use crate::graph::{Dimension, NodeId};
 use crate::ops::{
     ArgMax, ArgMin, AveragePool, BatchNormalization, BoxOrder, Cast, CastLike, Concat,
-    ConstantOfShape, Conv, ConvInteger, ConvTranspose, CoordTransformMode, DepthToSpace,
+    ConstantOfShape, Conv, ConvInteger, ConvTranspose, CoordTransformMode, CumSum, DepthToSpace,
     DepthToSpaceMode, DequantizeLinear, Einsum, Elu, EyeLike, Flatten, Gather, GatherElements,
     GatherND, Gelu, Gemm, HardSigmoid, InstanceNormalization, LayerNormalization, LeakyRelu,
     LogSoftmax, MaxPool, Mod, NearestMode, NonMaxSuppression, OneHot, Padding, QuantizeLinear,
@@ -56,6 +56,7 @@ pub enum OpType<'a> {
     ConvTranspose(ConvTranspose),
     Cos,
     Cosh,
+    CumSum(CumSum),
     DequantizeLinear(DequantizeLinear),
     DepthToSpace(DepthToSpace),
     Div,
@@ -574,6 +575,13 @@ impl<'mb, 'a> GraphBuilder<'mb, 'a> {
             }),
             OpType::Cos => op!(Cos),
             OpType::Cosh => op!(Cosh),
+            OpType::CumSum(args) => op_with_attrs!(
+                CumSum,
+                CumSumAttrs,
+                sg::CumSumAttrsArgs {
+                    exclusive: args.exclusive,
+                }
+            ),
             OpType::DequantizeLinear(args) => op_with_attrs!(
                 DequantizeLinear,
                 DequantizeLinearAttrs,

--- a/src/model/rten_builder.rs
+++ b/src/model/rten_builder.rs
@@ -580,6 +580,7 @@ impl<'mb, 'a> GraphBuilder<'mb, 'a> {
                 CumSumAttrs,
                 sg::CumSumAttrsArgs {
                     exclusive: args.exclusive,
+                    reverse: args.reverse,
                 }
             ),
             OpType::DequantizeLinear(args) => op_with_attrs!(

--- a/src/op_registry/onnx_registry.rs
+++ b/src/op_registry/onnx_registry.rs
@@ -1031,9 +1031,9 @@ impl_read_op!(ConvTranspose, |attrs: &Attrs| {
 impl_read_op!(Cos);
 impl_read_op!(Cosh);
 impl_read_op!(CumSum, |attrs: &Attrs| {
-    attrs.check_eq("exclusive", 0)?;
+    let exclusive = attrs.get_as("exclusive").unwrap_or(false);
     attrs.check_eq("reverse", 0)?;
-    Ok(ops::CumSum {})
+    Ok(ops::CumSum { exclusive })
 });
 
 #[cfg(feature = "fft")]

--- a/src/op_registry/onnx_registry.rs
+++ b/src/op_registry/onnx_registry.rs
@@ -1032,8 +1032,8 @@ impl_read_op!(Cos);
 impl_read_op!(Cosh);
 impl_read_op!(CumSum, |attrs: &Attrs| {
     let exclusive = attrs.get_as("exclusive").unwrap_or(false);
-    attrs.check_eq("reverse", 0)?;
-    Ok(ops::CumSum { exclusive })
+    let reverse = attrs.get_as("reverse").unwrap_or(false);
+    Ok(ops::CumSum { exclusive, reverse })
 });
 
 #[cfg(feature = "fft")]

--- a/src/op_registry/rten_registry.rs
+++ b/src/op_registry/rten_registry.rs
@@ -553,7 +553,8 @@ impl ReadOp for ops::CumSum {
         // CumSum attributes are optional for backwards compatibility.
         let attrs = op.attrs_as_cum_sum_attrs();
         let exclusive = attrs.map(|a| a.exclusive()).unwrap_or(false);
-        Ok(ops::CumSum { exclusive })
+        let reverse = attrs.map(|a| a.reverse()).unwrap_or(false);
+        Ok(ops::CumSum { exclusive, reverse })
     }
 }
 

--- a/src/op_registry/rten_registry.rs
+++ b/src/op_registry/rten_registry.rs
@@ -543,7 +543,20 @@ impl_read_op!(
 );
 impl_read_op!(Cos);
 impl_read_op!(Cosh);
-impl_read_op!(CumSum);
+
+impl ReadOp for ops::CumSum {
+    fn op_type() -> sg::OperatorType {
+        sg::OperatorType::CumSum
+    }
+
+    fn read(op: &sg::OperatorNode, _ctx: &dyn OpLoadContext) -> Result<Self, ReadOpError> {
+        // CumSum attributes are optional for backwards compatibility.
+        let attrs = op.attrs_as_cum_sum_attrs();
+        let exclusive = attrs.map(|a| a.exclusive()).unwrap_or(false);
+        Ok(ops::CumSum { exclusive })
+    }
+}
+
 #[cfg(feature = "fft")]
 impl_read_op!(DFT, attrs_as_dftattrs, |attrs: sg::DFTAttrs| {
     Ok(ops::DFT {

--- a/src/ops/reduce.rs
+++ b/src/ops/reduce.rs
@@ -212,28 +212,40 @@ impl_infer_shapes_for_arg_op!(ArgMin);
 /// Compute the cumulative sum of `input` along `axis`.
 ///
 /// If `exclusive` is true, each output element is the sum of the elements
-/// which precede it along `axis`, excluding the element itself.
+/// which precede it along `axis`, excluding the element itself. If `reverse`
+/// is true, the sum is accumulated from the end of the axis towards the start.
 pub fn cum_sum<T: Copy + Default + Identities + std::ops::AddAssign>(
     pool: &BufferPool,
     input: TensorView<T>,
     axis: isize,
     exclusive: bool,
+    reverse: bool,
 ) -> Result<Tensor<T>, OpError> {
     let resolved_axis = resolve_axis(input.ndim(), axis)?;
     let mut output = Tensor::uninit_in(pool, input.shape());
 
     let mut n_init = 0;
     if !input.is_empty() {
-        for (in_slice, out_slice) in input
+        for (in_lane, out_lane) in input
             .lanes(resolved_axis)
             .zip(output.lanes_mut(resolved_axis))
         {
             let mut cum_sum = T::zero();
-            for (x, y) in in_slice.zip(out_slice) {
-                let prev_sum = cum_sum;
-                cum_sum += *x;
-                y.write(if exclusive { prev_sum } else { cum_sum });
-                n_init += 1;
+
+            if reverse {
+                for (x, y) in in_lane.rev().zip(out_lane.rev()) {
+                    let prev_sum = cum_sum;
+                    cum_sum += *x;
+                    y.write(if exclusive { prev_sum } else { cum_sum });
+                    n_init += 1;
+                }
+            } else {
+                for (x, y) in in_lane.zip(out_lane) {
+                    let prev_sum = cum_sum;
+                    cum_sum += *x;
+                    y.write(if exclusive { prev_sum } else { cum_sum });
+                    n_init += 1;
+                }
             }
         }
     }
@@ -247,6 +259,7 @@ pub fn cum_sum<T: Copy + Default + Identities + std::ops::AddAssign>(
 #[derive(Debug)]
 pub struct CumSum {
     pub exclusive: bool,
+    pub reverse: bool,
 }
 
 impl Operator for CumSum {
@@ -263,7 +276,14 @@ impl Operator for CumSum {
         let input = inputs.require(0)?;
         let axis: i32 = inputs.require_as(1)?;
         map_value_view!(input, input, [FloatTensor, Int32Tensor], {
-            cum_sum(ctx.pool(), input, axis as isize, self.exclusive).into_op_result()
+            cum_sum(
+                ctx.pool(),
+                input,
+                axis as isize,
+                self.exclusive,
+                self.reverse,
+            )
+            .into_op_result()
         })
     }
 
@@ -1359,61 +1379,94 @@ mod tests {
             input: Tensor<f32>,
             axis: isize,
             exclusive: bool,
+            reverse: bool,
             expected: Result<Tensor<f32>, OpError>,
+        }
+
+        impl Default for Case {
+            fn default() -> Case {
+                Case {
+                    input: Tensor::from([0.; 0]),
+                    axis: 0,
+                    exclusive: false,
+                    reverse: false,
+                    expected: Ok(Tensor::from([0.; 0])),
+                }
+            }
         }
 
         let cases = [
             // Simple 1D case
             Case {
                 input: Tensor::from([0., 1., 2., 3., 4., 5.]),
-                axis: 0,
-                exclusive: false,
                 expected: Ok(Tensor::from([0., 1., 3., 6., 10., 15.])),
+                ..Default::default()
             },
             // 3D tensor, cumsum along axis 1
             Case {
                 input: Tensor::from_data(&[1, 4, 4], vec![1.; 16]),
                 axis: 1,
-                exclusive: false,
                 expected: Ok(Tensor::from_data(
                     &[1, 4, 4],
                     vec![
                         1., 1., 1., 1., 2., 2., 2., 2., 3., 3., 3., 3., 4., 4., 4., 4.,
                     ],
                 )),
+                ..Default::default()
             },
             // Same 3D tensor, cumsum along last axis (-1)
             Case {
                 input: Tensor::from_data(&[1, 4, 4], vec![1.; 16]),
                 axis: -1,
-                exclusive: false,
                 expected: Ok(Tensor::from_data(
                     &[1, 4, 4],
                     vec![
                         1., 2., 3., 4., 1., 2., 3., 4., 1., 2., 3., 4., 1., 2., 3., 4.,
                     ],
                 )),
+                ..Default::default()
             },
             // Empty tensor
             Case {
                 input: Tensor::from([0.; 0]),
-                axis: 0,
-                exclusive: false,
                 expected: Ok(Tensor::from([0.; 0])),
+                ..Default::default()
             },
             // Exclusive sum along a 1D tensor
             Case {
                 input: Tensor::from([0., 1., 2., 3., 4., 5.]),
-                axis: 0,
                 exclusive: true,
                 expected: Ok(Tensor::from([0., 0., 1., 3., 6., 10.])),
+                ..Default::default()
             },
             // Exclusive sum over an empty tensor
             Case {
                 input: Tensor::from([0.; 0]),
-                axis: 0,
                 exclusive: true,
                 expected: Ok(Tensor::from([0.; 0])),
+                ..Default::default()
+            },
+            // Reverse sum along a 1D tensor
+            Case {
+                input: Tensor::from([0., 1., 2., 3., 4., 5.]),
+                reverse: true,
+                expected: Ok(Tensor::from([15., 15., 14., 12., 9., 5.])),
+                ..Default::default()
+            },
+            // Reverse exclusive sum along a 1D tensor
+            Case {
+                input: Tensor::from([0., 1., 2., 3., 4., 5.]),
+                exclusive: true,
+                reverse: true,
+                expected: Ok(Tensor::from([15., 14., 12., 9., 5., 0.])),
+                ..Default::default()
+            },
+            // Reverse sum over an empty tensor
+            Case {
+                input: Tensor::from([0.; 0]),
+                reverse: true,
+                expected: Ok(Tensor::from([0.; 0])),
+                ..Default::default()
             },
         ];
 
@@ -1422,11 +1475,12 @@ mod tests {
                 input,
                 axis,
                 exclusive,
+                reverse,
                 expected,
             } = case;
 
             let pool = BufferPool::new();
-            let result = cum_sum(&pool, input.view(), *axis, *exclusive);
+            let result = cum_sum(&pool, input.view(), *axis, *exclusive, *reverse);
 
             assert_eq!(result, *expected);
         });

--- a/src/ops/reduce.rs
+++ b/src/ops/reduce.rs
@@ -209,10 +209,15 @@ impl Operator for ArgMin {
 
 impl_infer_shapes_for_arg_op!(ArgMin);
 
+/// Compute the cumulative sum of `input` along `axis`.
+///
+/// If `exclusive` is true, each output element is the sum of the elements
+/// which precede it along `axis`, excluding the element itself.
 pub fn cum_sum<T: Copy + Default + Identities + std::ops::AddAssign>(
     pool: &BufferPool,
     input: TensorView<T>,
     axis: isize,
+    exclusive: bool,
 ) -> Result<Tensor<T>, OpError> {
     let resolved_axis = resolve_axis(input.ndim(), axis)?;
     let mut output = Tensor::uninit_in(pool, input.shape());
@@ -225,8 +230,9 @@ pub fn cum_sum<T: Copy + Default + Identities + std::ops::AddAssign>(
         {
             let mut cum_sum = T::zero();
             for (x, y) in in_slice.zip(out_slice) {
+                let prev_sum = cum_sum;
                 cum_sum += *x;
-                y.write(cum_sum);
+                y.write(if exclusive { prev_sum } else { cum_sum });
                 n_init += 1;
             }
         }
@@ -239,7 +245,9 @@ pub fn cum_sum<T: Copy + Default + Identities + std::ops::AddAssign>(
 }
 
 #[derive(Debug)]
-pub struct CumSum {}
+pub struct CumSum {
+    pub exclusive: bool,
+}
 
 impl Operator for CumSum {
     fn name(&self) -> &str {
@@ -255,7 +263,7 @@ impl Operator for CumSum {
         let input = inputs.require(0)?;
         let axis: i32 = inputs.require_as(1)?;
         map_value_view!(input, input, [FloatTensor, Int32Tensor], {
-            cum_sum(ctx.pool(), input, axis as isize).into_op_result()
+            cum_sum(ctx.pool(), input, axis as isize, self.exclusive).into_op_result()
         })
     }
 
@@ -1350,6 +1358,7 @@ mod tests {
         struct Case {
             input: Tensor<f32>,
             axis: isize,
+            exclusive: bool,
             expected: Result<Tensor<f32>, OpError>,
         }
 
@@ -1358,12 +1367,14 @@ mod tests {
             Case {
                 input: Tensor::from([0., 1., 2., 3., 4., 5.]),
                 axis: 0,
+                exclusive: false,
                 expected: Ok(Tensor::from([0., 1., 3., 6., 10., 15.])),
             },
             // 3D tensor, cumsum along axis 1
             Case {
                 input: Tensor::from_data(&[1, 4, 4], vec![1.; 16]),
                 axis: 1,
+                exclusive: false,
                 expected: Ok(Tensor::from_data(
                     &[1, 4, 4],
                     vec![
@@ -1375,6 +1386,7 @@ mod tests {
             Case {
                 input: Tensor::from_data(&[1, 4, 4], vec![1.; 16]),
                 axis: -1,
+                exclusive: false,
                 expected: Ok(Tensor::from_data(
                     &[1, 4, 4],
                     vec![
@@ -1386,6 +1398,21 @@ mod tests {
             Case {
                 input: Tensor::from([0.; 0]),
                 axis: 0,
+                exclusive: false,
+                expected: Ok(Tensor::from([0.; 0])),
+            },
+            // Exclusive sum along a 1D tensor
+            Case {
+                input: Tensor::from([0., 1., 2., 3., 4., 5.]),
+                axis: 0,
+                exclusive: true,
+                expected: Ok(Tensor::from([0., 0., 1., 3., 6., 10.])),
+            },
+            // Exclusive sum over an empty tensor
+            Case {
+                input: Tensor::from([0.; 0]),
+                axis: 0,
+                exclusive: true,
                 expected: Ok(Tensor::from([0.; 0])),
             },
         ];
@@ -1394,11 +1421,12 @@ mod tests {
             let Case {
                 input,
                 axis,
+                exclusive,
                 expected,
             } = case;
 
             let pool = BufferPool::new();
-            let result = cum_sum(&pool, input.view(), *axis);
+            let result = cum_sum(&pool, input.view(), *axis, *exclusive);
 
             assert_eq!(result, *expected);
         });


### PR DESCRIPTION
Add support for `exclusive=1` and `reverse=1` in the CumSum operator.