### PR TITLE
Improve error message for unsupported BatchNormalization outputs

### DIFF
--- a/src/operator.rs
+++ b/src/operator.rs
@@ -138,6 +138,9 @@ pub enum OpError {
 
     /// An input or attribute has a value that is valid, but not currently supported.
     UnsupportedValue(&'static str),
+
+    /// An output was requested that is currently unsupported.
+    UnsupportedOutput(&'static str),
 }
 
 impl OpError {
@@ -185,6 +188,9 @@ impl Display for OpError {
             }
             OpError::UnsupportedValue(details) => {
                 write!(f, "unsupported input or attribute value: {}", details)
+            }
+            OpError::UnsupportedOutput(name) => {
+                write!(f, "unsupported output: {}", name)
             }
             OpError::UnsupportedType => {
                 write!(f, "unsupported input type")
@@ -303,6 +309,16 @@ impl OutputMask {
             self.mask.get(idx as u32)
         } else {
             idx < self.len as usize
+        }
+    }
+
+    /// Return [`OpError::UnsupportedOutput`] if the unsupported output at the
+    /// given index is requested.
+    pub fn check_unsupported(&self, idx: usize, name: &'static str) -> Result<(), OpError> {
+        if self.is_used(idx) {
+            Err(OpError::UnsupportedOutput(name))
+        } else {
+            Ok(())
         }
     }
 }

--- a/src/ops/norm.rs
+++ b/src/ops/norm.rs
@@ -245,6 +245,17 @@ pub struct BatchNormalization {
     pub epsilon: f32,
 }
 
+impl BatchNormalization {
+    fn check_outputs(&self, ctx: &OpRunContext) -> Result<(), OpError> {
+        let outputs = ctx.outputs();
+        outputs.check_unsupported(1, "running_mean")?;
+        outputs.check_unsupported(2, "running_var")?;
+        outputs.check_unsupported(3, "saved_mean")?;
+        outputs.check_unsupported(4, "saved_var")?;
+        Ok(())
+    }
+}
+
 impl Operator for BatchNormalization {
     fn name(&self) -> &str {
         "BatchNormalization"
@@ -255,9 +266,10 @@ impl Operator for BatchNormalization {
     }
 
     fn max_outputs(&self) -> Option<usize> {
-        // ONNX allows additional outputs in training mode (`running_mean`,
-        // `running_var`), but we only support inference.
-        Some(1)
+        // Outputs are Y, running_mean, running_var, saved_mean, saved_var.
+        // The last 4 are for training mode, which is unsupported. `saved_mean`
+        // and `saved_var` were removed in opset 14.
+        Some(5)
     }
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
@@ -267,6 +279,8 @@ impl Operator for BatchNormalization {
         let bias = inputs.require_as(2)?;
         let mean = inputs.require_as(3)?;
         let var = inputs.require_as(4)?;
+
+        self.check_outputs(ctx)?;
 
         batch_norm(ctx.pool(), input, &scale, &bias, &mean, &var, self.epsilon).into_op_result()
     }
@@ -286,6 +300,8 @@ impl Operator for BatchNormalization {
         let bias = inputs.require_as(2)?;
         let mean = inputs.require_as(3)?;
         let var = inputs.require_as(4)?;
+
+        self.check_outputs(ctx)?;
 
         batch_norm_in_place(&mut output, &scale, &bias, &mean, &var, self.epsilon)?;
 


### PR DESCRIPTION
Previously if a model requested the unsupported training-mode outputs for BatchNormalization, which could include the deprecated/removed `saved_mean` and `saved_var` outputs for opset < 14 models, the model would fail to load with an error such as `operator error: operator has 5 outputs but maximum is 1`.

Change this so the model fails at inference with a more helpful error such as `operator "/stem/conv/BatchNormalization" failed: unsupported output: running_mean`.

I encountered the error with models from
https://github.com/RapidAI/RapidLaTeXOCR/tree/main, where BatchNormalization operators have 5 outputs but only the first is actually used.

**Workaround:** The workaround for this issue for now is to modify the ONNX models to remove the unused outputs. AI tools can easily produce Python scripts for this.

In future the need for the workaround could be removed by adding a graph optimization that removes value nodes from the graph that are never consumed - as graph outputs, captured by subgraphs or used by a downstream operator.