### PR TITLE
Fix two bugs relating to `ceil_mode=1` support in pooling ops

### DIFF
--- a/rten-shape-inference/src/ops/conv_pool.rs
+++ b/rten-shape-inference/src/ops/conv_pool.rs
@@ -17,6 +17,7 @@ fn output_size(
     stride: usize,
     dilation: usize,
     padding: DimPadding,
+    ceil_mode: bool,
 ) -> SymExpr {
     let stride = SymExpr::from(stride as i32);
 
@@ -27,10 +28,20 @@ fn output_size(
         } => {
             let dilation = SymExpr::from(dilation as i32);
             let one = SymExpr::from(1);
+            let pad_start = SymExpr::from(pad_start as i32);
             let padded_in_size =
-                in_size + SymExpr::from(pad_start as i32) + SymExpr::from(pad_end as i32);
-            (padded_in_size - dilation * (kernel_size - one.clone()) - one.clone()) / stride
-                + one.clone()
+                in_size.clone() + pad_start.clone() + SymExpr::from(pad_end as i32);
+            let windowed_in_size =
+                padded_in_size - dilation * (kernel_size - one.clone()) - one.clone();
+
+            if !ceil_mode {
+                return windowed_in_size / stride + one;
+            }
+
+            // Rounding up can produce a final window which starts beyond the
+            // end of the input. Exclude those positions.
+            let max_size = (in_size + pad_start - one.clone()) / stride.clone() + one.clone();
+            (windowed_in_size.div_ceil(&stride) + one).min(&max_size)
         }
         DimPadding::Same => in_size.div_ceil(&stride),
     }
@@ -125,6 +136,7 @@ impl InferShapes for Conv<'_> {
                 .first()
                 .ok_or(InferShapesError::InvalidValue)?,
             pad_h,
+            false,
         );
 
         let mut out_shape = Vec::with_capacity(data_shape.len());
@@ -148,6 +160,7 @@ impl InferShapes for Conv<'_> {
                     .get(1)
                     .ok_or(InferShapesError::InvalidValue)?,
                 pad_w,
+                false,
             );
             out_shape.push(out_w);
         }
@@ -269,6 +282,9 @@ pub struct Pool<'a> {
     pub kernel_size: &'a [usize],
     pub padding: Padding<'a>,
     pub strides: &'a [usize],
+
+    /// Round the output size up rather than down.
+    pub ceil_mode: bool,
 }
 
 impl InferShapes for Pool<'_> {
@@ -308,6 +324,7 @@ impl InferShapes for Pool<'_> {
                 .first()
                 .ok_or(InferShapesError::InvalidValue)?,
             pad_h,
+            self.ceil_mode,
         );
 
         let mut out_shape = Vec::with_capacity(data_shape.len());
@@ -334,6 +351,7 @@ impl InferShapes for Pool<'_> {
                     .get(1)
                     .ok_or(InferShapesError::InvalidValue)?,
                 pad_w,
+                self.ceil_mode,
             );
             out_shape.push(out_w);
         }
