### PR TITLE
Prevent overflow when computing tensor data offsets in ONNX and .rten loaders

### DIFF
--- a/src/model/external_data.rs
+++ b/src/model/external_data.rs
@@ -483,7 +483,7 @@ impl DataLoader for MemLoader {
                 ),
             ));
         };
-        let end_offset = location.offset + location.length;
+        let end_offset = location.offset.saturating_add(location.length);
         if end_offset > storage.data().len() as u64 {
             return Err(make_err(ExternalDataErrorKind::TooShort {
                 required_len: end_offset as usize,
@@ -671,5 +671,20 @@ mod tests {
             map.insert("test_mem_loader.onnx.data".to_string(), storage);
             Ok(MemLoader::new(map))
         })
+    }
+
+    #[test]
+    fn test_mem_loader_offset_length_overflow() {
+        let loader = MemLoader::from_entries([("model.onnx.data".to_string(), (0..32).collect())]);
+
+        let err = loader
+            .load(&DataLocation {
+                path: "model.onnx.data".to_string(),
+                offset: u64::MAX,
+                length: 8,
+            })
+            .expect_err("should not load");
+
+        assert!(err.to_string().contains("file too short"));
     }
 }

--- a/src/model/rten_loader.rs
+++ b/src/model/rten_loader.rs
@@ -324,7 +324,12 @@ fn add_graph_constant(
         let Some(tensor_data_offset) = tensor_data_offset else {
             return Err(load_error!(GraphError, name, "tensor data section missing"));
         };
-        let data_offset = (tensor_data_offset + data_offset) as usize;
+        let Some(data_offset) = tensor_data_offset
+            .checked_add(data_offset)
+            .and_then(|offset| usize::try_from(offset).ok())
+        else {
+            return Err(load_error!(GraphError, name, "invalid tensor data offset"));
+        };
 
         let graph_node = match constant.dtype() {
             Some(sg::ConstantDataType::Int32) => {


### PR DESCRIPTION
Fix a couple of potential `usize` overflow issues found by Claude while looking for problems related to https://github.com/robertknight/rten/pull/1419.