### PR TITLE
Implement LpNormalization operator

### DIFF
--- a/rten-convert/rten_convert/converter.py
+++ b/rten-convert/rten_convert/converter.py
@@ -602,6 +602,11 @@ def op_node_from_onnx_operator(
             )
             attrs.body = DummyGraphT(body, None)
 
+        case "LpNormalization":
+            attrs = sg.LpNormalizationAttrsT()
+            attrs.axis = attr_reader.get_attr("axis", "int", -1)
+            attrs.p = attr_reader.get_attr("p", "int", 2)
+
         case "LSTM":
             attrs = sg.LSTMAttrsT()
             attrs.direction = attr_reader.get_enum_attr(

--- a/rten-convert/rten_convert/schema_generated.py
+++ b/rten-convert/rten_convert/schema_generated.py
@@ -149,6 +149,7 @@ class OperatorType(object):
     Upsample = 139
     RotaryEmbedding = 140
     Attention = 141
+    LpNormalization = 142
 
 
 class RNNDirection(object):
@@ -251,6 +252,7 @@ class OperatorAttrs(object):
     RotaryEmbeddingAttrs = 59
     AttentionAttrs = 60
     CumSumAttrs = 61
+    LpNormalizationAttrs = 62
 
 def OperatorAttrsCreator(unionType, table):
     from flatbuffers.table import Table
@@ -378,6 +380,8 @@ def OperatorAttrsCreator(unionType, table):
         return AttentionAttrsT.InitFromBuf(table.Bytes, table.Pos)
     if unionType == OperatorAttrs.CumSumAttrs:
         return CumSumAttrsT.InitFromBuf(table.Bytes, table.Pos)
+    if unionType == OperatorAttrs.LpNormalizationAttrs:
+        return LpNormalizationAttrsT.InitFromBuf(table.Bytes, table.Pos)
     return None
 
 
@@ -2914,6 +2918,100 @@ class LayerNormalizationAttrsT(object):
         LayerNormalizationAttrsAddEpsilon(builder, self.epsilon)
         layerNormalizationAttrs = LayerNormalizationAttrsEnd(builder)
         return layerNormalizationAttrs
+
+
+class LpNormalizationAttrs(object):
+    __slots__ = ['_tab']
+
+    @classmethod
+    def GetRootAs(cls, buf, offset=0):
+        n = flatbuffers.encode.Get(flatbuffers.packer.uoffset, buf, offset)
+        x = LpNormalizationAttrs()
+        x.Init(buf, n + offset)
+        return x
+
+    @classmethod
+    def GetRootAsLpNormalizationAttrs(cls, buf, offset=0):
+        """This method is deprecated. Please switch to GetRootAs."""
+        return cls.GetRootAs(buf, offset)
+    @classmethod
+    def LpNormalizationAttrsBufferHasIdentifier(cls, buf, offset, size_prefixed=False):
+        return flatbuffers.util.BufferHasIdentifier(buf, offset, b"\x52\x54\x45\x4E", size_prefixed=size_prefixed)
+
+    # LpNormalizationAttrs
+    def Init(self, buf, pos):
+        self._tab = flatbuffers.table.Table(buf, pos)
+
+    # LpNormalizationAttrs
+    def Axis(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(4))
+        if o != 0:
+            return self._tab.Get(flatbuffers.number_types.Int32Flags, o + self._tab.Pos)
+        return -1
+
+    # LpNormalizationAttrs
+    def P(self):
+        o = flatbuffers.number_types.UOffsetTFlags.py_type(self._tab.Offset(6))
+        if o != 0:
+            return self._tab.Get(flatbuffers.number_types.Uint32Flags, o + self._tab.Pos)
+        return 2
+
+def LpNormalizationAttrsStart(builder):
+    builder.StartObject(2)
+
+def LpNormalizationAttrsAddAxis(builder, axis):
+    builder.PrependInt32Slot(0, axis, -1)
+
+def LpNormalizationAttrsAddP(builder, p):
+    builder.PrependUint32Slot(1, p, 2)
+
+def LpNormalizationAttrsEnd(builder):
+    return builder.EndObject()
+
+
+
+class LpNormalizationAttrsT(object):
+
+    # LpNormalizationAttrsT
+    def __init__(
+        self,
+        axis = -1,
+        p = 2,
+    ):
+        self.axis = axis  # type: int
+        self.p = p  # type: int
+
+    @classmethod
+    def InitFromBuf(cls, buf, pos):
+        lpNormalizationAttrs = LpNormalizationAttrs()
+        lpNormalizationAttrs.Init(buf, pos)
+        return cls.InitFromObj(lpNormalizationAttrs)
+
+    @classmethod
+    def InitFromPackedBuf(cls, buf, pos=0):
+        n = flatbuffers.encode.Get(flatbuffers.packer.uoffset, buf, pos)
+        return cls.InitFromBuf(buf, pos+n)
+
+    @classmethod
+    def InitFromObj(cls, lpNormalizationAttrs):
+        x = LpNormalizationAttrsT()
+        x._UnPack(lpNormalizationAttrs)
+        return x
+
+    # LpNormalizationAttrsT
+    def _UnPack(self, lpNormalizationAttrs):
+        if lpNormalizationAttrs is None:
+            return
+        self.axis = lpNormalizationAttrs.Axis()
+        self.p = lpNormalizationAttrs.P()
+
+    # LpNormalizationAttrsT
+    def Pack(self, builder):
+        LpNormalizationAttrsStart(builder)
+        LpNormalizationAttrsAddAxis(builder, self.axis)
+        LpNormalizationAttrsAddP(builder, self.p)
+        lpNormalizationAttrs = LpNormalizationAttrsEnd(builder)
+        return lpNormalizationAttrs
 
 
 class LoopAttrs(object):
@@ -7277,7 +7375,7 @@ class OperatorNodeT(object):
     ):
         self.type = type  # type: int
         self.attrsType = attrsType  # type: int
