### PR TITLE
Remove unused operator outputs during graph optimization

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -631,6 +631,28 @@ impl Graph {
         self.nodes.get_mut(&id)
     }
 
+    /// Mark an operator output as unused.
+    ///
+    /// This allows the operator to skip computing the output when the graph is
+    /// run.
+    ///
+    /// Returns the ID of the value node which was previously produced at this
+    /// position, if any. Note this node is not automatically removed from the
+    /// graph.
+    pub fn clear_operator_output(&mut self, op_id: NodeId, index: usize) -> Option<NodeId> {
+        let Some(Node::Operator(op_node)) = self.get_node_mut(op_id) else {
+            panic!("operator node not found");
+        };
+        let output_id = op_node.clear_output(index)?;
+
+        if self.source_ids.get(&output_id) == Some(&op_id) {
+            self.source_ids.remove(&output_id);
+        }
+        self.clear_cached_plan();
+
+        Some(output_id)
+    }
+
     /// Replace an operator input with a different value or constant.
     pub fn replace_input(&mut self, op_id: NodeId, old_input_id: NodeId, new_input_id: NodeId) {
         let Some(Node::Operator(op_node)) = self.get_node_mut(op_id) else {
@@ -1197,7 +1219,13 @@ impl Graph {
 
             // Extract outputs or fail if an error occurred.
             let outputs = op_result?;
-            let expected_num_outputs = op_node.output_ids().len();
+
+            // Get expected output count, ignoring trailing unused outputs.
+            let expected_num_outputs = op_node
+                .output_ids()
+                .iter()
+                .rposition(|id| id.is_some())
+                .map_or(0, |index| index + 1);
             if expected_num_outputs > outputs.len() {
                 return Err(RunErrorImpl::OutputMismatch {
                     name: op_node.name().unwrap_or_default().to_string(),

--- a/src/graph/node.rs
+++ b/src/graph/node.rs
@@ -213,6 +213,16 @@ impl OperatorNode {
         self.operator.clone()
     }
 
+    /// Mark the output at `index` as unused and return its previous ID.
+    ///
+    /// The entry is set to `None` rather than removed, as the number of outputs
+    /// affects the behavior of some operators (eg. `Split`).
+    pub(super) fn clear_output(&mut self, index: usize) -> Option<NodeId> {
+        let output_id = self.outputs.get_mut(index)?.take()?;
+        self.output_mask.set_unused(index);
+        Some(output_id)
+    }
+
     /// Replace an input in the operator's list of inputs.
     ///
     /// Consumers outside the graph module should use graph-level methods instead

--- a/src/graph/tests.rs
+++ b/src/graph/tests.rs
@@ -2035,6 +2035,36 @@ fn test_run_context_outputs() {
 }
 
 #[test]
+fn test_clear_operator_output() {
+    let mut g = Graph::new();
+    let input_id = g.add_value(Some("input"), None, None);
+    let out_0 = g.add_value(Some("out_0"), None, None);
+    let out_1 = g.add_value(Some("out_1"), None, None);
+    let op_id = g.add_op(
+        Some("test_op"),
+        Arc::new(RunFn::new(|ctx| {
+            assert_eq!(ctx.outputs(), OutputMask::new(BitSet::from_indices([0]), 2));
+
+            // Values only have to be returned for outputs which are used.
+            Ok([Tensor::from(1.).into()].into_iter().collect())
+        })),
+        &[Some(input_id)],
+        &[Some(out_0), Some(out_1)],
+    );
+
+    assert_eq!(g.clear_operator_output(op_id, 1), Some(out_1));
+    assert_eq!(g.clear_operator_output(op_id, 1), None);
+
+    let (_, op) = g.get_source_node(out_0).unwrap();
+    assert_eq!(op.output_ids(), [Some(out_0), None]);
+    assert!(g.get_source_node(out_1).is_none());
+
+    let input = Tensor::from([1, 2, 3]);
+    g.run(vec![(input_id, input.into())], &[out_0], None, None)
+        .unwrap();
+}
+
+#[test]
 fn test_operator_with_many_outputs() {
     // Operators can have more outputs than the mask tracks individually. All
     // outputs beyond the first 32 are treated as used.

--- a/src/model.rs
+++ b/src/model.rs
@@ -1381,6 +1381,17 @@ mod tests {
         let input_2d_u8 = graph_builder.add_value("input.2d.u8", None, None);
         let input_2d_i8 = graph_builder.add_value("input.2d.i8", None, None);
 
+        for input in [
+            input_node,
+            input_2d,
+            input_bool,
+            input_u8,
+            input_2d_u8,
+            input_2d_i8,
+        ] {
+            graph_builder.add_input(input);
+        }
+
         // 4D shape used as the primary input to test most operators (eg. NCHW image). A few
         // require a different shape.
         let input_shape = [1, 1, 3, 3];
@@ -1399,6 +1410,7 @@ mod tests {
                 let output_name = format!("{}_out", name);
                 let op_output_node = builder.add_value(&output_name, None, None);
                 builder.add_operator(name, op, input_nodes, &[op_output_node]);
+                builder.add_output(op_output_node);
                 op_outputs.push(output_name);
                 op_output_node
             };
@@ -1531,6 +1543,8 @@ mod tests {
                 &[input_2d].map(Some),
                 &[dropout_out, dropout_out_mask],
             );
+            graph_builder.add_output(dropout_out);
+            graph_builder.add_output(dropout_out_mask);
         }
         add_operator!(Elu, [input_node], { alpha: 1.0 });
         add_operator!(Equal, [input_node, input_node]);
@@ -1707,6 +1721,9 @@ mod tests {
         let range_start_node = graph_builder.add_value("range_start", None, None);
         let range_limit_node = graph_builder.add_value("range_limit", None, None);
         let range_delta_node = graph_builder.add_value("range_delta", None, None);
+        for input in [range_start_node, range_limit_node, range_delta_node] {
+            graph_builder.add_input(input);
+        }
         let range_out = add_operator!(
             Range,
             [range_start_node, range_limit_node, range_delta_node]
@@ -1837,6 +1854,8 @@ mod tests {
             &[input_2d, split_splits].map(Some),
             &[split_out_1, split_out_2],
         );
+        graph_builder.add_output(split_out_1);
+        graph_builder.add_output(split_out_2);
 
         add_operator!(Sub, [input_node, input_node]);
         add_operator!(Sum, [input_node, input_node]);
@@ -1859,6 +1878,8 @@ mod tests {
             &[input_2d, topk_k].map(Some),
             &[topk_out_values, topk_out_indices],
         );
+        graph_builder.add_output(topk_out_values);
+        graph_builder.add_output(topk_out_indices);
 
         add_operator!(Transpose, [input_node], { perm: None });
 
@@ -1870,6 +1891,9 @@ mod tests {
         let where_cond = graph_builder.add_value("where_cond", None, None);
         let where_x = graph_builder.add_value("where_x", None, None);
         let where_y = graph_builder.add_value("where_y", None, None);
+        for input in [where_cond, where_x, where_y] {
+            graph_builder.add_input(input);
+        }
         let where_out = add_operator!(Where, [where_cond, where_x, where_y]);
 
         add_operator!(Xor, [input_bool, input_bool]);

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -312,6 +312,16 @@ impl OutputMask {
         }
     }
 
+    /// Mark the output at position `idx` as unused.
+    ///
+    /// This has no effect for outputs beyond the first 32, which are always
+    /// treated as used.
+    pub fn set_unused(&mut self, idx: usize) {
+        if idx < u32::BITS as usize {
+            self.mask.delete(idx as u32);
+        }
+    }
+
     /// Return [`OpError::UnsupportedOutput`] if the unsupported output at the
     /// given index is requested.
     pub fn check_unsupported(&self, idx: usize, name: &'static str) -> Result<(), OpError> {

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -328,6 +328,16 @@ impl GraphMutator {
         &self.output_ids
     }
 
+    /// Mark operator outputs as unused and remove their value nodes from the
+    /// graph.
+    fn clear_operator_outputs(&mut self, outputs: &[(NodeId, usize)]) {
+        let removed_values: Vec<NodeId> = outputs
+            .iter()
+            .filter_map(|(op_id, index)| self.graph.clear_operator_output(*op_id, *index))
+            .collect();
+        self.graph.remove_nodes(&removed_values);
+    }
+
     fn set_captures(&mut self, captures: &[NodeId]) {
         self.graph.set_captures(captures)
     }
@@ -518,6 +528,13 @@ impl GraphOptimizer {
             diag.set_level(level);
         }
 
+        // Remove unused operator outputs.
+        //
+        // This is done first so that later passes, in particular constant
+        // propagation, don't evaluate operators which would fail because an
+        // unsupported output was requested.
+        self.remove_unused_outputs(&mut graph_mut);
+
         // Perform shape inference to update type and shape metadata for nodes.
         //
         // This can unlock fusions which have restrictions on the shapes and
@@ -659,6 +676,39 @@ impl GraphOptimizer {
         }
 
         Ok(graph_mut.finalize_graph())
+    }
+
+    /// Mark operator outputs whose values are not used anywhere in the graph
+    /// as unused, and remove the corresponding value nodes.
+    fn remove_unused_outputs(&self, graph: &mut GraphMutator) {
+        let captured_values = graph.graph().subgraph_capture_value_ids();
+
+        // Check if a value is used - either as a graph output, captured by a
+        // subgraph or as an input to another operator.
+        let is_used = |value_id: NodeId| {
+            graph.output_ids().contains(&value_id)
+                || captured_values.contains(&value_id)
+                || graph
+                    .graph()
+                    .get_consumers(value_id)
+                    .is_some_and(|consumers| !consumers.is_empty())
+        };
+
+        // Unused operator outputs as `(operator_id, output_index)` pairs.
+        let unused: Vec<(NodeId, usize)> = graph
+            .graph()
+            .iter()
+            .filter_map(|(op_id, node)| node.as_operator().map(|op| (op_id, op)))
+            .flat_map(|(op_id, op)| {
+                op.output_ids()
+                    .iter()
+                    .enumerate()
+                    .filter(|(_index, output_id)| output_id.is_some_and(|id| !is_used(id)))
+                    .map(move |(index, _output_id)| (op_id, index))
+            })
+            .collect();
+
+        graph.clear_operator_outputs(&unused);
     }
 
     /// Replace captured values in a graph with constants if the captured value

--- a/src/optimize/tests.rs
+++ b/src/optimize/tests.rs
@@ -18,7 +18,7 @@ use crate::ops::{
     Add, Cast, ComputeShape, Conv, ConvInteger, DynamicQuantizeLinear, Erf, Expand, FusedMatMul,
     Gather, Gelu, GroupedQueryAttentionMatMul, Identity, If, IsNaN, LayerNormalization, MatMul,
     MatMulInteger, Neg, Padding, Pow, RMSNormalization, ReduceMean, RepeatInterleave, Reshape,
-    Shape, Sigmoid, Slice, Softmax, Sqrt, Swish, Tanh, Transpose, Unsqueeze, Where,
+    Shape, Sigmoid, Slice, Softmax, Split, Sqrt, Swish, Tanh, Transpose, Unsqueeze, Where,
 };
 use crate::value::{DataType, Value, ValueType};
 
@@ -933,6 +933,145 @@ fn test_no_eliminate_value_captured_by_subgraph() {
         .get_source_node(cast_out)
         .expect("captured value should still have a producer");
     assert_eq!(op.operator().name(), "Cast");
+}
+
+/// Create a graph containing a `DynamicQuantizeLinear` operator with three
+/// outputs, of which only those in `used_outputs` are graph outputs.
+fn quantize_graph(used_outputs: &[usize]) -> Graph {
+    let x = Expr::value("x");
+    let quant = x.apply(
+        DynamicQuantizeLinear {},
+        &[],
+        &[OutputMeta::NoMeta, OutputMeta::NoMeta, OutputMeta::NoMeta],
+    );
+    let outputs: Vec<_> = used_outputs.iter().map(|&i| quant.output(i)).collect();
+    Expr::make_graph([x], outputs)
+}
+
+/// Return the operator which produces the first output of `graph`.
+fn first_output_source(graph: &Graph) -> &OperatorNode {
+    let (_, op) = graph.get_source_node(graph.output_ids()[0]).unwrap();
+    op
+}
+
+#[test]
+fn test_remove_unused_outputs() {
+    let graph = quantize_graph(&[0]);
+
+    let unused_ids: Vec<NodeId> = first_output_source(&graph).output_ids()[1..]
+        .iter()
+        .flatten()
+        .copied()
+        .collect();
+    assert_eq!(unused_ids.len(), 2);
+
+    let graph = optimize_graph(graph).unwrap();
+
+    let op = first_output_source(&graph);
+    assert_eq!(op.operator().name(), "DynamicQuantizeLinear");
+    assert_eq!(op.output_ids()[1..], [None, None]);
+
+    for id in unused_ids {
+        assert!(graph.get_node(id).is_none());
+    }
+}
+
+#[test]
+fn test_does_not_remove_output_used_as_graph_output() {
+    let graph = optimize_graph(quantize_graph(&[0, 2])).unwrap();
+
+    let op = first_output_source(&graph);
+    assert!(op.output_ids()[1].is_none());
+    assert_eq!(op.output_ids()[2], Some(graph.output_ids()[1]));
+}
+
+#[test]
+fn test_does_not_remove_output_used_by_operator() {
+    let x = Expr::value("x");
+    let quant = x.apply(
+        DynamicQuantizeLinear {},
+        &[],
+        &[OutputMeta::NoMeta, OutputMeta::NoMeta, OutputMeta::NoMeta],
+    );
+    let neg_scale = quant.output(1).unary(Neg {});
+    let graph = optimize_graph(Expr::make_graph([x], [quant.output(0), neg_scale])).unwrap();
+
+    let op = first_output_source(&graph);
+    let scale_id = op.output_ids()[1].expect("scale output should be preserved");
+    assert_eq!(
+        graph
+            .get_consuming_op(scale_id)
+            .map(|op| op.operator().name()),
+        Some("Neg")
+    );
+    assert!(op.output_ids()[2].is_none());
+}
+
+#[test]
+fn test_does_not_remove_output_captured_by_subgraph() {
+    let mut graph = Graph::new();
+    let input = graph.add_value(Some("x"), None, Some(ValueType::Tensor(DataType::Float)));
+    let cond = graph.add_value(Some("cond"), None, Some(ValueType::Tensor(DataType::Int32)));
+    graph.set_input_ids(&[input, cond]);
+
+    let quant_out = graph.add_value(Some("quant_out"), None, None);
+    let scale = graph.add_value(Some("scale"), None, None);
+    let zero_point = graph.add_value(Some("zero_point"), None, None);
+    graph.add_op(
+        Some("quant"),
+        Arc::new(DynamicQuantizeLinear {}),
+        &[Some(input)],
+        &[quant_out, scale, zero_point].map(Some),
+    );
+
+    // Build then/else branches which each capture "scale" and return it.
+    let make_branch = || {
+        let mut sg = Graph::new();
+        let cap = sg.add_value(Some("scale"), None, None);
+        sg.set_captures(&[cap]);
+        sg.set_output_ids(&[cap]);
+        sg
+    };
+
+    let if_out = graph.add_value(Some("if_out"), None, None);
+    graph.add_op(
+        Some("If"),
+        Arc::new(If {
+            then_branch: make_branch(),
+            else_branch: make_branch(),
+        }),
+        &[Some(cond)],
+        &[Some(if_out)],
+    );
+    graph.set_output_ids(&[quant_out, if_out]);
+
+    let graph = optimize_graph(graph).unwrap();
+
+    let op = first_output_source(&graph);
+    assert_eq!(op.output_ids()[1], Some(scale));
+    // Un-captured zero-point output should be removed.
+    assert!(op.output_ids()[2].is_none());
+}
+
+#[test]
+fn test_removing_unused_output_preserves_output_count() {
+    // When the optimizer removes unused operator outputs, it must preserve
+    // the length of the output list as this can affect the behavior of the
+    // `Split` operator.
+    let x = Expr::value("x");
+    let split = x.apply(
+        Split {
+            axis: 0,
+            num_outputs: None,
+        },
+        &[],
+        &[OutputMeta::NoMeta, OutputMeta::NoMeta, OutputMeta::NoMeta],
+    );
+    let graph = optimize_graph(Expr::make_graph([x.clone()], [split.output(0)])).unwrap();
+
+    let op = first_output_source(&graph);
+    assert_eq!(op.output_ids().len(), 3);
+    assert_eq!(op.output_ids()[1..], [None, None]);
 }
 
 #[test]


### PR DESCRIPTION
Add an optimization pass which marks operator outputs as unused if their value is not used, either as a graph output, captured by a subgraph or used as an input to another operator. The value nodes for these outputs are removed from the graph.

This allows operators to skip computing unused outputs and enables models to run if an operator requests an unsupported output but doesn't use it. A caveat with this is that such models will _only_ run when graph optimization is enabled.

Outputs are set to `None` rather than being removed from the operator's output list, as the number of outputs affects the behavior of `Split`. As a result operators may now return fewer values than they have outputs, so the check for this in `Graph::run` only requires values up to the last used output.

A consequence of these changes is that calling `Model::run` with an output list which requests an intermediate node's value may have succeeded before if that output was unused but now it will fail. This affected the `test_all_op_types` test, which now declares all op inputs/outputs as graph inputs/outputs.

Fixes https://github.com/robertknight/rten/issues/1434