### PR TITLE
Fix default `axis` for Softmax and LogSoftmax in rten-convert

### DIFF
--- a/rten-convert/rten_convert/converter.py
+++ b/rten-convert/rten_convert/converter.py
@@ -592,7 +592,7 @@ def op_node_from_onnx_operator(
 
         case "LogSoftmax":
             attrs = sg.SoftmaxAttrsT()
-            attrs.axis = attr_reader.get_attr("axis", "int", 0)
+            attrs.axis = attr_reader.get_attr("axis", "int", -1)
 
         case "Loop":
             attrs = sg.LoopAttrsT()
@@ -794,7 +794,7 @@ def op_node_from_onnx_operator(
 
         case "Softmax":
             attrs = sg.SoftmaxAttrsT()
-            attrs.axis = attr_reader.get_attr("axis", "int", 0)
+            attrs.axis = attr_reader.get_attr("axis", "int", -1)
 
         case "Split":
             attrs = sg.SplitAttrsT()


### PR DESCRIPTION
Update the `axis` default in the `.rten` converter to match the current version of the Softmax spec and the ONNX loader. There is an issue here that the Softmax default axis was 1 rather than -1 in opset 11 and earlier. The earlier version also implicitly reshaped the input to 2D (so -1 and 1 mean the same). These opset <= 11 differences are not handled yet for either format.

The issue was noticed while testing
https://huggingface.co/nddttt/en-vi-translation-model/blob/main/transformer_en_vi.onnx which required adding `exclusive=1` to the CumSum op.