### PR TITLE
Move shape inference ops from `rten_shape_inference::ops` into submodules

### DIFF
--- a/rten-shape-inference/src/ops.rs
+++ b/rten-shape-inference/src/ops.rs
@@ -20,6 +20,7 @@ mod grid_sample;
 mod identity;
 mod layout;
 mod matmul;
+mod norm;
 mod pad;
 mod quantize;
 mod random;
@@ -44,6 +45,7 @@ pub use layout::{
     DepthToSpace, Expand, Flatten, Reshape, Shape, Size, Squeeze, Transpose, Unsqueeze,
 };
 pub use matmul::{Gemm, MatMul, MatMulNBits};
+pub use norm::SkipLayerNormalization;
 pub use pad::Pad;
 pub use quantize::DynamicQuantizeLinear;
 pub use random::{Dropout, Multinomial};
@@ -86,81 +88,14 @@ impl InferShapes for NonMaxSuppression {
     }
 }
 
-/// SkipLayerNormalization / SkipSimplifiedLayerNormalization operators.
-///
-/// See <https://github.com/microsoft/onnxruntime/blob/main/docs/ContribOperators.md#com.microsoft.SkipLayerNormalization>.
-pub struct SkipLayerNormalization;
-
-impl InferShapes for SkipLayerNormalization {
-    fn infer_shapes(
-        &self,
-        inputs: InferShapesContext,
-        _sym_gen: &mut SymbolGen,
-    ) -> Result<Vec<SymTensor>, InferShapesError> {
-        let data = inputs.require(0)?;
-
-        let shape = if let Some(dims) = data.shape() {
-            SymTensor::from_shape(dims.collect())
-        } else {
-            SymTensor::unknown("unknown input shape")
-        };
-
-        // Outputs are `output`, `mean`, `inv_std_var` and `input_skip_bias_sum`.
-        //
-        // `output` and `input_skip_bias_sum` have the same shape as the input.
-        // `mean` and `inv_std_var` are not computed by the rten implementation
-        // and are returned as empty placeholders.
-        let placeholder = SymTensor::from_fixed_shape(&[0]);
-        Ok([shape.clone(), placeholder.clone(), placeholder, shape].into())
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use crate::infer_shapes::{InferShapes, InferShapesContext, InferShapesError};
+    use crate::infer_shapes::{InferShapes, InferShapesContext};
     use crate::sym_expr::SymExpr;
     use crate::sym_gen::SymbolGen;
     use crate::sym_tensor::{SymTensor, sym_shape};
 
-    use super::{FixedShape, NonMaxSuppression, SkipLayerNormalization};
-
-    #[test]
-    fn test_skip_layer_normalization() {
-        let mut sym_gen = SymbolGen::new();
-
-        // `output` and `input_skip_bias_sum` match the input shape, while
-        // `mean` and `inv_std_var` are empty placeholders.
-        let data = sym_shape!("batch", "seq", 32);
-        let result = SkipLayerNormalization
-            .infer_shapes([data].into(), &mut sym_gen)
-            .unwrap();
-        assert_eq!(
-            result,
-            &[
-                sym_shape!("batch", "seq", 32),
-                sym_shape!(0),
-                sym_shape!(0),
-                sym_shape!("batch", "seq", 32),
-            ]
-        );
-
-        // Unknown input shape.
-        let data = SymTensor::unknown("unknown");
-        let result = SkipLayerNormalization
-            .infer_shapes([data].into(), &mut sym_gen)
-            .unwrap();
-        assert_eq!(result.len(), 4);
-        assert_eq!(result[0].ndim(), None);
-        assert_eq!(result[1], sym_shape!(0));
-        assert_eq!(result[2], sym_shape!(0));
-        assert_eq!(result[3].ndim(), None);
-
-        // Missing input.
-        let err = SkipLayerNormalization
-            .infer_shapes(InferShapesContext::new(&[]), &mut sym_gen)
-            .err();
-        assert_eq!(err, Some(InferShapesError::IncorrectInputCount));
-    }
+    use super::{FixedShape, NonMaxSuppression};
 
     #[test]
     fn test_fixed_shape() {

--- a/rten-shape-inference/src/ops.rs
+++ b/rten-shape-inference/src/ops.rs
@@ -3,7 +3,7 @@
 //! See the [ONNX operator reference](https://onnx.ai/onnx/operators/index.html)
 //! for operator details.
 
-use crate::infer_shapes::{InferShapes, InferShapesContext, InferShapesError, resolve_axis};
+use crate::infer_shapes::{InferShapes, InferShapesContext, InferShapesError};
 use crate::sym_gen::SymbolGen;
 use crate::sym_tensor::SymTensor;
 

--- a/rten-shape-inference/src/ops.rs
+++ b/rten-shape-inference/src/ops.rs
@@ -21,6 +21,7 @@ mod generate;
 mod layout;
 mod matmul;
 mod pad;
+mod quantize;
 mod random;
 mod resize;
 mod rnn;
@@ -41,37 +42,13 @@ pub use layout::{
 };
 pub use matmul::{Gemm, MatMul, MatMulNBits};
 pub use pad::Pad;
+pub use quantize::DynamicQuantizeLinear;
 pub use random::{Dropout, Multinomial};
 pub use resize::{Resize, Upsample};
 pub use rnn::{Direction, GRU, LSTM};
 pub use slice::Slice;
 pub use split::Split;
 pub use unary::Neg;
-
-/// DynamicQuantizeLinear operator.
-///
-/// See <https://onnx.ai/onnx/operators/onnx__DynamicQuantizeLinear.html>.
-pub struct DynamicQuantizeLinear;
-
-impl InferShapes for DynamicQuantizeLinear {
-    fn infer_shapes(
-        &self,
-        inputs: InferShapesContext,
-        _sym_gen: &mut SymbolGen,
-    ) -> Result<Vec<SymTensor>, InferShapesError> {
-        let data = inputs.require(0)?;
-
-        let shape = if let Some(shape) = data.shape() {
-            SymTensor::from_shape(shape.collect())
-        } else {
-            SymTensor::unknown("unknown input shape")
-        };
-
-        let scale_shape = SymTensor::from_shape(vec![]);
-        let zero_point_shape = SymTensor::from_shape(vec![]);
-        Ok([shape, scale_shape, zero_point_shape].into())
-    }
-}
 
 /// GridSample operator.
 ///
@@ -330,8 +307,8 @@ mod tests {
     use crate::sym_tensor::{SymTensor, sym_shape, sym_vec};
 
     use super::{
-        DynamicQuantizeLinear, FixedShape, GridSample, Identity, NonMaxSuppression, NonZero,
-        SkipLayerNormalization, TopK, Where,
+        FixedShape, GridSample, Identity, NonMaxSuppression, NonZero, SkipLayerNormalization, TopK,
+        Where,
     };
 
     #[test]
@@ -387,16 +364,6 @@ mod tests {
             .infer_shapes(InferShapesContext::new(&[]), &mut sym_gen)
             .err();
         assert_eq!(err, Some(InferShapesError::IncorrectInputCount));
-    }
-
-    #[test]
-    fn test_dynamic_quantize_linear() {
-        let mut sym_gen = SymbolGen::new();
-        let data = sym_shape!(32, 32);
-        let result = DynamicQuantizeLinear
-            .infer_shapes([data].into(), &mut sym_gen)
-            .unwrap();
-        assert_eq!(result, &[sym_shape!(32, 32), sym_shape!(), sym_shape!(),]);
     }
 
     #[test]

--- a/rten-shape-inference/src/ops.rs
+++ b/rten-shape-inference/src/ops.rs
@@ -18,6 +18,7 @@ mod einsum;
 mod fft;
 mod gather;
 mod generate;
+mod grid_sample;
 mod layout;
 mod matmul;
 mod pad;
@@ -38,6 +39,7 @@ pub use einsum::Einsum;
 pub use fft::{DFT, STFT};
 pub use gather::{Gather, GatherElements, GatherND};
 pub use generate::{ConstantOfShape, OneHot, Range};
+pub use grid_sample::GridSample;
 pub use layout::{
     DepthToSpace, Expand, Flatten, Reshape, Shape, Size, Squeeze, Transpose, Unsqueeze,
 };
@@ -51,47 +53,6 @@ pub use rnn::{Direction, GRU, LSTM};
 pub use slice::Slice;
 pub use split::Split;
 pub use unary::Neg;
-
-/// GridSample operator.
-///
-/// See <https://onnx.ai/onnx/operators/onnx__GridSample.html>.
-pub struct GridSample;
-
-impl InferShapes for GridSample {
-    fn infer_shapes(
-        &self,
-        inputs: InferShapesContext,
-        _sym_gen: &mut SymbolGen,
-    ) -> Result<Vec<SymTensor>, InferShapesError> {
-        let data = inputs.require(0)?;
-        let grid = inputs.require(1)?;
-
-        let Some(data_dims) = data.shape() else {
-            return Ok([SymTensor::unknown("unknown input shape")].into());
-        };
-        let Some(grid_dims) = grid.shape() else {
-            return Ok([SymTensor::unknown("unknown grid shape")].into());
-        };
-
-        // data is (N, C, D1, D2) and grid is (N, D1_out, D2_out, ..., r) where
-        // D1..Dn are the spatial dims.
-        let data_shape: Vec<_> = data_dims.collect();
-        let grid_shape: Vec<_> = grid_dims.collect();
-        if data_shape.len() < 3 || data_shape.len() != grid_shape.len() {
-            return Err(InferShapesError::IncorrectRank);
-        }
-
-        // Output is (N, C, D1_out, D2_out, ...).
-        let spatial_dims = data_shape.len() - 2;
-        let out_shape = data_shape
-            .into_iter()
-            .take(2) // (N, C)
-            .chain(grid_shape.into_iter().skip(1).take(spatial_dims))
-            .collect();
-
-        Ok([SymTensor::from_shape(out_shape)].into())
-    }
-}
 
 /// Identity operator.
 ///
@@ -266,9 +227,7 @@ mod tests {
     use crate::sym_gen::SymbolGen;
     use crate::sym_tensor::{SymTensor, sym_shape, sym_vec};
 
-    use super::{
-        FixedShape, GridSample, Identity, NonMaxSuppression, NonZero, SkipLayerNormalization, Where,
-    };
+    use super::{FixedShape, Identity, NonMaxSuppression, NonZero, SkipLayerNormalization, Where};
 
     #[test]
     fn test_identity() {
@@ -340,43 +299,6 @@ mod tests {
             .infer_shapes(InferShapesContext::new(&[]), &mut sym_gen)
             .unwrap();
         assert_eq!(result[0], sym_shape!());
-    }
-
-    #[test]
-    fn test_grid_sample() {
-        let mut sym_gen = SymbolGen::new();
-
-        // 2D sampling: data is (N, C, H, W), grid is (N, H_out, W_out, 2).
-        let data = sym_shape!("batch", 3, 224, 224);
-        let grid = sym_shape!("batch", 32, 64, 2);
-        let result = GridSample
-            .infer_shapes([data, grid].into(), &mut sym_gen)
-            .unwrap();
-        assert_eq!(result[0], sym_shape!("batch", 3, 32, 64));
-
-        // 1D sampling: data is (N, C, W), grid is (N, W_out, 1).
-        let data = sym_shape!("batch", 3, 224);
-        let grid = sym_shape!("batch", 32, 1);
-        let result = GridSample
-            .infer_shapes([data, grid].into(), &mut sym_gen)
-            .unwrap();
-        assert_eq!(result[0], sym_shape!("batch", 3, 32));
-
-        // Unknown input shape.
-        let data = SymTensor::unknown("unknown");
-        let grid = sym_shape!(1, 32, 64, 2);
-        let result = GridSample
-            .infer_shapes([data, grid].into(), &mut sym_gen)
-            .unwrap();
-        assert_eq!(result[0].ndim(), None);
-
-        // Wrong rank.
-        let data = sym_shape!(1, 3, 224);
-        let grid = sym_shape!(1, 32, 64, 2);
-        let err = GridSample
-            .infer_shapes([data, grid].into(), &mut sym_gen)
-            .unwrap_err();
-        assert_eq!(err, InferShapesError::IncorrectRank);
     }
 
     #[test]

--- a/rten-shape-inference/src/ops.rs
+++ b/rten-shape-inference/src/ops.rs
@@ -17,6 +17,7 @@ mod fft;
 mod gather;
 mod generate;
 mod grid_sample;
+mod identity;
 mod layout;
 mod matmul;
 mod pad;
@@ -38,6 +39,7 @@ pub use fft::{DFT, STFT};
 pub use gather::{Gather, GatherElements, GatherND};
 pub use generate::{ConstantOfShape, OneHot, Range};
 pub use grid_sample::GridSample;
+pub use identity::Identity;
 pub use layout::{
     DepthToSpace, Expand, Flatten, Reshape, Shape, Size, Squeeze, Transpose, Unsqueeze,
 };
@@ -51,25 +53,6 @@ pub use rnn::{Direction, GRU, LSTM};
 pub use slice::Slice;
 pub use split::Split;
 pub use unary::Neg;
-
-/// Identity operator.
-///
-/// See <https://onnx.ai/onnx/operators/onnx__Identity.html>.
-///
-/// Unlike [`UnaryOp`](crate::UnaryOp), this copies the input's values (when
-/// known) to the output, not just its shape.
-pub struct Identity;
-
-impl InferShapes for Identity {
-    fn infer_shapes(
-        &self,
-        inputs: InferShapesContext,
-        _sym_gen: &mut SymbolGen,
-    ) -> Result<Vec<SymTensor>, InferShapesError> {
-        let data = inputs.require(0)?;
-        Ok([data.clone()].into())
-    }
-}
 
 /// NonZero operator.
 ///
@@ -161,26 +144,9 @@ mod tests {
     use crate::infer_shapes::{InferShapes, InferShapesContext, InferShapesError};
     use crate::sym_expr::SymExpr;
     use crate::sym_gen::SymbolGen;
-    use crate::sym_tensor::{SymTensor, sym_shape, sym_vec};
+    use crate::sym_tensor::{SymTensor, sym_shape};
 
-    use super::{FixedShape, Identity, NonMaxSuppression, NonZero, SkipLayerNormalization};
-
-    #[test]
-    fn test_identity() {
-        let mut sym_gen = SymbolGen::new();
-
-        let input = sym_vec!("batch", 16, "seq", 24);
-        let result = Identity
-            .infer_shapes([input.clone()].into(), &mut sym_gen)
-            .unwrap();
-        assert_eq!(result, &[input]);
-
-        let err = Identity
-            .infer_shapes(InferShapesContext::new(&[]), &mut sym_gen)
-            .err()
-            .unwrap();
-        assert_eq!(err, InferShapesError::IncorrectInputCount);
-    }
+    use super::{FixedShape, NonMaxSuppression, NonZero, SkipLayerNormalization};
 
     #[test]
     fn test_skip_layer_normalization() {

--- a/rten-shape-inference/src/ops.rs
+++ b/rten-shape-inference/src/ops.rs
@@ -4,7 +4,6 @@
 //! for operator details.
 
 use crate::infer_shapes::{InferShapes, InferShapesContext, InferShapesError, resolve_axis};
-use crate::sym_expr::SymExpr;
 use crate::sym_gen::SymbolGen;
 use crate::sym_tensor::SymTensor;
 
@@ -20,6 +19,7 @@ mod grid_sample;
 mod identity;
 mod layout;
 mod matmul;
+mod non_max_suppression;
 mod norm;
 mod pad;
 mod quantize;
@@ -45,6 +45,7 @@ pub use layout::{
     DepthToSpace, Expand, Flatten, Reshape, Shape, Size, Squeeze, Transpose, Unsqueeze,
 };
 pub use matmul::{Gemm, MatMul, MatMulNBits};
+pub use non_max_suppression::NonMaxSuppression;
 pub use norm::SkipLayerNormalization;
 pub use pad::Pad;
 pub use quantize::DynamicQuantizeLinear;
@@ -71,23 +72,6 @@ impl InferShapes for FixedShape<'_> {
     }
 }
 
-/// NonMaxSuppression operator.
-///
-/// See <https://onnx.ai/onnx/operators/onnx__NonMaxSuppression.html>.
-pub struct NonMaxSuppression;
-
-impl InferShapes for NonMaxSuppression {
-    fn infer_shapes(
-        &self,
-        _inputs: InferShapesContext,
-        sym_gen: &mut SymbolGen,
-    ) -> Result<Vec<SymTensor>, InferShapesError> {
-        // Output is `(num_selected, 3)`. `num_selected` is data-dependent.
-        let out_shape = vec![sym_gen.gen_positive(), SymExpr::Value(3)];
-        Ok([SymTensor::from_shape(out_shape)].into())
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use crate::infer_shapes::{InferShapes, InferShapesContext};
@@ -95,7 +79,7 @@ mod tests {
     use crate::sym_gen::SymbolGen;
     use crate::sym_tensor::{SymTensor, sym_shape};
 
-    use super::{FixedShape, NonMaxSuppression};
+    use super::FixedShape;
 
     #[test]
     fn test_fixed_shape() {
@@ -112,21 +96,5 @@ mod tests {
             .infer_shapes(InferShapesContext::new(&[]), &mut sym_gen)
             .unwrap();
         assert_eq!(result[0], sym_shape!());
-    }
-
-    #[test]
-    fn test_non_max_suppression() {
-        let mut sym_gen = SymbolGen::new();
-
-        // Output is `(num_selected, 3)` with a symbolic first dim.
-        let boxes = sym_shape!(1, 100, 4);
-        let scores = sym_shape!(1, 80, 100);
-        let result = NonMaxSuppression
-            .infer_shapes([boxes, scores].into(), &mut sym_gen)
-            .unwrap();
-        let shape: Vec<_> = result[0].shape().unwrap().collect();
-        assert_eq!(shape.len(), 2);
-        assert!(matches!(shape[0], SymExpr::Var(_)));
-        assert_eq!(shape[1], SymExpr::Value(3));
     }
 }

--- a/rten-shape-inference/src/ops.rs
+++ b/rten-shape-inference/src/ops.rs
@@ -3,9 +3,7 @@
 //! See the [ONNX operator reference](https://onnx.ai/onnx/operators/index.html)
 //! for operator details.
 
-use crate::infer_shapes::{
-    BinaryOp, InferShapes, InferShapesContext, InferShapesError, resolve_axis,
-};
+use crate::infer_shapes::{InferShapes, InferShapesContext, InferShapesError, resolve_axis};
 use crate::sym_expr::SymExpr;
 use crate::sym_gen::SymbolGen;
 use crate::sym_tensor::SymTensor;
@@ -32,7 +30,7 @@ mod split;
 mod unary;
 
 pub use attention::{Attention, GroupQueryAttention, MultiHeadAttention};
-pub use binary::{Add, Div, Equal, Mul, Sub};
+pub use binary::{Add, Div, Equal, Mul, Sub, Where};
 pub use concat::{Concat, Tile};
 pub use conv_pool::{Conv, ConvTranspose, GlobalPool, Padding, Pool};
 pub use einsum::Einsum;
@@ -158,68 +156,6 @@ impl InferShapes for SkipLayerNormalization {
     }
 }
 
-/// Where operator.
-///
-/// See <https://onnx.ai/onnx/operators/onnx__Where.html>.
-pub struct Where;
-
-impl InferShapes for Where {
-    fn infer_shapes(
-        &self,
-        inputs: InferShapesContext,
-        sym_gen: &mut SymbolGen,
-    ) -> Result<Vec<SymTensor>, InferShapesError> {
-        let cond = inputs.require(0)?;
-        let x = inputs.require(1)?;
-        let y = inputs.require(2)?;
-
-        if let Some(cond_vals) = cond.values()
-            && let Some(x_vals) = x.values()
-            && let Some(y_vals) = y.values()
-        {
-            let len = cond_vals.len().max(x_vals.len()).max(y_vals.len());
-
-            let cs = cond_vals.iter().cycle().take(len);
-            let xs = x_vals.iter().cycle().take(len);
-            let ys = y_vals.iter().cycle().take(len);
-
-            let vals: Option<Vec<SymExpr>> = cs
-                .zip(xs.zip(ys))
-                .map(|(cond, (x, y))| {
-                    let cond_bool = match cond {
-                        SymExpr::Value(v) => Some(*v == 1),
-                        SymExpr::Var(_)
-                        | SymExpr::Neg(_)
-                        | SymExpr::Add(..)
-                        | SymExpr::Sub(..)
-                        | SymExpr::Mul(..)
-                        | SymExpr::Div(..)
-                        | SymExpr::DivCeil(..)
-                        | SymExpr::Max(..)
-                        | SymExpr::Min(..)
-                        | SymExpr::Broadcast(..) => None,
-                    }?;
-                    if cond_bool {
-                        Some(x.clone())
-                    } else {
-                        Some(y.clone())
-                    }
-                })
-                .collect();
-            if let Some(vals) = vals {
-                return Ok([SymTensor::from_vec(vals)].into());
-            }
-        }
-
-        // Broadcast the first two inputs together, then broadcast the result
-        // against the last input.
-        let cond_x = BinaryOp
-            .infer_shapes([cond.clone(), x.clone()].into(), sym_gen)?
-            .remove(0);
-        BinaryOp.infer_shapes([cond_x, y.clone()].into(), sym_gen)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use crate::infer_shapes::{InferShapes, InferShapesContext, InferShapesError};
@@ -227,7 +163,7 @@ mod tests {
     use crate::sym_gen::SymbolGen;
     use crate::sym_tensor::{SymTensor, sym_shape, sym_vec};
 
-    use super::{FixedShape, Identity, NonMaxSuppression, NonZero, SkipLayerNormalization, Where};
+    use super::{FixedShape, Identity, NonMaxSuppression, NonZero, SkipLayerNormalization};
 
     #[test]
     fn test_identity() {
@@ -334,30 +270,5 @@ mod tests {
         assert_eq!(shape.len(), 2);
         assert!(matches!(shape[0], SymExpr::Var(_)));
         assert_eq!(shape[1], SymExpr::Value(3));
-    }
-
-    #[test]
-    fn test_where() {
-        let mut sym_gen = SymbolGen::new();
-
-        // Where op with symbolic vectors.
-        let cond = sym_vec!(0, 1, 0, 1);
-        let x = sym_vec!(1, 2, 3, 4);
-        let y = sym_vec!("foo", "bar", "baz", "meep");
-        let result = Where
-            .infer_shapes([cond, x, y].into(), &mut sym_gen)
-            .unwrap();
-        assert_eq!(result[0], sym_vec!("foo", 2, "baz", 4));
-
-        // Where op with shapes.
-        //
-        // This broadcasts the three inputs together.
-        let cond = sym_shape!(1, 16, 1);
-        let x = sym_shape!(8, 16, 1);
-        let y = sym_shape!(1, 16, 24);
-        let result = Where
-            .infer_shapes([cond, x, y].into(), &mut sym_gen)
-            .unwrap();
-        assert_eq!(result[0], sym_shape!(8, 16, 24));
     }
 }

--- a/rten-shape-inference/src/ops.rs
+++ b/rten-shape-inference/src/ops.rs
@@ -21,6 +21,7 @@ mod generate;
 mod layout;
 mod matmul;
 mod pad;
+mod random;
 mod resize;
 mod rnn;
 mod slice;
@@ -40,36 +41,12 @@ pub use layout::{
 };
 pub use matmul::{Gemm, MatMul, MatMulNBits};
 pub use pad::Pad;
+pub use random::{Dropout, Multinomial};
 pub use resize::{Resize, Upsample};
 pub use rnn::{Direction, GRU, LSTM};
 pub use slice::Slice;
 pub use split::Split;
 pub use unary::Neg;
-
-/// Dropout operator.
-///
-/// See <https://onnx.ai/onnx/operators/onnx__Dropout.html>.
-pub struct Dropout;
-
-impl InferShapes for Dropout {
-    fn infer_shapes(
-        &self,
-        inputs: InferShapesContext,
-        _sym_gen: &mut SymbolGen,
-    ) -> Result<Vec<SymTensor>, InferShapesError> {
-        let data = inputs.require(0)?;
-
-        let shape = if let Some(dims) = data.shape() {
-            SymTensor::from_shape(dims.collect())
-        } else {
-            SymTensor::unknown("unknown input shape")
-        };
-
-        // Output 0 is the dropped-out data; output 1 is the boolean mask. Both
-        // have the same shape as the input.
-        Ok([shape.clone(), shape].into())
-    }
-}
 
 /// DynamicQuantizeLinear operator.
 ///
@@ -192,35 +169,6 @@ impl InferShapes for FixedShape<'_> {
         _sym_gen: &mut SymbolGen,
     ) -> Result<Vec<SymTensor>, InferShapesError> {
         Ok([SymTensor::from_fixed_shape(self.shape)].into())
-    }
-}
-
-/// Multinomial operator.
-///
-/// See <https://onnx.ai/onnx/operators/onnx__Multinomial.html>.
-pub struct Multinomial {
-    /// Number of times to sample for each row of the input.
-    pub sample_size: usize,
-}
-
-impl InferShapes for Multinomial {
-    fn infer_shapes(
-        &self,
-        inputs: InferShapesContext,
-        sym_gen: &mut SymbolGen,
-    ) -> Result<Vec<SymTensor>, InferShapesError> {
-        let input = inputs.require(0)?;
-
-        if input.ndim().is_some_and(|ndim| ndim != 2) {
-            return Err(InferShapesError::IncorrectRank);
-        }
-
-        // Input is `(batch_size, class_size)`, output is
-        // `(batch_size, sample_size)`.
-        let batch_size = input.size(0).unwrap_or_else(|| sym_gen.gen_positive());
-        let sample_size = SymExpr::Value(self.sample_size as i32);
-        let out_shape = vec![batch_size, sample_size];
-        Ok([SymTensor::from_shape(out_shape)].into())
     }
 }
 
@@ -382,26 +330,9 @@ mod tests {
     use crate::sym_tensor::{SymTensor, sym_shape, sym_vec};
 
     use super::{
-        Dropout, DynamicQuantizeLinear, FixedShape, GridSample, Identity, Multinomial,
-        NonMaxSuppression, NonZero, SkipLayerNormalization, TopK, Where,
+        DynamicQuantizeLinear, FixedShape, GridSample, Identity, NonMaxSuppression, NonZero,
+        SkipLayerNormalization, TopK, Where,
     };
-
-    #[test]
-    fn test_dropout() {
-        let mut sym_gen = SymbolGen::new();
-        let data = sym_shape!("batch", 16, 32);
-        let result = Dropout.infer_shapes([data].into(), &mut sym_gen).unwrap();
-        assert_eq!(result.len(), 2);
-        assert_eq!(result[0], sym_shape!("batch", 16, 32));
-        assert_eq!(result[1], sym_shape!("batch", 16, 32));
-
-        // Unknown input shape.
-        let data = SymTensor::unknown("unknown");
-        let result = Dropout.infer_shapes([data].into(), &mut sym_gen).unwrap();
-        assert_eq!(result.len(), 2);
-        assert_eq!(result[0].ndim(), None);
-        assert_eq!(result[1].ndim(), None);
-    }
 
     #[test]
     fn test_identity() {
@@ -418,33 +349,6 @@ mod tests {
             .err()
             .unwrap();
         assert_eq!(err, InferShapesError::IncorrectInputCount);
-    }
-
-    #[test]
-    fn test_multinomial() {
-        let mut sym_gen = SymbolGen::new();
-
-        // Known batch size.
-        let data = sym_shape!("batch", 32);
-        let result = Multinomial { sample_size: 4 }
-            .infer_shapes([data].into(), &mut sym_gen)
-            .unwrap();
-        assert_eq!(result, &[sym_shape!("batch", 4)]);
-
-        // Unknown input shape still yields a known sample size.
-        let data = SymTensor::unknown("unknown");
-        let result = Multinomial { sample_size: 4 }
-            .infer_shapes([data].into(), &mut sym_gen)
-            .unwrap();
-        assert_eq!(result[0].ndim(), Some(2));
-        assert_eq!(result[0].size(1), Some(4.into()));
-
-        // Input with a known rank other than 2 is an error.
-        let data = sym_shape!("batch", 32, 8);
-        let err = Multinomial { sample_size: 4 }
-            .infer_shapes([data].into(), &mut sym_gen)
-            .err();
-        assert_eq!(err, Some(InferShapesError::IncorrectRank));
     }
 
     #[test]

--- a/rten-shape-inference/src/ops.rs
+++ b/rten-shape-inference/src/ops.rs
@@ -47,36 +47,12 @@ pub use matmul::{Gemm, MatMul, MatMulNBits};
 pub use pad::Pad;
 pub use quantize::DynamicQuantizeLinear;
 pub use random::{Dropout, Multinomial};
-pub use reduce::TopK;
+pub use reduce::{NonZero, TopK};
 pub use resize::{Resize, Upsample};
 pub use rnn::{Direction, GRU, LSTM};
 pub use slice::Slice;
 pub use split::Split;
 pub use unary::Neg;
-
-/// NonZero operator.
-///
-/// See <https://onnx.ai/onnx/operators/onnx__NonZero.html>.
-pub struct NonZero;
-
-impl InferShapes for NonZero {
-    fn infer_shapes(
-        &self,
-        inputs: InferShapesContext,
-        sym_gen: &mut SymbolGen,
-    ) -> Result<Vec<SymTensor>, InferShapesError> {
-        let data = inputs.require(0)?;
-
-        // Output is a 2D tensor of shape `(input.ndim(), num_nonzero)`.
-        let first_dim = data
-            .ndim()
-            .map(|n| SymExpr::Value(n as i32))
-            .unwrap_or_else(|| sym_gen.gen_positive());
-        let out_shape = vec![first_dim, sym_gen.gen_positive()];
-
-        Ok([SymTensor::from_shape(out_shape)].into())
-    }
-}
 
 /// Operator which produces a tensor of a fixed shape.
 pub struct FixedShape<'a> {
@@ -146,7 +122,7 @@ mod tests {
     use crate::sym_gen::SymbolGen;
     use crate::sym_tensor::{SymTensor, sym_shape};
 
-    use super::{FixedShape, NonMaxSuppression, NonZero, SkipLayerNormalization};
+    use super::{FixedShape, NonMaxSuppression, SkipLayerNormalization};
 
     #[test]
     fn test_skip_layer_normalization() {
@@ -201,25 +177,6 @@ mod tests {
             .infer_shapes(InferShapesContext::new(&[]), &mut sym_gen)
             .unwrap();
         assert_eq!(result[0], sym_shape!());
-    }
-
-    #[test]
-    fn test_non_zero() {
-        let mut sym_gen = SymbolGen::new();
-
-        // Known input shape, output is 2D with first dim = ndim.
-        let data = sym_shape!("batch", 16, 32);
-        let result = NonZero.infer_shapes([data].into(), &mut sym_gen).unwrap();
-        let shape: Vec<_> = result[0].shape().unwrap().collect();
-        assert_eq!(shape.len(), 2);
-        assert_eq!(shape[0], SymExpr::Value(3));
-        assert!(matches!(shape[1], SymExpr::Var(_)));
-
-        // Unknown input shape, output is still 2D.
-        let data = SymTensor::unknown("unknown");
-        let result = NonZero.infer_shapes([data].into(), &mut sym_gen).unwrap();
-        let shape: Vec<_> = result[0].shape().unwrap().collect();
-        assert_eq!(shape.len(), 2);
     }
 
     #[test]

--- a/rten-shape-inference/src/ops.rs
+++ b/rten-shape-inference/src/ops.rs
@@ -34,7 +34,7 @@ pub use conv_pool::{Conv, ConvTranspose, GlobalPool, Padding, Pool};
 pub use einsum::Einsum;
 pub use fft::{DFT, STFT};
 pub use gather::{Gather, GatherElements, GatherND};
-pub use generate::OneHot;
+pub use generate::{ConstantOfShape, OneHot, Range};
 pub use layout::{
     DepthToSpace, Expand, Flatten, Reshape, Shape, Size, Squeeze, Transpose, Unsqueeze,
 };
@@ -45,69 +45,6 @@ pub use rnn::{Direction, GRU, LSTM};
 pub use slice::Slice;
 pub use split::Split;
 pub use unary::Neg;
-
-/// ConstantOfShape operator.
-///
-/// See <https://onnx.ai/onnx/operators/onnx__ConstantOfShape.html>.
-pub struct ConstantOfShape {
-    /// The integer value. This should be set to `None` if the operator has
-    /// a value attribute of a different type.
-    pub value: Option<i32>,
-}
-
-impl InferShapes for ConstantOfShape {
-    fn infer_shapes(
-        &self,
-        inputs: InferShapesContext,
-        sym_gen: &mut SymbolGen,
-    ) -> Result<Vec<SymTensor>, InferShapesError> {
-        let shape = inputs.require(0)?;
-
-        let out_shape = if let Some(values) = shape.values() {
-            if let Some(val) = self.value
-                && values.len() <= 1
-            {
-                if let Some(vec_len) = values.first() {
-                    match vec_len {
-                        &SymExpr::Value(vec_len) => {
-                            if let Ok(vec_len) = vec_len.try_into() {
-                                SymTensor::from_vec(vec![SymExpr::Value(val); vec_len])
-                            } else {
-                                return Err(InferShapesError::InvalidValue);
-                            }
-                        }
-                        SymExpr::Var(_)
-                        | SymExpr::Neg(_)
-                        | SymExpr::Add(..)
-                        | SymExpr::Sub(..)
-                        | SymExpr::Mul(..)
-                        | SymExpr::Div(..)
-                        | SymExpr::DivCeil(..)
-                        | SymExpr::Max(..)
-                        | SymExpr::Min(..)
-                        | SymExpr::Broadcast(..) => SymTensor::from_shape(vec![vec_len.clone()]),
-                    }
-                } else {
-                    SymTensor::from_scalar(SymExpr::Value(val))
-                }
-            } else {
-                SymTensor::from_shape(values.to_vec())
-            }
-        } else if let Some(mut dims) = shape.shape()
-            && dims.len() == 1
-            && let Some(SymExpr::Value(out_ndim)) = dims.next()
-            && let Ok(out_ndim) = usize::try_from(out_ndim)
-        {
-            // The rank is known, but not the shape.
-            let out_shape = (0..out_ndim).map(|_| sym_gen.gen_positive()).collect();
-            SymTensor::from_shape(out_shape)
-        } else {
-            SymTensor::unknown("unknown shape")
-        };
-
-        Ok(vec![out_shape])
-    }
-}
 
 /// Dropout operator.
 ///
@@ -304,83 +241,6 @@ impl InferShapes for NonMaxSuppression {
     }
 }
 
-/// Range operator.
-///
-/// See <https://onnx.ai/onnx/operators/onnx__Range.html>.
-pub struct Range;
-
-/// Maximum number of elements of a `Range` output for which the individual
-/// values are computed, rather than just the length.
-const MAX_RANGE_VALUES: i64 = 1024;
-
-impl InferShapes for Range {
-    fn infer_shapes(
-        &self,
-        inputs: InferShapesContext,
-        sym_gen: &mut SymbolGen,
-    ) -> Result<Vec<SymTensor>, InferShapesError> {
-        let start = inputs.require(0)?;
-        let limit = inputs.require(1)?;
-        let delta = inputs.require(2)?;
-
-        let start = start.values().map(|v| v[0].clone());
-        let limit = limit.values().map(|v| v[0].clone());
-        let delta = delta.values().map(|v| v[0].clone());
-
-        let out_value = match (start, limit, delta) {
-            (
-                Some(SymExpr::Value(start)),
-                Some(SymExpr::Value(limit)),
-                Some(SymExpr::Value(delta)),
-            ) => {
-                if delta == 0 {
-                    return Err(InferShapesError::InvalidValue);
-                }
-
-                // Compute the element count as `max(ceil((limit - start) / delta), 0)`,
-                // as specified by the ONNX spec. `i64` arithmetic avoids overflow
-                // when negating `delta` or subtracting `i32` values.
-                let (start, limit, delta) = (start as i64, limit as i64, delta as i64);
-                let (span, step) = if delta > 0 {
-                    (limit - start, delta)
-                } else {
-                    (start - limit, -delta)
-                };
-                let len = ((span + step - 1) / step).max(0);
-
-                if len <= MAX_RANGE_VALUES {
-                    // Values are between `start` and `limit`, so they fit in `i32`.
-                    let values = (0..len)
-                        .map(|i| SymExpr::Value((start + i * delta) as i32))
-                        .collect();
-                    SymTensor::from_vec(values)
-                } else if let Ok(len) = i32::try_from(len) {
-                    SymTensor::from_shape(vec![SymExpr::Value(len)])
-                } else {
-                    SymTensor::from_shape(vec![sym_gen.gen_positive()])
-                }
-            }
-            // Range(0, limit, 1) has shape [limit]
-            (Some(SymExpr::Value(0)), Some(limit), Some(SymExpr::Value(1))) => {
-                SymTensor::from_shape(vec![limit])
-            }
-            // Range(start, start + limit, 1) has shape [limit]
-            (Some(start), Some(SymExpr::Add(limit_lhs, limit_rhs)), Some(SymExpr::Value(1)))
-                if start == *limit_lhs =>
-            {
-                SymTensor::from_shape(vec![(*limit_rhs).clone()])
-            }
-            // Range(start, limit, 1) has shape [limit - start]
-            (Some(start), Some(limit), Some(SymExpr::Value(1))) => {
-                SymTensor::from_shape(vec![limit - start])
-            }
-            _ => SymTensor::from_shape(vec![sym_gen.gen_positive()]),
-        };
-
-        Ok(vec![out_value])
-    }
-}
-
 /// SkipLayerNormalization / SkipSimplifiedLayerNormalization operators.
 ///
 /// See <https://github.com/microsoft/onnxruntime/blob/main/docs/ContribOperators.md#com.microsoft.SkipLayerNormalization>.
@@ -522,57 +382,9 @@ mod tests {
     use crate::sym_tensor::{SymTensor, sym_shape, sym_vec};
 
     use super::{
-        ConstantOfShape, Dropout, DynamicQuantizeLinear, FixedShape, GridSample, Identity,
-        Multinomial, NonMaxSuppression, NonZero, Range, SkipLayerNormalization, TopK, Where,
+        Dropout, DynamicQuantizeLinear, FixedShape, GridSample, Identity, Multinomial,
+        NonMaxSuppression, NonZero, SkipLayerNormalization, TopK, Where,
     };
-
-    #[test]
-    fn test_constant_of_shape() {
-        let mut sym_gen = SymbolGen::new();
-
-        // Scalar shape, int value.
-        let shape = sym_vec!();
-        let op = ConstantOfShape { value: Some(1) };
-        let result = op.infer_shapes([shape].into(), &mut sym_gen).unwrap();
-        assert_eq!(result[0], SymTensor::from_scalar(1.into()));
-
-        // Vector shape, int value.
-        let shape = sym_vec!(3);
-        let op = ConstantOfShape { value: Some(1) };
-        let result = op.infer_shapes([shape].into(), &mut sym_gen).unwrap();
-        assert_eq!(result[0], sym_vec!(1, 1, 1));
-
-        // Vector shape, non-int value.
-        let shape = sym_vec!(3);
-        let op = ConstantOfShape { value: None };
-        let result = op.infer_shapes([shape].into(), &mut sym_gen).unwrap();
-        assert_eq!(result[0], sym_shape!(3));
-
-        // 2D+ shape
-        let shape = sym_vec!(2, 2);
-        let op = ConstantOfShape { value: Some(1) };
-        let result = op.infer_shapes([shape].into(), &mut sym_gen).unwrap();
-        assert_eq!(result[0], sym_shape!(2, 2));
-
-        // Shape with unknown values but a known length.
-        let mut sym_gen = SymbolGen::new();
-        let shape = sym_shape!(3);
-        let op = ConstantOfShape { value: Some(1) };
-        let result = op.infer_shapes([shape].into(), &mut sym_gen).unwrap();
-        assert_eq!(result[0], sym_shape!("unknown_1", "unknown_2", "unknown_3"));
-
-        // Shape with unknown values and a symbolic length.
-        let shape = sym_shape!("n");
-        let op = ConstantOfShape { value: Some(1) };
-        let result = op.infer_shapes([shape].into(), &mut sym_gen).unwrap();
-        assert_eq!(result[0].ndim(), None);
-
-        // Unknown shape input.
-        let shape = SymTensor::unknown("unknown");
-        let op = ConstantOfShape { value: Some(1) };
-        let result = op.infer_shapes([shape].into(), &mut sym_gen).unwrap();
-        assert_eq!(result[0].ndim(), None);
-    }
 
     #[test]
     fn test_dropout() {
@@ -770,130 +582,6 @@ mod tests {
         assert_eq!(shape.len(), 2);
         assert!(matches!(shape[0], SymExpr::Var(_)));
         assert_eq!(shape[1], SymExpr::Value(3));
-    }
-
-    #[test]
-    fn test_range() {
-        struct Case {
-            start: SymTensor,
-            limit: SymTensor,
-            delta: SymTensor,
-            expected: Result<SymTensor, InferShapesError>,
-        }
-
-        let cases = [
-            // Range with fixed values
-            Case {
-                start: sym_vec!(0),
-                limit: sym_vec!(5),
-                delta: sym_vec!(1),
-                expected: Ok(sym_vec!(0, 1, 2, 3, 4)),
-            },
-            // Fixed values with a delta that doesn't evenly divide the range
-            Case {
-                start: sym_vec!(0),
-                limit: sym_vec!(5),
-                delta: sym_vec!(2),
-                expected: Ok(sym_vec!(0, 2, 4)),
-            },
-            // Fixed values with a negative delta
-            Case {
-                start: sym_vec!(15),
-                limit: sym_vec!(-1),
-                delta: sym_vec!(-1),
-                expected: Ok(SymTensor::from_vec(
-                    (0..=15).rev().map(SymExpr::Value).collect(),
-                )),
-            },
-            Case {
-                start: sym_vec!(10),
-                limit: sym_vec!(0),
-                delta: sym_vec!(-3),
-                expected: Ok(sym_vec!(10, 7, 4, 1)),
-            },
-            // Empty ranges
-            Case {
-                start: sym_vec!(5),
-                limit: sym_vec!(5),
-                delta: sym_vec!(1),
-                expected: Ok(sym_vec!()),
-            },
-            Case {
-                start: sym_vec!(0),
-                limit: sym_vec!(5),
-                delta: sym_vec!(-1),
-                expected: Ok(sym_vec!()),
-            },
-            // A zero delta is invalid, as it would produce an infinite range.
-            Case {
-                start: sym_vec!(0),
-                limit: sym_vec!(5),
-                delta: sym_vec!(0),
-                expected: Err(InferShapesError::InvalidValue),
-            },
-            // Ranges longer than `MAX_RANGE_VALUES` have only their length inferred.
-            Case {
-                start: sym_vec!(0),
-                limit: sym_vec!(5000),
-                delta: sym_vec!(1),
-                expected: Ok(sym_shape!(5000)),
-            },
-            Case {
-                start: sym_vec!(5000),
-                limit: sym_vec!(0),
-                delta: sym_vec!(-1),
-                expected: Ok(sym_shape!(5000)),
-            },
-            // A range whose length exceeds `i32::MAX`.
-            Case {
-                start: sym_vec!(i32::MIN),
-                limit: sym_vec!(i32::MAX),
-                delta: sym_vec!(1),
-                expected: Ok(sym_shape!("unknown_1")),
-            },
-            // Range from 0..limit
-            Case {
-                start: sym_vec!(0),
-                limit: sym_vec!("limit"),
-                delta: sym_vec!(1),
-                expected: Ok(sym_shape!("limit")),
-            },
-            // Range from start..(start + limit)
-            Case {
-                start: sym_vec!("start"),
-                limit: sym_vec!(SymExpr::from("start") + SymExpr::from("limit")),
-                delta: sym_vec!(1),
-                expected: Ok(sym_shape!("limit")),
-            },
-            // Range from start..limit
-            Case {
-                start: sym_vec!("start"),
-                limit: sym_vec!("limit"),
-                delta: sym_vec!(1),
-                expected: Ok(sym_shape!(SymExpr::from("limit") - SymExpr::from("start"))),
-            },
-            // Range of unknown size
-            Case {
-                start: sym_vec!("start"),
-                limit: sym_vec!("end"),
-                delta: sym_vec!("delta"),
-                expected: Ok(sym_shape!("unknown_1")),
-            },
-        ];
-
-        for Case {
-            start,
-            limit,
-            delta,
-            expected,
-        } in cases
-        {
-            let mut sym_gen = SymbolGen::new();
-            let result = Range
-                .infer_shapes([start, limit, delta].into(), &mut sym_gen)
-                .map(|mut outputs| outputs.remove(0));
-            assert_eq!(result, expected);
-        }
     }
 
     #[test]

--- a/rten-shape-inference/src/ops.rs
+++ b/rten-shape-inference/src/ops.rs
@@ -23,6 +23,7 @@ mod matmul;
 mod pad;
 mod quantize;
 mod random;
+mod reduce;
 mod resize;
 mod rnn;
 mod slice;
@@ -44,6 +45,7 @@ pub use matmul::{Gemm, MatMul, MatMulNBits};
 pub use pad::Pad;
 pub use quantize::DynamicQuantizeLinear;
 pub use random::{Dropout, Multinomial};
+pub use reduce::TopK;
 pub use resize::{Resize, Upsample};
 pub use rnn::{Direction, GRU, LSTM};
 pub use slice::Slice;
@@ -195,48 +197,6 @@ impl InferShapes for SkipLayerNormalization {
     }
 }
 
-/// TopK operator.
-///
-/// See <https://onnx.ai/onnx/operators/onnx__TopK.html>.
-pub struct TopK {
-    pub axis: Option<i32>,
-}
-
-impl InferShapes for TopK {
-    fn infer_shapes(
-        &self,
-        inputs: InferShapesContext,
-        sym_gen: &mut SymbolGen,
-    ) -> Result<Vec<SymTensor>, InferShapesError> {
-        let data = inputs.require(0)?;
-        let k = inputs.require(1)?;
-
-        let Some(data_dims) = data.shape() else {
-            return Ok([
-                SymTensor::unknown("unknown input shape"),
-                SymTensor::unknown("unknown input shape"),
-            ]
-            .into());
-        };
-
-        let ndim = data_dims.len();
-        let axis = resolve_axis(ndim, self.axis.unwrap_or(-1))
-            .map_err(|_| InferShapesError::IncorrectRank)?;
-
-        // `k` is a 1D tensor with one element.
-        let k_val = k
-            .as_vector()
-            .and_then(|v| v.first().cloned())
-            .unwrap_or_else(|| sym_gen.gen_positive());
-
-        let mut out_shape: Vec<SymExpr> = data_dims.collect();
-        out_shape[axis] = k_val;
-
-        let shape = SymTensor::from_shape(out_shape);
-        Ok([shape.clone(), shape].into())
-    }
-}
-
 /// Where operator.
 ///
 /// See <https://onnx.ai/onnx/operators/onnx__Where.html>.
@@ -307,8 +267,7 @@ mod tests {
     use crate::sym_tensor::{SymTensor, sym_shape, sym_vec};
 
     use super::{
-        FixedShape, GridSample, Identity, NonMaxSuppression, NonZero, SkipLayerNormalization, TopK,
-        Where,
+        FixedShape, GridSample, Identity, NonMaxSuppression, NonZero, SkipLayerNormalization, Where,
     };
 
     #[test]
@@ -453,34 +412,6 @@ mod tests {
         assert_eq!(shape.len(), 2);
         assert!(matches!(shape[0], SymExpr::Var(_)));
         assert_eq!(shape[1], SymExpr::Value(3));
-    }
-
-    #[test]
-    fn test_top_k() {
-        let mut sym_gen = SymbolGen::new();
-
-        // Default axis (-1) with known K.
-        let data = sym_shape!("batch", 16, 32);
-        let k = sym_vec!(5);
-        let op = TopK { axis: None };
-        let result = op.infer_shapes([data, k].into(), &mut sym_gen).unwrap();
-        assert_eq!(result.len(), 2);
-        assert_eq!(result[0], sym_shape!("batch", 16, 5));
-        assert_eq!(result[1], sym_shape!("batch", 16, 5));
-
-        // Explicit axis.
-        let data = sym_shape!("batch", 16, 32);
-        let k = sym_vec!(5);
-        let op = TopK { axis: Some(0) };
-        let result = op.infer_shapes([data, k].into(), &mut sym_gen).unwrap();
-        assert_eq!(result[0], sym_shape!(5, 16, 32));
-
-        // Symbolic K value.
-        let data = sym_shape!("batch", 32);
-        let k = sym_vec!(SymExpr::from("k"));
-        let op = TopK { axis: Some(-1) };
-        let result = op.infer_shapes([data, k].into(), &mut sym_gen).unwrap();
-        assert_eq!(result[0], sym_shape!("batch", "k"));
     }
 
     #[test]

--- a/rten-shape-inference/src/ops.rs
+++ b/rten-shape-inference/src/ops.rs
@@ -4,11 +4,11 @@
 //! for operator details.
 
 use crate::infer_shapes::{
-    BinaryOp, InferShapes, InferShapesContext, InferShapesError, resolve_axis, resolve_index,
+    BinaryOp, InferShapes, InferShapesContext, InferShapesError, resolve_axis,
 };
 use crate::sym_expr::SymExpr;
 use crate::sym_gen::SymbolGen;
-use crate::sym_tensor::{Constant, SymTensor};
+use crate::sym_tensor::SymTensor;
 
 mod attention;
 mod binary;
@@ -16,6 +16,7 @@ mod concat;
 mod conv_pool;
 mod einsum;
 mod fft;
+mod gather;
 mod generate;
 mod layout;
 mod matmul;
@@ -32,6 +33,7 @@ pub use concat::{Concat, Tile};
 pub use conv_pool::{Conv, ConvTranspose, GlobalPool, Padding, Pool};
 pub use einsum::Einsum;
 pub use fft::{DFT, STFT};
+pub use gather::{Gather, GatherElements, GatherND};
 pub use generate::OneHot;
 pub use layout::{
     DepthToSpace, Expand, Flatten, Reshape, Shape, Size, Squeeze, Transpose, Unsqueeze,
@@ -154,146 +156,6 @@ impl InferShapes for DynamicQuantizeLinear {
         let scale_shape = SymTensor::from_shape(vec![]);
         let zero_point_shape = SymTensor::from_shape(vec![]);
         Ok([shape, scale_shape, zero_point_shape].into())
-    }
-}
-
-/// Gather operator.
-///
-/// See <https://onnx.ai/onnx/operators/onnx__Gather.html>.
-pub struct Gather {
-    pub axis: i32,
-}
-
-impl InferShapes for Gather {
-    fn infer_shapes(
-        &self,
-        inputs: InferShapesContext,
-        _sym_gen: &mut SymbolGen,
-    ) -> Result<Vec<SymTensor>, InferShapesError> {
-        let data = inputs.require(0)?;
-        let indices = inputs.require(1)?;
-
-        let Some(mut data_dims) = data.shape() else {
-            return Ok([SymTensor::unknown("unknown data shape")].into());
-        };
-
-        let data_ndim = data_dims.len();
-        let axis = resolve_axis(data_ndim, self.axis)?;
-
-        fn get<T: Clone>(vec: &[T], index: i32) -> Result<T, InferShapesError> {
-            let index = resolve_index(vec.len(), index).ok_or(InferShapesError::InvalidValue)?;
-            Ok(vec[index].clone())
-        }
-
-        // If the input is a symbolic value and indices are concrete the output
-        // is a symbolic value. For example `Gather<axis=0>(Shape(X), 0)` returns
-        // a symbolic scalar that is the size of the first dimension of X.
-        //
-        // Otherwise we do standard shape inference and return a symbolic shape.
-        let value = if let Some(sym_vec) = data.values()
-            && let Some(indices) = indices.to_constant()
-        {
-            match indices {
-                Constant::Vector(idxs) => {
-                    let values = idxs
-                        .iter()
-                        .map(|idx| get(sym_vec, *idx))
-                        .collect::<Result<Vec<_>, _>>()?;
-                    SymTensor::from_vec(values)
-                }
-                Constant::Scalar(idx) => SymTensor::from_scalar(get(sym_vec, idx)?),
-            }
-        } else if let Some(index_dims) = indices.shape() {
-            let mut out_shape = Vec::with_capacity(data_dims.len() + index_dims.len() - 1);
-            out_shape.extend(data_dims.by_ref().take(axis));
-            out_shape.extend(index_dims);
-            out_shape.extend(data_dims.skip(1));
-            SymTensor::from_shape(out_shape)
-        } else {
-            SymTensor::unknown("unknown indices shape")
-        };
-
-        Ok([value].into())
-    }
-}
-
-/// GatherElements operator.
-///
-/// See <https://onnx.ai/onnx/operators/onnx__GatherElements.html>.
-pub struct GatherElements;
-
-impl InferShapes for GatherElements {
-    fn infer_shapes(
-        &self,
-        inputs: InferShapesContext,
-        _sym_gen: &mut SymbolGen,
-    ) -> Result<Vec<SymTensor>, InferShapesError> {
-        let indices = inputs.require(1)?;
-
-        let shape = if let Some(dims) = indices.shape() {
-            SymTensor::from_shape(dims.collect())
-        } else {
-            SymTensor::unknown("unknown indices shape")
-        };
-
-        Ok([shape].into())
-    }
-}
-
-/// GatherND operator.
-///
-/// See <https://onnx.ai/onnx/operators/onnx__GatherND.html>.
-pub struct GatherND {
-    pub batch_dims: usize,
-}
-
-impl InferShapes for GatherND {
-    fn infer_shapes(
-        &self,
-        inputs: InferShapesContext,
-        _sym_gen: &mut SymbolGen,
-    ) -> Result<Vec<SymTensor>, InferShapesError> {
-        let data = inputs.require(0)?;
-        let indices = inputs.require(1)?;
-
-        let Some(data_dims) = data.shape() else {
-            return Ok([SymTensor::unknown("unknown data shape")].into());
-        };
-        let Some(indices_dims) = indices.shape() else {
-            return Ok([SymTensor::unknown("unknown indices shape")].into());
-        };
-
-        let indices_shape: Vec<SymExpr> = indices_dims.collect();
-
-        // The last dim of indices is the size of the index tuple. We need this
-        // to be a concrete value to determine which input dimensions are
-        // gathered vs. preserved.
-        let idx_tuple_size = match indices_shape.last() {
-            Some(&SymExpr::Value(v)) => {
-                usize::try_from(v).map_err(|_| InferShapesError::InvalidValue)?
-            }
-            Some(_) => {
-                return Ok([SymTensor::unknown("unknown index tuple size")].into());
-            }
-            None => {
-                return Err(InferShapesError::IncorrectRank);
-            }
-        };
-
-        let suffix_start = self.batch_dims + idx_tuple_size;
-        if suffix_start > data_dims.len() {
-            return Err(InferShapesError::IncorrectRank);
-        }
-        let idx_len = indices_shape.len() - 1;
-
-        // Output shape = indices.shape[:-1] + data.shape[batch_dims + idx_tuple_size:]
-        let out_shape: Vec<SymExpr> = indices_shape
-            .into_iter()
-            .take(idx_len)
-            .chain(data_dims.skip(suffix_start))
-            .collect();
-
-        Ok([SymTensor::from_shape(out_shape)].into())
     }
 }
 
@@ -660,9 +522,8 @@ mod tests {
     use crate::sym_tensor::{SymTensor, sym_shape, sym_vec};
 
     use super::{
-        ConstantOfShape, Dropout, DynamicQuantizeLinear, FixedShape, Gather, GatherElements,
-        GatherND, GridSample, Identity, Multinomial, NonMaxSuppression, NonZero, Range,
-        SkipLayerNormalization, TopK, Where,
+        ConstantOfShape, Dropout, DynamicQuantizeLinear, FixedShape, GridSample, Identity,
+        Multinomial, NonMaxSuppression, NonZero, Range, SkipLayerNormalization, TopK, Where,
     };
 
     #[test]
@@ -820,132 +681,6 @@ mod tests {
             .infer_shapes([data].into(), &mut sym_gen)
             .unwrap();
         assert_eq!(result, &[sym_shape!(32, 32), sym_shape!(), sym_shape!(),]);
-    }
-
-    #[test]
-    fn test_gather() {
-        let infer = |data, indices, axis| {
-            let mut sym_gen = SymbolGen::new();
-            let op = Gather { axis };
-            op.infer_shapes([data, indices].into(), &mut sym_gen)
-        };
-
-        // Gather scalar from symbolic vec.
-        let shape = sym_vec!("batch", 16, "seq");
-        let indices = SymTensor::from_scalar(2.into());
-        let result = infer(shape, indices, 0).unwrap();
-        assert_eq!(result[0], SymTensor::from_scalar("seq".into()));
-
-        // Gather vector from symbolic vec.
-        let shape = sym_vec!("batch", 16, "seq");
-        let indices = sym_vec!(0, 2, -2);
-        let result = infer(shape, indices, 0).unwrap();
-        assert_eq!(result[0], sym_vec!("batch", "seq", 16));
-
-        // Gather with 2D data and symbolic vec indices
-        let data = sym_shape!("vocab", "embed");
-        let indices = sym_vec!(1, 2, 3);
-        let result = infer(data, indices, 0).unwrap();
-        assert_eq!(result[0], sym_shape!(3, "embed"));
-
-        // Gather with 2D data and symbolic shape indices
-        let data = sym_shape!("vocab", "embed");
-        let indices = sym_shape!("n_tokens");
-        let result = infer(data, indices, 0).unwrap();
-        assert_eq!(result[0], sym_shape!("n_tokens", "embed"));
-
-        // Gather with invalid index from symbolic vec.
-        let shape = sym_vec!("batch", 16, "seq");
-        let indices = SymTensor::from_scalar(3.into());
-        let result = infer(shape, indices, 0).err().unwrap();
-        assert_eq!(result, InferShapesError::InvalidValue);
-    }
-
-    #[test]
-    fn test_gather_elements() {
-        let mut sym_gen = SymbolGen::new();
-
-        // Output shape = indices shape.
-        let data = sym_shape!(4, 3, 2);
-        let indices = sym_shape!(2, 3, 2);
-        let result = GatherElements
-            .infer_shapes([data, indices].into(), &mut sym_gen)
-            .unwrap();
-        assert_eq!(result[0], sym_shape!(2, 3, 2));
-
-        // Unknown indices shape.
-        let data = sym_shape!(4, 3, 2);
-        let indices = SymTensor::unknown("unknown");
-        let result = GatherElements
-            .infer_shapes([data, indices].into(), &mut sym_gen)
-            .unwrap();
-        assert_eq!(result[0].ndim(), None);
-    }
-
-    #[test]
-    fn test_gather_nd() {
-        let mut sym_gen = SymbolGen::new();
-
-        // No batch dims, index tuple selects entire dimensions.
-        let data = sym_shape!(4, 3, 2);
-        let indices = sym_shape!(2, 1);
-        let op = GatherND { batch_dims: 0 };
-        let result = op
-            .infer_shapes([data, indices].into(), &mut sym_gen)
-            .unwrap();
-        assert_eq!(result[0], sym_shape!(2, 3, 2));
-
-        // Index tuple covers all input dims.
-        let data = sym_shape!(4, 3, 2);
-        let indices = sym_shape!(2, 3);
-        let op = GatherND { batch_dims: 0 };
-        let result = op
-            .infer_shapes([data, indices].into(), &mut sym_gen)
-            .unwrap();
-        assert_eq!(result[0], sym_shape!(2));
-
-        // With batch_dims.
-        let data = sym_shape!(2, 3, 4);
-        let indices = sym_shape!(2, 1);
-        let op = GatherND { batch_dims: 1 };
-        let result = op
-            .infer_shapes([data, indices].into(), &mut sym_gen)
-            .unwrap();
-        assert_eq!(result[0], sym_shape!(2, 4));
-
-        // Symbolic dims preserved.
-        let data = sym_shape!("batch", "seq", 64);
-        let indices = sym_shape!("batch", "k", 1);
-        let op = GatherND { batch_dims: 1 };
-        let result = op
-            .infer_shapes([data, indices].into(), &mut sym_gen)
-            .unwrap();
-        assert_eq!(result[0], sym_shape!("batch", "k", 64));
-
-        // Unknown data shape.
-        let data = SymTensor::unknown("unknown");
-        let indices = sym_shape!(2, 1);
-        let op = GatherND { batch_dims: 0 };
-        let result = op
-            .infer_shapes([data, indices].into(), &mut sym_gen)
-            .unwrap();
-        assert_eq!(result[0].ndim(), None);
-
-        // Symbolic index tuple size — output rank can't be determined.
-        let data = sym_shape!(4, 3, 2);
-        let indices = sym_shape!(2, "k");
-        let op = GatherND { batch_dims: 0 };
-        let result = op
-            .infer_shapes([data, indices].into(), &mut sym_gen)
-            .unwrap();
-        assert_eq!(result[0].ndim(), None);
-
-        // Negative index tuple size — invalid value.
-        let data = sym_shape!(4, 3, 2);
-        let indices = sym_shape!(2, -1);
-        let op = GatherND { batch_dims: 0 };
-        let result = op.infer_shapes([data, indices].into(), &mut sym_gen);
-        assert_eq!(result, Err(InferShapesError::InvalidValue));
     }
 
     #[test]

--- a/rten-shape-inference/src/ops/binary.rs
+++ b/rten-shape-inference/src/ops/binary.rs
@@ -174,6 +174,68 @@ impl InferShapes for Mul {
     }
 }
 
+/// Where operator.
+///
+/// See <https://onnx.ai/onnx/operators/onnx__Where.html>.
+pub struct Where;
+
+impl InferShapes for Where {
+    fn infer_shapes(
+        &self,
+        inputs: InferShapesContext,
+        sym_gen: &mut SymbolGen,
+    ) -> Result<Vec<SymTensor>, InferShapesError> {
+        let cond = inputs.require(0)?;
+        let x = inputs.require(1)?;
+        let y = inputs.require(2)?;
+
+        if let Some(cond_vals) = cond.values()
+            && let Some(x_vals) = x.values()
+            && let Some(y_vals) = y.values()
+        {
+            let len = cond_vals.len().max(x_vals.len()).max(y_vals.len());
+
+            let cs = cond_vals.iter().cycle().take(len);
+            let xs = x_vals.iter().cycle().take(len);
+            let ys = y_vals.iter().cycle().take(len);
+
+            let vals: Option<Vec<SymExpr>> = cs
+                .zip(xs.zip(ys))
+                .map(|(cond, (x, y))| {
+                    let cond_bool = match cond {
+                        SymExpr::Value(v) => Some(*v == 1),
+                        SymExpr::Var(_)
+                        | SymExpr::Neg(_)
+                        | SymExpr::Add(..)
+                        | SymExpr::Sub(..)
+                        | SymExpr::Mul(..)
+                        | SymExpr::Div(..)
+                        | SymExpr::DivCeil(..)
+                        | SymExpr::Max(..)
+                        | SymExpr::Min(..)
+                        | SymExpr::Broadcast(..) => None,
+                    }?;
+                    if cond_bool {
+                        Some(x.clone())
+                    } else {
+                        Some(y.clone())
+                    }
+                })
+                .collect();
+            if let Some(vals) = vals {
+                return Ok([SymTensor::from_vec(vals)].into());
+            }
+        }
+
+        // Broadcast the first two inputs together, then broadcast the result
+        // against the last input.
+        let cond_x = BinaryOp
+            .infer_shapes([cond.clone(), x.clone()].into(), sym_gen)?
+            .remove(0);
+        BinaryOp.infer_shapes([cond_x, y.clone()].into(), sym_gen)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::infer_shapes::InferShapes;
@@ -181,7 +243,7 @@ mod tests {
     use crate::sym_gen::SymbolGen;
     use crate::sym_tensor::{SymTensor, sym_shape, sym_vec};
 
-    use super::{Add, Div, Equal, Mul, Sub};
+    use super::{Add, Div, Equal, Mul, Sub, Where};
 
     #[test]
     fn test_add() {
@@ -312,5 +374,30 @@ mod tests {
         let b = sym_shape!(1, "foo");
         let result = Mul.infer_shapes([a, b].into(), &mut sym_gen).unwrap();
         assert_eq!(result[0], sym_shape!(5, "foo"));
+    }
+
+    #[test]
+    fn test_where() {
+        let mut sym_gen = SymbolGen::new();
+
+        // Where op with symbolic vectors.
+        let cond = sym_vec!(0, 1, 0, 1);
+        let x = sym_vec!(1, 2, 3, 4);
+        let y = sym_vec!("foo", "bar", "baz", "meep");
+        let result = Where
+            .infer_shapes([cond, x, y].into(), &mut sym_gen)
+            .unwrap();
+        assert_eq!(result[0], sym_vec!("foo", 2, "baz", 4));
+
+        // Where op with shapes.
+        //
+        // This broadcasts the three inputs together.
+        let cond = sym_shape!(1, 16, 1);
+        let x = sym_shape!(8, 16, 1);
+        let y = sym_shape!(1, 16, 24);
+        let result = Where
+            .infer_shapes([cond, x, y].into(), &mut sym_gen)
+            .unwrap();
+        assert_eq!(result[0], sym_shape!(8, 16, 24));
     }
 }

--- a/rten-shape-inference/src/ops/gather.rs
+++ b/rten-shape-inference/src/ops/gather.rs
@@ -1,0 +1,282 @@
+use crate::infer_shapes::{
+    InferShapes, InferShapesContext, InferShapesError, resolve_axis, resolve_index,
+};
+use crate::sym_expr::SymExpr;
+use crate::sym_gen::SymbolGen;
+use crate::sym_tensor::{Constant, SymTensor};
+
+/// Gather operator.
+///
+/// See <https://onnx.ai/onnx/operators/onnx__Gather.html>.
+pub struct Gather {
+    pub axis: i32,
+}
+
+impl InferShapes for Gather {
+    fn infer_shapes(
+        &self,
+        inputs: InferShapesContext,
+        _sym_gen: &mut SymbolGen,
+    ) -> Result<Vec<SymTensor>, InferShapesError> {
+        let data = inputs.require(0)?;
+        let indices = inputs.require(1)?;
+
+        let Some(mut data_dims) = data.shape() else {
+            return Ok([SymTensor::unknown("unknown data shape")].into());
+        };
+
+        let data_ndim = data_dims.len();
+        let axis = resolve_axis(data_ndim, self.axis)?;
+
+        fn get<T: Clone>(vec: &[T], index: i32) -> Result<T, InferShapesError> {
+            let index = resolve_index(vec.len(), index).ok_or(InferShapesError::InvalidValue)?;
+            Ok(vec[index].clone())
+        }
+
+        // If the input is a symbolic value and indices are concrete the output
+        // is a symbolic value. For example `Gather<axis=0>(Shape(X), 0)` returns
+        // a symbolic scalar that is the size of the first dimension of X.
+        //
+        // Otherwise we do standard shape inference and return a symbolic shape.
+        let value = if let Some(sym_vec) = data.values()
+            && let Some(indices) = indices.to_constant()
+        {
+            match indices {
+                Constant::Vector(idxs) => {
+                    let values = idxs
+                        .iter()
+                        .map(|idx| get(sym_vec, *idx))
+                        .collect::<Result<Vec<_>, _>>()?;
+                    SymTensor::from_vec(values)
+                }
+                Constant::Scalar(idx) => SymTensor::from_scalar(get(sym_vec, idx)?),
+            }
+        } else if let Some(index_dims) = indices.shape() {
+            let mut out_shape = Vec::with_capacity(data_dims.len() + index_dims.len() - 1);
+            out_shape.extend(data_dims.by_ref().take(axis));
+            out_shape.extend(index_dims);
+            out_shape.extend(data_dims.skip(1));
+            SymTensor::from_shape(out_shape)
+        } else {
+            SymTensor::unknown("unknown indices shape")
+        };
+
+        Ok([value].into())
+    }
+}
+
+/// GatherElements operator.
+///
+/// See <https://onnx.ai/onnx/operators/onnx__GatherElements.html>.
+pub struct GatherElements;
+
+impl InferShapes for GatherElements {
+    fn infer_shapes(
+        &self,
+        inputs: InferShapesContext,
+        _sym_gen: &mut SymbolGen,
+    ) -> Result<Vec<SymTensor>, InferShapesError> {
+        let indices = inputs.require(1)?;
+
+        let shape = if let Some(dims) = indices.shape() {
+            SymTensor::from_shape(dims.collect())
+        } else {
+            SymTensor::unknown("unknown indices shape")
+        };
+
+        Ok([shape].into())
+    }
+}
+
+/// GatherND operator.
+///
+/// See <https://onnx.ai/onnx/operators/onnx__GatherND.html>.
+pub struct GatherND {
+    pub batch_dims: usize,
+}
+
+impl InferShapes for GatherND {
+    fn infer_shapes(
+        &self,
+        inputs: InferShapesContext,
+        _sym_gen: &mut SymbolGen,
+    ) -> Result<Vec<SymTensor>, InferShapesError> {
+        let data = inputs.require(0)?;
+        let indices = inputs.require(1)?;
+
+        let Some(data_dims) = data.shape() else {
+            return Ok([SymTensor::unknown("unknown data shape")].into());
+        };
+        let Some(indices_dims) = indices.shape() else {
+            return Ok([SymTensor::unknown("unknown indices shape")].into());
+        };
+
+        let indices_shape: Vec<SymExpr> = indices_dims.collect();
+
+        // The last dim of indices is the size of the index tuple. We need this
+        // to be a concrete value to determine which input dimensions are
+        // gathered vs. preserved.
+        let idx_tuple_size = match indices_shape.last() {
+            Some(&SymExpr::Value(v)) => {
+                usize::try_from(v).map_err(|_| InferShapesError::InvalidValue)?
+            }
+            Some(_) => {
+                return Ok([SymTensor::unknown("unknown index tuple size")].into());
+            }
+            None => {
+                return Err(InferShapesError::IncorrectRank);
+            }
+        };
+
+        let suffix_start = self.batch_dims + idx_tuple_size;
+        if suffix_start > data_dims.len() {
+            return Err(InferShapesError::IncorrectRank);
+        }
+        let idx_len = indices_shape.len() - 1;
+
+        // Output shape = indices.shape[:-1] + data.shape[batch_dims + idx_tuple_size:]
+        let out_shape: Vec<SymExpr> = indices_shape
+            .into_iter()
+            .take(idx_len)
+            .chain(data_dims.skip(suffix_start))
+            .collect();
+
+        Ok([SymTensor::from_shape(out_shape)].into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::infer_shapes::{InferShapes, InferShapesError};
+    use crate::sym_expr::SymExpr;
+    use crate::sym_gen::SymbolGen;
+    use crate::sym_tensor::{SymTensor, sym_shape, sym_vec};
+
+    use super::{Gather, GatherElements, GatherND};
+
+    #[test]
+    fn test_gather() {
+        let infer = |data, indices, axis| {
+            let mut sym_gen = SymbolGen::new();
+            let op = Gather { axis };
+            op.infer_shapes([data, indices].into(), &mut sym_gen)
+        };
+
+        // Gather scalar from symbolic vec.
+        let shape = sym_vec!("batch", 16, "seq");
+        let indices = SymTensor::from_scalar(2.into());
+        let result = infer(shape, indices, 0).unwrap();
+        assert_eq!(result[0], SymTensor::from_scalar("seq".into()));
+
+        // Gather vector from symbolic vec.
+        let shape = sym_vec!("batch", 16, "seq");
+        let indices = sym_vec!(0, 2, -2);
+        let result = infer(shape, indices, 0).unwrap();
+        assert_eq!(result[0], sym_vec!("batch", "seq", 16));
+
+        // Gather with 2D data and symbolic vec indices
+        let data = sym_shape!("vocab", "embed");
+        let indices = sym_vec!(1, 2, 3);
+        let result = infer(data, indices, 0).unwrap();
+        assert_eq!(result[0], sym_shape!(3, "embed"));
+
+        // Gather with 2D data and symbolic shape indices
+        let data = sym_shape!("vocab", "embed");
+        let indices = sym_shape!("n_tokens");
+        let result = infer(data, indices, 0).unwrap();
+        assert_eq!(result[0], sym_shape!("n_tokens", "embed"));
+
+        // Gather with invalid index from symbolic vec.
+        let shape = sym_vec!("batch", 16, "seq");
+        let indices = SymTensor::from_scalar(3.into());
+        let result = infer(shape, indices, 0).err().unwrap();
+        assert_eq!(result, InferShapesError::InvalidValue);
+    }
+
+    #[test]
+    fn test_gather_elements() {
+        let mut sym_gen = SymbolGen::new();
+
+        // Output shape = indices shape.
+        let data = sym_shape!(4, 3, 2);
+        let indices = sym_shape!(2, 3, 2);
+        let result = GatherElements
+            .infer_shapes([data, indices].into(), &mut sym_gen)
+            .unwrap();
+        assert_eq!(result[0], sym_shape!(2, 3, 2));
+
+        // Unknown indices shape.
+        let data = sym_shape!(4, 3, 2);
+        let indices = SymTensor::unknown("unknown");
+        let result = GatherElements
+            .infer_shapes([data, indices].into(), &mut sym_gen)
+            .unwrap();
+        assert_eq!(result[0].ndim(), None);
+    }
+
+    #[test]
+    fn test_gather_nd() {
+        let mut sym_gen = SymbolGen::new();
+
+        // No batch dims, index tuple selects entire dimensions.
+        let data = sym_shape!(4, 3, 2);
+        let indices = sym_shape!(2, 1);
+        let op = GatherND { batch_dims: 0 };
+        let result = op
+            .infer_shapes([data, indices].into(), &mut sym_gen)
+            .unwrap();
+        assert_eq!(result[0], sym_shape!(2, 3, 2));
+
+        // Index tuple covers all input dims.
+        let data = sym_shape!(4, 3, 2);
+        let indices = sym_shape!(2, 3);
+        let op = GatherND { batch_dims: 0 };
+        let result = op
+            .infer_shapes([data, indices].into(), &mut sym_gen)
+            .unwrap();
+        assert_eq!(result[0], sym_shape!(2));
+
+        // With batch_dims.
+        let data = sym_shape!(2, 3, 4);
+        let indices = sym_shape!(2, 1);
+        let op = GatherND { batch_dims: 1 };
+        let result = op
+            .infer_shapes([data, indices].into(), &mut sym_gen)
+            .unwrap();
+        assert_eq!(result[0], sym_shape!(2, 4));
+
+        // Symbolic dims preserved.
+        let data = sym_shape!("batch", "seq", 64);
+        let indices = sym_shape!("batch", "k", 1);
+        let op = GatherND { batch_dims: 1 };
+        let result = op
+            .infer_shapes([data, indices].into(), &mut sym_gen)
+            .unwrap();
+        assert_eq!(result[0], sym_shape!("batch", "k", 64));
+
+        // Unknown data shape.
+        let data = SymTensor::unknown("unknown");
+        let indices = sym_shape!(2, 1);
+        let op = GatherND { batch_dims: 0 };
+        let result = op
+            .infer_shapes([data, indices].into(), &mut sym_gen)
+            .unwrap();
+        assert_eq!(result[0].ndim(), None);
+
+        // Symbolic index tuple size — output rank can't be determined.
+        let data = sym_shape!(4, 3, 2);
+        let indices = sym_shape!(2, "k");
+        let op = GatherND { batch_dims: 0 };
+        let result = op
+            .infer_shapes([data, indices].into(), &mut sym_gen)
+            .unwrap();
+        assert_eq!(result[0].ndim(), None);
+
+        // Negative index tuple size — invalid value.
+        let data = sym_shape!(4, 3, 2);
+        let indices = sym_shape!(2, -1);
+        let op = GatherND { batch_dims: 0 };
+        let result = op.infer_shapes([data, indices].into(), &mut sym_gen);
+        assert_eq!(result, Err(InferShapesError::InvalidValue));
+    }
+}

--- a/rten-shape-inference/src/ops/generate.rs
+++ b/rten-shape-inference/src/ops/generate.rs
@@ -3,6 +3,69 @@ use crate::sym_expr::SymExpr;
 use crate::sym_gen::SymbolGen;
 use crate::sym_tensor::SymTensor;
 
+/// ConstantOfShape operator.
+///
+/// See <https://onnx.ai/onnx/operators/onnx__ConstantOfShape.html>.
+pub struct ConstantOfShape {
+    /// The integer value. This should be set to `None` if the operator has
+    /// a value attribute of a different type.
+    pub value: Option<i32>,
+}
+
+impl InferShapes for ConstantOfShape {
+    fn infer_shapes(
+        &self,
+        inputs: InferShapesContext,
+        sym_gen: &mut SymbolGen,
+    ) -> Result<Vec<SymTensor>, InferShapesError> {
+        let shape = inputs.require(0)?;
+
+        let out_shape = if let Some(values) = shape.values() {
+            if let Some(val) = self.value
+                && values.len() <= 1
+            {
+                if let Some(vec_len) = values.first() {
+                    match vec_len {
+                        &SymExpr::Value(vec_len) => {
+                            if let Ok(vec_len) = vec_len.try_into() {
+                                SymTensor::from_vec(vec![SymExpr::Value(val); vec_len])
+                            } else {
+                                return Err(InferShapesError::InvalidValue);
+                            }
+                        }
+                        SymExpr::Var(_)
+                        | SymExpr::Neg(_)
+                        | SymExpr::Add(..)
+                        | SymExpr::Sub(..)
+                        | SymExpr::Mul(..)
+                        | SymExpr::Div(..)
+                        | SymExpr::DivCeil(..)
+                        | SymExpr::Max(..)
+                        | SymExpr::Min(..)
+                        | SymExpr::Broadcast(..) => SymTensor::from_shape(vec![vec_len.clone()]),
+                    }
+                } else {
+                    SymTensor::from_scalar(SymExpr::Value(val))
+                }
+            } else {
+                SymTensor::from_shape(values.to_vec())
+            }
+        } else if let Some(mut dims) = shape.shape()
+            && dims.len() == 1
+            && let Some(SymExpr::Value(out_ndim)) = dims.next()
+            && let Ok(out_ndim) = usize::try_from(out_ndim)
+        {
+            // The rank is known, but not the shape.
+            let out_shape = (0..out_ndim).map(|_| sym_gen.gen_positive()).collect();
+            SymTensor::from_shape(out_shape)
+        } else {
+            SymTensor::unknown("unknown shape")
+        };
+
+        Ok(vec![out_shape])
+    }
+}
+
 /// OneHot operator.
 ///
 /// See <https://onnx.ai/onnx/operators/onnx__OneHot.html>.
@@ -44,14 +107,139 @@ impl InferShapes for OneHot {
     }
 }
 
+/// Range operator.
+///
+/// See <https://onnx.ai/onnx/operators/onnx__Range.html>.
+pub struct Range;
+
+/// Maximum number of elements of a `Range` output for which the individual
+/// values are computed, rather than just the length.
+const MAX_RANGE_VALUES: i64 = 1024;
+
+impl InferShapes for Range {
+    fn infer_shapes(
+        &self,
+        inputs: InferShapesContext,
+        sym_gen: &mut SymbolGen,
+    ) -> Result<Vec<SymTensor>, InferShapesError> {
+        let start = inputs.require(0)?;
+        let limit = inputs.require(1)?;
+        let delta = inputs.require(2)?;
+
+        let start = start.values().map(|v| v[0].clone());
+        let limit = limit.values().map(|v| v[0].clone());
+        let delta = delta.values().map(|v| v[0].clone());
+
+        let out_value = match (start, limit, delta) {
+            (
+                Some(SymExpr::Value(start)),
+                Some(SymExpr::Value(limit)),
+                Some(SymExpr::Value(delta)),
+            ) => {
+                if delta == 0 {
+                    return Err(InferShapesError::InvalidValue);
+                }
+
+                // Compute the element count as `max(ceil((limit - start) / delta), 0)`,
+                // as specified by the ONNX spec. `i64` arithmetic avoids overflow
+                // when negating `delta` or subtracting `i32` values.
+                let (start, limit, delta) = (start as i64, limit as i64, delta as i64);
+                let (span, step) = if delta > 0 {
+                    (limit - start, delta)
+                } else {
+                    (start - limit, -delta)
+                };
+                let len = ((span + step - 1) / step).max(0);
+
+                if len <= MAX_RANGE_VALUES {
+                    // Values are between `start` and `limit`, so they fit in `i32`.
+                    let values = (0..len)
+                        .map(|i| SymExpr::Value((start + i * delta) as i32))
+                        .collect();
+                    SymTensor::from_vec(values)
+                } else if let Ok(len) = i32::try_from(len) {
+                    SymTensor::from_shape(vec![SymExpr::Value(len)])
+                } else {
+                    SymTensor::from_shape(vec![sym_gen.gen_positive()])
+                }
+            }
+            // Range(0, limit, 1) has shape [limit]
+            (Some(SymExpr::Value(0)), Some(limit), Some(SymExpr::Value(1))) => {
+                SymTensor::from_shape(vec![limit])
+            }
+            // Range(start, start + limit, 1) has shape [limit]
+            (Some(start), Some(SymExpr::Add(limit_lhs, limit_rhs)), Some(SymExpr::Value(1)))
+                if start == *limit_lhs =>
+            {
+                SymTensor::from_shape(vec![(*limit_rhs).clone()])
+            }
+            // Range(start, limit, 1) has shape [limit - start]
+            (Some(start), Some(limit), Some(SymExpr::Value(1))) => {
+                SymTensor::from_shape(vec![limit - start])
+            }
+            _ => SymTensor::from_shape(vec![sym_gen.gen_positive()]),
+        };
+
+        Ok(vec![out_value])
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::infer_shapes::InferShapes;
+    use crate::infer_shapes::{InferShapes, InferShapesError};
     use crate::sym_expr::SymExpr;
     use crate::sym_gen::SymbolGen;
     use crate::sym_tensor::{SymTensor, sym_shape, sym_vec};
 
-    use super::OneHot;
+    use super::{ConstantOfShape, OneHot, Range};
+
+    #[test]
+    fn test_constant_of_shape() {
+        let mut sym_gen = SymbolGen::new();
+
+        // Scalar shape, int value.
+        let shape = sym_vec!();
+        let op = ConstantOfShape { value: Some(1) };
+        let result = op.infer_shapes([shape].into(), &mut sym_gen).unwrap();
+        assert_eq!(result[0], SymTensor::from_scalar(1.into()));
+
+        // Vector shape, int value.
+        let shape = sym_vec!(3);
+        let op = ConstantOfShape { value: Some(1) };
+        let result = op.infer_shapes([shape].into(), &mut sym_gen).unwrap();
+        assert_eq!(result[0], sym_vec!(1, 1, 1));
+
+        // Vector shape, non-int value.
+        let shape = sym_vec!(3);
+        let op = ConstantOfShape { value: None };
+        let result = op.infer_shapes([shape].into(), &mut sym_gen).unwrap();
+        assert_eq!(result[0], sym_shape!(3));
+
+        // 2D+ shape
+        let shape = sym_vec!(2, 2);
+        let op = ConstantOfShape { value: Some(1) };
+        let result = op.infer_shapes([shape].into(), &mut sym_gen).unwrap();
+        assert_eq!(result[0], sym_shape!(2, 2));
+
+        // Shape with unknown values but a known length.
+        let mut sym_gen = SymbolGen::new();
+        let shape = sym_shape!(3);
+        let op = ConstantOfShape { value: Some(1) };
+        let result = op.infer_shapes([shape].into(), &mut sym_gen).unwrap();
+        assert_eq!(result[0], sym_shape!("unknown_1", "unknown_2", "unknown_3"));
+
+        // Shape with unknown values and a symbolic length.
+        let shape = sym_shape!("n");
+        let op = ConstantOfShape { value: Some(1) };
+        let result = op.infer_shapes([shape].into(), &mut sym_gen).unwrap();
+        assert_eq!(result[0].ndim(), None);
+
+        // Unknown shape input.
+        let shape = SymTensor::unknown("unknown");
+        let op = ConstantOfShape { value: Some(1) };
+        let result = op.infer_shapes([shape].into(), &mut sym_gen).unwrap();
+        assert_eq!(result[0].ndim(), None);
+    }
 
     #[test]
     fn test_one_hot() {
@@ -106,5 +294,129 @@ mod tests {
             .infer_shapes([indices, depth, values].into(), &mut sym_gen)
             .unwrap();
         assert_eq!(result[0].ndim(), None);
+    }
+
+    #[test]
+    fn test_range() {
+        struct Case {
+            start: SymTensor,
+            limit: SymTensor,
+            delta: SymTensor,
+            expected: Result<SymTensor, InferShapesError>,
+        }
+
+        let cases = [
+            // Range with fixed values
+            Case {
+                start: sym_vec!(0),
+                limit: sym_vec!(5),
+                delta: sym_vec!(1),
+                expected: Ok(sym_vec!(0, 1, 2, 3, 4)),
+            },
+            // Fixed values with a delta that doesn't evenly divide the range
+            Case {
+                start: sym_vec!(0),
+                limit: sym_vec!(5),
+                delta: sym_vec!(2),
+                expected: Ok(sym_vec!(0, 2, 4)),
+            },
+            // Fixed values with a negative delta
+            Case {
+                start: sym_vec!(15),
+                limit: sym_vec!(-1),
+                delta: sym_vec!(-1),
+                expected: Ok(SymTensor::from_vec(
+                    (0..=15).rev().map(SymExpr::Value).collect(),
+                )),
+            },
+            Case {
+                start: sym_vec!(10),
+                limit: sym_vec!(0),
+                delta: sym_vec!(-3),
+                expected: Ok(sym_vec!(10, 7, 4, 1)),
+            },
+            // Empty ranges
+            Case {
+                start: sym_vec!(5),
+                limit: sym_vec!(5),
+                delta: sym_vec!(1),
+                expected: Ok(sym_vec!()),
+            },
+            Case {
+                start: sym_vec!(0),
+                limit: sym_vec!(5),
+                delta: sym_vec!(-1),
+                expected: Ok(sym_vec!()),
+            },
+            // A zero delta is invalid, as it would produce an infinite range.
+            Case {
+                start: sym_vec!(0),
+                limit: sym_vec!(5),
+                delta: sym_vec!(0),
+                expected: Err(InferShapesError::InvalidValue),
+            },
+            // Ranges longer than `MAX_RANGE_VALUES` have only their length inferred.
+            Case {
+                start: sym_vec!(0),
+                limit: sym_vec!(5000),
+                delta: sym_vec!(1),
+                expected: Ok(sym_shape!(5000)),
+            },
+            Case {
+                start: sym_vec!(5000),
+                limit: sym_vec!(0),
+                delta: sym_vec!(-1),
+                expected: Ok(sym_shape!(5000)),
+            },
+            // A range whose length exceeds `i32::MAX`.
+            Case {
+                start: sym_vec!(i32::MIN),
+                limit: sym_vec!(i32::MAX),
+                delta: sym_vec!(1),
+                expected: Ok(sym_shape!("unknown_1")),
+            },
+            // Range from 0..limit
+            Case {
+                start: sym_vec!(0),
+                limit: sym_vec!("limit"),
+                delta: sym_vec!(1),
+                expected: Ok(sym_shape!("limit")),
+            },
+            // Range from start..(start + limit)
+            Case {
+                start: sym_vec!("start"),
+                limit: sym_vec!(SymExpr::from("start") + SymExpr::from("limit")),
+                delta: sym_vec!(1),
+                expected: Ok(sym_shape!("limit")),
+            },
+            // Range from start..limit
+            Case {
+                start: sym_vec!("start"),
+                limit: sym_vec!("limit"),
+                delta: sym_vec!(1),
+                expected: Ok(sym_shape!(SymExpr::from("limit") - SymExpr::from("start"))),
+            },
+            // Range of unknown size
+            Case {
+                start: sym_vec!("start"),
+                limit: sym_vec!("end"),
+                delta: sym_vec!("delta"),
+                expected: Ok(sym_shape!("unknown_1")),
+            },
+        ];
+
+        for Case {
+            start,
+            limit,
+            delta,
+            expected,
+        } in cases
+        {
+            let mut sym_gen = SymbolGen::new();
+            let result = Range
+                .infer_shapes([start, limit, delta].into(), &mut sym_gen)
+                .map(|mut outputs| outputs.remove(0));
+            assert_eq!(result, expected);
+        }
     }
 }

--- a/rten-shape-inference/src/ops/grid_sample.rs
+++ b/rten-shape-inference/src/ops/grid_sample.rs
@@ -1,0 +1,91 @@
+use crate::infer_shapes::{InferShapes, InferShapesContext, InferShapesError};
+use crate::sym_gen::SymbolGen;
+use crate::sym_tensor::SymTensor;
+
+/// GridSample operator.
+///
+/// See <https://onnx.ai/onnx/operators/onnx__GridSample.html>.
+pub struct GridSample;
+
+impl InferShapes for GridSample {
+    fn infer_shapes(
+        &self,
+        inputs: InferShapesContext,
+        _sym_gen: &mut SymbolGen,
+    ) -> Result<Vec<SymTensor>, InferShapesError> {
+        let data = inputs.require(0)?;
+        let grid = inputs.require(1)?;
+
+        let Some(data_dims) = data.shape() else {
+            return Ok([SymTensor::unknown("unknown input shape")].into());
+        };
+        let Some(grid_dims) = grid.shape() else {
+            return Ok([SymTensor::unknown("unknown grid shape")].into());
+        };
+
+        // data is (N, C, D1, D2) and grid is (N, D1_out, D2_out, ..., r) where
+        // D1..Dn are the spatial dims.
+        let data_shape: Vec<_> = data_dims.collect();
+        let grid_shape: Vec<_> = grid_dims.collect();
+        if data_shape.len() < 3 || data_shape.len() != grid_shape.len() {
+            return Err(InferShapesError::IncorrectRank);
+        }
+
+        // Output is (N, C, D1_out, D2_out, ...).
+        let spatial_dims = data_shape.len() - 2;
+        let out_shape = data_shape
+            .into_iter()
+            .take(2) // (N, C)
+            .chain(grid_shape.into_iter().skip(1).take(spatial_dims))
+            .collect();
+
+        Ok([SymTensor::from_shape(out_shape)].into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::infer_shapes::{InferShapes, InferShapesError};
+    use crate::sym_expr::SymExpr;
+    use crate::sym_gen::SymbolGen;
+    use crate::sym_tensor::{SymTensor, sym_shape};
+
+    use super::GridSample;
+
+    #[test]
+    fn test_grid_sample() {
+        let mut sym_gen = SymbolGen::new();
+
+        // 2D sampling: data is (N, C, H, W), grid is (N, H_out, W_out, 2).
+        let data = sym_shape!("batch", 3, 224, 224);
+        let grid = sym_shape!("batch", 32, 64, 2);
+        let result = GridSample
+            .infer_shapes([data, grid].into(), &mut sym_gen)
+            .unwrap();
+        assert_eq!(result[0], sym_shape!("batch", 3, 32, 64));
+
+        // 1D sampling: data is (N, C, W), grid is (N, W_out, 1).
+        let data = sym_shape!("batch", 3, 224);
+        let grid = sym_shape!("batch", 32, 1);
+        let result = GridSample
+            .infer_shapes([data, grid].into(), &mut sym_gen)
+            .unwrap();
+        assert_eq!(result[0], sym_shape!("batch", 3, 32));
+
+        // Unknown input shape.
+        let data = SymTensor::unknown("unknown");
+        let grid = sym_shape!(1, 32, 64, 2);
+        let result = GridSample
+            .infer_shapes([data, grid].into(), &mut sym_gen)
+            .unwrap();
+        assert_eq!(result[0].ndim(), None);
+
+        // Wrong rank.
+        let data = sym_shape!(1, 3, 224);
+        let grid = sym_shape!(1, 32, 64, 2);
+        let err = GridSample
+            .infer_shapes([data, grid].into(), &mut sym_gen)
+            .unwrap_err();
+        assert_eq!(err, InferShapesError::IncorrectRank);
+    }
+}

--- a/rten-shape-inference/src/ops/identity.rs
+++ b/rten-shape-inference/src/ops/identity.rs
@@ -1,0 +1,49 @@
+use crate::infer_shapes::{InferShapes, InferShapesContext, InferShapesError};
+use crate::sym_gen::SymbolGen;
+use crate::sym_tensor::SymTensor;
+
+/// Identity operator.
+///
+/// See <https://onnx.ai/onnx/operators/onnx__Identity.html>.
+///
+/// Unlike [`UnaryOp`](crate::UnaryOp), this copies the input's values (when
+/// known) to the output, not just its shape.
+pub struct Identity;
+
+impl InferShapes for Identity {
+    fn infer_shapes(
+        &self,
+        inputs: InferShapesContext,
+        _sym_gen: &mut SymbolGen,
+    ) -> Result<Vec<SymTensor>, InferShapesError> {
+        let data = inputs.require(0)?;
+        Ok([data.clone()].into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::infer_shapes::{InferShapes, InferShapesContext, InferShapesError};
+    use crate::sym_expr::SymExpr;
+    use crate::sym_gen::SymbolGen;
+    use crate::sym_tensor::{SymTensor, sym_vec};
+
+    use super::Identity;
+
+    #[test]
+    fn test_identity() {
+        let mut sym_gen = SymbolGen::new();
+
+        let input = sym_vec!("batch", 16, "seq", 24);
+        let result = Identity
+            .infer_shapes([input.clone()].into(), &mut sym_gen)
+            .unwrap();
+        assert_eq!(result, &[input]);
+
+        let err = Identity
+            .infer_shapes(InferShapesContext::new(&[]), &mut sym_gen)
+            .err()
+            .unwrap();
+        assert_eq!(err, InferShapesError::IncorrectInputCount);
+    }
+}

--- a/rten-shape-inference/src/ops/non_max_suppression.rs
+++ b/rten-shape-inference/src/ops/non_max_suppression.rs
@@ -1,0 +1,47 @@
+use crate::infer_shapes::{InferShapes, InferShapesContext, InferShapesError};
+use crate::sym_expr::SymExpr;
+use crate::sym_gen::SymbolGen;
+use crate::sym_tensor::SymTensor;
+
+/// NonMaxSuppression operator.
+///
+/// See <https://onnx.ai/onnx/operators/onnx__NonMaxSuppression.html>.
+pub struct NonMaxSuppression;
+
+impl InferShapes for NonMaxSuppression {
+    fn infer_shapes(
+        &self,
+        _inputs: InferShapesContext,
+        sym_gen: &mut SymbolGen,
+    ) -> Result<Vec<SymTensor>, InferShapesError> {
+        // Output is `(num_selected, 3)`. `num_selected` is data-dependent.
+        let out_shape = vec![sym_gen.gen_positive(), SymExpr::Value(3)];
+        Ok([SymTensor::from_shape(out_shape)].into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::infer_shapes::InferShapes;
+    use crate::sym_expr::SymExpr;
+    use crate::sym_gen::SymbolGen;
+    use crate::sym_tensor::{SymTensor, sym_shape};
+
+    use super::NonMaxSuppression;
+
+    #[test]
+    fn test_non_max_suppression() {
+        let mut sym_gen = SymbolGen::new();
+
+        // Output is `(num_selected, 3)` with a symbolic first dim.
+        let boxes = sym_shape!(1, 100, 4);
+        let scores = sym_shape!(1, 80, 100);
+        let result = NonMaxSuppression
+            .infer_shapes([boxes, scores].into(), &mut sym_gen)
+            .unwrap();
+        let shape: Vec<_> = result[0].shape().unwrap().collect();
+        assert_eq!(shape.len(), 2);
+        assert!(matches!(shape[0], SymExpr::Var(_)));
+        assert_eq!(shape[1], SymExpr::Value(3));
+    }
+}

--- a/rten-shape-inference/src/ops/norm.rs
+++ b/rten-shape-inference/src/ops/norm.rs
@@ -1,0 +1,80 @@
+use crate::infer_shapes::{InferShapes, InferShapesContext, InferShapesError};
+use crate::sym_gen::SymbolGen;
+use crate::sym_tensor::SymTensor;
+
+/// SkipLayerNormalization / SkipSimplifiedLayerNormalization operators.
+///
+/// See <https://github.com/microsoft/onnxruntime/blob/main/docs/ContribOperators.md#com.microsoft.SkipLayerNormalization>.
+pub struct SkipLayerNormalization;
+
+impl InferShapes for SkipLayerNormalization {
+    fn infer_shapes(
+        &self,
+        inputs: InferShapesContext,
+        _sym_gen: &mut SymbolGen,
+    ) -> Result<Vec<SymTensor>, InferShapesError> {
+        let data = inputs.require(0)?;
+
+        let shape = if let Some(dims) = data.shape() {
+            SymTensor::from_shape(dims.collect())
+        } else {
+            SymTensor::unknown("unknown input shape")
+        };
+
+        // Outputs are `output`, `mean`, `inv_std_var` and `input_skip_bias_sum`.
+        //
+        // `output` and `input_skip_bias_sum` have the same shape as the input.
+        // `mean` and `inv_std_var` are not computed by the rten implementation
+        // and are returned as empty placeholders.
+        let placeholder = SymTensor::from_fixed_shape(&[0]);
+        Ok([shape.clone(), placeholder.clone(), placeholder, shape].into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::infer_shapes::{InferShapes, InferShapesContext, InferShapesError};
+    use crate::sym_expr::SymExpr;
+    use crate::sym_gen::SymbolGen;
+    use crate::sym_tensor::{SymTensor, sym_shape};
+
+    use super::SkipLayerNormalization;
+
+    #[test]
+    fn test_skip_layer_normalization() {
+        let mut sym_gen = SymbolGen::new();
+
+        // `output` and `input_skip_bias_sum` match the input shape, while
+        // `mean` and `inv_std_var` are empty placeholders.
+        let data = sym_shape!("batch", "seq", 32);
+        let result = SkipLayerNormalization
+            .infer_shapes([data].into(), &mut sym_gen)
+            .unwrap();
+        assert_eq!(
+            result,
+            &[
+                sym_shape!("batch", "seq", 32),
+                sym_shape!(0),
+                sym_shape!(0),
+                sym_shape!("batch", "seq", 32),
+            ]
+        );
+
+        // Unknown input shape.
+        let data = SymTensor::unknown("unknown");
+        let result = SkipLayerNormalization
+            .infer_shapes([data].into(), &mut sym_gen)
+            .unwrap();
+        assert_eq!(result.len(), 4);
+        assert_eq!(result[0].ndim(), None);
+        assert_eq!(result[1], sym_shape!(0));
+        assert_eq!(result[2], sym_shape!(0));
+        assert_eq!(result[3].ndim(), None);
+
+        // Missing input.
+        let err = SkipLayerNormalization
+            .infer_shapes(InferShapesContext::new(&[]), &mut sym_gen)
+            .err();
+        assert_eq!(err, Some(InferShapesError::IncorrectInputCount));
+    }
+}

--- a/rten-shape-inference/src/ops/quantize.rs
+++ b/rten-shape-inference/src/ops/quantize.rs
@@ -1,0 +1,48 @@
+use crate::infer_shapes::{InferShapes, InferShapesContext, InferShapesError};
+use crate::sym_gen::SymbolGen;
+use crate::sym_tensor::SymTensor;
+
+/// DynamicQuantizeLinear operator.
+///
+/// See <https://onnx.ai/onnx/operators/onnx__DynamicQuantizeLinear.html>.
+pub struct DynamicQuantizeLinear;
+
+impl InferShapes for DynamicQuantizeLinear {
+    fn infer_shapes(
+        &self,
+        inputs: InferShapesContext,
+        _sym_gen: &mut SymbolGen,
+    ) -> Result<Vec<SymTensor>, InferShapesError> {
+        let data = inputs.require(0)?;
+
+        let shape = if let Some(shape) = data.shape() {
+            SymTensor::from_shape(shape.collect())
+        } else {
+            SymTensor::unknown("unknown input shape")
+        };
+
+        let scale_shape = SymTensor::from_shape(vec![]);
+        let zero_point_shape = SymTensor::from_shape(vec![]);
+        Ok([shape, scale_shape, zero_point_shape].into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::infer_shapes::InferShapes;
+    use crate::sym_expr::SymExpr;
+    use crate::sym_gen::SymbolGen;
+    use crate::sym_tensor::{SymTensor, sym_shape};
+
+    use super::DynamicQuantizeLinear;
+
+    #[test]
+    fn test_dynamic_quantize_linear() {
+        let mut sym_gen = SymbolGen::new();
+        let data = sym_shape!(32, 32);
+        let result = DynamicQuantizeLinear
+            .infer_shapes([data].into(), &mut sym_gen)
+            .unwrap();
+        assert_eq!(result, &[sym_shape!(32, 32), sym_shape!(), sym_shape!(),]);
+    }
+}

--- a/rten-shape-inference/src/ops/random.rs
+++ b/rten-shape-inference/src/ops/random.rs
@@ -1,0 +1,112 @@
+use crate::infer_shapes::{InferShapes, InferShapesContext, InferShapesError};
+use crate::sym_expr::SymExpr;
+use crate::sym_gen::SymbolGen;
+use crate::sym_tensor::SymTensor;
+
+/// Multinomial operator.
+///
+/// See <https://onnx.ai/onnx/operators/onnx__Multinomial.html>.
+pub struct Multinomial {
+    /// Number of times to sample for each row of the input.
+    pub sample_size: usize,
+}
+
+impl InferShapes for Multinomial {
+    fn infer_shapes(
+        &self,
+        inputs: InferShapesContext,
+        sym_gen: &mut SymbolGen,
+    ) -> Result<Vec<SymTensor>, InferShapesError> {
+        let input = inputs.require(0)?;
+
+        if input.ndim().is_some_and(|ndim| ndim != 2) {
+            return Err(InferShapesError::IncorrectRank);
+        }
+
+        // Input is `(batch_size, class_size)`, output is
+        // `(batch_size, sample_size)`.
+        let batch_size = input.size(0).unwrap_or_else(|| sym_gen.gen_positive());
+        let sample_size = SymExpr::Value(self.sample_size as i32);
+        let out_shape = vec![batch_size, sample_size];
+        Ok([SymTensor::from_shape(out_shape)].into())
+    }
+}
+
+/// Dropout operator.
+///
+/// See <https://onnx.ai/onnx/operators/onnx__Dropout.html>.
+pub struct Dropout;
+
+impl InferShapes for Dropout {
+    fn infer_shapes(
+        &self,
+        inputs: InferShapesContext,
+        _sym_gen: &mut SymbolGen,
+    ) -> Result<Vec<SymTensor>, InferShapesError> {
+        let data = inputs.require(0)?;
+
+        let shape = if let Some(dims) = data.shape() {
+            SymTensor::from_shape(dims.collect())
+        } else {
+            SymTensor::unknown("unknown input shape")
+        };
+
+        // Output 0 is the dropped-out data; output 1 is the boolean mask. Both
+        // have the same shape as the input.
+        Ok([shape.clone(), shape].into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::infer_shapes::{InferShapes, InferShapesError};
+    use crate::sym_expr::SymExpr;
+    use crate::sym_gen::SymbolGen;
+    use crate::sym_tensor::{SymTensor, sym_shape};
+
+    use super::{Dropout, Multinomial};
+
+    #[test]
+    fn test_multinomial() {
+        let mut sym_gen = SymbolGen::new();
+
+        // Known batch size.
+        let data = sym_shape!("batch", 32);
+        let result = Multinomial { sample_size: 4 }
+            .infer_shapes([data].into(), &mut sym_gen)
+            .unwrap();
+        assert_eq!(result, &[sym_shape!("batch", 4)]);
+
+        // Unknown input shape still yields a known sample size.
+        let data = SymTensor::unknown("unknown");
+        let result = Multinomial { sample_size: 4 }
+            .infer_shapes([data].into(), &mut sym_gen)
+            .unwrap();
+        assert_eq!(result[0].ndim(), Some(2));
+        assert_eq!(result[0].size(1), Some(4.into()));
+
+        // Input with a known rank other than 2 is an error.
+        let data = sym_shape!("batch", 32, 8);
+        let err = Multinomial { sample_size: 4 }
+            .infer_shapes([data].into(), &mut sym_gen)
+            .err();
+        assert_eq!(err, Some(InferShapesError::IncorrectRank));
+    }
+
+    #[test]
+    fn test_dropout() {
+        let mut sym_gen = SymbolGen::new();
+        let data = sym_shape!("batch", 16, 32);
+        let result = Dropout.infer_shapes([data].into(), &mut sym_gen).unwrap();
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0], sym_shape!("batch", 16, 32));
+        assert_eq!(result[1], sym_shape!("batch", 16, 32));
+
+        // Unknown input shape.
+        let data = SymTensor::unknown("unknown");
+        let result = Dropout.infer_shapes([data].into(), &mut sym_gen).unwrap();
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].ndim(), None);
+        assert_eq!(result[1].ndim(), None);
+    }
+}

--- a/rten-shape-inference/src/ops/reduce.rs
+++ b/rten-shape-inference/src/ops/reduce.rs
@@ -3,6 +3,30 @@ use crate::sym_expr::SymExpr;
 use crate::sym_gen::SymbolGen;
 use crate::sym_tensor::SymTensor;
 
+/// NonZero operator.
+///
+/// See <https://onnx.ai/onnx/operators/onnx__NonZero.html>.
+pub struct NonZero;
+
+impl InferShapes for NonZero {
+    fn infer_shapes(
+        &self,
+        inputs: InferShapesContext,
+        sym_gen: &mut SymbolGen,
+    ) -> Result<Vec<SymTensor>, InferShapesError> {
+        let data = inputs.require(0)?;
+
+        // Output is a 2D tensor of shape `(input.ndim(), num_nonzero)`.
+        let first_dim = data
+            .ndim()
+            .map(|n| SymExpr::Value(n as i32))
+            .unwrap_or_else(|| sym_gen.gen_positive());
+        let out_shape = vec![first_dim, sym_gen.gen_positive()];
+
+        Ok([SymTensor::from_shape(out_shape)].into())
+    }
+}
+
 /// TopK operator.
 ///
 /// See <https://onnx.ai/onnx/operators/onnx__TopK.html>.
@@ -52,7 +76,26 @@ mod tests {
     use crate::sym_gen::SymbolGen;
     use crate::sym_tensor::{SymTensor, sym_shape, sym_vec};
 
-    use super::TopK;
+    use super::{NonZero, TopK};
+
+    #[test]
+    fn test_non_zero() {
+        let mut sym_gen = SymbolGen::new();
+
+        // Known input shape, output is 2D with first dim = ndim.
+        let data = sym_shape!("batch", 16, 32);
+        let result = NonZero.infer_shapes([data].into(), &mut sym_gen).unwrap();
+        let shape: Vec<_> = result[0].shape().unwrap().collect();
+        assert_eq!(shape.len(), 2);
+        assert_eq!(shape[0], SymExpr::Value(3));
+        assert!(matches!(shape[1], SymExpr::Var(_)));
+
+        // Unknown input shape, output is still 2D.
+        let data = SymTensor::unknown("unknown");
+        let result = NonZero.infer_shapes([data].into(), &mut sym_gen).unwrap();
+        let shape: Vec<_> = result[0].shape().unwrap().collect();
+        assert_eq!(shape.len(), 2);
+    }
 
     #[test]
     fn test_top_k() {

--- a/rten-shape-inference/src/ops/reduce.rs
+++ b/rten-shape-inference/src/ops/reduce.rs
@@ -1,0 +1,84 @@
+use crate::infer_shapes::{InferShapes, InferShapesContext, InferShapesError, resolve_axis};
+use crate::sym_expr::SymExpr;
+use crate::sym_gen::SymbolGen;
+use crate::sym_tensor::SymTensor;
+
+/// TopK operator.
+///
+/// See <https://onnx.ai/onnx/operators/onnx__TopK.html>.
+pub struct TopK {
+    pub axis: Option<i32>,
+}
+
+impl InferShapes for TopK {
+    fn infer_shapes(
+        &self,
+        inputs: InferShapesContext,
+        sym_gen: &mut SymbolGen,
+    ) -> Result<Vec<SymTensor>, InferShapesError> {
+        let data = inputs.require(0)?;
+        let k = inputs.require(1)?;
+
+        let Some(data_dims) = data.shape() else {
+            return Ok([
+                SymTensor::unknown("unknown input shape"),
+                SymTensor::unknown("unknown input shape"),
+            ]
+            .into());
+        };
+
+        let ndim = data_dims.len();
+        let axis = resolve_axis(ndim, self.axis.unwrap_or(-1))
+            .map_err(|_| InferShapesError::IncorrectRank)?;
+
+        // `k` is a 1D tensor with one element.
+        let k_val = k
+            .as_vector()
+            .and_then(|v| v.first().cloned())
+            .unwrap_or_else(|| sym_gen.gen_positive());
+
+        let mut out_shape: Vec<SymExpr> = data_dims.collect();
+        out_shape[axis] = k_val;
+
+        let shape = SymTensor::from_shape(out_shape);
+        Ok([shape.clone(), shape].into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::infer_shapes::InferShapes;
+    use crate::sym_expr::SymExpr;
+    use crate::sym_gen::SymbolGen;
+    use crate::sym_tensor::{SymTensor, sym_shape, sym_vec};
+
+    use super::TopK;
+
+    #[test]
+    fn test_top_k() {
+        let mut sym_gen = SymbolGen::new();
+
+        // Default axis (-1) with known K.
+        let data = sym_shape!("batch", 16, 32);
+        let k = sym_vec!(5);
+        let op = TopK { axis: None };
+        let result = op.infer_shapes([data, k].into(), &mut sym_gen).unwrap();
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0], sym_shape!("batch", 16, 5));
+        assert_eq!(result[1], sym_shape!("batch", 16, 5));
+
+        // Explicit axis.
+        let data = sym_shape!("batch", 16, 32);
+        let k = sym_vec!(5);
+        let op = TopK { axis: Some(0) };
+        let result = op.infer_shapes([data, k].into(), &mut sym_gen).unwrap();
+        assert_eq!(result[0], sym_shape!(5, 16, 32));
+
+        // Symbolic K value.
+        let data = sym_shape!("batch", 32);
+        let k = sym_vec!(SymExpr::from("k"));
+        let op = TopK { axis: Some(-1) };
+        let result = op.infer_shapes([data, k].into(), &mut sym_gen).unwrap();
+        assert_eq!(result[0], sym_shape!("batch", "k"));
+    }
+}

--- a/rten-shape-inference/src/ops/slice.rs
+++ b/rten-shape-inference/src/ops/slice.rs
@@ -1,7 +1,6 @@
 use rten_tensor::SliceRange;
 
-use crate::infer_shapes::{InferShapes, InferShapesContext, InferShapesError};
-use crate::ops::resolve_axis;
+use crate::infer_shapes::{InferShapes, InferShapesContext, InferShapesError, resolve_axis};
 use crate::sym_expr::SymExpr;
 use crate::sym_gen::SymbolGen;
 use crate::sym_tensor::{Constant, SymTensor};

--- a/rten-shape-inference/src/ops/split.rs
+++ b/rten-shape-inference/src/ops/split.rs
@@ -1,5 +1,4 @@
-use crate::infer_shapes::{InferShapes, InferShapesContext, InferShapesError};
-use crate::ops::resolve_axis;
+use crate::infer_shapes::{InferShapes, InferShapesContext, InferShapesError, resolve_axis};
 use crate::sym_gen::SymbolGen;
 use crate::sym_tensor::SymTensor;
 


### PR DESCRIPTION
Move shape inference implementations for various operators from `rten_shape_inference::ops` into submodules. The organization follows that of the operator runtime implementation in `src/ops.rs`. See commits for details.