-        self.attrs = attrs  # type: Union[None, 'ArgMaxAttrsT', 'AveragePoolAttrsT', 'BatchNormalizationAttrsT', 'CastAttrsT', 'ConcatAttrsT', 'ConstantOfShapeAttrsT', 'ConvAttrsT', 'ConvTransposeAttrsT', 'FlattenAttrsT', 'GatherAttrsT', 'GemmAttrsT', 'GRUAttrsT', 'LeakyReluAttrsT', 'LSTMAttrsT', 'MaxPoolAttrsT', 'ReduceMeanAttrsT', 'ReshapeAttrsT', 'ResizeAttrsT', 'SplitAttrsT', 'SoftmaxAttrsT', 'TransposeAttrsT', 'ModAttrsT', 'ScatterElementsAttrsT', 'OneHotAttrsT', 'TopKAttrsT', 'HardSigmoidAttrsT', 'TriluAttrsT', 'ScatterNDAttrsT', 'NonMaxSuppressionAttrsT', 'LayerNormalizationAttrsT', 'RandomUniformAttrsT', 'EluAttrsT', 'RandomUniformLikeAttrsT', 'RandomNormalAttrsT', 'RandomNormalLikeAttrsT', 'GatherNDAttrsT', 'GeluAttrsT', 'EinsumAttrsT', 'IfAttrsT', 'PadAttrsT', 'DequantizeLinearAttrsT', 'QuantizeLinearAttrsT', 'DepthToSpaceAttrsT', 'CastLikeAttrsT', 'ShapeAttrsT', 'DropoutAttrsT', 'EyeLikeAttrsT', 'IsInfAttrsT', 'LoopAttrsT', 'SequenceEmptyAttrsT', 'ConcatFromSequenceAttrsT', 'SplitToSequenceAttrsT', 'GridSampleAttrsT', 'STFTAttrsT', 'MultinomialAttrsT', 'ReverseSequenceAttrsT', 'DFTAttrsT', 'UpsampleAttrsT', 'RotaryEmbeddingAttrsT', 'AttentionAttrsT', 'CumSumAttrsT']
+        self.attrs = attrs  # type: Union[None, 'ArgMaxAttrsT', 'AveragePoolAttrsT', 'BatchNormalizationAttrsT', 'CastAttrsT', 'ConcatAttrsT', 'ConstantOfShapeAttrsT', 'ConvAttrsT', 'ConvTransposeAttrsT', 'FlattenAttrsT', 'GatherAttrsT', 'GemmAttrsT', 'GRUAttrsT', 'LeakyReluAttrsT', 'LSTMAttrsT', 'MaxPoolAttrsT', 'ReduceMeanAttrsT', 'ReshapeAttrsT', 'ResizeAttrsT', 'SplitAttrsT', 'SoftmaxAttrsT', 'TransposeAttrsT', 'ModAttrsT', 'ScatterElementsAttrsT', 'OneHotAttrsT', 'TopKAttrsT', 'HardSigmoidAttrsT', 'TriluAttrsT', 'ScatterNDAttrsT', 'NonMaxSuppressionAttrsT', 'LayerNormalizationAttrsT', 'RandomUniformAttrsT', 'EluAttrsT', 'RandomUniformLikeAttrsT', 'RandomNormalAttrsT', 'RandomNormalLikeAttrsT', 'GatherNDAttrsT', 'GeluAttrsT', 'EinsumAttrsT', 'IfAttrsT', 'PadAttrsT', 'DequantizeLinearAttrsT', 'QuantizeLinearAttrsT', 'DepthToSpaceAttrsT', 'CastLikeAttrsT', 'ShapeAttrsT', 'DropoutAttrsT', 'EyeLikeAttrsT', 'IsInfAttrsT', 'LoopAttrsT', 'SequenceEmptyAttrsT', 'ConcatFromSequenceAttrsT', 'SplitToSequenceAttrsT', 'GridSampleAttrsT', 'STFTAttrsT', 'MultinomialAttrsT', 'ReverseSequenceAttrsT', 'DFTAttrsT', 'UpsampleAttrsT', 'RotaryEmbeddingAttrsT', 'AttentionAttrsT', 'CumSumAttrsT', 'LpNormalizationAttrsT']
         self.inputs = inputs  # type: Optional[List[int]]
         self.outputs = outputs  # type: Optional[List[int]]
 

