### PR TITLE
Add attribute -> input promotion for `TopK` and `Reshape`

### DIFF
--- a/rten-convert/rten_convert/converter.py
+++ b/rten-convert/rten_convert/converter.py
@@ -833,6 +833,9 @@ def op_node_from_onnx_operator(
             attrs.largest = bool(attr_reader.get_attr("largest", "int", 1))
             attrs.sorted = bool(attr_reader.get_attr("sorted", "int", 1))
 
+            # `k` was an attribute until opset 10, when it became an input.
+            attr_reader.generate_input_from_attr(1, "k", "int")
+
         case "Transpose":
             attrs = sg.TransposeAttrsT()
             attrs.perm = attr_reader.get_attr("perm", "ints", None)

--- a/rten-convert/rten_convert/converter.py
+++ b/rten-convert/rten_convert/converter.py
@@ -713,6 +713,9 @@ def op_node_from_onnx_operator(
             attrs = sg.ReshapeAttrsT()
             attrs.allowZero = bool(attr_reader.get_attr("allowzero", "int", 0))
 
+            # `shape` was an attribute until opset 5, when it became an input.
+            attr_reader.generate_input_from_attr(1, "shape", "ints")
+
         case "ReverseSequence":
             attrs = sg.ReverseSequenceAttrsT()
             attrs.batchAxis = attr_reader.get_attr("batch_axis", "int", 1)

--- a/src/op_registry/onnx_registry.rs
+++ b/src/op_registry/onnx_registry.rs
@@ -1650,7 +1650,14 @@ impl_read_op!(Relu);
 
 impl_read_op!(Reshape, |attrs: &Attrs| {
     let allow_zero = attrs.get_as("allowzero").unwrap_or(false);
-    Ok(ops::Reshape { allow_zero })
+
+    // `shape` was an attribute before opset 5.
+    let mut const_inputs = Vec::new();
+    if let Some(shape) = attrs.get("shape") {
+        const_inputs.push((1, ConstInput::Ints(shape.as_ints().to_vec())));
+    }
+
+    Ok(ParsedOp::new(ops::Reshape { allow_zero }).with_inputs(const_inputs))
 });
 
 impl_read_op!(Resize, |attrs: &Attrs| {
@@ -2550,6 +2557,10 @@ mod tests {
             Case {
                 op: create_node("Pad").with_attr("pads", vec![1, 1, 1, 1]),
                 expected_inputs: [(1, ConstInput::Ints([1, 1, 1, 1].into()))].into(),
+            },
+            Case {
+                op: create_node("Reshape").with_attr("shape", vec![2, -1]),
+                expected_inputs: [(1, ConstInput::Ints([2, -1].into()))].into(),
             },
             Case {
                 op: create_node("Squeeze").with_attr("axes", vec![-1]),

--- a/src/op_registry/onnx_registry.rs
+++ b/src/op_registry/onnx_registry.rs
@@ -1951,11 +1951,19 @@ impl_read_op!(TopK, |attrs: &Attrs| {
     let axis = attrs.get_as_int("axis")?;
     let largest = attrs.get_as("largest").unwrap_or(true);
     let sorted = attrs.get_as("sorted").unwrap_or(true);
-    Ok(ops::TopK {
+
+    // `k` was an attribute before opset 10.
+    let mut const_inputs = Vec::new();
+    if let Some(k) = attrs.get("k") {
+        const_inputs.push((1, ConstInput::Int(k.as_i64())));
+    }
+
+    Ok(ParsedOp::new(ops::TopK {
         axis,
         largest,
         sorted,
     })
+    .with_inputs(const_inputs))
 });
 
 impl_read_op!(Transpose, |attrs: &Attrs| {
@@ -2581,6 +2589,10 @@ mod tests {
             Case {
                 op: create_node("Split").with_attr("split", vec![10]),
                 expected_inputs: [(1, ConstInput::Ints([10].into()))].into(),
+            },
+            Case {
+                op: create_node("TopK").with_attr("k", 3),
+                expected_inputs: [(1, ConstInput::Int(3))].into(),
             },
             Case {
                 op: create_node("Unsqueeze").with_attr("axes", vec![-1]),


### PR DESCRIPTION
Add attribute to input promotion for:

- `TopK`'s `k` attribute (opset < 10)
- `Reshape`'s `shape` attribute (opset < 5)

Found by asking Claude to check all supported ONNX ops for any missing attribute -> input promotions similar to https://github.com/robertknight/rten/pull/1425.