### PR TITLE
Accept attributes explicitly set to default value in RNN, cast and quantize ops

### DIFF
--- a/rten-convert/rten_convert/attr_reader.py
+++ b/rten-convert/rten_convert/attr_reader.py
@@ -50,7 +50,7 @@ class AttributeReader:
 
         self._handled_attrs = set()
 
-    def get_attr(self, name: str, expected_type: str, default):
+    def get_attr(self, name: str, expected_type: str, default) -> Any:
         """
         Get the value of an optional operator attribute.
 
@@ -84,6 +84,8 @@ class AttributeReader:
         # them.
         if expected_type == "string":
             val = val.decode()
+        elif expected_type == "strings":
+            val = [s.decode() for s in val]
 
         return val
 

--- a/rten-convert/rten_convert/converter.py
+++ b/rten-convert/rten_convert/converter.py
@@ -225,6 +225,29 @@ def read_pads(attr_reader: AttributeReader, attrs: PadAttrs) -> None:
         attrs.pads = pads
 
 
+def read_rnn_attrs(
+    attr_reader: AttributeReader, direction, default_activations: list[str]
+) -> None:
+    """
+    Check the attributes which are common to all RNN operators.
+
+    `default_activations` are the activation functions the operator uses for one
+    direction, in the order the ONNX spec lists them.
+    """
+    attr_reader.check_attr("activation_alpha", "floats", [])
+    attr_reader.check_attr("activation_beta", "floats", [])
+
+    # Only the default activations are supported. A bidirectional operator
+    # repeats the list once per direction.
+    n_directions = 2 if direction == sg.RNNDirection.Bidirectional else 1
+    attr_reader.check_attr(
+        "activations", "strings", ([], default_activations * n_directions)
+    )
+
+    attr_reader.check_attr("clip", "float", 0.0)
+    attr_reader.check_attr("layout", "int", 0)
+
+
 def read_strides(
     attr_reader: AttributeReader,
 ):
@@ -556,6 +579,8 @@ def op_node_from_onnx_operator(
                 attr_reader.get_attr("linear_before_reset", "int", 0)
             )
 
+            read_rnn_attrs(attr_reader, attrs.direction, ["Sigmoid", "Tanh"])
+
         case "HardSigmoid":
             attrs = sg.HardSigmoidAttrsT()
             attrs.alpha = attr_reader.get_attr("alpha", "float", 0.2)
@@ -617,12 +642,8 @@ def op_node_from_onnx_operator(
             )
             attrs.hiddenSize = attr_reader.require_attr("hidden_size", "int")
 
-            attr_reader.check_attr("activation_alpha", "floats", [])
-            attr_reader.check_attr("activation_beta", "floats", [])
-            attr_reader.check_attr("activations", "strings", [])
-            attr_reader.check_attr("clip", "float", 0.0)
+            read_rnn_attrs(attr_reader, attrs.direction, ["Sigmoid", "Tanh", "Tanh"])
             attr_reader.check_attr("input_forget", "int", 0)
-            attr_reader.check_attr("layout", "int", 0)
 
         case "MaxPool":
             attrs = sg.MaxPoolAttrsT()

--- a/src/model/onnx_builder.rs
+++ b/src/model/onnx_builder.rs
@@ -16,6 +16,7 @@ pub enum AttrValue {
     Int(i64),
     Ints(Vec<i64>),
     String(String),
+    Strings(Vec<String>),
     Tensor(onnx::TensorProto),
 }
 
@@ -26,6 +27,7 @@ enum_from!(AttrValue, Graph, onnx::GraphProto);
 enum_from!(AttrValue, Int, i64);
 enum_from!(AttrValue, Ints, Vec<i64>);
 enum_from!(AttrValue, String, String);
+enum_from!(AttrValue, Strings, Vec<String>);
 enum_from!(AttrValue, Tensor, onnx::TensorProto);
 
 pub fn create_attr(name: &str, value: AttrValue) -> onnx::AttributeProto {
@@ -39,6 +41,7 @@ pub fn create_attr(name: &str, value: AttrValue) -> onnx::AttributeProto {
         AttrValue::Int(val) => attr.i = Some(val),
         AttrValue::Ints(val) => attr.ints = val,
         AttrValue::String(val) => attr.s = Some(val),
+        AttrValue::Strings(val) => attr.strings = val,
         AttrValue::Tensor(val) => attr.t = Some(val),
     }
     attr

--- a/src/op_registry/onnx_registry.rs
+++ b/src/op_registry/onnx_registry.rs
@@ -864,11 +864,21 @@ impl_read_op!(Cast, |attrs: &Attrs| {
     // Conversions to other types do not saturate, even if this attribute is 1.
     attrs.check_eq("saturate", 1)?;
 
+    // "round_mode" only applies to conversions to float8e8m0.
+    attrs.check_eq("round_mode", "up")?;
+
     let to = attrs.require("to")?.as_dtype()?;
     Ok(ops::Cast { to })
 });
 
-impl_read_op!(CastLike);
+impl_read_op!(CastLike, |attrs: &Attrs| {
+    // The "saturate" attribute only applies to FP8, which is unsupported.
+    // Conversions to other types do not saturate, even if this attribute is 1.
+    attrs.check_eq("saturate", 1)?;
+
+    attrs.check_eq("round_mode", "up")?;
+    Ok(ops::CastLike {})
+});
 impl_read_op!(Ceil);
 
 impl_read_op!(Clip, |attrs: &Attrs| {
@@ -1067,6 +1077,14 @@ impl_read_op!(DFT, |attrs: &Attrs| {
 
 impl_read_op!(DequantizeLinear, |attrs: &Attrs| {
     let axis = attrs.get_as_int("axis")?.unwrap_or(1);
+
+    // A non-zero "block_size" selects blocked quantization, which is
+    // unsupported.
+    attrs.check_eq("block_size", 0)?;
+
+    // A zero "output_dtype" means the type is taken from the `scale` input.
+    attrs.check_eq("output_dtype", 0)?;
+
     Ok(ops::DequantizeLinear { axis })
 });
 
@@ -1194,7 +1212,7 @@ impl_read_op!(GRU, |attrs: &Attrs| {
     let RnnAttrs {
         direction,
         hidden_size,
-    } = get_common_rnn_attrs(attrs)?;
+    } = get_common_rnn_attrs(attrs, &["Sigmoid", "Tanh"])?;
 
     let linear_before_reset = attrs.get_as("linear_before_reset").unwrap_or(false);
     Ok(ops::GRU {
@@ -1287,7 +1305,14 @@ struct RnnAttrs {
     direction: Direction,
 }
 
-fn get_common_rnn_attrs(attrs: &Attrs) -> Result<RnnAttrs, ReadOpError> {
+/// Read the attributes which are common to all RNN operators.
+///
+/// `default_activations` are the activation functions the operator uses for
+/// one direction, in the order the ONNX spec lists them.
+fn get_common_rnn_attrs(
+    attrs: &Attrs,
+    default_activations: &[&str],
+) -> Result<RnnAttrs, ReadOpError> {
     // ONNX spec does not state that hidden_size is required, but doesn't
     // provide a default. ONNX Runtime requires it to be present and non-zero.
     let hidden_size = attrs.require("hidden_size")?.cast_int()?;
@@ -1304,6 +1329,23 @@ fn get_common_rnn_attrs(attrs: &Attrs) -> Result<RnnAttrs, ReadOpError> {
         .transpose()?
         .unwrap_or(Direction::Forward);
 
+    attrs.check("activation_alpha", |val: &[f32]| val.is_empty())?;
+    attrs.check("activation_beta", |val: &[f32]| val.is_empty())?;
+
+    // Only the default activations are supported. A bidirectional operator
+    // repeats the list once per direction.
+    attrs.check("activations", |val: &[String]| {
+        val.is_empty()
+            || (val.len() == default_activations.len() * direction.num_directions()
+                && val
+                    .iter()
+                    .zip(default_activations.iter().cycle())
+                    .all(|(act, default)| act == default))
+    })?;
+
+    attrs.check_eq("clip", 0.)?;
+    attrs.check_eq("layout", 0)?;
+
     Ok(RnnAttrs {
         hidden_size,
         direction,
@@ -1314,14 +1356,9 @@ impl_read_op!(LSTM, |attrs: &Attrs| {
     let RnnAttrs {
         direction,
         hidden_size,
-    } = get_common_rnn_attrs(attrs)?;
+    } = get_common_rnn_attrs(attrs, &["Sigmoid", "Tanh", "Tanh"])?;
 
-    attrs.check("activation_alpha", |val: &[f32]| val.is_empty())?;
-    attrs.check("activation_beta", |val: &[f32]| val.is_empty())?;
-    attrs.check("activations", |val: &[String]| val.is_empty())?;
-    attrs.check_eq("clip", 0.)?;
     attrs.check_eq("input_forget", 0)?;
-    attrs.check_eq("layout", 0)?;
 
     Ok(ops::LSTM {
         direction,
@@ -1518,11 +1555,26 @@ impl_read_op!(Pow);
 impl_read_op!(PRelu);
 
 impl_read_op!(QuantizeLinear, |attrs: &Attrs| {
+    // A zero "output_dtype" means the type is taken from the `zero_point`
+    // input instead.
     let output_dtype = attrs
         .get("output_dtype")
-        .map(|v| v.as_dtype())
+        .filter(|dt| dt.as_i64() != 0)
+        .map(|dt| dt.as_dtype())
         .transpose()?;
     let axis = attrs.get_as_int("axis")?.unwrap_or(-1);
+
+    // A non-zero "block_size" selects blocked quantization, which is
+    // unsupported.
+    attrs.check_eq("block_size", 0)?;
+
+    // "saturate" only applies to FP8, which is unsupported.
+    attrs.check_eq("saturate", 1)?;
+
+    // A zero "precision" means the division is performed using the type of the
+    // `scale` input.
+    attrs.check_eq("precision", 0)?;
+
     Ok(ops::QuantizeLinear { axis, output_dtype })
 });
 
@@ -1618,7 +1670,10 @@ impl_read_op!(RandomUniformLike, |attrs: &Attrs| {
     Ok(ops::RandomUniformLike { low, high, seed })
 });
 
-impl_read_op!(Range);
+impl_read_op!(Range, |attrs: &Attrs| {
+    attrs.check_eq("stash_type", 1)?;
+    Ok(ops::Range {})
+});
 impl_read_op!(Reciprocal);
 
 macro_rules! impl_read_op_for_reduce_op {
@@ -2218,6 +2273,116 @@ mod tests {
                 (Ok(op), Ok(())) => {
                     assert!(op.op.downcast_ref::<GridSample>().is_some());
                 }
+                (Err(err), Err(expected)) => {
+                    assert!(
+                        err.to_string().contains(expected),
+                        "{} does not contain {}",
+                        err,
+                        expected
+                    );
+                }
+                (result, expected) => {
+                    panic!("expected {:?} but got {:?}", expected, result.map(|_| ()))
+                }
+            }
+        })
+    }
+
+    #[test]
+    fn test_read_rnn_activations() {
+        #[derive(Debug)]
+        struct Case<'a> {
+            op_type: &'a str,
+            direction: Option<&'a str>,
+            activations: Option<&'a [&'a str]>,
+            expected: Result<(), &'a str>,
+        }
+
+        let cases = [
+            // Unset.
+            Case {
+                op_type: "LSTM",
+                direction: None,
+                activations: None,
+                expected: Ok(()),
+            },
+            Case {
+                op_type: "GRU",
+                direction: None,
+                activations: None,
+                expected: Ok(()),
+            },
+            // Defaults set explicitly.
+            Case {
+                op_type: "LSTM",
+                direction: None,
+                activations: Some(&["Sigmoid", "Tanh", "Tanh"]),
+                expected: Ok(()),
+            },
+            Case {
+                op_type: "GRU",
+                direction: None,
+                activations: Some(&["Sigmoid", "Tanh"]),
+                expected: Ok(()),
+            },
+            // Defaults repeated once per direction.
+            Case {
+                op_type: "LSTM",
+                direction: Some("bidirectional"),
+                activations: Some(&["Sigmoid", "Tanh", "Tanh", "Sigmoid", "Tanh", "Tanh"]),
+                expected: Ok(()),
+            },
+            Case {
+                op_type: "GRU",
+                direction: Some("bidirectional"),
+                activations: Some(&["Sigmoid", "Tanh", "Sigmoid", "Tanh"]),
+                expected: Ok(()),
+            },
+            // Non-default activations are not implemented.
+            Case {
+                op_type: "LSTM",
+                direction: None,
+                activations: Some(&["Sigmoid", "Tanh", "Relu"]),
+                expected: Err("unsupported value"),
+            },
+            Case {
+                op_type: "GRU",
+                direction: None,
+                activations: Some(&["Relu", "Tanh"]),
+                expected: Err("unsupported value"),
+            },
+            // Defaults with wrong length for operator.
+            Case {
+                op_type: "GRU",
+                direction: None,
+                activations: Some(&["Sigmoid", "Tanh", "Tanh"]),
+                expected: Err("unsupported value"),
+            },
+            // Defaults with wrong length for direction count.
+            Case {
+                op_type: "LSTM",
+                direction: None,
+                activations: Some(&["Sigmoid", "Tanh", "Tanh", "Sigmoid", "Tanh", "Tanh"]),
+                expected: Err("unsupported value"),
+            },
+        ];
+
+        cases.test_each(|case| {
+            let reg = OnnxOpRegistry::with_all_ops();
+            let mut node = create_node(case.op_type).with_attr("hidden_size", 4i64);
+            if let Some(direction) = case.direction {
+                node = node.with_attr("direction", direction.to_string());
+            }
+            if let Some(activations) = case.activations {
+                let activations: Vec<String> =
+                    activations.iter().map(|act| act.to_string()).collect();
+                node = node.with_attr("activations", activations);
+            }
+
+            let result = reg.read_op(&node, &FakeOpLoadContext::default());
+
+            match (result, case.expected) {
+                (Ok(op), Ok(())) => assert_eq!(op.op.name(), case.op_type),
                 (Err(err), Err(expected)) => {
                     assert!(
                         err.to_string().contains(expected),


### PR DESCRIPTION
Fix several cases where models failed to load if an attribute was explicitly set to a default value, rather than omitted. This includes:

 - `activations` for `LSTM` and `GRU`, plus several other attrs for `GRU`
 - `round_mode` for `Cast` and `CastLike`
 - `saturate` for `CastLike`, `QuantizeLinear`
 - `block_size` for `QuantizeLinear`, `DequantizeLinear`
 - `output_dtype` for `DequantizeLinear`
 - `precision` for `QuantizeLinear`
 - `stash_type` for `Range`

For `QuantizeLinear`'s `output_dtype` the value zero was incorrectly read as a data type, but it is a sentinel that means the type is taken from the `y_zero_point` input.

The issue was initially encountered with the `activations` attribute which caused a `tf2onnx`-exported model to fail to load. The other fixes are the result of asking Claude to look for similar problems with other operators and attributes.