--- a/rten-model-file/src/schema.fbs
+++ b/rten-model-file/src/schema.fbs
@@ -155,6 +155,7 @@ enum OperatorType: ubyte {
   Upsample,
   RotaryEmbedding,
   Attention,
+  LpNormalization,
 }
 
 enum RNNDirection: ubyte {
@@ -268,6 +269,7 @@ union OperatorAttrs {
   RotaryEmbeddingAttrs,
   AttentionAttrs,
   CumSumAttrs,
+  LpNormalizationAttrs,
 }
 
 table ArgMaxAttrs {
@@ -399,6 +401,11 @@ table FlattenAttrs {
 table LayerNormalizationAttrs {
   axis:int;
   epsilon:float;
+}
+
+table LpNormalizationAttrs {
+  axis:int = -1;
+  p:uint = 2;
 }
 
 table LoopAttrs {

--- a/rten-model-file/src/schema_generated.rs
+++ b/rten-model-file/src/schema_generated.rs
@@ -11,13 +11,13 @@ pub const ENUM_MIN_OPERATOR_TYPE: u8 = 0;
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
-pub const ENUM_MAX_OPERATOR_TYPE: u8 = 141;
+pub const ENUM_MAX_OPERATOR_TYPE: u8 = 142;
 #[deprecated(
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 142] = [
+pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 143] = [
     OperatorType::Add,
     OperatorType::ArgMin,
     OperatorType::ArgMax,
@@ -160,6 +160,7 @@ pub const ENUM_VALUES_OPERATOR_TYPE: [OperatorType; 142] = [
     OperatorType::Upsample,
     OperatorType::RotaryEmbedding,
     OperatorType::Attention,
+    OperatorType::LpNormalization,
 ];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -309,9 +310,10 @@ impl OperatorType {
     pub const Upsample: Self = Self(139);
     pub const RotaryEmbedding: Self = Self(140);
     pub const Attention: Self = Self(141);
+    pub const LpNormalization: Self = Self(142);
 
     pub const ENUM_MIN: u8 = 0;
-    pub const ENUM_MAX: u8 = 141;
+    pub const ENUM_MAX: u8 = 142;
     pub const ENUM_VALUES: &'static [Self] = &[
         Self::Add,
         Self::ArgMin,
@@ -455,6 +457,7 @@ impl OperatorType {
         Self::Upsample,
         Self::RotaryEmbedding,
         Self::Attention,
+        Self::LpNormalization,
     ];
     /// Returns the variant's name or "" if unknown.
     pub fn variant_name(self) -> Option<&'static str> {
@@ -601,6 +604,7 @@ impl OperatorType {
             Self::Upsample => Some("Upsample"),
             Self::RotaryEmbedding => Some("RotaryEmbedding"),
             Self::Attention => Some("Attention"),
+            Self::LpNormalization => Some("LpNormalization"),
             _ => None,
         }
     }
@@ -1236,13 +1240,13 @@ pub const ENUM_MIN_OPERATOR_ATTRS: u8 = 0;
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
-pub const ENUM_MAX_OPERATOR_ATTRS: u8 = 61;
+pub const ENUM_MAX_OPERATOR_ATTRS: u8 = 62;
 #[deprecated(
     since = "2.0.0",
     note = "Use associated constants instead. This will no longer be generated in 2021."
 )]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_OPERATOR_ATTRS: [OperatorAttrs; 62] = [
+pub const ENUM_VALUES_OPERATOR_ATTRS: [OperatorAttrs; 63] = [
     OperatorAttrs::NONE,
     OperatorAttrs::ArgMaxAttrs,
     OperatorAttrs::AveragePoolAttrs,
@@ -1305,6 +1309,7 @@ pub const ENUM_VALUES_OPERATOR_ATTRS: [OperatorAttrs; 62] = [
     OperatorAttrs::RotaryEmbeddingAttrs,
     OperatorAttrs::AttentionAttrs,
     OperatorAttrs::CumSumAttrs,
+    OperatorAttrs::LpNormalizationAttrs,
 ];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -1374,9 +1379,10 @@ impl OperatorAttrs {
     pub const RotaryEmbeddingAttrs: Self = Self(59);
     pub const AttentionAttrs: Self = Self(60);
     pub const CumSumAttrs: Self = Self(61);
+    pub const LpNormalizationAttrs: Self = Self(62);
 
     pub const ENUM_MIN: u8 = 0;
-    pub const ENUM_MAX: u8 = 61;
+    pub const ENUM_MAX: u8 = 62;
     pub const ENUM_VALUES: &'static [Self] = &[
         Self::NONE,
         Self::ArgMaxAttrs,
@@ -1440,6 +1446,7 @@ impl OperatorAttrs {
         Self::RotaryEmbeddingAttrs,
         Self::AttentionAttrs,
         Self::CumSumAttrs,
+        Self::LpNormalizationAttrs,
     ];
     /// Returns the variant's name or "" if unknown.
     pub fn variant_name(self) -> Option<&'static str> {
@@ -1506,6 +1513,7 @@ impl OperatorAttrs {
             Self::RotaryEmbeddingAttrs => Some("RotaryEmbeddingAttrs"),
             Self::AttentionAttrs => Some("AttentionAttrs"),
             Self::CumSumAttrs => Some("CumSumAttrs"),
+            Self::LpNormalizationAttrs => Some("LpNormalizationAttrs"),
             _ => None,
         }
     }
@@ -5404,6 +5412,134 @@ impl ::core::fmt::Debug for LayerNormalizationAttrs<'_> {
         let mut ds = f.debug_struct("LayerNormalizationAttrs");
         ds.field("axis", &self.axis());
         ds.field("epsilon", &self.epsilon());
+        ds.finish()
+    }
+}
+pub enum LpNormalizationAttrsOffset {}
+#[derive(Copy, Clone, PartialEq)]
+
+pub struct LpNormalizationAttrs<'a> {
+    pub _tab: ::flatbuffers::Table<'a>,
+}
+
+impl<'a> ::flatbuffers::Follow<'a> for LpNormalizationAttrs<'a> {
+    type Inner = LpNormalizationAttrs<'a>;
+    #[inline]
+    unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+        Self {
+            _tab: unsafe { ::flatbuffers::Table::new(buf, loc) },
+        }
+    }
+}
+
+impl<'a> LpNormalizationAttrs<'a> {
+    pub const VT_AXIS: ::flatbuffers::VOffsetT = 4;
+    pub const VT_P: ::flatbuffers::VOffsetT = 6;
+
+    #[inline]
+    pub unsafe fn init_from_table(table: ::flatbuffers::Table<'a>) -> Self {
+        LpNormalizationAttrs { _tab: table }
+    }
+    #[allow(unused_mut)]
+    pub fn create<
+        'bldr: 'args,
+        'args: 'mut_bldr,
+        'mut_bldr,
+        A: ::flatbuffers::Allocator + 'bldr,
+    >(
+        _fbb: &'mut_bldr mut ::flatbuffers::FlatBufferBuilder<'bldr, A>,
+        args: &'args LpNormalizationAttrsArgs,
+    ) -> ::flatbuffers::WIPOffset<LpNormalizationAttrs<'bldr>> {
+        let mut builder = LpNormalizationAttrsBuilder::new(_fbb);
+        builder.add_p(args.p);
+        builder.add_axis(args.axis);
+        builder.finish()
+    }
+
+    #[inline]
+    pub fn axis(&self) -> i32 {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab
+                .get::<i32>(LpNormalizationAttrs::VT_AXIS, Some(-1))
+                .unwrap()
+        }
+    }
+    #[inline]
+    pub fn p(&self) -> u32 {
+        // Safety:
+        // Created from valid Table for this object
+        // which contains a valid value in this slot
+        unsafe {
+            self._tab
+                .get::<u32>(LpNormalizationAttrs::VT_P, Some(2))
+                .unwrap()
+        }
+    }
+}
+
+impl ::flatbuffers::Verifiable for LpNormalizationAttrs<'_> {
+    #[inline]
+    fn run_verifier(
+        v: &mut ::flatbuffers::Verifier,
+        pos: usize,
+    ) -> Result<(), ::flatbuffers::InvalidFlatbuffer> {
+        v.visit_table(pos)?
+            .visit_field::<i32>("axis", Self::VT_AXIS, false)?
+            .visit_field::<u32>("p", Self::VT_P, false)?
+            .finish();
+        Ok(())
+    }
+}
+pub struct LpNormalizationAttrsArgs {
+    pub axis: i32,
+    pub p: u32,
+}
+impl<'a> Default for LpNormalizationAttrsArgs {
+    #[inline]
+    fn default() -> Self {
+        LpNormalizationAttrsArgs { axis: -1, p: 2 }
+    }
+}
+
+pub struct LpNormalizationAttrsBuilder<'a: 'b, 'b, A: ::flatbuffers::Allocator + 'a> {
+    fbb_: &'b mut ::flatbuffers::FlatBufferBuilder<'a, A>,
+    start_: ::flatbuffers::WIPOffset<::flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b, A: ::flatbuffers::Allocator + 'a> LpNormalizationAttrsBuilder<'a, 'b, A> {
+    #[inline]
+    pub fn add_axis(&mut self, axis: i32) {
+        self.fbb_
+            .push_slot::<i32>(LpNormalizationAttrs::VT_AXIS, axis, -1);
+    }
+    #[inline]
+    pub fn add_p(&mut self, p: u32) {
+        self.fbb_.push_slot::<u32>(LpNormalizationAttrs::VT_P, p, 2);
+    }
+    #[inline]
+    pub fn new(
+        _fbb: &'b mut ::flatbuffers::FlatBufferBuilder<'a, A>,
+    ) -> LpNormalizationAttrsBuilder<'a, 'b, A> {
+        let start = _fbb.start_table();
+        LpNormalizationAttrsBuilder {
+            fbb_: _fbb,
+            start_: start,
+        }
+    }
+    #[inline]
+    pub fn finish(self) -> ::flatbuffers::WIPOffset<LpNormalizationAttrs<'a>> {
+        let o = self.fbb_.end_table(self.start_);
+        ::flatbuffers::WIPOffset::new(o.value())
+    }
+}
+
+impl ::core::fmt::Debug for LpNormalizationAttrs<'_> {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+        let mut ds = f.debug_struct("LpNormalizationAttrs");
+        ds.field("axis", &self.axis());
+        ds.field("p", &self.p());
         ds.finish()
     }
 }
