### PR TITLE
Fix `Dropout` operator's declared `max_inputs` and support older models that set `ratio` as an attribute

### DIFF
--- a/rten-convert/rten_convert/converter.py
+++ b/rten-convert/rten_convert/converter.py
@@ -497,6 +497,9 @@ def op_node_from_onnx_operator(
             attrs = sg.DropoutAttrsT()
             attrs.seed = attr_reader.get_attr("seed", "int", None)
 
+            # `ratio` was an attribute until opset 12, when it became an input.
+            attr_reader.generate_input_from_attr(1, "ratio", "float")
+
         case "Einsum":
             attrs = sg.EinsumAttrsT()
             attrs.equation = attr_reader.require_attr("equation", "string")

--- a/src/model/onnx_loader.rs
+++ b/src/model/onnx_loader.rs
@@ -1625,6 +1625,26 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "random")]
+    #[test]
+    fn test_load_dropout_with_training_mode_input() {
+        let node = create_node("Dropout")
+            .with_input("x")
+            .with_input("ratio")
+            .with_input("training_mode")
+            .with_output("y")
+            .with_name("dropout_op");
+
+        let model_proto = onnx::GraphProto::default()
+            .with_input(create_value_info("x"))
+            .with_input(create_value_info("ratio"))
+            .with_input(create_value_info("training_mode"))
+            .with_node(node)
+            .into_model();
+
+        load_model(model_proto, None).unwrap();
+    }
+
     #[test]
     fn test_too_many_outputs_for_operator() {
         // Test operator-specific limit.

--- a/src/op_registry/onnx_registry.rs
+++ b/src/op_registry/onnx_registry.rs
@@ -1091,7 +1091,14 @@ impl_read_op!(Div);
 #[cfg(feature = "random")]
 impl_read_op!(Dropout, |attrs: &Attrs| {
     let seed = attrs.get_as_int("seed")?;
-    Ok(ops::Dropout { seed })
+
+    // `ratio` was an attribute until opset 12, when it became an input.
+    let mut const_inputs = Vec::new();
+    if let Some(ratio) = attrs.get("ratio") {
+        const_inputs.push((1, ConstInput::Float(ratio.as_f32())));
+    }
+
+    Ok(ParsedOp::new(ops::Dropout { seed }).with_inputs(const_inputs))
 });
 
 impl_read_op!(DynamicQuantizeLinear);
@@ -2516,6 +2523,17 @@ mod tests {
                     .with_attr("min", -0.5)
                     .with_attr("max", 0.5),
                 expected_inputs: [(1, ConstInput::Float(-0.5)), (2, ConstInput::Float(0.5))].into(),
+            },
+            #[cfg(feature = "random")]
+            Case {
+                op: create_node("Dropout").with_attr("ratio", 0.25),
+                expected_inputs: [(1, ConstInput::Float(0.25))].into(),
+            },
+            // Dropout op with no `ratio` attribute.
+            #[cfg(feature = "random")]
+            Case {
+                op: create_node("Dropout"),
+                expected_inputs: [].into(),
             },
             // Pad op with `pads` and `value` attributes.
             Case {

--- a/src/ops/random.rs
+++ b/src/ops/random.rs
@@ -308,7 +308,7 @@ impl Operator for Dropout {
     }
 
     fn max_inputs(&self) -> Option<usize> {
-        Some(2)
+        Some(3)
     }
 
     fn max_outputs(&self) -> Option<usize> {


### PR DESCRIPTION
Fix two issues with the `Dropout` operator:

1. The `Operator::max_inputs` impl declared 2 inputs but the operator reads 3 (data, ratio, training_mode). A model that provided all 3 failed to load.
2. Older models (opset < 12) set `ratio` as an attribute instead of an input. Add attribute -> input promotion when deserializing the operator