@@ -370,6 +388,8 @@ impl InferShapes for GlobalPool {
 
 #[cfg(test)]
 mod tests {
+    use rten_testing::TestCases;
+
     use crate::infer_shapes::InferShapes;
     use crate::sym_expr::SymExpr;
     use crate::sym_gen::SymbolGen;
@@ -460,6 +480,7 @@ mod tests {
         // 1D pool
         let data = sym_shape!("batch", "in_c", "seq");
         let op = Pool {
+            ceil_mode: false,
             kernel_size: &[32],
             padding: Padding::Fixed(&[0, 2]),
             dilations: &[4],
@@ -483,6 +504,7 @@ mod tests {
 
         // 1D pool with "same" padding
         let op = Pool {
+            ceil_mode: false,
             kernel_size: &[32],
             padding: Padding::Same,
             dilations: &[4],
@@ -501,6 +523,7 @@ mod tests {
         // 2D pool
         let data = sym_shape!("batch", "in_c", "height", "width");
         let op = Pool {
+            ceil_mode: false,
             kernel_size: &[32, 32],
             padding: Padding::Fixed(&[0, 1, 2, 3]),
             dilations: &[4, 5],
@@ -524,6 +547,78 @@ mod tests {
                     + SymExpr::from(1),
             )
         );
+    }
+
+    #[test]
+    fn test_pool_ceil_mode() {
+        #[derive(Debug)]
+        struct Case {
+            in_size: i32,
+            kernel_size: usize,
+            stride: usize,
+            padding: [usize; 2],
+            expected_ceil: i32,
+            expected_floor: i32,
+        }
+
+        let cases = [
+            // Rounding up adds an output position.
+            Case {
+                in_size: 10,
+                kernel_size: 3,
+                stride: 2,
+                padding: [0, 0],
+                expected_ceil: 5,
+                expected_floor: 4,
+            },
+            // Rounding up does not add one, as the division is exact.
+            Case {
+                in_size: 9,
+                kernel_size: 3,
+                stride: 2,
+                padding: [0, 0],
+                expected_ceil: 4,
+                expected_floor: 4,
+            },
+            // Padding is included in the division.
+            Case {
+                in_size: 9,
+                kernel_size: 3,
+                stride: 2,
+                padding: [1, 1],
+                expected_ceil: 5,
+                expected_floor: 5,
+            },
+            // The final window would start beyond the end of the input.
+            Case {
+                in_size: 12,
+                kernel_size: 1,
+                stride: 2,
+                padding: [0, 0],
+                expected_ceil: 6,
+                expected_floor: 6,
+            },
+        ];
+
+        cases.test_each(|case| {
+            let mut sym_gen = SymbolGen::new();
+            let data = sym_shape!(1, 1, case.in_size);
+
+            for (ceil_mode, expected) in [(true, case.expected_ceil), (false, case.expected_floor)]
+            {
+                let op = Pool {
+                    ceil_mode,
+                    kernel_size: &[case.kernel_size],
+                    padding: Padding::Fixed(&case.padding),
+                    dilations: &[1],
+                    strides: &[case.stride],
+                };
+                let result = op
+                    .infer_shapes([data.clone()].into(), &mut sym_gen)
+                    .unwrap();
+                assert_eq!(result[0].clone().simplify(), sym_shape!(1, 1, expected));
+            }
+        })
     }
 
     #[test]

--- a/src/ops/pooling.rs
+++ b/src/ops/pooling.rs
@@ -470,6 +470,7 @@ impl_infer_shapes!(
         dilations: &[1, 1],
         kernel_size: &op.kernel_size,
         padding: op.padding.as_shape_inference_padding(),
+        ceil_mode: op.ceil_mode,
     }
 );
 
@@ -655,6 +656,7 @@ impl_infer_shapes!(
         dilations: &[1, 1],
         kernel_size: &op.kernel_size,
         padding: op.padding.as_shape_inference_padding(),
+        ceil_mode: op.ceil_mode,
     }
 );
 

--- a/src/ops/pooling.rs
+++ b/src/ops/pooling.rs
@@ -103,15 +103,10 @@ fn output_size_and_padding_for_axis(
 
             // Compute output size. The PyTorch docs provide the clearest
             // formulae for this: https://docs.pytorch.org/docs/stable/generated/torch.nn.MaxPool1d.html.
+            let windowed_in_size = padded_in_size - dilation * (kernel_size - 1) - 1;
             let mut out_size = match round_mode {
-                RoundMode::Floor => {
-                    (padded_in_size - dilation * (kernel_size - 1) - 1) / stride + 1
-                }
-                RoundMode::Ceil => {
-                    (padded_in_size - dilation * (kernel_size - 1) - 1 + stride - 1)
-                        .div_ceil(stride)
-                        + 1
-                }
+                RoundMode::Floor => windowed_in_size / stride + 1,
+                RoundMode::Ceil => windowed_in_size.div_ceil(stride) + 1,
             };
 
             // In ceil mode, it is possible that the input for the last output
@@ -1104,6 +1099,22 @@ mod tests {
                 strides: (2, 2),
                 round_mode: RoundMode::Floor,
                 expected: Ok((3, 3, [0, 0, 0, 0])),
+                ..Default::default()
+            },
+            // Ceil mode test cases that produced an incorrect result prior to a
+            // ceiling division fix.
+            Case {
+                in_size: (9, 9),
+                strides: (2, 2),
+                round_mode: RoundMode::Ceil,
+                expected: Ok((4, 4, [0, 0, 0, 0])),
+                ..Default::default()
+            },
+            Case {
+                in_size: (11, 11),
+                strides: (2, 2),
+                round_mode: RoundMode::Ceil,
+                expected: Ok((5, 5, [0, 0, 0, 0])),
                 ..Default::default()
             },
             // Floor vs ceil round mode with "same" padding. It is intentional


### PR DESCRIPTION
Fix two bugs which caused incorrect outputs from AveragePool and MaxPool when `ceil_mode=1` was used, with certain input shapes:

1. Ceiling division was computed incorrectly in pooling ops. The equation contained two different ways of doing ceiling division: both the C-style addition of `divisor - 1` to the numerator and `div_ceil`. This mistake was inherited from an error in the equations shown on https://docs.pytorch.org/docs/2.13/generated/torch.nn.MaxPool1d.html. The fix is to remove the `divisor - 1` addition in the numerator.
2. Shape inference didn't handle `ceil_mode` at all, and since this changes the output shape, it needs to.

The issue was found while testing the `RNet_truncated_fix.onnx` and `ONet_truncated_fix.onnx` models from https://huggingface.co/R0rschach7/ProjectOrange-Models/tree/main/face/onnx.