@@ -11917,6 +12053,21 @@ impl<'a> OperatorNode<'a> {
             None
         }
     }
+
+    #[inline]
+    #[allow(non_snake_case)]
+    pub fn attrs_as_lp_normalization_attrs(&self) -> Option<LpNormalizationAttrs<'a>> {
+        if self.attrs_type() == OperatorAttrs::LpNormalizationAttrs {
+            self.attrs().map(|t| {
+                // Safety:
+                // Created from a valid Table for this object
+                // Which contains a valid union in this slot
+                unsafe { LpNormalizationAttrs::init_from_table(t) }
+            })
+        } else {
+            None
+        }
+    }
 }
 
 impl ::flatbuffers::Verifiable for OperatorNode<'_> {
@@ -11990,6 +12141,7 @@ impl ::flatbuffers::Verifiable for OperatorNode<'_> {
           OperatorAttrs::RotaryEmbeddingAttrs => v.verify_union_variant::<::flatbuffers::ForwardsUOffset<RotaryEmbeddingAttrs>>("OperatorAttrs::RotaryEmbeddingAttrs", pos),
           OperatorAttrs::AttentionAttrs => v.verify_union_variant::<::flatbuffers::ForwardsUOffset<AttentionAttrs>>("OperatorAttrs::AttentionAttrs", pos),
           OperatorAttrs::CumSumAttrs => v.verify_union_variant::<::flatbuffers::ForwardsUOffset<CumSumAttrs>>("OperatorAttrs::CumSumAttrs", pos),
