### PR TITLE
Improve error messages for unsupported outputs

### DIFF
--- a/src/ops/attention.rs
+++ b/src/ops/attention.rs
@@ -675,11 +675,7 @@ impl Attention {
         // key/value inputs are right-padded.
         let nonpad_kv_seqlen: Option<NdTensorView<i32, 1>> = inputs.get_as(6)?;
 
-        if ctx.outputs().is_used(3) {
-            return Err(OpError::UnsupportedValue(
-                "qk_matmul_output output is not supported",
-            ));
-        }
+        ctx.outputs().check_unsupported(3, "qk_matmul_output")?;
 
         let input_3d = match query.ndim() {
             3 => true,

--- a/src/ops/attention/contrib.rs
+++ b/src/ops/attention/contrib.rs
@@ -59,6 +59,8 @@ impl MultiHeadAttention {
         past_key: Option<PastCache>,
         past_value: Option<PastCache>,
     ) -> Result<OutputList, OpError> {
+        ctx.outputs().check_unsupported(3, "qk")?;
+
         // (batch, seq, hidden) or (batch, kv_seq, num_heads, 3, head_size)
         let query: TensorView<f32> = ctx.inputs().require_as(0)?;
         let query = MhaQuery::new(query)?;
@@ -309,9 +311,9 @@ impl Operator for MultiHeadAttention {
     }
 
     fn max_outputs(&self) -> Option<usize> {
-        // Spec defines 4 outputs: output, present_key, present_value, qk.
-        // The `qk` output is not yet implemented.
-        Some(3)
+        // Outputs are output, present_key, present_value, qk. The `qk` output
+        // is not yet implemented.
+        Some(4)
     }
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
@@ -441,6 +443,8 @@ impl GroupQueryAttention {
         past_key: Option<PastCache>,
         past_value: Option<PastCache>,
     ) -> Result<OutputList, OpError> {
+        ctx.outputs().check_unsupported(3, "output_qk")?;
+
         let inputs = ctx.inputs();
 
         // (batch, seq, q_hidden)
@@ -821,9 +825,9 @@ impl Operator for GroupQueryAttention {
     }
 
     fn max_outputs(&self) -> Option<usize> {
-        // Spec defines 4 outputs: output, present_key, present_value, output_qk.
-        // The `output_qk` output is not implemented.
-        Some(3)
+        // Outputs are output, present_key, present_value, output_qk. The
+        // `output_qk` output is not implemented.
+        Some(4)
     }
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {

--- a/src/ops/norm.rs
+++ b/src/ops/norm.rs
@@ -544,12 +544,16 @@ impl Operator for LayerNormalization {
     }
 
     fn max_outputs(&self) -> Option<usize> {
-        // ONNX allows optional `Mean` and `InvStdDev` outputs, but we only
-        // produce the normalized output.
-        Some(1)
+        // Outputs are Y, Mean and InvStdDev. The last 2 are for training mode,
+        // which is unsupported.
+        Some(3)
     }
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+        let outputs = ctx.outputs();
+        outputs.check_unsupported(1, "Mean")?;
+        outputs.check_unsupported(2, "InvStdDev")?;
+
         let inputs = ctx.inputs();
         let input = inputs.require_as(0)?;
         let scale = inputs.require_as(1)?;

--- a/src/ops/norm/contrib.rs
+++ b/src/ops/norm/contrib.rs
@@ -29,6 +29,10 @@ fn skip_layer_normalization(
     epsilon: f32,
     mean_normalize: MeanNormalize,
 ) -> Result<OutputList, OpError> {
+    let outputs = ctx.outputs();
+    outputs.check_unsupported(1, "mean")?;
+    outputs.check_unsupported(2, "inv_std_var")?;
+
     if !matches!(input.ndim(), 2 | 3) {
         return Err(OpError::InvalidValue("input must be 2 or 3 dimensioned"));
     }
@@ -66,8 +70,8 @@ fn skip_layer_normalization(
 
     let mut outputs: OutputList = [output.into()].into();
     if ctx.outputs().is_used(3) {
-        // `mean` and `inv_std_var` are used for training. Here we push
-        // dummy values.
+        // Placeholders to align `input_skip_bias_sum` with output index 3.
+        // The checks above guarantee these positions are unused.
         outputs.push(Tensor::from(0.).into()); // mean
         outputs.push(Tensor::from(0.).into()); // inv_std_var
         outputs.push(x_plus_skip.take().into());
@@ -97,7 +101,15 @@ impl Operator for SimplifiedLayerNormalization {
         Some(2)
     }
 
+    fn max_outputs(&self) -> Option<usize> {
+        // Outputs are Y and inv_std_var. The latter is for training mode,
+        // which is unsupported.
+        Some(2)
+    }
+
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+        ctx.outputs().check_unsupported(1, "inv_std_var")?;
+
         let inputs = ctx.inputs();
         let input = inputs.require_as(0)?;
         let scale = inputs.require_as(1)?;

--- a/src/ops/pooling.rs
+++ b/src/ops/pooling.rs
@@ -617,12 +617,13 @@ impl Operator for MaxPool {
     }
 
     fn max_outputs(&self) -> Option<usize> {
-        // ONNX allows an optional `Indices` output, but we only produce the
-        // pooled output.
-        Some(1)
+        // Outputs are Y and Indices. `Indices` is unsupported.
+        Some(2)
     }
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
+        ctx.outputs().check_unsupported(1, "Indices")?;
+
         let input = ctx.inputs().require_as(0)?;
         max_pool(
             ctx.pool(),


### PR DESCRIPTION
Use the infrastructure added in https://github.com/robertknight/rten/pull/1432 to improve the error messages in additional operators for unsupported outputs.

This affects Attention, LayerNormalization and MaxPool standard ONNX ops, plus GroupQueryAttention, MultiHeadAttention, SkipLayerNormalization, SkipSimplifiedLayerNormalization and SimplifiedLayerNormalization contrib ops.

As noted in https://github.com/robertknight/rten/pull/1432, we could potentially add a step to model loading which automatically removes these outputs if they are unused.