### PR TITLE
Accept default value for `BatchNormalization`'s `spatial` attr

### DIFF
--- a/rten-convert/rten_convert/converter.py
+++ b/rten-convert/rten_convert/converter.py
@@ -408,6 +408,9 @@ def op_node_from_onnx_operator(
             # is unsupported.
             attr_reader.ignore_attr("momentum")
 
+            # `spatial` was removed in opset 9.
+            attr_reader.check_attr("spatial", "int", 1)
+
         case "Cast":
             attrs = sg.CastAttrsT()
             to = attr_reader.get_attr(

--- a/src/op_registry/onnx_registry.rs
+++ b/src/op_registry/onnx_registry.rs
@@ -834,6 +834,9 @@ impl_read_op!(BatchNormalization, |attrs: &Attrs| {
     // unsupported.
     attrs.check_unused::<f32>("momentum")?;
 
+    // "spatial" was removed in opset 9.
+    attrs.check_eq("spatial", 1)?;
+
     let epsilon = attrs.get("epsilon").map(|v| v.as_f32()).unwrap_or(1e-05);
     Ok(ops::BatchNormalization { epsilon })
 });


### PR DESCRIPTION
This is a deprecated attribute that was removed in opset 9. Accept it if present and set to the default value.