+          OperatorAttrs::LpNormalizationAttrs => v.verify_union_variant::<::flatbuffers::ForwardsUOffset<LpNormalizationAttrs>>("OperatorAttrs::LpNormalizationAttrs", pos),
           _ => Ok(()),
         }
      })?
@@ -12680,6 +12832,16 @@ impl ::core::fmt::Debug for OperatorNode<'_> {
             }
             OperatorAttrs::CumSumAttrs => {
                 if let Some(x) = self.attrs_as_cum_sum_attrs() {
+                    ds.field("attrs", &x)
+                } else {
+                    ds.field(
+                        "attrs",
+                        &"InvalidFlatbuffer: Union discriminant does not match value.",
+                    )
+                }
+            }
+            OperatorAttrs::LpNormalizationAttrs => {
+                if let Some(x) = self.attrs_as_lp_normalization_attrs() {
                     ds.field("attrs", &x)
                 } else {
                     ds.field(

--- a/src/op_registry.rs
+++ b/src/op_registry.rs
@@ -273,6 +273,7 @@ pub mod op_types {
     declare_op!(Log);
     declare_op!(LogSoftmax);
     declare_op!(Loop);
+    declare_op!(LpNormalization);
     declare_op!(LSTM);
     declare_op!(MatMul);
     declare_op!(MatMulInteger);

--- a/src/op_registry/onnx_registry.rs
+++ b/src/op_registry/onnx_registry.rs
@@ -190,6 +190,7 @@ impl OnnxOpRegistry {
         register_op!(Log);
         register_op!(LogSoftmax);
         register_op!(Loop);
+        register_op!(LpNormalization);
         register_op!(LSTM);
         register_op!(MatMul);
         register_op!(MatMulInteger);
@@ -1243,6 +1244,11 @@ impl_read_op!(Less);
 impl_read_op!(LessOrEqual);
 impl_read_op!(Log);
 
+impl_read_op!(LpNormalization, |attrs: &Attrs| {
+    let axis = attrs.get_as_int("axis")?.unwrap_or(-1);
+    let p = attrs.get_as_int("p")?.unwrap_or(2);
+    Ok(ops::LpNormalization { axis, p })
+});
 impl_read_op!(LogSoftmax, |attrs: &Attrs| {
     let axis = attrs.get_as_int("axis")?.unwrap_or(-1);
     Ok(ops::LogSoftmax { axis })

--- a/src/op_registry/rten_registry.rs
+++ b/src/op_registry/rten_registry.rs
@@ -160,6 +160,7 @@ impl RtenOpRegistry {
         register_op!(Log);
         register_op!(LogSoftmax);
         register_op!(Loop);
+        register_op!(LpNormalization);
         register_op!(LSTM);
         register_op!(MatMul);
         register_op!(MatMulInteger);
@@ -756,6 +757,16 @@ impl_read_op!(Less);
 impl_read_op!(LessOrEqual);
 impl_read_op!(Log);
 impl_read_op!(LogSoftmax, attrs_as_softmax_attrs, axis);
+impl_read_op!(
+    LpNormalization,
+    attrs_as_lp_normalization_attrs,
+    |attrs: sg::LpNormalizationAttrs| {
+        Ok(ops::LpNormalization {
+            axis: attrs.axis() as isize,
+            p: attrs.p(),
+        })
+    }
+);
 
 impl ReadOp for ops::Loop {
     fn op_type() -> sg::OperatorType {

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -90,7 +90,7 @@ pub(crate) use {
     matmul::{FusedMatMul, Gemm, MatMul, MatMulInteger, MatMulIntegerToFloat},
     non_max_suppression::NonMaxSuppression,
     norm::{
-        BatchNormalization, InstanceNormalization, LayerNormalization, LogSoftmax,
+        BatchNormalization, InstanceNormalization, LayerNormalization, LogSoftmax, LpNormalization,
         RMSNormalization, Softmax,
     },
     pad::Pad,
@@ -153,8 +153,8 @@ pub use layout::{DepthToSpaceMode, depth_to_space, expand, flatten, reshape, squ
 pub use matmul::{gemm, matmul};
 pub use non_max_suppression::{BoxOrder, non_max_suppression};
 pub use norm::{
-    batch_norm, instance_normalization, layer_normalization, log_softmax, rms_normalization,
-    softmax,
+    batch_norm, instance_normalization, layer_normalization, log_softmax, lp_normalization,
+    rms_normalization, softmax,
 };
 pub use pad::{PadMode, pad};
 pub use pooling::{average_pool, global_average_pool, max_pool};

--- a/src/ops/norm.rs
+++ b/src/ops/norm.rs
@@ -591,6 +591,91 @@ impl Operator for RMSNormalization {
     }
 }
 
+/// Normalize lanes of `input` along `axis` by their L1 or L2 norm.
+pub fn lp_normalization(
+    pool: &BufferPool,
+    input: TensorView,
+    axis: isize,
+    p: u32,
+) -> Result<Tensor, OpError> {
+    let mut output = input.to_tensor_in(pool);
+    lp_normalization_in_place(&mut output, axis, p)?;
+    Ok(output)
+}
+
+pub fn lp_normalization_in_place(output: &mut Tensor, axis: isize, p: u32) -> Result<(), OpError> {
+    fn scale_by_norm(lane: &mut [f32], norm: f32) {
+        // ONNX specifies a zero output, rather than NaN, for zero norms.
+        if norm == 0. {
+            lane.fill(0.);
+            return;
+        }
+        let norm_recip = norm.recip();
+        for x in lane {
+            *x *= norm_recip;
+        }
+    }
+
+    let normalize: fn(&mut [f32]) = match p {
+        1 => |lane: &mut [f32]| {
+            let norm = vecmath::SumAbs::new(lane).dispatch();
+            scale_by_norm(lane, norm);
+        },
+        2 => |lane: &mut [f32]| {
+            let norm = vecmath::SumSquare::new(lane).dispatch().sqrt();
+            scale_by_norm(lane, norm);
+        },
+        _ => {
+            return Err(OpError::UnsupportedValue("`p` must be 1 or 2"));
+        }
+    };
+
+    normalize_lanes(output, axis, normalize)
+}
+
+#[derive(Debug)]
+pub struct LpNormalization {
+    pub axis: isize,
+    pub p: u32,
+}
+
+impl Operator for LpNormalization {
+    fn name(&self) -> &str {
+        "LpNormalization"
+    }
+
+    fn max_inputs(&self) -> Option<usize> {
+        Some(1)
+    }
+
+    fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+        let input = ctx.inputs().require_as(0)?;
+        lp_normalization(ctx.pool(), input, self.axis, self.p).into_op_result()
+    }
+
+    fn in_place_inputs(&self) -> BitSet<u16> {
+        BitSet::from_indices([0])
+    }
+
+    fn run_in_place(
+        &self,
+        in_place: InPlaceInputs,
+        _ctx: &OpRunContext,
+    ) -> Result<OutputList, OpError> {
+        let mut output: Tensor = in_place.into_single().try_into()?;
+        lp_normalization_in_place(&mut output, self.axis, self.p)?;
+        output.into_op_result()
+    }
+
+    fn output_types(&self, _ctx: &OutputTypesContext) -> Option<OutputTypeList> {
+        Some([OutputType::CopyFromInput(0)].into())
+    }
+
+    fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
+        Some(&UnaryOp)
+    }
+}
+
 pub fn log_softmax(pool: &BufferPool, input: TensorView, axis: isize) -> Result<Tensor, OpError> {
     let mut output = input.to_tensor_in(pool);
     log_softmax_in_place(&mut output, axis)?;
@@ -817,10 +902,11 @@ mod tests {
 
     use super::NORMALIZE_GRAIN_SIZE;
     use super::{
-        NanHandling, batch_norm, batch_norm_in_place, instance_normalization, layer_normalization,
-        log_softmax, rms_normalization, softmax,
+        LpNormalization, NanHandling, batch_norm, batch_norm_in_place, instance_normalization,
+        layer_normalization, log_softmax, lp_normalization, rms_normalization, softmax,
     };
     use crate::buffer_pool::BufferPool;
+    use crate::operator::{InputList, OperatorExt};
     use crate::ops::OpError;
     use crate::ops::tests::expect_eq_1e4;
 
@@ -1117,6 +1203,46 @@ mod tests {
 
         let expected = reference_rms(input.nd_view(), scale.nd_view()).into_dyn();
         expect_eq_1e4(&result, &expected)?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_lp_normalization() -> Result<(), Box<dyn Error>> {
+        let pool = BufferPool::new();
+        let input = Tensor::from([[3., 4.], [1., -1.]]);
+
+        // L2 normalization along the last axis.
+        let result = lp_normalization(&pool, input.view(), -1, 2).unwrap();
+        let norm_1 = 2f32.sqrt();
+        let expected = Tensor::from([[3. / 5., 4. / 5.], [1. / norm_1, -1. / norm_1]]);
+        expect_equal(&result, &expected)?;
+
+        // L1 normalization along axis 0.
+        let result = lp_normalization(&pool, input.view(), 0, 1).unwrap();
+        let expected = Tensor::from([[3. / 4., 4. / 5.], [1. / 4., -1. / 5.]]);
+        expect_equal(&result, &expected)?;
+
+        // Lanes with a zero norm are set to zero rather than NaN.
+        let zero_input = Tensor::from([[0., 0.], [3., 4.]]);
+        let result = lp_normalization(&pool, zero_input.view(), -1, 2).unwrap();
+        let expected = Tensor::from([[0., 0.], [3. / 5., 4. / 5.]]);
+        expect_equal(&result, &expected)?;
+
+        // Normalization applied in-place.
+        let op = LpNormalization { axis: -1, p: 2 };
+        let result: Tensor = op
+            .run_simple_in_place(input.clone(), InputList::new())
+            .unwrap();
+        let expected = Tensor::from([[3. / 5., 4. / 5.], [1. / norm_1, -1. / norm_1]]);
+        expect_equal(&result, &expected)?;
+
+        // Unsupported p value.
+        let result = lp_normalization(&pool, input.view(), 0, 3);
+        assert_eq!(
+            result.err(),
+            Some(OpError::UnsupportedValue("`p` must be 1 or 2"))
+        );
 
         Ok(())
     }


### PR DESCRIPTION
Add support for the [LpNormalization](https://onnx.ai/onnx/operators/onnx__LpNormalization.html) operator, which normalizes slices of the input along a given axis by their L1 or L2 norm.

Tested with [this model](https://huggingface.co/suryatmodulus/Fara-7B-Onnx/blob/main/onnxruntime/vitisai-int4/qwen2_5_vl_webcua_visual_patch_merger.onnx).