### PR TITLE
Allow operator error messages to contain dynamic details

### DIFF
--- a/src/graph/tests.rs
+++ b/src/graph/tests.rs
@@ -1562,7 +1562,7 @@ impl Operator for Subgraph {
     }
 
     fn run(&self, _ctx: &OpRunContext) -> Result<OutputList, OpError> {
-        Err(OpError::InvalidValue(
+        Err(OpError::invalid_value(
             "operator must be run with `run_subgraph`",
         ))
     }

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -128,22 +128,42 @@ pub enum OpError {
 
     /// Input tensor shapes are not compatible with each other or operator
     /// attributes.
-    IncompatibleInputShapes(&'static str),
+    IncompatibleInputShapes(Cow<'static, str>),
 
     /// The number of inputs was less than the required number.
     MissingInputs,
 
     /// An input has a value that is incorrect.
-    InvalidValue(&'static str),
+    InvalidValue(Cow<'static, str>),
 
     /// An input or attribute has a value that is valid, but not currently supported.
-    UnsupportedValue(&'static str),
+    UnsupportedValue(Cow<'static, str>),
 
     /// An output was requested that is currently unsupported.
-    UnsupportedOutput(&'static str),
+    UnsupportedOutput(Cow<'static, str>),
 }
 
 impl OpError {
+    /// Create an [`IncompatibleInputShapes`](OpError::IncompatibleInputShapes) error.
+    pub fn incompatible_input_shapes(details: impl Into<Cow<'static, str>>) -> OpError {
+        OpError::IncompatibleInputShapes(details.into())
+    }
+
+    /// Create an [`InvalidValue`](OpError::InvalidValue) error.
+    pub fn invalid_value(details: impl Into<Cow<'static, str>>) -> OpError {
+        OpError::InvalidValue(details.into())
+    }
+
+    /// Create an [`UnsupportedValue`](OpError::UnsupportedValue) error.
+    pub fn unsupported_value(details: impl Into<Cow<'static, str>>) -> OpError {
+        OpError::UnsupportedValue(details.into())
+    }
+
+    /// Create an [`UnsupportedOutput`](OpError::UnsupportedOutput) error.
+    pub fn unsupported_output(name: impl Into<Cow<'static, str>>) -> OpError {
+        OpError::UnsupportedOutput(name.into())
+    }
+
     /// Associate this error with a given operator input.
     pub fn with_input_index(self, index: usize) -> OpError {
         match self {
@@ -212,7 +232,7 @@ macro_rules! static_dims {
         use rten_tensor::prelude::*;
 
         if $tensor.ndim() != $ndim {
-            Err(OpError::InvalidValue(concat!(
+            Err(OpError::invalid_value(concat!(
                 stringify!($tensor),
                 " must have ",
                 stringify!($ndim),
@@ -229,7 +249,7 @@ macro_rules! static_dims {
         use rten_tensor::prelude::*;
 
         if $tensor.ndim() != $ndim {
-            Err(OpError::InvalidValue(concat!(
+            Err(OpError::invalid_value(concat!(
                 stringify!($tensor),
                 " must have ",
                 stringify!($ndim),
@@ -261,7 +281,7 @@ macro_rules! check_eq {
     };
     ($actual:expr, $expected:expr, $msg:expr) => {{
         if $actual != $expected {
-            return Err(OpError::IncompatibleInputShapes($msg));
+            return Err(OpError::incompatible_input_shapes($msg));
         }
         Ok::<_, OpError>(())
     }};
@@ -324,9 +344,13 @@ impl OutputMask {
 
     /// Return [`OpError::UnsupportedOutput`] if the unsupported output at the
     /// given index is requested.
-    pub fn check_unsupported(&self, idx: usize, name: &'static str) -> Result<(), OpError> {
+    pub fn check_unsupported(
+        &self,
+        idx: usize,
+        name: impl Into<Cow<'static, str>>,
+    ) -> Result<(), OpError> {
         if self.is_used(idx) {
-            Err(OpError::UnsupportedOutput(name))
+            Err(OpError::unsupported_output(name))
         } else {
             Ok(())
         }
@@ -590,7 +614,7 @@ pub trait Operator: Any + Debug {
         #[allow(unused)] in_place: InPlaceInputs,
         #[allow(unused)] ctx: &OpRunContext,
     ) -> Result<OutputList, OpError> {
-        Err(OpError::InvalidValue("In-place execution not supported"))
+        Err(OpError::invalid_value("In-place execution not supported"))
     }
 
     /// Return the IDs of inputs which can be pre-packed using [`prepack`](Operator::prepack).

--- a/src/ops/attention.rs
+++ b/src/ops/attention.rs
@@ -1,5 +1,6 @@
 //! Attention-related operations.
 
+use std::borrow::Cow;
 use std::mem::MaybeUninit;
 
 use rayon::prelude::*;
@@ -22,7 +23,8 @@ use crate::ops::{
 };
 use crate::value::{Value, ValueView};
 
-const BROADCAST_ERROR: OpError = OpError::IncompatibleInputShapes("Cannot broadcast inputs");
+const BROADCAST_ERROR: OpError =
+    OpError::IncompatibleInputShapes(Cow::Borrowed("Cannot broadcast inputs"));
 
 /// Perform lanewise `Add + Softmax` on tensors `qk` and `m`.
 ///
@@ -171,7 +173,7 @@ fn repeat_interleave<T: Copy>(
     repeats: usize,
 ) -> Result<Tensor<T>, OpError> {
     if input.ndim() <= axis {
-        return Err(OpError::InvalidValue("Input has too few dims"));
+        return Err(OpError::invalid_value("Input has too few dims"));
     }
 
     // Insert temporary 1-sized axis and use broadcasting to repeat along
@@ -264,13 +266,13 @@ impl Operator for GroupedQueryAttentionMatMul {
         let [rhs_batch, rhs_heads, rhs_k, rhs_n] = rhs.shape();
 
         if batch != rhs_batch {
-            return Err(OpError::IncompatibleInputShapes("Batch size mismatch"));
+            return Err(OpError::incompatible_input_shapes("Batch size mismatch"));
         }
         if k != rhs_k {
-            return Err(OpError::IncompatibleInputShapes("K size mismatch"));
+            return Err(OpError::incompatible_input_shapes("K size mismatch"));
         }
         if rhs_heads * self.repeats != heads {
-            return Err(OpError::IncompatibleInputShapes(
+            return Err(OpError::incompatible_input_shapes(
                 "Repeated axis size mismatch",
             ));
         }
@@ -329,7 +331,7 @@ pub fn split_attention_heads<'a>(
 ) -> Result<CowNdTensor<'a, f32, 4>, OpError> {
     let [batch_size, seq_len, hidden] = input.shape();
     if hidden != num_heads * head_size {
-        return Err(OpError::IncompatibleInputShapes(
+        return Err(OpError::incompatible_input_shapes(
             "Hidden size does not match number of attention heads",
         ));
     }
@@ -452,7 +454,7 @@ fn take_past_kv(
         } else if index == past_value_index {
             past_value = Some(cache);
         } else {
-            return Err(OpError::InvalidValue("unexpected in-place input"));
+            return Err(OpError::invalid_value("unexpected in-place input"));
         }
     }
     Ok((past_key, past_value))
@@ -488,7 +490,7 @@ fn concat_past_kv<'a, 'b>(
                 || pv_head_size != v_head_size
                 || pk_seq != pv_seq
             {
-                return Err(OpError::IncompatibleInputShapes(
+                return Err(OpError::incompatible_input_shapes(
                     "past_key/past_value shape does not match key/value shape",
                 ));
             }
@@ -501,7 +503,7 @@ fn concat_past_kv<'a, 'b>(
             Ok(pk_seq)
         }
         (None, None) => Ok(0),
-        _ => Err(OpError::InvalidValue(
+        _ => Err(OpError::invalid_value(
             "past_key and past_value must either both be present or both be absent",
         )),
     }
@@ -681,11 +683,11 @@ impl Attention {
             3 => true,
             4 => false,
             _ => {
-                return Err(OpError::InvalidValue("query must have 3 or 4 dimensions"));
+                return Err(OpError::invalid_value("query must have 3 or 4 dimensions"));
             }
         };
         if key.ndim() != query.ndim() || value.ndim() != query.ndim() {
-            return Err(OpError::IncompatibleInputShapes(
+            return Err(OpError::incompatible_input_shapes(
                 "query, key and value must have the same rank",
             ));
         }
@@ -694,14 +696,14 @@ impl Attention {
 
         // Reshape inputs to (batch, heads, seq, head_size) layout.
         let (query, key, value) = if input_3d {
-            let q_num_heads = self.q_num_heads.ok_or(OpError::InvalidValue(
+            let q_num_heads = self.q_num_heads.ok_or(OpError::invalid_value(
                 "q_num_heads is required for 3D inputs",
             ))? as usize;
-            let kv_num_heads = self.kv_num_heads.ok_or(OpError::InvalidValue(
+            let kv_num_heads = self.kv_num_heads.ok_or(OpError::invalid_value(
                 "kv_num_heads is required for 3D inputs",
             ))? as usize;
             if q_num_heads == 0 || kv_num_heads == 0 {
-                return Err(OpError::InvalidValue(
+                return Err(OpError::invalid_value(
                     "q_num_heads and kv_num_heads must be positive",
                 ));
             }
@@ -714,28 +716,28 @@ impl Attention {
             let [key_batch, kv_seq, k_hidden] = key.shape();
             let [value_batch, v_seq, v_hidden] = value.shape();
             if key_batch != batch || value_batch != batch {
-                return Err(OpError::IncompatibleInputShapes(
+                return Err(OpError::incompatible_input_shapes(
                     "query, key and value must have the same batch size",
                 ));
             }
             if kv_seq != v_seq {
-                return Err(OpError::IncompatibleInputShapes(
+                return Err(OpError::incompatible_input_shapes(
                     "key and value must have the same sequence length",
                 ));
             }
             if q_hidden % q_num_heads != 0 {
-                return Err(OpError::IncompatibleInputShapes(
+                return Err(OpError::incompatible_input_shapes(
                     "query hidden size must be divisible by q_num_heads",
                 ));
             }
             let head_size = q_hidden / q_num_heads;
             if k_hidden % kv_num_heads != 0 || v_hidden % kv_num_heads != 0 {
-                return Err(OpError::IncompatibleInputShapes(
+                return Err(OpError::incompatible_input_shapes(
                     "key/value hidden size must be divisible by kv_num_heads",
                 ));
             }
             if k_hidden / kv_num_heads != head_size {
-                return Err(OpError::IncompatibleInputShapes(
+                return Err(OpError::incompatible_input_shapes(
                     "key head size must match query head size",
                 ));
             }
@@ -755,17 +757,17 @@ impl Attention {
             let [key_batch, kv_heads, kv_seq, k_head_size] = key.shape();
             let [value_batch, v_kv_heads, value_seq, _v_head_size] = value.shape();
             if key_batch != batch || value_batch != batch {
-                return Err(OpError::IncompatibleInputShapes(
+                return Err(OpError::incompatible_input_shapes(
                     "query, key and value must have the same batch size",
                 ));
             }
             if kv_heads != v_kv_heads || kv_seq != value_seq {
-                return Err(OpError::IncompatibleInputShapes(
+                return Err(OpError::incompatible_input_shapes(
                     "key and value must have the same number of heads and sequence length",
                 ));
             }
             if k_head_size != head_size {
-                return Err(OpError::IncompatibleInputShapes(
+                return Err(OpError::incompatible_input_shapes(
                     "key head size must match query head size",
                 ));
             }
@@ -781,7 +783,7 @@ impl Attention {
         let kv_num_heads = key.size(1);
 
         if q_num_heads == 0 || kv_num_heads == 0 || !q_num_heads.is_multiple_of(kv_num_heads) {
-            return Err(OpError::IncompatibleInputShapes(
+            return Err(OpError::incompatible_input_shapes(
                 "q_num_heads must be a positive multiple of kv_num_heads",
             ));
         }
@@ -796,12 +798,12 @@ impl Attention {
 
         if let Some(nonpad) = nonpad_kv_seqlen.as_ref() {
             if has_past_kv {
-                return Err(OpError::InvalidValue(
+                return Err(OpError::invalid_value(
                     "nonpad_kv_seqlen cannot be combined with past_key/past_value",
                 ));
             }
             if nonpad.len() != batch {
-                return Err(OpError::IncompatibleInputShapes(
+                return Err(OpError::incompatible_input_shapes(
                     "nonpad_kv_seqlen must have batch_size elements",
                 ));
             }
@@ -809,7 +811,7 @@ impl Attention {
                 .iter()
                 .any(|&len| len < 0 || len as usize > total_seq)
             {
-                return Err(OpError::InvalidValue(
+                return Err(OpError::invalid_value(
                     "nonpad_kv_seqlen entry is out of range",
                 ));
             }
@@ -829,7 +831,7 @@ impl Attention {
                 mask.try_broadcast(target).map_err(|_| BROADCAST_ERROR)?,
             )),
             Some(_) => {
-                return Err(OpError::InvalidValue(
+                return Err(OpError::invalid_value(
                     "attn_mask must have a float or bool (int32) type",
                 ));
             }
@@ -1723,7 +1725,7 @@ mod tests {
         let err = run_attention(&op, &inputs).unwrap_err();
         assert_eq!(
             err,
-            OpError::IncompatibleInputShapes("key and value must have the same sequence length")
+            OpError::incompatible_input_shapes("key and value must have the same sequence length")
         );
     }
 
@@ -1829,26 +1831,26 @@ mod tests {
             Case {
                 nonpad: vec![3, 3],
                 with_past: true,
-                expected: OpError::InvalidValue(
+                expected: OpError::invalid_value(
                     "nonpad_kv_seqlen cannot be combined with past_key/past_value",
                 ),
             },
             Case {
                 nonpad: vec![3],
                 with_past: false,
-                expected: OpError::IncompatibleInputShapes(
+                expected: OpError::incompatible_input_shapes(
                     "nonpad_kv_seqlen must have batch_size elements",
                 ),
             },
             Case {
                 nonpad: vec![-1, 3],
                 with_past: false,
-                expected: OpError::InvalidValue("nonpad_kv_seqlen entry is out of range"),
+                expected: OpError::invalid_value("nonpad_kv_seqlen entry is out of range"),
             },
             Case {
                 nonpad: vec![4, 3],
                 with_past: false,
-                expected: OpError::InvalidValue("nonpad_kv_seqlen entry is out of range"),
+                expected: OpError::invalid_value("nonpad_kv_seqlen entry is out of range"),
             },
         ];
 

--- a/src/ops/attention/contrib.rs
+++ b/src/ops/attention/contrib.rs
@@ -35,7 +35,7 @@ impl<'a> MhaQuery<'a> {
         match query.ndim() {
             5 => Ok(Self::Packed(query.nd_view())),
             3 => Ok(Self::Unpacked(query.nd_view())),
-            _ => Err(OpError::InvalidValue("query must have 3 or 5 dims")),
+            _ => Err(OpError::invalid_value("query must have 3 or 5 dims")),
         }
     }
 }
@@ -82,19 +82,19 @@ impl MultiHeadAttention {
 
         let past_seq_len: Option<NdTensorView<i32, 0>> = ctx.inputs().get_as(8)?;
         if past_seq_len.is_some() {
-            return Err(OpError::UnsupportedValue("past_seq_len is not supported"));
+            return Err(OpError::unsupported_value("past_seq_len is not supported"));
         }
 
         let cache_indirection: Option<NdTensorView<i32, 3>> = ctx.inputs().get_as(9)?;
         if cache_indirection.is_some() {
-            return Err(OpError::UnsupportedValue(
+            return Err(OpError::unsupported_value(
                 "cache_indirection is not supported",
             ));
         }
 
         let num_heads = self.num_heads as usize;
         if num_heads == 0 {
-            return Err(OpError::InvalidValue("num_heads must be positive"));
+            return Err(OpError::invalid_value("num_heads must be positive"));
         }
 
         let (query, key, value, batch_size, seq_len, head_size) = match query {
@@ -102,27 +102,27 @@ impl MultiHeadAttention {
                 let [batch_size, kv_seq_len, q_num_heads, three, head_size] = query.shape();
 
                 if key.is_some() {
-                    return Err(OpError::InvalidValue(
+                    return Err(OpError::invalid_value(
                         "key must be None when query is packed",
                     ));
                 }
                 if value.is_some() {
-                    return Err(OpError::InvalidValue(
+                    return Err(OpError::invalid_value(
                         "value must be None when query is packed",
                     ));
                 }
                 if bias.is_some() {
-                    return Err(OpError::InvalidValue(
+                    return Err(OpError::invalid_value(
                         "bias is not supported with packed QKV format",
                     ));
                 }
                 if three != 3 {
-                    return Err(OpError::InvalidValue(
+                    return Err(OpError::invalid_value(
                         "4th dimension of packed qkv input must be 3",
                     ));
                 }
                 if q_num_heads != num_heads {
-                    return Err(OpError::InvalidValue(
+                    return Err(OpError::invalid_value(
                         "2nd dimension of packed qkv input must be equal to number of attention heads",
                     ));
                 }
@@ -143,7 +143,7 @@ impl MultiHeadAttention {
             MhaQuery::Unpacked(query) => {
                 let [batch_size, seq_len, hidden] = query.shape();
                 if hidden % num_heads != 0 {
-                    return Err(OpError::IncompatibleInputShapes(
+                    return Err(OpError::incompatible_input_shapes(
                         "Hidden size must be divisible by number of attention heads",
                     ));
                 }
@@ -153,7 +153,7 @@ impl MultiHeadAttention {
                     (None, _) => (query, query), // Reference impl ignores if value is some
                     (Some(key), Some(value)) => (key, value),
                     (Some(_), None) => {
-                        return Err(OpError::InvalidValue(
+                        return Err(OpError::invalid_value(
                             "value input must be set if key input is present",
                         ));
                     }
@@ -165,17 +165,17 @@ impl MultiHeadAttention {
                     || value_batch != batch_size
                     || value_seq_len != key_seq_len
                 {
-                    return Err(OpError::IncompatibleInputShapes(
+                    return Err(OpError::incompatible_input_shapes(
                         "Key and value batch or sequence lengths do not match",
                     ));
                 }
                 if key_hidden != hidden {
-                    return Err(OpError::IncompatibleInputShapes(
+                    return Err(OpError::incompatible_input_shapes(
                         "Key hidden size does not match query hidden size",
                     ));
                 }
                 if v_hidden % num_heads != 0 {
-                    return Err(OpError::IncompatibleInputShapes(
+                    return Err(OpError::incompatible_input_shapes(
                         "Value hidden size must be divisible by number of attention heads",
                     ));
                 }
@@ -183,7 +183,7 @@ impl MultiHeadAttention {
 
                 let (query, key, value) = if let Some(bias) = bias {
                     if bias.shape() != [hidden * 2 + v_hidden] {
-                        return Err(OpError::IncompatibleInputShapes(
+                        return Err(OpError::incompatible_input_shapes(
                             "Bias shape does not match QKV hidden sizes",
                         ));
                     }
@@ -249,7 +249,7 @@ impl MultiHeadAttention {
         if let Some(key_padding_mask) = key_padding_mask
             && key_padding_mask.shape() != [batch_size, total_seq_len]
         {
-            return Err(OpError::IncompatibleInputShapes(
+            return Err(OpError::incompatible_input_shapes(
                 "key_padding_mask shape does not match key sequence length",
             ));
         }
@@ -463,7 +463,7 @@ impl GroupQueryAttention {
         }
         let seqlens_k = seqlens_k
             .into_rank::<1>()
-            .map_err(|_| OpError::UnsupportedValue("seqlens_k must be a vector"))?;
+            .map_err(|_| OpError::unsupported_value("seqlens_k must be a vector"))?;
 
         // Scalar. Maximum total sequence length (past + new) across the batch.
         let total_seqlen: NdTensorView<i32, 0> = inputs.require_as(6)?;
@@ -477,21 +477,23 @@ impl GroupQueryAttention {
         let head_sink: Option<NdTensorView<f32, 1>> = inputs.get_as(11)?;
 
         if head_sink.is_some() {
-            return Err(OpError::UnsupportedValue("head_sink is not supported"));
+            return Err(OpError::unsupported_value("head_sink is not supported"));
         }
         if self.smooth_softmax {
-            return Err(OpError::UnsupportedValue("smooth_softmax is not supported"));
+            return Err(OpError::unsupported_value(
+                "smooth_softmax is not supported",
+            ));
         }
 
         let num_heads = self.num_heads as usize;
         let kv_num_heads = self.kv_num_heads as usize;
         if num_heads == 0 || kv_num_heads == 0 {
-            return Err(OpError::InvalidValue(
+            return Err(OpError::invalid_value(
                 "num_heads and kv_num_heads must be positive",
             ));
         }
         if !num_heads.is_multiple_of(kv_num_heads) {
-            return Err(OpError::InvalidValue(
+            return Err(OpError::invalid_value(
                 "num_heads must be a multiple of kv_num_heads",
             ));
         }
@@ -506,7 +508,7 @@ impl GroupQueryAttention {
             (Some(key), Some(value)) => {
                 let [batch, seq, q_hidden] = query.shape();
                 if !q_hidden.is_multiple_of(num_heads) {
-                    return Err(OpError::IncompatibleInputShapes(
+                    return Err(OpError::incompatible_input_shapes(
                         "query hidden size must be divisible by num_heads",
                     ));
                 }
@@ -515,17 +517,17 @@ impl GroupQueryAttention {
                 let [key_batch, kv_seq, kv_hidden] = key.shape();
                 let [value_batch, value_seq, value_hidden] = value.shape();
                 if key_batch != batch || value_batch != batch {
-                    return Err(OpError::IncompatibleInputShapes(
+                    return Err(OpError::incompatible_input_shapes(
                         "key and value batch size must match query",
                     ));
                 }
                 if kv_seq != value_seq || kv_hidden != value_hidden {
-                    return Err(OpError::IncompatibleInputShapes(
+                    return Err(OpError::incompatible_input_shapes(
                         "key and value must have the same shape",
                     ));
                 }
                 if kv_hidden != kv_num_heads * head_size {
-                    return Err(OpError::IncompatibleInputShapes(
+                    return Err(OpError::incompatible_input_shapes(
                         "key hidden size must equal kv_num_heads * head_size",
                     ));
                 }
@@ -533,7 +535,7 @@ impl GroupQueryAttention {
                 // not supported. New key/value sequence length must match the
                 // query.
                 if kv_seq != seq {
-                    return Err(OpError::UnsupportedValue(
+                    return Err(OpError::unsupported_value(
                         "key sequence length must match query sequence length",
                     ));
                 }
@@ -551,7 +553,7 @@ impl GroupQueryAttention {
                 let [batch, seq, packed_hidden] = query.shape();
                 let total_heads = num_heads + 2 * kv_num_heads;
                 if !packed_hidden.is_multiple_of(total_heads) {
-                    return Err(OpError::IncompatibleInputShapes(
+                    return Err(OpError::incompatible_input_shapes(
                         "packed query hidden size must be divisible by num_heads + 2 * kv_num_heads",
                     ));
                 }
@@ -568,7 +570,7 @@ impl GroupQueryAttention {
                 )
             }
             _ => {
-                return Err(OpError::InvalidValue(
+                return Err(OpError::invalid_value(
                     "key and value must both be present or both absent",
                 ));
             }
@@ -577,14 +579,14 @@ impl GroupQueryAttention {
 
         // Resolve per-batch sequence lengths.
         if seqlens_k.len() != batch {
-            return Err(OpError::IncompatibleInputShapes(
+            return Err(OpError::incompatible_input_shapes(
                 "seqlens_k must have batch_size elements",
             ));
         }
 
         let total_sequence_length = total_seqlen.item().copied().unwrap();
         if total_sequence_length <= 0 {
-            return Err(OpError::InvalidValue(
+            return Err(OpError::invalid_value(
                 "total_sequence_length must be positive",
             ));
         }
@@ -602,7 +604,7 @@ impl GroupQueryAttention {
                     || pv_head_size != head_size
                     || pk_seq != pv_seq
                 {
-                    return Err(OpError::IncompatibleInputShapes(
+                    return Err(OpError::incompatible_input_shapes(
                         "past_key/past_value shape does not match",
                     ));
                 }
@@ -610,7 +612,7 @@ impl GroupQueryAttention {
             }
             (None, None) => 0,
             _ => {
-                return Err(OpError::InvalidValue(
+                return Err(OpError::invalid_value(
                     "past_key and past_value must both be present or both absent",
                 ));
             }
@@ -621,22 +623,22 @@ impl GroupQueryAttention {
         let is_subsequent_prompt = seq > 1 && seq != total_sequence_length;
 
         if is_subsequent_prompt && batch != 1 {
-            return Err(OpError::UnsupportedValue(
+            return Err(OpError::unsupported_value(
                 "batch size must be 1 when sequence_length > 1 and a past context is given",
             ));
         }
         if !is_first_prompt && !is_subsequent_prompt && seq != 1 {
-            return Err(OpError::InvalidValue(
+            return Err(OpError::invalid_value(
                 "sequence_length must be 1 when query is not a prompt",
             ));
         }
 
         for &len in seqlens_k.iter() {
             if len < 0 || len as usize >= present_seq {
-                return Err(OpError::InvalidValue("seqlens_k entry is out of range"));
+                return Err(OpError::invalid_value("seqlens_k entry is out of range"));
             }
             if (len as usize + 1) < seq {
-                return Err(OpError::InvalidValue(
+                return Err(OpError::invalid_value(
                     "seqlens_k entry is too small for the query sequence length",
                 ));
             }
@@ -650,7 +652,7 @@ impl GroupQueryAttention {
                 || bias_seq < seq
                 || bias_total < present_seq
             {
-                return Err(OpError::IncompatibleInputShapes(
+                return Err(OpError::incompatible_input_shapes(
                     "attention_bias shape is incompatible with query/key shapes",
                 ));
             }
@@ -671,7 +673,7 @@ impl GroupQueryAttention {
         // Apply rotary embeddings to Q and K
         let (rotary_q, rotary_k) = if self.do_rotary {
             let (Some(cos), Some(sin)) = (cos_cache, sin_cache) else {
-                return Err(OpError::InvalidValue(
+                return Err(OpError::invalid_value(
                     "cos_cache and sin_cache are required when do_rotary is set",
                 ));
             };
@@ -1235,7 +1237,7 @@ mod tests {
         let result = run_gqa(&op, &query, &key, &value, None, None, &seqlens_k, 2);
         assert_eq!(
             result.err().unwrap(),
-            OpError::UnsupportedValue("smooth_softmax is not supported")
+            OpError::unsupported_value("smooth_softmax is not supported")
         );
 
         // num_heads must be a multiple of kv_num_heads.
@@ -1243,7 +1245,7 @@ mod tests {
         let result = run_gqa(&op, &query, &key, &value, None, None, &seqlens_k, 2);
         assert_eq!(
             result.err().unwrap(),
-            OpError::InvalidValue("num_heads must be a multiple of kv_num_heads")
+            OpError::invalid_value("num_heads must be a multiple of kv_num_heads")
         );
 
         // Inconsistent seqlens_k / total_sequence_length
@@ -1260,7 +1262,7 @@ mod tests {
         );
         assert_eq!(
             result.err().unwrap(),
-            OpError::InvalidValue("seqlens_k entry is too small for the query sequence length")
+            OpError::invalid_value("seqlens_k entry is too small for the query sequence length")
         );
 
         // First-prompt query (seq == total_sequence_length) whose seqlens_k entry
@@ -1278,7 +1280,7 @@ mod tests {
         );
         assert_eq!(
             result.err().unwrap(),
-            OpError::InvalidValue("seqlens_k entry is too small for the query sequence length")
+            OpError::invalid_value("seqlens_k entry is too small for the query sequence length")
         );
 
         // seqlens_k implies a past context larger than the supplied past_key
@@ -1302,7 +1304,7 @@ mod tests {
         );
         assert_eq!(
             result.err().unwrap(),
-            OpError::InvalidValue("seqlens_k entry is out of range")
+            OpError::invalid_value("seqlens_k entry is out of range")
         );
     }
 
@@ -1384,7 +1386,7 @@ mod tests {
         let bias = NdTensor::<f32, 4>::zeros([1, 1, 1, 2]);
         assert_eq!(
             run_with_bias(&bias).err().unwrap(),
-            OpError::IncompatibleInputShapes(
+            OpError::incompatible_input_shapes(
                 "attention_bias shape is incompatible with query/key shapes"
             )
         );
@@ -1393,7 +1395,7 @@ mod tests {
         let bias = NdTensor::<f32, 4>::zeros([1, 1, 2, 1]);
         assert_eq!(
             run_with_bias(&bias).err().unwrap(),
-            OpError::IncompatibleInputShapes(
+            OpError::incompatible_input_shapes(
                 "attention_bias shape is incompatible with query/key shapes"
             )
         );
@@ -1402,7 +1404,7 @@ mod tests {
         let bias = NdTensor::<f32, 4>::zeros([1, 3, 2, 2]);
         assert_eq!(
             run_with_bias(&bias).err().unwrap(),
-            OpError::IncompatibleInputShapes(
+            OpError::incompatible_input_shapes(
                 "attention_bias shape is incompatible with query/key shapes"
             )
         );

--- a/src/ops/binary_elementwise.rs
+++ b/src/ops/binary_elementwise.rs
@@ -259,8 +259,9 @@ pub fn binary_op<T: Copy, U: Copy, R>(
     b: TensorView<U>,
     op: &dyn BinaryKernel<T, U, R>,
 ) -> Result<Tensor<R>, OpError> {
-    let out_shape = broadcast_shapes(a.shape(), b.shape())
-        .ok_or(OpError::IncompatibleInputShapes("Cannot broadcast inputs"))?;
+    let out_shape = broadcast_shapes(a.shape(), b.shape()).ok_or(
+        OpError::incompatible_input_shapes("Cannot broadcast inputs"),
+    )?;
 
     // Fast path for when LHS and RHS are contiguous, and fast broadcasting is
     // possible.
@@ -603,7 +604,7 @@ logical_boolean_op!(Xor, xor, |x, y| x ^ y);
 /// inputs zeros are allowed in the divisor and produce inf or NaN.
 fn check_nonzero<T: Default + PartialEq>(x: &TensorView<T>) -> Result<(), OpError> {
     if x.iter().any(|x| *x == T::default()) {
-        Err(OpError::InvalidValue("Divisor contains zero"))
+        Err(OpError::invalid_value("Divisor contains zero"))
     } else {
         Ok(())
     }
@@ -1059,7 +1060,7 @@ impl Pow {
             (ValueView::Int32Tensor(base), ValueView::Int32Tensor(exponent)) => {
                 pow(ctx.pool(), base, exponent).map(|t| t.into())
             }
-            _ => Err(OpError::UnsupportedValue(
+            _ => Err(OpError::unsupported_value(
                 "Unsupported base and exponent type combination",
             )),
         }
@@ -1107,7 +1108,7 @@ impl Operator for Pow {
                     pow_in_place(base.view_mut(), exponent);
                     Ok(base.into())
                 }
-                _ => Err(OpError::UnsupportedValue(
+                _ => Err(OpError::unsupported_value(
                     "Unsupported base and exponent type combination",
                 )),
             }
@@ -1192,10 +1193,12 @@ pub fn where_op<T: Copy>(
     x: TensorView<T>,
     y: TensorView<T>,
 ) -> Result<Tensor<T>, OpError> {
-    let broadcast_xy_shape = broadcast_shapes(x.shape(), y.shape())
-        .ok_or(OpError::IncompatibleInputShapes("Cannot broadcast inputs"))?;
-    let result_shape = broadcast_shapes(cond.shape(), &broadcast_xy_shape)
-        .ok_or(OpError::IncompatibleInputShapes("Cannot broadcast inputs"))?;
+    let broadcast_xy_shape = broadcast_shapes(x.shape(), y.shape()).ok_or(
+        OpError::incompatible_input_shapes("Cannot broadcast inputs"),
+    )?;
+    let result_shape = broadcast_shapes(cond.shape(), &broadcast_xy_shape).ok_or(
+        OpError::incompatible_input_shapes("Cannot broadcast inputs"),
+    )?;
 
     let out_len = result_shape.iter().product();
     let mut out_data = pool.alloc(out_len);
@@ -1484,7 +1487,9 @@ mod tests {
 
         assert_eq!(
             result.err(),
-            Some(OpError::IncompatibleInputShapes("Cannot broadcast inputs"))
+            Some(OpError::incompatible_input_shapes(
+                "Cannot broadcast inputs"
+            ))
         );
     }
 
@@ -1536,7 +1541,7 @@ mod tests {
         let result = div(&pool, a.view(), b.view());
         assert_eq!(
             result.err(),
-            Some(OpError::InvalidValue("Divisor contains zero"))
+            Some(OpError::invalid_value("Divisor contains zero"))
         );
 
         // Zero in float divisor
@@ -1585,7 +1590,7 @@ mod tests {
         let result = div_in_place(a.view_mut(), b.view());
         assert_eq!(
             result.err(),
-            Some(OpError::InvalidValue("Divisor contains zero"))
+            Some(OpError::invalid_value("Divisor contains zero"))
         );
 
         // Zero in float divisor
@@ -1727,7 +1732,7 @@ mod tests {
         let result = mod_op(&pool, a.view(), b.view(), DivMode::FloorDiv);
         assert_eq!(
             result.err(),
-            Some(OpError::InvalidValue("Divisor contains zero"))
+            Some(OpError::invalid_value("Divisor contains zero"))
         );
 
         // Zero in float divisor
@@ -2027,14 +2032,18 @@ mod tests {
         let result = where_op(&pool, cond.view(), x.view(), y.view());
         assert_eq!(
             result.err(),
-            Some(OpError::IncompatibleInputShapes("Cannot broadcast inputs"))
+            Some(OpError::incompatible_input_shapes(
+                "Cannot broadcast inputs"
+            ))
         );
 
         // Failure to broadcast `y` to match `cond`
         let result = where_op(&pool, cond.view(), y.view(), x.view());
         assert_eq!(
             result.err(),
-            Some(OpError::IncompatibleInputShapes("Cannot broadcast inputs"))
+            Some(OpError::incompatible_input_shapes(
+                "Cannot broadcast inputs"
+            ))
         );
     }
 

--- a/src/ops/compute_shape.rs
+++ b/src/ops/compute_shape.rs
@@ -56,7 +56,7 @@ impl Operator for ComputeShape {
             .map(|sym| {
                 let input = inputs.require(sym.input.as_usize())?;
                 if input.ndim() <= sym.axis.as_usize() {
-                    return Err(OpError::InvalidValue("Axis invalid for input shape"));
+                    return Err(OpError::invalid_value("Axis invalid for input shape"));
                 }
                 let size = input.size(sym.axis.as_usize()) as i32;
                 Ok((sym.name.as_str(), size))
@@ -69,7 +69,7 @@ impl Operator for ComputeShape {
             .iter()
             .map(|expr| {
                 expr.eval(&symbols)
-                    .map_err(|_| OpError::InvalidValue("Failed to evaluate symbolic shape"))
+                    .map_err(|_| OpError::invalid_value("Failed to evaluate symbolic shape"))
             })
             .collect::<Result<Vec<i32>, _>>()?;
 
@@ -166,7 +166,7 @@ mod tests {
         let result: Result<NdTensor<i32, 1>, _> = op.run_simple(input_a.view());
         assert_eq!(
             result.err().unwrap(),
-            OpError::InvalidValue("Axis invalid for input shape")
+            OpError::invalid_value("Axis invalid for input shape")
         );
     }
 }

--- a/src/ops/concat.rs
+++ b/src/ops/concat.rs
@@ -27,14 +27,14 @@ fn concatenated_shape<T: Copy>(
     for other in inputs {
         let other_shape = other.shape();
         if other_shape.len() != first_shape.len() {
-            return Err(OpError::IncompatibleInputShapes(
+            return Err(OpError::incompatible_input_shapes(
                 "Tensors must have the same number of dimensions",
             ));
         }
         for (d, (first_size, other_size)) in first_shape.iter().zip(other_shape.iter()).enumerate()
         {
             if d != axis && first_size != other_size {
-                return Err(OpError::IncompatibleInputShapes(
+                return Err(OpError::incompatible_input_shapes(
                     "Dimensions must be the same except for concat axis",
                 ));
             } else if d == axis {
@@ -242,7 +242,7 @@ pub fn tile<T: Copy>(
     repeats: NdTensorView<i32, 1>,
 ) -> Result<Tensor<T>, OpError> {
     if repeats.size(0) != input.ndim() || repeats.iter().any(|n| *n < 0) {
-        return Err(OpError::InvalidValue("invalid repeats"));
+        return Err(OpError::invalid_value("invalid repeats"));
     }
 
     let repeats: Vec<usize> = repeats.iter().map(|r| *r as usize).collect();
@@ -424,7 +424,10 @@ mod tests {
         // Invalid `dim` attribute
         let input = from_slice(&[1, 2, 3]);
         let result = concat(&pool, &[input.view(), input.view()], 1);
-        assert_eq!(result.err(), Some(OpError::InvalidValue("Axis is invalid")));
+        assert_eq!(
+            result.err(),
+            Some(OpError::invalid_value("Axis is invalid"))
+        );
 
         // Shape mismatch
         let a = Tensor::<f32>::zeros(&[1]);
@@ -432,7 +435,7 @@ mod tests {
         let result = concat(&pool, &[a.view(), b.view()], 0);
         assert_eq!(
             result.err(),
-            Some(OpError::IncompatibleInputShapes(
+            Some(OpError::incompatible_input_shapes(
                 "Tensors must have the same number of dimensions"
             ))
         );
@@ -443,7 +446,7 @@ mod tests {
         let result = concat(&pool, &[a.view(), b.view()], 0);
         assert_eq!(
             result.err(),
-            Some(OpError::IncompatibleInputShapes(
+            Some(OpError::incompatible_input_shapes(
                 "Dimensions must be the same except for concat axis"
             ))
         );
@@ -536,13 +539,13 @@ mod tests {
             Case {
                 input: Tensor::from([1, 2, 3]),
                 repeats: Tensor::from([1, 2]),
-                expected_error: OpError::InvalidValue("invalid repeats"),
+                expected_error: OpError::invalid_value("invalid repeats"),
             },
             // Negative repeats
             Case {
                 input: Tensor::from([1, 2, 3]),
                 repeats: Tensor::from([-1]),
-                expected_error: OpError::InvalidValue("invalid repeats"),
+                expected_error: OpError::invalid_value("invalid repeats"),
             },
         ];
 

--- a/src/ops/control_flow.rs
+++ b/src/ops/control_flow.rs
@@ -43,7 +43,7 @@ impl Operator for If {
     }
 
     fn run(&self, _ctx: &OpRunContext) -> Result<OutputList, OpError> {
-        Err(OpError::InvalidValue(
+        Err(OpError::invalid_value(
             "operator must be run with `run_subgraph`",
         ))
     }
@@ -84,7 +84,7 @@ impl SubgraphOperator for If {
         let Some(cond_bool) = cond.item().copied() else {
             return Err(RunError::op_error(
                 node_name,
-                OpError::InvalidValue("cond must be a single value"),
+                OpError::invalid_value("cond must be a single value"),
                 ctx,
             ));
         };
@@ -141,7 +141,7 @@ impl Operator for Loop {
     }
 
     fn run(&self, _ctx: &OpRunContext) -> Result<OutputList, OpError> {
-        Err(OpError::InvalidValue(
+        Err(OpError::invalid_value(
             "operator must be run with `run_subgraph`",
         ))
     }
@@ -199,14 +199,14 @@ impl SubgraphOperator for Loop {
 
         let input_ids = self.body.input_ids();
         if input_ids.len() != 2 + loop_carried_deps.len() {
-            return Err(make_run_error(OpError::InvalidValue(
+            return Err(make_run_error(OpError::invalid_value(
                 "loop body has too few inputs",
             )));
         }
 
         let output_ids = self.body.output_ids();
         if output_ids.len() < 1 + loop_carried_deps.len() {
-            return Err(make_run_error(OpError::InvalidValue(
+            return Err(make_run_error(OpError::invalid_value(
                 "loop body has too few outputs",
             )));
         }
@@ -238,10 +238,12 @@ impl SubgraphOperator for Loop {
 
             // Extract condition.
             let next_cond: Tensor<i32> = step_outputs.remove(0).try_into().map_err(|_| {
-                make_run_error(OpError::InvalidValue("condition output has incorrect type"))
+                make_run_error(OpError::invalid_value(
+                    "condition output has incorrect type",
+                ))
             })?;
             let Some(&next_cond) = next_cond.item() else {
-                return Err(make_run_error(OpError::InvalidValue(
+                return Err(make_run_error(OpError::invalid_value(
                     "condition output should be a scalar",
                 )));
             };
@@ -307,11 +309,11 @@ where
 
     for output in rest {
         let mut typed_output: Tensor<T> = output.try_into().map_err(|_| {
-            OpError::InvalidValue("scan output has different type across iterations")
+            OpError::invalid_value("scan output has different type across iterations")
         })?;
         typed_output.insert_axis(0);
         tensor.append(0, &typed_output).map_err(|_| {
-            OpError::InvalidValue("scan output has different shape across iterations")
+            OpError::invalid_value("scan output has different shape across iterations")
         })?;
     }
 

--- a/src/ops/conv.rs
+++ b/src/ops/conv.rs
@@ -153,14 +153,14 @@ where
         let strides_2d = match strides {
             &[stride] => [1, stride],
             _ => {
-                return Err(OpError::InvalidValue("expected 1 stride value"));
+                return Err(OpError::invalid_value("expected 1 stride value"));
             }
         };
 
         let dilations_2d = match dilations {
             &[dilation] => [1, dilation],
             _ => {
-                return Err(OpError::InvalidValue("expected 1 dilation value"));
+                return Err(OpError::invalid_value("expected 1 dilation value"));
             }
         };
 
@@ -199,10 +199,10 @@ where
 
     let [stride_y, stride_x]: [usize; 2] = strides
         .try_into()
-        .map_err(|_| OpError::InvalidValue("expected 2 stride values"))?;
+        .map_err(|_| OpError::invalid_value("expected 2 stride values"))?;
     let [dilation_y, dilation_x]: [usize; 2] = dilations
         .try_into()
-        .map_err(|_| OpError::InvalidValue("expected 2 dilation values"))?;
+        .map_err(|_| OpError::invalid_value("expected 2 dilation values"))?;
 
     let (out_h, out_w, fixed_padding) = calc_output_size_and_padding(
         (in_h, in_w),
@@ -224,25 +224,25 @@ where
         .map(|zero_point| QuantParams { zero_point });
 
     if groups == 0 {
-        return Err(OpError::InvalidValue("Group count must be > 0"));
+        return Err(OpError::invalid_value("Group count must be > 0"));
     }
 
     let in_chans_per_group = in_c / groups;
     if in_c % groups != 0 {
-        return Err(OpError::InvalidValue(
+        return Err(OpError::invalid_value(
             "Input channel count not divisible by groups",
         ));
     }
 
     if in_chans_per_group != k_in_c {
-        return Err(OpError::IncompatibleInputShapes(
+        return Err(OpError::incompatible_input_shapes(
             "Input channels (per group) does not match kernel input channels",
         ));
     }
 
     let out_chans_per_group = out_channels / groups;
     if out_channels % groups != 0 {
-        return Err(OpError::InvalidValue(
+        return Err(OpError::invalid_value(
             "Output channel count not divisible by groups",
         ));
     }
@@ -445,7 +445,7 @@ where
 
     let input_zero = if let Some(zero_point) = input_zero {
         let Some(&zero) = zero_point.item() else {
-            return Err(OpError::InvalidValue("input zero point must be a scalar"));
+            return Err(OpError::invalid_value("input zero point must be a scalar"));
         };
         zero
     } else {
@@ -571,7 +571,7 @@ impl Operator for ConvIntegerToFloat {
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let scale: TensorView<f32> = ctx.inputs().require_as(4)?;
         let Some(&scale) = scale.item() else {
-            return Err(OpError::InvalidValue("scale should be a scalar"));
+            return Err(OpError::invalid_value("scale should be a scalar"));
         };
         let output: Tensor<i32> = self.conv.run(ctx)?.remove(0).try_into().unwrap();
         cast_scale(ctx.pool(), output, OutputScale::Scalar(scale)).into_op_result()
@@ -1199,7 +1199,7 @@ mod tests {
                 strides: &[1, 1],
                 dilations: &[1, 1],
                 groups: 1,
-                expected: OpError::InvalidValue("Input too small for kernel size"),
+                expected: OpError::invalid_value("Input too small for kernel size"),
             },
             // Zero stride
             Case {
@@ -1208,7 +1208,7 @@ mod tests {
                 strides: &[0, 0],
                 dilations: &[1, 1],
                 groups: 1,
-                expected: OpError::InvalidValue("Strides must be > 0"),
+                expected: OpError::invalid_value("Strides must be > 0"),
             },
             // Unsupported stride count
             Case {
@@ -1217,7 +1217,7 @@ mod tests {
                 strides: &[1, 1, 1],
                 dilations: &[1, 1],
                 groups: 1,
-                expected: OpError::InvalidValue("expected 2 stride values"),
+                expected: OpError::invalid_value("expected 2 stride values"),
             },
             // Unsupported dilation count
             Case {
@@ -1226,7 +1226,7 @@ mod tests {
                 strides: &[1, 1],
                 dilations: &[1, 1, 1],
                 groups: 1,
-                expected: OpError::InvalidValue("expected 2 dilation values"),
+                expected: OpError::invalid_value("expected 2 dilation values"),
             },
             // Zero groups
             Case {
@@ -1235,7 +1235,7 @@ mod tests {
                 strides: &[1, 1],
                 dilations: &[1, 1],
                 groups: 0,
-                expected: OpError::InvalidValue("Group count must be > 0"),
+                expected: OpError::invalid_value("Group count must be > 0"),
             },
             // Input channels don't match kernel input channels. This is a 1x1
             // kernel, so it exercises the pointwise fast path.
@@ -1245,7 +1245,7 @@ mod tests {
                 strides: &[1, 1],
                 dilations: &[1, 1],
                 groups: 1,
-                expected: OpError::IncompatibleInputShapes(
+                expected: OpError::incompatible_input_shapes(
                     "Input channels (per group) does not match kernel input channels",
                 ),
             },
@@ -1582,7 +1582,7 @@ mod tests {
             // Non-scalar scale.
             Case {
                 scale: Tensor::from([0.1, 0.2, 0.3]),
-                expected: Err(OpError::InvalidValue("scale should be a scalar")),
+                expected: Err(OpError::invalid_value("scale should be a scalar")),
             },
         ];
 

--- a/src/ops/conv_transpose.rs
+++ b/src/ops/conv_transpose.rs
@@ -155,19 +155,19 @@ fn conv_transpose_output_size_and_padding(
     let [out_pad_h, out_pad_w] = output_padding;
 
     if stride_h == 0 || stride_w == 0 {
-        return Err(OpError::InvalidValue("Strides must be > 0"));
+        return Err(OpError::invalid_value("Strides must be > 0"));
     }
 
     if dilation_h == 0 || dilation_w == 0 {
-        return Err(OpError::InvalidValue("Dilations must be > 0"));
+        return Err(OpError::invalid_value("Dilations must be > 0"));
     }
 
     if kernel_shape.contains(&0) {
-        return Err(OpError::InvalidValue("Kernel size must be > 0"));
+        return Err(OpError::invalid_value("Kernel size must be > 0"));
     }
 
     if in_h == 0 || in_w == 0 {
-        return Err(OpError::InvalidValue("Input width and height must be > 0"));
+        return Err(OpError::invalid_value("Input width and height must be > 0"));
     }
 
     // Effective kernel size after dilation.
@@ -188,7 +188,7 @@ fn conv_transpose_output_size_and_padding(
             let (Some(pad_h), Some(pad_w)) = (pad_h, pad_w) else {
                 // We can't achieve an output size of (out_h, out_w) even with
                 // no padding.
-                return Err(OpError::InvalidValue("Input is too small"));
+                return Err(OpError::invalid_value("Input is too small"));
             };
 
             // If the total padding is not even, we assign the remaining unit to
@@ -209,12 +209,12 @@ fn conv_transpose_output_size_and_padding(
                     ((in_w - 1) * stride_w + out_pad_w + k_w).checked_sub(pad_left + pad_right);
 
                 let (Some(out_h), Some(out_w)) = (out_h, out_w) else {
-                    return Err(OpError::InvalidValue("Input is too small"));
+                    return Err(OpError::invalid_value("Input is too small"));
                 };
 
                 Ok(([out_h, out_w], [pad_top, pad_left, pad_bottom, pad_right]))
             }
-            _ => Err(OpError::InvalidValue("Wrong number of pad values")),
+            _ => Err(OpError::invalid_value("Wrong number of pad values")),
         },
     }
 }
@@ -251,14 +251,14 @@ pub fn conv_transpose(
         let strides_2d = match strides {
             &[stride] => [1, stride],
             _ => {
-                return Err(OpError::InvalidValue("expected 1 stride value"));
+                return Err(OpError::invalid_value("expected 1 stride value"));
             }
         };
 
         let dilations_2d = match dilations {
             &[dilation] => [1, dilation],
             _ => {
-                return Err(OpError::InvalidValue("expected 1 dilation value"));
+                return Err(OpError::invalid_value("expected 1 dilation value"));
             }
         };
 
@@ -266,7 +266,7 @@ pub fn conv_transpose(
             Some(&[pad]) => [0, pad],
             None => [0, 0],
             _ => {
-                return Err(OpError::InvalidValue("expected 1 output_padding value"));
+                return Err(OpError::invalid_value("expected 1 output_padding value"));
             }
         };
 
@@ -290,7 +290,7 @@ pub fn conv_transpose(
     }
 
     if groups == 0 {
-        return Err(OpError::InvalidValue("Group count must be > 0"));
+        return Err(OpError::invalid_value("Group count must be > 0"));
     }
 
     let input = static_dims!(input, 4, "NCHW")?;
@@ -306,28 +306,28 @@ pub fn conv_transpose(
     let bias = bias.map(|b| b.nd_view());
 
     if in_c != k_in_c {
-        return Err(OpError::IncompatibleInputShapes(
+        return Err(OpError::incompatible_input_shapes(
             "Input channels does not match kernel input channels",
         ));
     }
 
     if k_in_c % groups != 0 {
-        return Err(OpError::InvalidValue(
+        return Err(OpError::invalid_value(
             "Input channel count not divisible by groups",
         ));
     }
 
     let &[stride_h, stride_w] = strides else {
-        return Err(OpError::InvalidValue("expected 2 stride values"));
+        return Err(OpError::invalid_value("expected 2 stride values"));
     };
     let &[dilation_h, dilation_w] = dilations else {
-        return Err(OpError::InvalidValue("expected 2 dilation values"));
+        return Err(OpError::invalid_value("expected 2 dilation values"));
     };
     let [out_pad_h, out_pad_w] = match output_padding {
         Some(&[h, w]) => [h, w],
         None => [0, 0],
         _ => {
-            return Err(OpError::InvalidValue("expected 2 output_padding values"));
+            return Err(OpError::invalid_value("expected 2 output_padding values"));
         }
     };
 
@@ -781,7 +781,7 @@ mod tests {
                     strides: [1, 1],
                     dilations: [1, 1],
                     output_padding: [0, 0],
-                    expected: Err(OpError::InvalidValue("default value")),
+                    expected: Err(OpError::invalid_value("default value")),
                 }
             }
         }
@@ -856,7 +856,7 @@ mod tests {
                 kernel_shape: [1, 1],
                 padding: Padding::Same,
                 strides: [3, 3],
-                expected: Err(OpError::InvalidValue("Input is too small")),
+                expected: Err(OpError::invalid_value("Input is too small")),
                 ..Default::default()
             },
             // Padding too large
@@ -865,7 +865,7 @@ mod tests {
                 kernel_shape: [3, 3],
                 padding: Padding::Fixed([4, 4, 4, 4].into()),
                 strides: [1, 1],
-                expected: Err(OpError::InvalidValue("Input is too small")),
+                expected: Err(OpError::invalid_value("Input is too small")),
                 ..Default::default()
             },
             // Dilations, stride of 1
@@ -900,7 +900,7 @@ mod tests {
                 kernel_shape: [3, 3],
                 padding: Padding::zero::<2>(),
                 strides: [0, 0],
-                expected: Err(OpError::InvalidValue("Strides must be > 0")),
+                expected: Err(OpError::invalid_value("Strides must be > 0")),
                 ..Default::default()
             },
             // Invalid dilations
@@ -908,14 +908,14 @@ mod tests {
                 input_shape: [5, 5],
                 kernel_shape: [3, 3],
                 dilations: [0, 0],
-                expected: Err(OpError::InvalidValue("Dilations must be > 0")),
+                expected: Err(OpError::invalid_value("Dilations must be > 0")),
                 ..Default::default()
             },
             // Empty kernel
             Case {
                 input_shape: [5, 5],
                 kernel_shape: [0, 0],
-                expected: Err(OpError::InvalidValue("Kernel size must be > 0")),
+                expected: Err(OpError::invalid_value("Kernel size must be > 0")),
                 ..Default::default()
             },
             // Empty input
@@ -924,7 +924,7 @@ mod tests {
                 kernel_shape: [3, 3],
                 padding: Padding::zero::<2>(),
                 strides: [1, 1],
-                expected: Err(OpError::InvalidValue("Input width and height must be > 0")),
+                expected: Err(OpError::invalid_value("Input width and height must be > 0")),
                 ..Default::default()
             },
             // Wrong padding size for input spatial shape.
@@ -933,7 +933,7 @@ mod tests {
                 kernel_shape: [3, 3],
                 padding: Padding::zero::<1>(),
                 strides: [1, 1],
-                expected: Err(OpError::InvalidValue("Wrong number of pad values")),
+                expected: Err(OpError::invalid_value("Wrong number of pad values")),
                 ..Default::default()
             },
             // Output padding on Y axis

--- a/src/ops/convert.rs
+++ b/src/ops/convert.rs
@@ -192,7 +192,9 @@ impl Operator for CastLike {
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let target_type = ctx.inputs().require(1)?;
         let ValueType::Tensor(to) = target_type.dtype() else {
-            return Err(OpError::InvalidValue("expected target_type to be a tensor"));
+            return Err(OpError::invalid_value(
+                "expected target_type to be a tensor",
+            ));
         };
         Cast { to }.run(ctx)
     }
@@ -208,7 +210,9 @@ impl Operator for CastLike {
     ) -> Result<OutputList, OpError> {
         let target_type = ctx.inputs().require(1)?;
         let ValueType::Tensor(to) = target_type.dtype() else {
-            return Err(OpError::InvalidValue("expected target_type to be a tensor"));
+            return Err(OpError::invalid_value(
+                "expected target_type to be a tensor",
+            ));
         };
         Cast { to }.run_in_place(in_place, ctx)
     }

--- a/src/ops/einsum.rs
+++ b/src/ops/einsum.rs
@@ -64,22 +64,22 @@ pub fn einsum(
     equation_str: &str,
 ) -> Result<Tensor, OpError> {
     let equation =
-        EinsumExpr::parse(equation_str).map_err(|err| OpError::InvalidValue(err.as_str()))?;
+        EinsumExpr::parse(equation_str).map_err(|err| OpError::invalid_value(err.as_str()))?;
 
     let broadcast_ndim = equation
         .validate_inputs(inputs.iter().map(|view| Some(view.ndim())))
         .map_err(|err| match err {
-            ValidateError::IncorrectInputCount => OpError::InvalidValue(
+            ValidateError::IncorrectInputCount => OpError::invalid_value(
                 "Number of terms in Einsum equation does not match input tensor count",
             ),
             ValidateError::TooManyDims => {
-                OpError::UnsupportedValue("Einsum input or term has too many dimensions")
+                OpError::unsupported_value("Einsum input or term has too many dimensions")
             }
             ValidateError::BroadcastMismatch => {
-                OpError::InvalidValue("Number of broadcast dims does not match across inputs")
+                OpError::invalid_value("Number of broadcast dims does not match across inputs")
             }
             ValidateError::RankMismatch => {
-                OpError::InvalidValue("Einsum term dimension count does not match input tensor")
+                OpError::invalid_value("Einsum term dimension count does not match input tensor")
             }
             // Should not happen as the rank of every input is known.
             ValidateError::UnknownRank => unreachable!(),
@@ -144,7 +144,7 @@ fn take_diagonals<'a>(term: &str, x: &TensorView<'a>) -> Result<(String, TensorV
                 continue;
             }
             if x.size(k) != dim_size {
-                return Err(OpError::InvalidValue(
+                return Err(OpError::invalid_value(
                     "Dimension sizes for repeated labels in term do not match",
                 ));
             }
@@ -198,7 +198,7 @@ fn broadcast_size(a: usize, b: usize) -> Result<usize, OpError> {
     match (a, b) {
         (a, b) if a == b => Ok(a),
         (1, size) | (size, 1) => Ok(size),
-        _ => Err(OpError::IncompatibleInputShapes(
+        _ => Err(OpError::incompatible_input_shapes(
             "Einsum label has different sizes in different terms",
         )),
     }
@@ -972,7 +972,7 @@ mod tests {
             Case {
                 equation: "ij,jk->ik",
                 inputs: vec![mat_a.view()],
-                expected: Err(OpError::InvalidValue(
+                expected: Err(OpError::invalid_value(
                     "Number of terms in Einsum equation does not match input tensor count",
                 )),
             },
@@ -1069,7 +1069,7 @@ mod tests {
             Case {
                 equation: "",
                 inputs: vec![],
-                expected: Err(OpError::InvalidValue(
+                expected: Err(OpError::invalid_value(
                     "Number of terms in Einsum equation does not match input tensor count",
                 )),
             },
@@ -1130,17 +1130,17 @@ mod tests {
             Case {
                 equation: "i1j", // Digits are used internally for ellipsis dims
                 inputs: vec![mat_a.view()],
-                expected: Err(OpError::InvalidValue("Input term is invalid")),
+                expected: Err(OpError::invalid_value("Input term is invalid")),
             },
             Case {
                 equation: "i.j", // Period that is not part of an ellipsis
                 inputs: vec![mat_a.view()],
-                expected: Err(OpError::InvalidValue("Input term is invalid")),
+                expected: Err(OpError::invalid_value("Input term is invalid")),
             },
             Case {
                 equation: "i...j...", // Multiple ellipses in a term
                 inputs: vec![mat_a.view()],
-                expected: Err(OpError::InvalidValue("Input term is invalid")),
+                expected: Err(OpError::invalid_value("Input term is invalid")),
             },
             // Repeated labels in input term take the diagonal.
             Case {
@@ -1163,7 +1163,7 @@ mod tests {
             Case {
                 equation: "ii->i",
                 inputs: vec![mat_a.view()],
-                expected: Err(OpError::InvalidValue(
+                expected: Err(OpError::invalid_value(
                     "Dimension sizes for repeated labels in term do not match",
                 )),
             },
@@ -1171,14 +1171,14 @@ mod tests {
             Case {
                 equation: "ij,jk->i.k",
                 inputs: vec![mat_a.view(), mat_b.view()],
-                expected: Err(OpError::InvalidValue("Output term is invalid")),
+                expected: Err(OpError::invalid_value("Output term is invalid")),
             },
             // Output labels which differ only in case from the input labels
             // refer to dimensions which are not in any input.
             Case {
                 equation: "ij,jk->IK",
                 inputs: vec![mat_a.view(), mat_b.view()],
-                expected: Err(OpError::InvalidValue(
+                expected: Err(OpError::invalid_value(
                     "Einsum output term contains a label not present in any input term",
                 )),
             },
@@ -1186,7 +1186,7 @@ mod tests {
             Case {
                 equation: "ij->ii",
                 inputs: vec![mat_a.view()],
-                expected: Err(OpError::InvalidValue(
+                expected: Err(OpError::invalid_value(
                     "Einsum output term contains repeated labels",
                 )),
             },
@@ -1194,14 +1194,14 @@ mod tests {
             Case {
                 equation: "ij",
                 inputs: vec![vec_a.view()],
-                expected: Err(OpError::InvalidValue(
+                expected: Err(OpError::invalid_value(
                     "Einsum term dimension count does not match input tensor",
                 )),
             },
             Case {
                 equation: "i...j",
                 inputs: vec![vec_a.view()],
-                expected: Err(OpError::InvalidValue(
+                expected: Err(OpError::invalid_value(
                     "Einsum term dimension count does not match input tensor",
                 )),
             },
@@ -1209,7 +1209,7 @@ mod tests {
             Case {
                 equation: "abcdefghijkl...",
                 inputs: vec![TensorView::from_data([0; 12].as_slice(), &[])],
-                expected: Err(OpError::UnsupportedValue(
+                expected: Err(OpError::unsupported_value(
                     "Einsum input or term has too many dimensions",
                 )),
             },
@@ -1217,7 +1217,7 @@ mod tests {
             Case {
                 equation: "...",
                 inputs: vec![TensorView::from_data([0; 11].as_slice(), &[])],
-                expected: Err(OpError::UnsupportedValue(
+                expected: Err(OpError::unsupported_value(
                     "Einsum input or term has too many dimensions",
                 )),
             },
@@ -1287,7 +1287,7 @@ mod tests {
             Case {
                 equation: "...,...->...",
                 inputs: vec![vec_a.view(), mat_a.view()],
-                expected: Err(OpError::InvalidValue(
+                expected: Err(OpError::invalid_value(
                     "Number of broadcast dims does not match across inputs",
                 )),
             },

--- a/src/ops/embedding.rs
+++ b/src/ops/embedding.rs
@@ -25,18 +25,18 @@ fn rotary_cache_dims(
     bad_last_dim: &'static str,
 ) -> Result<(usize, usize), OpError> {
     let &[cache_batch, cache_seq, cache_half] = cache_shape else {
-        return Err(OpError::InvalidValue("cos/sin cache must be a 3D tensor"));
+        return Err(OpError::invalid_value("cos/sin cache must be a 3D tensor"));
     };
     if cache_half != half {
-        return Err(OpError::InvalidValue(bad_last_dim));
+        return Err(OpError::invalid_value(bad_last_dim));
     }
     if cache_seq != 1 && cache_seq != seq_len {
-        return Err(OpError::InvalidValue(
+        return Err(OpError::invalid_value(
             "cos/sin cache sequence length must be 1 or match the input",
         ));
     }
     if cache_batch != 1 && cache_batch != batch {
-        return Err(OpError::InvalidValue(
+        return Err(OpError::invalid_value(
             "cos/sin cache batch size must be 1 or match the input",
         ));
     }
@@ -57,12 +57,12 @@ pub(crate) fn rotary_embedding(
     let reshaped_input = match input.shape() {
         &[batch, seq_len, hidden_size] => {
             if num_heads == 0 {
-                return Err(OpError::InvalidValue(
+                return Err(OpError::invalid_value(
                     "num_heads must not be 0 for 3 dimensioned input",
                 ));
             }
             if hidden_size % num_heads != 0 {
-                return Err(OpError::InvalidValue(
+                return Err(OpError::invalid_value(
                     "hidden_size must be divisible by num_heads",
                 ));
             }
@@ -74,7 +74,7 @@ pub(crate) fn rotary_embedding(
             input.nd_view().permuted([0, 2, 1, 3]).as_cow()
         }
         _ => {
-            return Err(OpError::IncompatibleInputShapes(
+            return Err(OpError::incompatible_input_shapes(
                 "Input processed needs 3-4 dimensions",
             ));
         }
@@ -87,12 +87,12 @@ pub(crate) fn rotary_embedding(
         rotary_embedding_dim
     };
     if rotary_embedding_dim == 0 || rotary_embedding_dim % 2 != 0 {
-        return Err(OpError::InvalidValue(
+        return Err(OpError::invalid_value(
             "rotary_embedding_dim must be a positive even number",
         ));
     }
     if rotary_embedding_dim > head_size {
-        return Err(OpError::InvalidValue(
+        return Err(OpError::invalid_value(
             "rotary_embedding_dim must not exceed head size",
         ));
     }
@@ -603,7 +603,7 @@ mod tests {
 
             assert_eq!(
                 result,
-                Err(OpError::InvalidValue(
+                Err(OpError::invalid_value(
                     "rotary_embedding_dim must be a positive even number"
                 ))
             );

--- a/src/ops/embedding/contrib.rs
+++ b/src/ops/embedding/contrib.rs
@@ -44,7 +44,7 @@ impl Operator for RotaryEmbeddingMicrosoft {
             [batch, seq_len, _] => (batch, seq_len),
             [batch, _, seq_len, _] => (batch, seq_len),
             _ => {
-                return Err(OpError::IncompatibleInputShapes(
+                return Err(OpError::incompatible_input_shapes(
                     "Input processed needs 3-4 dimensions",
                 ));
             }
@@ -66,7 +66,7 @@ impl Operator for RotaryEmbeddingMicrosoft {
             }
             (2, _) => position_ids.nd_view(),
             _ => {
-                return Err(OpError::InvalidValue(
+                return Err(OpError::invalid_value(
                     "position_ids must be a scalar, a 1-element vector or have 2 dims",
                 ));
             }
@@ -84,7 +84,7 @@ impl Operator for RotaryEmbeddingMicrosoft {
                 // be provided explicitly.
                 Some(0) | None => {
                     if self.rotary_embedding_dim != 0 {
-                        return Err(OpError::InvalidValue(
+                        return Err(OpError::invalid_value(
                             "num_heads must be specified when rotary_embedding_dim is set",
                         ));
                     }
@@ -92,15 +92,15 @@ impl Operator for RotaryEmbeddingMicrosoft {
                         .shape()
                         .last()
                         .copied()
-                        .ok_or(OpError::InvalidValue("cos cache must not be scalar"))?;
+                        .ok_or(OpError::invalid_value("cos cache must not be scalar"))?;
                     if head_size_half == 0 {
-                        return Err(OpError::InvalidValue(
+                        return Err(OpError::invalid_value(
                             "Last dimension of cos cache must not be 0",
                         ));
                     }
                     let head_size = head_size_half * 2;
                     if hidden_size % head_size != 0 {
-                        return Err(OpError::InvalidValue(
+                        return Err(OpError::invalid_value(
                             "hidden_size must be divisible by head size",
                         ));
                     }
@@ -192,7 +192,7 @@ mod tests {
 
         assert_eq!(
             result,
-            Err(OpError::InvalidValue(
+            Err(OpError::invalid_value(
                 "num_heads must be specified when rotary_embedding_dim is set"
             ))
         );
@@ -220,7 +220,7 @@ mod tests {
 
         assert_eq!(
             result,
-            Err(OpError::InvalidValue(
+            Err(OpError::invalid_value(
                 "Last dimension of cos cache must not be 0"
             ))
         );
@@ -341,7 +341,7 @@ mod tests {
         ));
         assert_eq!(
             result,
-            Err(OpError::InvalidValue(
+            Err(OpError::invalid_value(
                 "position_ids must be a scalar, a 1-element vector or have 2 dims"
             ))
         );

--- a/src/ops/fft.rs
+++ b/src/ops/fft.rs
@@ -37,7 +37,7 @@ pub fn stft(
         }
         3 => signal.nd_view(),
         _ => {
-            return Err(OpError::InvalidValue("signal must have 2 or 3 dims"));
+            return Err(OpError::invalid_value("signal must have 2 or 3 dims"));
         }
     };
 
@@ -48,7 +48,7 @@ pub fn stft(
             if fl >= 1 && fl as usize <= signal_len {
                 Ok(fl as usize)
             } else {
-                Err(OpError::InvalidValue(
+                Err(OpError::invalid_value(
                     "frame_length must be in range [1, signal_length]",
                 ))
             }
@@ -58,20 +58,20 @@ pub fn stft(
     let frame_step = if frame_step > 0 {
         frame_step as usize
     } else {
-        return Err(OpError::InvalidValue("frame_step must be > 0"));
+        return Err(OpError::invalid_value("frame_step must be > 0"));
     };
 
     // If both `frame_length` and `window` are set, their sizes must match.
     if let (Some(frame_length), Some(window)) = (frame_length, window)
         && frame_length != window.size(0)
     {
-        return Err(OpError::InvalidValue(
+        return Err(OpError::invalid_value(
             "window length must equal frame_length",
         ));
     }
 
     let Some(n_fft) = frame_length.or_else(|| window.map(|w| w.size(0))) else {
-        return Err(OpError::InvalidValue(
+        return Err(OpError::invalid_value(
             "Either frame_length or window must be set",
         ));
     };
@@ -80,14 +80,14 @@ pub fn stft(
         1 => FftType::Real,
         2 => FftType::Complex,
         _ => {
-            return Err(OpError::InvalidValue(
+            return Err(OpError::invalid_value(
                 "Last dimension of signal must have size 1 or 2",
             ));
         }
     };
 
     if matches!(fft_type, FftType::Complex) && onesided {
-        return Err(OpError::InvalidValue(
+        return Err(OpError::invalid_value(
             "FFT cannot be one-sided if input is complex",
         ));
     }
@@ -207,13 +207,15 @@ pub fn dft(
 ) -> Result<Tensor<f32>, OpError> {
     let ndim = input.ndim();
     if ndim < 2 {
-        return Err(OpError::InvalidValue("DFT input must have at least 2 dims"));
+        return Err(OpError::invalid_value(
+            "DFT input must have at least 2 dims",
+        ));
     }
 
     let complex_dim = ndim - 1;
     let n_components = input.size(complex_dim);
     if n_components != 1 && n_components != 2 {
-        return Err(OpError::InvalidValue(
+        return Err(OpError::invalid_value(
             "Last dimension of DFT input must have size 1 or 2",
         ));
     }
@@ -224,12 +226,12 @@ pub fn dft(
     // signal, so it requires real input.
     let irfft = inverse && onesided;
     if irfft && n_components != 2 {
-        return Err(OpError::InvalidValue(
+        return Err(OpError::invalid_value(
             "Inverse one-sided DFT (IRFFT) requires complex input",
         ));
     }
     if onesided && !inverse && n_components == 2 {
-        return Err(OpError::InvalidValue(
+        return Err(OpError::invalid_value(
             "DFT cannot be one-sided if input is complex",
         ));
     }
@@ -238,7 +240,7 @@ pub fn dft(
     // `[-r, -2] ∪ [0, r-2]`, ie. the final (complex) dimension is excluded.
     let dft_axis = resolve_axis(ndim, axis)?;
     if dft_axis == complex_dim {
-        return Err(OpError::InvalidValue(
+        return Err(OpError::invalid_value(
             "DFT axis cannot be the complex dimension",
         ));
     }
@@ -252,7 +254,7 @@ pub fn dft(
     // the default `N` is `2 * (signal_len - 1)`. Matches NumPy's `irfft`.
     let n_fft = match dft_length {
         Some(len) if len >= 1 => len as usize,
-        Some(_) => return Err(OpError::InvalidValue("dft_length must be >= 1")),
+        Some(_) => return Err(OpError::invalid_value("dft_length must be >= 1")),
         None if irfft => 2 * signal_len.saturating_sub(1),
         None => signal_len,
     };
@@ -486,7 +488,7 @@ mod tests {
                     window: None,
                     frame_length: None,
                     onesided: true,
-                    expected: Err(OpError::InvalidValue("Invalid expectation")),
+                    expected: Err(OpError::invalid_value("Invalid expectation")),
                 }
             }
         }
@@ -584,7 +586,7 @@ mod tests {
                 signal: real_signal.clone(),
                 frame_step: 4,
                 frame_length: Some(0),
-                expected: Err(OpError::InvalidValue(
+                expected: Err(OpError::invalid_value(
                     "frame_length must be in range [1, signal_length]",
                 )),
                 ..Default::default()
@@ -593,7 +595,7 @@ mod tests {
                 signal: real_signal.clone(),
                 frame_step: 4,
                 frame_length: Some(real_signal.size(1) as i32 + 1),
-                expected: Err(OpError::InvalidValue(
+                expected: Err(OpError::invalid_value(
                     "frame_length must be in range [1, signal_length]",
                 )),
                 ..Default::default()
@@ -603,14 +605,14 @@ mod tests {
                 signal: real_signal.clone(),
                 frame_step: 0,
                 frame_length: Some(4),
-                expected: Err(OpError::InvalidValue("frame_step must be > 0")),
+                expected: Err(OpError::invalid_value("frame_step must be > 0")),
                 ..Default::default()
             },
             // Missing window and frame_length
             Case {
                 signal: real_signal.clone(),
                 frame_step: 4,
-                expected: Err(OpError::InvalidValue(
+                expected: Err(OpError::invalid_value(
                     "Either frame_length or window must be set",
                 )),
                 ..Default::default()
@@ -621,7 +623,7 @@ mod tests {
                 frame_step: 4,
                 frame_length: Some(4),
                 window: Some([0., 0.5].into()),
-                expected: Err(OpError::InvalidValue(
+                expected: Err(OpError::invalid_value(
                     "window length must equal frame_length",
                 )),
                 ..Default::default()
@@ -632,7 +634,7 @@ mod tests {
                 frame_step: 4,
                 frame_length: Some(4),
                 onesided: true,
-                expected: Err(OpError::InvalidValue(
+                expected: Err(OpError::invalid_value(
                     "FFT cannot be one-sided if input is complex",
                 )),
                 ..Default::default()
@@ -685,7 +687,7 @@ mod tests {
                     axis: -2,
                     inverse: false,
                     onesided: false,
-                    expected: Err(OpError::InvalidValue("Invalid expectation")),
+                    expected: Err(OpError::invalid_value("Invalid expectation")),
                 }
             }
         }
@@ -763,7 +765,7 @@ mod tests {
                 input: real_signal.clone(),
                 inverse: true,
                 onesided: true,
-                expected: Err(OpError::InvalidValue(
+                expected: Err(OpError::invalid_value(
                     "Inverse one-sided DFT (IRFFT) requires complex input",
                 )),
                 ..Default::default()
@@ -773,7 +775,7 @@ mod tests {
             Case {
                 input: complex_signal.clone(),
                 onesided: true,
-                expected: Err(OpError::InvalidValue(
+                expected: Err(OpError::invalid_value(
                     "DFT cannot be one-sided if input is complex",
                 )),
                 ..Default::default()
@@ -820,7 +822,7 @@ mod tests {
             // Invalid component count.
             Case {
                 input: Tensor::from([[[1., 2., 3.]]]),
-                expected: Err(OpError::InvalidValue(
+                expected: Err(OpError::invalid_value(
                     "Last dimension of DFT input must have size 1 or 2",
                 )),
                 ..Default::default()
@@ -829,7 +831,7 @@ mod tests {
             Case {
                 input: real_signal.clone(),
                 dft_length: Some(0),
-                expected: Err(OpError::InvalidValue("dft_length must be >= 1")),
+                expected: Err(OpError::invalid_value("dft_length must be >= 1")),
                 ..Default::default()
             },
         ];

--- a/src/ops/gather.rs
+++ b/src/ops/gather.rs
@@ -1,4 +1,5 @@
 use rayon::prelude::*;
+use std::borrow::Cow;
 use std::mem::MaybeUninit;
 
 use rten_shape_inference::UnaryOp;
@@ -17,7 +18,8 @@ use crate::operator::{
 use crate::ops::{map_value_view, resolve_axis, resolve_index};
 use crate::value::{Value, ValueView};
 
-const INVALID_INDEX_ERR: OpError = OpError::InvalidValue("Entry in `indices` is out of range");
+const INVALID_INDEX_ERR: OpError =
+    OpError::InvalidValue(Cow::Borrowed("Entry in `indices` is out of range"));
 
 /// Trait for random-access to 1D slices.
 trait GetItem {
@@ -200,7 +202,7 @@ pub fn gather_elements<T: Copy + Default + Send + Sync + std::fmt::Debug>(
     axis: isize,
 ) -> Result<Tensor<T>, OpError> {
     if input.ndim() != indices.ndim() {
-        return Err(OpError::IncompatibleInputShapes(
+        return Err(OpError::incompatible_input_shapes(
             "Input and indices must have same rank",
         ));
     }
@@ -210,7 +212,7 @@ pub fn gather_elements<T: Copy + Default + Send + Sync + std::fmt::Debug>(
     // corresponding input dimension, but not larger.
     for d in 0..input.ndim() {
         if d != axis && indices.size(d) > input.size(d) {
-            return Err(OpError::IncompatibleInputShapes(
+            return Err(OpError::incompatible_input_shapes(
                 "`indices` size must be <= input size in non-axis dimensions",
             ));
         }
@@ -240,7 +242,7 @@ pub fn gather_elements<T: Copy + Default + Send + Sync + std::fmt::Debug>(
             if let Some(el) = data.get(idx as usize) {
                 out.write(*el);
             } else {
-                return Err(OpError::InvalidValue("Entry in `indices` is out of range"));
+                return Err(OpError::invalid_value("Entry in `indices` is out of range"));
             }
         }
         Ok(())
@@ -325,25 +327,25 @@ pub fn gather_nd<T: Clone + Default>(
     batch_dims: usize,
 ) -> Result<Tensor<T>, OpError> {
     if input.ndim() < 1 || indices.ndim() < 1 {
-        return Err(OpError::InvalidValue(
+        return Err(OpError::invalid_value(
             "Input and indices must have >= 1 dims",
         ));
     }
     if batch_dims >= input.ndim().min(indices.ndim()) {
-        return Err(OpError::InvalidValue(
+        return Err(OpError::invalid_value(
             "`input` and `indices` ndim must be > `batch_dims`",
         ));
     }
 
     if input.shape()[..batch_dims] != indices.shape()[..batch_dims] {
-        return Err(OpError::InvalidValue(
+        return Err(OpError::invalid_value(
             "`input` and `indices` batch dims have different sizes",
         ));
     }
 
     let idx_tuple_size = indices.size(indices.ndim() - 1);
     if idx_tuple_size < 1 || idx_tuple_size > input.ndim() - batch_dims {
-        return Err(OpError::InvalidValue(
+        return Err(OpError::invalid_value(
             "Size of last dim of `indices` is incorrect",
         ));
     }
@@ -393,7 +395,7 @@ pub fn gather_nd<T: Clone + Default>(
                     .map(|(idx, (size, stride))| {
                         resolve_index(*size, *idx as isize)
                             .map(|idx| idx * stride)
-                            .ok_or(OpError::InvalidValue("Invalid index"))
+                            .ok_or(OpError::invalid_value("Invalid index"))
                     })
                     .sum::<Result<usize, OpError>>()?;
 
@@ -408,7 +410,7 @@ pub fn gather_nd<T: Clone + Default>(
                 let slice_items = to_slice_items(idx);
                 let in_slice = input
                     .try_slice(slice_items.as_slice())
-                    .map_err(|_| OpError::InvalidValue("Invalid index"))?;
+                    .map_err(|_| OpError::invalid_value("Invalid index"))?;
 
                 for (out, x) in out_slice.iter_mut().zip(in_slice.iter()) {
                     out.write(x.clone());
@@ -485,7 +487,7 @@ fn reverse_sequence<T: Copy>(
     layout: SequenceLayout,
 ) -> Result<Tensor<T>, OpError> {
     if input.ndim() < 2 {
-        return Err(OpError::InvalidValue(
+        return Err(OpError::invalid_value(
             "ReverseSequence input must have at least 2 dims",
         ));
     }
@@ -496,13 +498,13 @@ fn reverse_sequence<T: Copy>(
     };
 
     if seq_lens.size(0) != batch_size {
-        return Err(OpError::InvalidValue(
+        return Err(OpError::invalid_value(
             "sequence_lens length must match the batch dimension size",
         ));
     }
     for &len in seq_lens.iter() {
         if len < 0 || len as usize > time_size {
-            return Err(OpError::InvalidValue(
+            return Err(OpError::invalid_value(
                 "sequence_lens values must be in the range [0, time_size]",
             ));
         }
@@ -575,7 +577,7 @@ impl Operator for ReverseSequence {
             (0, 1) => SequenceLayout::BatchFirst,
             (1, 0) => SequenceLayout::TimeFirst,
             _ => {
-                return Err(OpError::InvalidValue(
+                return Err(OpError::invalid_value(
                     "batch_axis and time_axis must be 0 and 1 in some order",
                 ));
             }
@@ -705,7 +707,10 @@ mod tests {
         let input = Tensor::<f32>::rand(&[128, 10], &mut rng);
         let indices = Tensor::from_data(&[2, 2], vec![2, 5, 8, 50]);
         let result = gather(&pool, input.view(), 5, indices.view());
-        assert_eq!(result.err(), Some(OpError::InvalidValue("Axis is invalid")));
+        assert_eq!(
+            result.err(),
+            Some(OpError::invalid_value("Axis is invalid"))
+        );
     }
 
     #[test]
@@ -743,7 +748,7 @@ mod tests {
             let result = gather(&pool, case.input.view(), 0, case.indices.view());
             assert_eq!(
                 result.err(),
-                Some(OpError::InvalidValue("Entry in `indices` is out of range"))
+                Some(OpError::invalid_value("Entry in `indices` is out of range"))
             );
         })
     }
@@ -842,25 +847,27 @@ mod tests {
                 input: [[1, 2], [3, 4]].into(),
                 indices: [[0, 0], [1, 0]].into(),
                 axis: 2,
-                expected: OpError::InvalidValue("Axis is invalid"),
+                expected: OpError::invalid_value("Axis is invalid"),
             },
             Case {
                 input: [[1, 2], [3, 4]].into(),
                 indices: [[0, 0], [1, 3]].into(),
                 axis: 1,
-                expected: OpError::InvalidValue("Entry in `indices` is out of range"),
+                expected: OpError::invalid_value("Entry in `indices` is out of range"),
             },
             Case {
                 input: [[1, 2], [3, 4]].into(),
                 indices: [1, 2, 3].into(),
                 axis: 1,
-                expected: OpError::IncompatibleInputShapes("Input and indices must have same rank"),
+                expected: OpError::incompatible_input_shapes(
+                    "Input and indices must have same rank",
+                ),
             },
             Case {
                 input: [[1, 2], [3, 4]].into(),
                 indices: [[1, 2, 3], [4, 5, 6]].into(),
                 axis: 0,
-                expected: OpError::IncompatibleInputShapes(
+                expected: OpError::incompatible_input_shapes(
                     "`indices` size must be <= input size in non-axis dimensions",
                 ),
             },
@@ -935,14 +942,14 @@ mod tests {
                 data: [[0, 1], [2, 3]].into(),
                 transpose: false,
                 indices: [[0, 0], [1, 2]].into(),
-                expected: Err(OpError::InvalidValue("Invalid index")),
+                expected: Err(OpError::invalid_value("Invalid index")),
             },
             Case {
                 batch_dims: 0,
                 data: [[0, 1], [2, 3]].into(),
                 transpose: false,
                 indices: [[-3, 0]].into(),
-                expected: Err(OpError::InvalidValue("Invalid index")),
+                expected: Err(OpError::invalid_value("Invalid index")),
             },
             // Input with a zero-size dimension in the gathered slice.
             Case {
@@ -981,7 +988,7 @@ mod tests {
                 data: [[0, 1], [2, 3]].into(),
                 transpose: true,
                 indices: [[0, 1], [1, 2]].into(),
-                expected: Err(OpError::InvalidValue("Invalid index")),
+                expected: Err(OpError::invalid_value("Invalid index")),
             },
             // Negative indexes with a transposed (non-contiguous) input.
             Case {
@@ -996,7 +1003,7 @@ mod tests {
                 data: [[0, 1], [2, 3]].into(),
                 transpose: true,
                 indices: [[-3, 0]].into(),
-                expected: Err(OpError::InvalidValue("Invalid index")),
+                expected: Err(OpError::invalid_value("Invalid index")),
             },
         ];
 
@@ -1077,7 +1084,7 @@ mod tests {
                 seq_lens: Tensor::from([1, 2]),
                 batch_axis: 1,
                 time_axis: 0,
-                expected: Err(OpError::InvalidValue(
+                expected: Err(OpError::invalid_value(
                     "sequence_lens length must match the batch dimension size",
                 )),
             },
@@ -1087,7 +1094,7 @@ mod tests {
                 seq_lens: Tensor::from([1, 2, 3, 5]),
                 batch_axis: 1,
                 time_axis: 0,
-                expected: Err(OpError::InvalidValue(
+                expected: Err(OpError::invalid_value(
                     "sequence_lens values must be in the range [0, time_size]",
                 )),
             },
@@ -1097,7 +1104,7 @@ mod tests {
                 seq_lens: Tensor::from([4, 4, 4, 4]),
                 batch_axis: 0,
                 time_axis: 2,
-                expected: Err(OpError::InvalidValue(
+                expected: Err(OpError::invalid_value(
                     "batch_axis and time_axis must be 0 and 1 in some order",
                 )),
             },

--- a/src/ops/generate.rs
+++ b/src/ops/generate.rs
@@ -24,7 +24,7 @@ pub fn constant_of_shape<T: Copy>(
         .iter()
         .map(|el| (*el).try_into())
         .collect::<Result<Vec<_>, _>>()
-        .map_err(|_| OpError::InvalidValue("Invalid shape"))?;
+        .map_err(|_| OpError::invalid_value("Invalid shape"))?;
     Ok(Tensor::full_in(pool, &shape, value))
 }
 
@@ -115,7 +115,7 @@ fn extract_off_on_values<T: Copy>(values: NdTensorView<T, 1>) -> Result<(T, T), 
     if values.len() == 2 {
         Ok((values[0], values[1]))
     } else {
-        Err(OpError::InvalidValue("Expected size-2 vector"))
+        Err(OpError::invalid_value("Expected size-2 vector"))
     }
 }
 
@@ -140,7 +140,7 @@ impl Operator for OneHot {
         let depth = depth
             .item()
             .and_then(|&val| if val > 0 { Some(val as usize) } else { None })
-            .ok_or(OpError::InvalidValue("`depth` must be a positive scalar"))?;
+            .ok_or(OpError::invalid_value("`depth` must be a positive scalar"))?;
         let values = inputs.require(2)?;
 
         map_value_view!(values, values, [Int32Tensor, FloatTensor], {
@@ -173,7 +173,7 @@ pub fn range<T: Copy + Default + ops::Add<Output = T> + PartialOrd>(
     delta: T,
 ) -> Result<Tensor<T>, OpError> {
     if delta == T::default() {
-        return Err(OpError::InvalidValue("delta must be non-zero"));
+        return Err(OpError::invalid_value("delta must be non-zero"));
     }
 
     // This is not very efficient as it grows the output gradually instead of
@@ -210,7 +210,7 @@ impl Operator for Range {
             let start = start
                 .item()
                 .copied()
-                .ok_or(OpError::InvalidValue("`start` must be a scalar"))?;
+                .ok_or(OpError::invalid_value("`start` must be a scalar"))?;
             let limit = limit.try_into()?;
             let delta = delta.try_into()?;
             range(start, limit, delta).into_op_result()
@@ -266,7 +266,7 @@ impl Operator for EyeLike {
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let input = ctx.inputs().require(0)?;
         let ValueType::Tensor(input_dtype) = input.dtype() else {
-            return Err(OpError::InvalidValue("expected input to be a tensor"));
+            return Err(OpError::invalid_value("expected input to be a tensor"));
         };
         let dtype = self.dtype.unwrap_or(input_dtype);
 
@@ -323,7 +323,7 @@ mod tests {
         let result: Result<Tensor<i32>, OpError> = op.run_simple(&shape);
         assert_eq!(
             result.err().unwrap(),
-            OpError::InvalidValue("Invalid shape")
+            OpError::invalid_value("Invalid shape")
         );
     }
 
@@ -468,7 +468,7 @@ mod tests {
                 depth: 2,
                 on_value: 1.,
                 off_value: 0.,
-                expected: Err(OpError::InvalidValue("Axis is invalid")),
+                expected: Err(OpError::invalid_value("Axis is invalid")),
             },
         ];
 
@@ -510,7 +510,7 @@ mod tests {
         let r = range(0, 5, 0);
         assert_eq!(
             r.err(),
-            Some(OpError::InvalidValue("delta must be non-zero"))
+            Some(OpError::invalid_value("delta must be non-zero"))
         );
     }
 }

--- a/src/ops/grid_sample.rs
+++ b/src/ops/grid_sample.rs
@@ -24,13 +24,13 @@ fn grid_sample(
     let [in_batch, in_c, in_h, in_w] = input.shape();
 
     if batch != in_batch {
-        return Err(OpError::IncompatibleInputShapes(
+        return Err(OpError::incompatible_input_shapes(
             "Batch size of input and grid must match",
         ));
     }
 
     if coord_ndim != 2 {
-        return Err(OpError::UnsupportedValue(
+        return Err(OpError::unsupported_value(
             "Unsupported grid coordinate size",
         ));
     }
@@ -312,14 +312,14 @@ mod tests {
             Case {
                 input_shape: [1, 1, 1, 1],
                 grid_shape: [2, 1, 1, 2],
-                expected: OpError::IncompatibleInputShapes(
+                expected: OpError::incompatible_input_shapes(
                     "Batch size of input and grid must match",
                 ),
             },
             Case {
                 input_shape: [1, 1, 1, 1],
                 grid_shape: [1, 1, 1, 3],
-                expected: OpError::UnsupportedValue("Unsupported grid coordinate size"),
+                expected: OpError::unsupported_value("Unsupported grid coordinate size"),
             },
         ];
 

--- a/src/ops/layout.rs
+++ b/src/ops/layout.rs
@@ -32,7 +32,7 @@ pub fn depth_to_space<T: Clone>(
     mode: DepthToSpaceMode,
 ) -> Result<Tensor<T>, OpError> {
     if block_size == 0 {
-        return Err(OpError::InvalidValue("`block_size` must be > 0"));
+        return Err(OpError::invalid_value("`block_size` must be > 0"));
     }
 
     let input = static_dims!(input, 4, "NCHW")?;
@@ -40,7 +40,7 @@ pub fn depth_to_space<T: Clone>(
     let block_size = block_size.as_usize();
 
     if c % (block_size * block_size) != 0 {
-        return Err(OpError::InvalidValue(
+        return Err(OpError::invalid_value(
             "input channels must be a multiple of `block_size` squared",
         ));
     }
@@ -111,8 +111,8 @@ fn expand_output_shape(
         .iter()
         .map(|el| usize::try_from(*el))
         .collect::<Result<_, _>>()
-        .map_err(|_| OpError::InvalidValue("Target shape contains negative values"))?;
-    broadcast_shapes(input_shape, &shape_vec).ok_or(OpError::IncompatibleInputShapes(
+        .map_err(|_| OpError::invalid_value("Target shape contains negative values"))?;
+    broadcast_shapes(input_shape, &shape_vec).ok_or(OpError::incompatible_input_shapes(
         "Cannot broadcast input with target shape",
     ))
 }
@@ -332,10 +332,10 @@ fn resolve_shape(
     let mut specified_dims_size = 1;
     for (dim, &size) in shape.iter().enumerate() {
         if size < -1 {
-            return Err(OpError::InvalidValue("Invalid dimension size in shape"));
+            return Err(OpError::invalid_value("Invalid dimension size in shape"));
         } else if size == 0 && !allow_zero {
             if dim >= input_shape.len() {
-                return Err(OpError::InvalidValue(
+                return Err(OpError::invalid_value(
                     "Zero dim has no corresponding input dim",
                 ));
             }
@@ -343,7 +343,7 @@ fn resolve_shape(
         } else if size != -1 {
             specified_dims_size *= size as usize;
         } else if unspecified_dim.is_some() {
-            return Err(OpError::InvalidValue(
+            return Err(OpError::invalid_value(
                 "Multiple dimensions in new shape set to -1",
             ));
         } else {
@@ -353,7 +353,7 @@ fn resolve_shape(
 
     let input_len: usize = input_shape.iter().product();
     let length_mismatch = || {
-        Err(OpError::InvalidValue(
+        Err(OpError::invalid_value(
             "Input length does not match target shape",
         ))
     };
@@ -363,7 +363,7 @@ fn resolve_shape(
             // The ONNX spec makes a target shape containing both a zero and a
             // `-1` invalid, as the size of the `-1` dim cannot be determined
             // uniquely when the other dims multiply to zero.
-            return Err(OpError::InvalidValue(
+            return Err(OpError::invalid_value(
                 "Cannot infer size of -1 dim when other dims are zero",
             ));
         } else if !input_len.is_multiple_of(specified_dims_size) {
@@ -565,7 +565,7 @@ pub fn squeeze_in_place<T: Clone>(
         let axes = resolve_axes(input.ndim(), axes.iter())?;
         for axis in axes.iter() {
             if input.size(*axis) != 1 {
-                return Err(OpError::InvalidValue(
+                return Err(OpError::invalid_value(
                     "Can only remove dimensions of size 1",
                 ));
             }
@@ -653,7 +653,7 @@ pub fn transpose<T: Copy>(
     match permutation {
         Some(order) => {
             if !is_valid_permutation(input.ndim(), order) {
-                return Err(OpError::InvalidValue("Permutation is invalid"));
+                return Err(OpError::invalid_value("Permutation is invalid"));
             }
             transposed.permute(order)
         }
@@ -723,7 +723,7 @@ pub fn unsqueeze_in_place<T: Clone>(
         .zip(resolved_axes.iter().skip(1))
         .any(|(prev, curr)| prev == curr)
     {
-        return Err(OpError::InvalidValue("Axes must be unique"));
+        return Err(OpError::invalid_value("Axes must be unique"));
     }
 
     for axis in resolved_axes {
@@ -857,7 +857,7 @@ mod tests {
                 input: NdTensor::full([1, 16, 2, 2], 1.0),
                 block_size: 3,
                 mode: DepthToSpaceMode::ColumnRowDepth,
-                expected: Err(OpError::InvalidValue(
+                expected: Err(OpError::invalid_value(
                     "input channels must be a multiple of `block_size` squared",
                 )),
             },
@@ -866,7 +866,7 @@ mod tests {
                 input: NdTensor::full([1, 16, 2, 2], 1.0),
                 block_size: 0,
                 mode: DepthToSpaceMode::ColumnRowDepth,
-                expected: Err(OpError::InvalidValue("`block_size` must be > 0")),
+                expected: Err(OpError::invalid_value("`block_size` must be > 0")),
             },
         ];
 
@@ -933,7 +933,7 @@ mod tests {
             Case {
                 input: Tensor::from([1, 2, 3]),
                 shape: vec![2, 2],
-                expected: Err(OpError::IncompatibleInputShapes(
+                expected: Err(OpError::incompatible_input_shapes(
                     "Cannot broadcast input with target shape",
                 )),
             },
@@ -941,7 +941,7 @@ mod tests {
             Case {
                 input: make_tensor([1]),
                 shape: vec![-1],
-                expected: Err(OpError::InvalidValue(
+                expected: Err(OpError::invalid_value(
                     "Target shape contains negative values",
                 )),
             },
@@ -1016,12 +1016,12 @@ mod tests {
             Case {
                 shape: [2, 3, 4].into(),
                 axis: 4,
-                expected: Err(OpError::InvalidValue("Axis is invalid")),
+                expected: Err(OpError::invalid_value("Axis is invalid")),
             },
             Case {
                 shape: [2, 3, 4].into(),
                 axis: -4,
-                expected: Err(OpError::InvalidValue("Axis is invalid")),
+                expected: Err(OpError::invalid_value("Axis is invalid")),
             },
         ];
 
@@ -1086,7 +1086,7 @@ mod tests {
                 input: &[8],
                 shape: &[9],
                 allow_zero: false,
-                expected: Err(OpError::InvalidValue(
+                expected: Err(OpError::invalid_value(
                     "Input length does not match target shape",
                 )),
             },
@@ -1095,7 +1095,7 @@ mod tests {
                 input: &[2],
                 shape: &[2, 0],
                 allow_zero: false,
-                expected: Err(OpError::InvalidValue(
+                expected: Err(OpError::invalid_value(
                     "Zero dim has no corresponding input dim",
                 )),
             },
@@ -1111,7 +1111,7 @@ mod tests {
                 input: &[10, 1],
                 shape: &[10, 0],
                 allow_zero: true,
-                expected: Err(OpError::InvalidValue(
+                expected: Err(OpError::invalid_value(
                     "Input length does not match target shape",
                 )),
             },
@@ -1120,7 +1120,7 @@ mod tests {
                 input: &[2, 2],
                 shape: &[-1, -1],
                 allow_zero: false,
-                expected: Err(OpError::InvalidValue(
+                expected: Err(OpError::invalid_value(
                     "Multiple dimensions in new shape set to -1",
                 )),
             },
@@ -1129,7 +1129,7 @@ mod tests {
                 input: &[2, 8],
                 shape: &[1, 8],
                 allow_zero: false,
-                expected: Err(OpError::InvalidValue(
+                expected: Err(OpError::invalid_value(
                     "Input length does not match target shape",
                 )),
             },
@@ -1138,7 +1138,7 @@ mod tests {
                 input: &[1, 2, 256, 0],
                 shape: &[1, 512, 256],
                 allow_zero: false,
-                expected: Err(OpError::InvalidValue(
+                expected: Err(OpError::invalid_value(
                     "Input length does not match target shape",
                 )),
             },
@@ -1147,7 +1147,7 @@ mod tests {
                 input: &[0, 4],
                 shape: &[0, -1],
                 allow_zero: true,
-                expected: Err(OpError::InvalidValue(
+                expected: Err(OpError::invalid_value(
                     "Cannot infer size of -1 dim when other dims are zero",
                 )),
             },
@@ -1156,7 +1156,7 @@ mod tests {
                 input: &[0, 4],
                 shape: &[0, -1],
                 allow_zero: false,
-                expected: Err(OpError::InvalidValue(
+                expected: Err(OpError::invalid_value(
                     "Cannot infer size of -1 dim when other dims are zero",
                 )),
             },
@@ -1341,7 +1341,7 @@ mod tests {
 
         assert_eq!(
             result.err(),
-            Some(OpError::InvalidValue(
+            Some(OpError::invalid_value(
                 "Can only remove dimensions of size 1"
             ))
         );
@@ -1381,28 +1381,28 @@ mod tests {
         let result = transpose(&pool, input.view(), Some(&[0, 1, 1]));
         assert_eq!(
             result.err(),
-            Some(OpError::InvalidValue("Permutation is invalid"))
+            Some(OpError::invalid_value("Permutation is invalid"))
         );
 
         // Too few dims
         let result = transpose(&pool, input.view(), Some(&[]));
         assert_eq!(
             result.err(),
-            Some(OpError::InvalidValue("Permutation is invalid"))
+            Some(OpError::invalid_value("Permutation is invalid"))
         );
 
         // Invalid dimension index
         let result = transpose(&pool, input.view(), Some(&[2, 1]));
         assert_eq!(
             result.err(),
-            Some(OpError::InvalidValue("Permutation is invalid"))
+            Some(OpError::invalid_value("Permutation is invalid"))
         );
 
         // Repeated dimension index
         let result = transpose(&pool, input.view(), Some(&[1, 1]));
         assert_eq!(
             result.err(),
-            Some(OpError::InvalidValue("Permutation is invalid"))
+            Some(OpError::invalid_value("Permutation is invalid"))
         );
     }
 
@@ -1435,13 +1435,16 @@ mod tests {
 
         // Invalid dimension index
         let result = unsqueeze(&pool, input.view(), &NdTensor::from([3]).view());
-        assert_eq!(result.err(), Some(OpError::InvalidValue("Axis is invalid")));
+        assert_eq!(
+            result.err(),
+            Some(OpError::invalid_value("Axis is invalid"))
+        );
 
         // Repeated dimension index
         let result = unsqueeze(&pool, input.view(), &NdTensor::from([1, 1]).view());
         assert_eq!(
             result.err(),
-            Some(OpError::InvalidValue("Axes must be unique"))
+            Some(OpError::invalid_value("Axes must be unique"))
         );
     }
 

--- a/src/ops/matmul.rs
+++ b/src/ops/matmul.rs
@@ -52,7 +52,7 @@ where
     let [b_rows, _b_cols] = b.shape();
 
     if a_cols != b_rows {
-        return Err(OpError::IncompatibleInputShapes(
+        return Err(OpError::incompatible_input_shapes(
             "Columns of first matrix does not match rows of second matrix",
         ));
     }
@@ -63,7 +63,7 @@ where
     let output = match c {
         Some(c) if beta != OutT::zero() => {
             if !c.can_broadcast_to(out_shape) {
-                return Err(OpError::IncompatibleInputShapes(
+                return Err(OpError::incompatible_input_shapes(
                     "Cannot broadcast c to output shape",
                 ));
             }
@@ -220,7 +220,7 @@ where
     GemmExecutor<LhsT, RhsT, OutT>: Default,
 {
     if a.ndim() < 1 || b.ndim() < 1 {
-        return Err(OpError::InvalidValue("Inputs must have >= 1 dimensions"));
+        return Err(OpError::invalid_value("Inputs must have >= 1 dimensions"));
     }
 
     // Expand vector inputs to matrices. This follows the rules of `numpy.matmul`.
@@ -241,7 +241,7 @@ where
     let b_cols = b.size(b.ndim() - 1);
 
     if a_cols != b_rows {
-        return Err(OpError::IncompatibleInputShapes(
+        return Err(OpError::incompatible_input_shapes(
             "Columns of first matrix does not match rows of second matrix",
         ));
     }
@@ -252,8 +252,9 @@ where
     let num_a_matrices: usize = a_prefix.iter().product();
     let num_b_matrices: usize = b_prefix.iter().product();
 
-    let out_prefix = broadcast_shapes(a_prefix, b_prefix)
-        .ok_or(OpError::IncompatibleInputShapes("Cannot broadcast shapes"))?;
+    let out_prefix = broadcast_shapes(a_prefix, b_prefix).ok_or(
+        OpError::incompatible_input_shapes("Cannot broadcast shapes"),
+    )?;
     let out_shape = &[out_prefix.as_slice(), &[a_rows, b_cols]].concat();
 
     // A batched matrix multiplication with `[A, M, K] x [K, N]`, where `A` can
@@ -518,12 +519,12 @@ pub fn zero_point_to_vec<T>(
         Some(zp) if zp.ndim() == 0 => Ok(Some(zp.broadcast([expected_len]))),
         Some(zp) if zp.ndim() == 1 => {
             if zp.size(0) != expected_len {
-                Err(OpError::InvalidValue("Zero point has incorrect size"))
+                Err(OpError::invalid_value("Zero point has incorrect size"))
             } else {
                 Ok(Some(zp.nd_view()))
             }
         }
-        Some(_) => Err(OpError::UnsupportedValue(
+        Some(_) => Err(OpError::unsupported_value(
             "Only scalar or vector zero points are supported",
         )),
         None => Ok(None),
@@ -725,7 +726,7 @@ impl<'a> OutputScale<'a> {
             0 => Ok(OutputScale::Scalar(scale.item().copied().unwrap())),
             1 if scale.size(0) == 1 => Ok(OutputScale::Scalar(scale.item().copied().unwrap())),
             1 => Ok(OutputScale::Vector(scale.into_rank().unwrap())),
-            _ => Err(OpError::InvalidValue("scale should have rank 0 or 1")),
+            _ => Err(OpError::invalid_value("scale should have rank 0 or 1")),
         }
     }
 }
@@ -739,7 +740,7 @@ pub fn cast_scale(
     match scale {
         OutputScale::Vector(scale) => {
             if data.size(data.ndim() - 1) != scale.size(0) {
-                return Err(OpError::IncompatibleInputShapes(
+                return Err(OpError::incompatible_input_shapes(
                     "Scale length does not match tensor columns",
                 ));
             }
@@ -970,7 +971,7 @@ mod tests {
             Case {
                 input: [[1, 2], [3, 4]].into(),
                 scales: OutputScale::Vector(NdTensorView::from(&[2., 3., 4.])),
-                expected: Err(OpError::IncompatibleInputShapes(
+                expected: Err(OpError::incompatible_input_shapes(
                     "Scale length does not match tensor columns",
                 )),
             },
@@ -1074,7 +1075,7 @@ mod tests {
 
         assert_eq!(
             result.err(),
-            Some(OpError::IncompatibleInputShapes(
+            Some(OpError::incompatible_input_shapes(
                 "Cannot broadcast c to output shape"
             ))
         );
@@ -1086,7 +1087,7 @@ mod tests {
 
         assert_eq!(
             result.err(),
-            Some(OpError::IncompatibleInputShapes(
+            Some(OpError::incompatible_input_shapes(
                 "Columns of first matrix does not match rows of second matrix",
             ))
         );
@@ -1293,24 +1294,24 @@ mod tests {
             Case {
                 a_shape: &[],
                 b_shape: &[10, 8],
-                error: OpError::InvalidValue("Inputs must have >= 1 dimensions"),
+                error: OpError::invalid_value("Inputs must have >= 1 dimensions"),
             },
             Case {
                 a_shape: &[3, 10],
                 b_shape: &[],
-                error: OpError::InvalidValue("Inputs must have >= 1 dimensions"),
+                error: OpError::invalid_value("Inputs must have >= 1 dimensions"),
             },
             Case {
                 a_shape: &[3, 10],
                 b_shape: &[11, 8],
-                error: OpError::IncompatibleInputShapes(
+                error: OpError::incompatible_input_shapes(
                     "Columns of first matrix does not match rows of second matrix",
                 ),
             },
             Case {
                 a_shape: &[2, 3, 10],
                 b_shape: &[3, 10, 8],
-                error: OpError::IncompatibleInputShapes("Cannot broadcast shapes"),
+                error: OpError::incompatible_input_shapes("Cannot broadcast shapes"),
             },
         ];
 
@@ -1435,7 +1436,7 @@ mod tests {
                 b: Tensor::from([[5, 6], [7, 8]]),
                 a_zero_point: Some(Tensor::from([1, 2, 4])),
                 b_zero_point: Some(Tensor::from([3, 4])),
-                expected_err: Some(OpError::InvalidValue("Zero point has incorrect size")),
+                expected_err: Some(OpError::invalid_value("Zero point has incorrect size")),
             },
             // Non-scalar zero points
             Case {
@@ -1443,7 +1444,7 @@ mod tests {
                 b: Tensor::from([[2, 2], [2, 2]]),
                 a_zero_point: Some(Tensor::from([[2, 2], [2, 2]])),
                 b_zero_point: None,
-                expected_err: Some(OpError::UnsupportedValue(
+                expected_err: Some(OpError::unsupported_value(
                     "Only scalar or vector zero points are supported",
                 )),
             },
@@ -1452,7 +1453,7 @@ mod tests {
                 b: Tensor::from([[2, 2], [2, 2]]),
                 a_zero_point: None,
                 b_zero_point: Some(Tensor::from([[2, 2], [2, 2]])),
-                expected_err: Some(OpError::UnsupportedValue(
+                expected_err: Some(OpError::unsupported_value(
                     "Only scalar or vector zero points are supported",
                 )),
             },
@@ -1470,7 +1471,7 @@ mod tests {
                 b: Tensor::zeros(&[3, 1]),
                 a_zero_point: None,
                 b_zero_point: None,
-                expected_err: Some(OpError::IncompatibleInputShapes(
+                expected_err: Some(OpError::incompatible_input_shapes(
                     "Columns of first matrix does not match rows of second matrix",
                 )),
             },
@@ -1480,7 +1481,7 @@ mod tests {
                 b: Tensor::zeros(&[3, 1]),
                 a_zero_point: None,
                 b_zero_point: None,
-                expected_err: Some(OpError::InvalidValue("Inputs must have >= 1 dimensions")),
+                expected_err: Some(OpError::invalid_value("Inputs must have >= 1 dimensions")),
             },
             // RHS is a scalar
             Case {
@@ -1488,14 +1489,16 @@ mod tests {
                 b: Tensor::zeros(&[]),
                 a_zero_point: None,
                 b_zero_point: None,
-                expected_err: Some(OpError::InvalidValue("Inputs must have >= 1 dimensions")),
+                expected_err: Some(OpError::invalid_value("Inputs must have >= 1 dimensions")),
             },
             Case {
                 a: Tensor::zeros(&[2, 2, 2]),
                 b: Tensor::zeros(&[3, 2, 2]),
                 a_zero_point: None,
                 b_zero_point: None,
-                expected_err: Some(OpError::IncompatibleInputShapes("Cannot broadcast shapes")),
+                expected_err: Some(OpError::incompatible_input_shapes(
+                    "Cannot broadcast shapes",
+                )),
             },
         ];
 

--- a/src/ops/matmul/contrib.rs
+++ b/src/ops/matmul/contrib.rs
@@ -27,7 +27,7 @@ fn matmul_nbits(
     accuracy: AccuracyLevel,
 ) -> Result<Tensor<f32>, OpError> {
     if lhs.ndim() < 2 {
-        return Err(OpError::InvalidValue("A input must have at least 2 dims"));
+        return Err(OpError::invalid_value("A input must have at least 2 dims"));
     }
 
     let batch_dims = &lhs.shape()[..lhs.ndim() - 2];
@@ -38,7 +38,7 @@ fn matmul_nbits(
     let scales = scales.to_contiguous_in(pool);
 
     let b_mat = BlockQuantizedMatrix::new(rhs.view(), scales.view(), bits).map_err(|err| {
-        OpError::UnsupportedValue(match err {
+        OpError::unsupported_value(match err {
             BlockQuantizedError::UnsupportedBlockSize => "Unsupported K block size",
             BlockQuantizedError::UnsupportedElementSize => "Unsupported bits-per-element",
         })
@@ -54,7 +54,7 @@ fn matmul_nbits(
     let mut out_data = pool.alloc(out_len);
 
     if lhs_cols != b_mat.rows() {
-        return Err(OpError::IncompatibleInputShapes(
+        return Err(OpError::incompatible_input_shapes(
             "Columns of first matrix does not match rows of second matrix",
         ));
     }
@@ -155,21 +155,21 @@ impl Operator for MatMulNBits {
                 let rhs_cols = rhs.size(0);
 
                 if scales.len() != rhs_cols * k_blocks {
-                    return Err(OpError::InvalidValue(
+                    return Err(OpError::invalid_value(
                         "Expected 1D `scales` size to match columns * block_size",
                     ));
                 }
                 scales.reshaped([rhs_cols, k_blocks])
             }
             _ => {
-                return Err(OpError::InvalidValue(
+                return Err(OpError::invalid_value(
                     "Expected `scales` to have one or two dims",
                 ));
             }
         };
 
         if ctx.inputs().len() > 3 {
-            return Err(OpError::UnsupportedValue(
+            return Err(OpError::unsupported_value(
                 "zero_points, g_idx and bias inputs are unsupported",
             ));
         }
@@ -365,7 +365,7 @@ mod tests {
             lhs_shape: [1].into(),
             rhs_shape: [1, 1, 16],
             scales_shape: [1, 1].into(),
-            expected: OpError::InvalidValue("A input must have at least 2 dims"),
+            expected: OpError::invalid_value("A input must have at least 2 dims"),
         }];
 
         cases.test_each(|case| {

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -206,7 +206,7 @@ impl Padding {
             Padding::Same => Ok(Padding::Same),
             Padding::Fixed(pads) => match pads.as_slice() {
                 &[pad_start, pad_end] => Ok([0, pad_start, 0, pad_end].into()),
-                _ => Err(OpError::InvalidValue("expected 2 pad values")),
+                _ => Err(OpError::invalid_value("expected 2 pad values")),
             },
         }
     }
@@ -247,7 +247,7 @@ fn resolve_index(len: usize, index: isize) -> Option<usize> {
 ///
 /// Negative axis values count backwards from the last dimension.
 fn resolve_axis(ndim: usize, axis: isize) -> Result<usize, OpError> {
-    resolve_index(ndim, axis).ok_or(OpError::InvalidValue("Axis is invalid"))
+    resolve_index(ndim, axis).ok_or(OpError::invalid_value("Axis is invalid"))
 }
 
 /// Resolve a sequence of axes values in `[-ndim, ndim-1]` to zero-based dimension
@@ -384,7 +384,7 @@ use map_value;
 macro_rules! check_value {
     ($condition:expr, $err_variant:ident, $err_msg:expr) => {
         if !$condition {
-            return Err(OpError::$err_variant($err_msg));
+            return Err(OpError::$err_variant($err_msg.into()));
         }
     };
 }

--- a/src/ops/non_max_suppression.rs
+++ b/src/ops/non_max_suppression.rs
@@ -79,13 +79,13 @@ pub fn non_max_suppression(
     let [scores_batch, n_classes, scores_n_boxes] = scores.shape();
 
     if n_coords != 4 {
-        return Err(OpError::InvalidValue(
+        return Err(OpError::invalid_value(
             "`boxes` last dimension should have size 4",
         ));
     }
 
     if batch != scores_batch || n_boxes != scores_n_boxes {
-        return Err(OpError::IncompatibleInputShapes(
+        return Err(OpError::incompatible_input_shapes(
             "`boxes` and `scores` have incompatible shapes",
         ));
     }
@@ -474,7 +474,7 @@ mod tests {
         let result = apply_nms(boxes.view(), scores.view());
         assert_eq!(
             result,
-            Err(OpError::IncompatibleInputShapes(
+            Err(OpError::incompatible_input_shapes(
                 "`boxes` and `scores` have incompatible shapes"
             ))
         );
@@ -484,7 +484,7 @@ mod tests {
         let result = apply_nms(boxes.view(), scores.view());
         assert_eq!(
             result,
-            Err(OpError::InvalidValue(
+            Err(OpError::invalid_value(
                 "`boxes` last dimension should have size 4"
             ))
         );

--- a/src/ops/norm.rs
+++ b/src/ops/norm.rs
@@ -200,7 +200,7 @@ pub fn batch_norm_in_place(
     epsilon: f32,
 ) -> Result<(), OpError> {
     if input.ndim() < 1 {
-        return Err(OpError::InvalidValue("Input must have at least 1 dim"));
+        return Err(OpError::invalid_value("Input must have at least 1 dim"));
     }
 
     let channels = if input.ndim() >= 2 { input.size(1) } else { 1 };
@@ -336,20 +336,20 @@ pub fn instance_normalization_in_place(
     epsilon: Option<f32>,
 ) -> Result<(), OpError> {
     let &[_batch, chans, ..] = input.shape() else {
-        return Err(OpError::InvalidValue("expected input with >= 2 dims"));
+        return Err(OpError::invalid_value("expected input with >= 2 dims"));
     };
 
     // If epsilon is None, use default from ONNX spec.
     let epsilon = epsilon.unwrap_or(1e-5);
 
     if scale.size(0) != chans {
-        return Err(OpError::InvalidValue(
+        return Err(OpError::invalid_value(
             "scale length should match channel count",
         ));
     }
 
     if bias.size(0) != chans {
-        return Err(OpError::InvalidValue(
+        return Err(OpError::invalid_value(
             "bias length should match channel count",
         ));
     }
@@ -473,7 +473,7 @@ fn layer_normalization_impl(
         scale_elements = scale
             .try_broadcast(normalized_slice_shape)
             .map_err(|_| {
-                OpError::InvalidValue("`scale` is not broadcastable to normalized axes of input")
+                OpError::invalid_value("`scale` is not broadcastable to normalized axes of input")
             })?
             .to_contiguous_in(pool);
         (1.0, Some(scale_elements.data()))
@@ -487,7 +487,9 @@ fn layer_normalization_impl(
             bias_elements = bias
                 .try_broadcast(normalized_slice_shape)
                 .map_err(|_| {
-                    OpError::InvalidValue("`bias` is not broadcastable to normalized axes of input")
+                    OpError::invalid_value(
+                        "`bias` is not broadcastable to normalized axes of input",
+                    )
                 })?
                 .to_contiguous_in(pool);
             (0.0, Some(bias_elements.data()))
@@ -646,7 +648,7 @@ pub fn lp_normalization_in_place(output: &mut Tensor, axis: isize, p: u32) -> Re
             scale_by_norm(lane, norm);
         },
         _ => {
-            return Err(OpError::UnsupportedValue("`p` must be 1 or 2"));
+            return Err(OpError::unsupported_value("`p` must be 1 or 2"));
         }
     };
 
@@ -1012,7 +1014,7 @@ mod tests {
 
         assert_eq!(
             result,
-            Err(OpError::InvalidValue("Input must have at least 1 dim"))
+            Err(OpError::invalid_value("Input must have at least 1 dim"))
         );
     }
 
@@ -1138,7 +1140,7 @@ mod tests {
                 scale: Tensor::full(&[2, 3], 1.0),
                 bias: None,
                 axis: -1,
-                expected: Err(OpError::InvalidValue(
+                expected: Err(OpError::invalid_value(
                     "`scale` is not broadcastable to normalized axes of input",
                 )),
             },
@@ -1148,7 +1150,7 @@ mod tests {
                 scale: Tensor::from([1., 1., 1.]),
                 bias: Some(Tensor::full(&[2, 3], 1.0)),
                 axis: -1,
-                expected: Err(OpError::InvalidValue(
+                expected: Err(OpError::invalid_value(
                     "`bias` is not broadcastable to normalized axes of input",
                 )),
             },
@@ -1261,7 +1263,7 @@ mod tests {
         let result = lp_normalization(&pool, input.view(), 0, 3);
         assert_eq!(
             result.err(),
-            Some(OpError::UnsupportedValue("`p` must be 1 or 2"))
+            Some(OpError::unsupported_value("`p` must be 1 or 2"))
         );
 
         Ok(())

--- a/src/ops/norm/contrib.rs
+++ b/src/ops/norm/contrib.rs
@@ -34,7 +34,7 @@ fn skip_layer_normalization(
     outputs.check_unsupported(2, "inv_std_var")?;
 
     if !matches!(input.ndim(), 2 | 3) {
-        return Err(OpError::InvalidValue("input must be 2 or 3 dimensioned"));
+        return Err(OpError::invalid_value("input must be 2 or 3 dimensioned"));
     }
 
     // `skip` may either match `input` exactly or broadcast over the batch
@@ -42,12 +42,12 @@ fn skip_layer_normalization(
     // trailing dimensions must match those of `input`. This matches ONNX
     // Runtime, which indexes `skip` modulo its own size.
     if !matches!(skip.ndim(), 2 | 3) {
-        return Err(OpError::InvalidValue("skip must be 2 or 3 dimensioned"));
+        return Err(OpError::invalid_value("skip must be 2 or 3 dimensioned"));
     }
     if skip.shape()[skip.ndim() - 2..] != input.shape()[input.ndim() - 2..]
         || !skip.can_broadcast_to(input.shape())
     {
-        return Err(OpError::IncompatibleInputShapes(
+        return Err(OpError::incompatible_input_shapes(
             "skip must broadcast to input over the batch dimension",
         ));
     }
@@ -525,7 +525,7 @@ mod tests {
                     input: Tensor::zeros(&[2, 4]),
                     skip: Tensor::zeros(&[2, 3]),
                     gamma: Tensor::zeros(&[4]),
-                    expected: OpError::IncompatibleInputShapes(
+                    expected: OpError::incompatible_input_shapes(
                         "skip must broadcast to input over the batch dimension",
                     ),
                 },
@@ -535,7 +535,7 @@ mod tests {
                     input: Tensor::zeros(&[4]),
                     skip: Tensor::zeros(&[4]),
                     gamma: Tensor::zeros(&[4]),
-                    expected: OpError::InvalidValue("input must be 2 or 3 dimensioned"),
+                    expected: OpError::invalid_value("input must be 2 or 3 dimensioned"),
                 },
                 // 4D input is unsupported
                 Case {
@@ -543,7 +543,7 @@ mod tests {
                     input: Tensor::zeros(&[1, 1, 2, 4]),
                     skip: Tensor::zeros(&[1, 1, 2, 4]),
                     gamma: Tensor::zeros(&[4]),
-                    expected: OpError::InvalidValue("input must be 2 or 3 dimensioned"),
+                    expected: OpError::invalid_value("input must be 2 or 3 dimensioned"),
                 },
             ]);
         }

--- a/src/ops/pad.rs
+++ b/src/ops/pad.rs
@@ -41,7 +41,7 @@ pub fn pad<T: Copy + Default + PartialEq>(
     let ndim = input.ndim();
 
     if padding.size(0) != ndim * 2 {
-        return Err(OpError::InvalidValue(
+        return Err(OpError::invalid_value(
             "padding length should be 2 * input dims",
         ));
     }
@@ -54,7 +54,7 @@ pub fn pad<T: Copy + Default + PartialEq>(
             let crop_start = crop_amount(padding[i]);
             let crop_end = crop_amount(padding[[ndim + i]]);
             if crop_start + crop_end > *size {
-                return Err(OpError::InvalidValue(
+                return Err(OpError::invalid_value(
                     "Negative pads remove more elements than axis contains",
                 ));
             }
@@ -112,13 +112,13 @@ pub fn pad<T: Copy + Default + PartialEq>(
             const PAD_DIMS: usize = 2;
             let batch_dims = input.ndim().saturating_sub(PAD_DIMS);
             if out_shape[..batch_dims] != input.shape()[..batch_dims] {
-                return Err(OpError::UnsupportedValue(
+                return Err(OpError::unsupported_value(
                     "Pad only supports non-constant padding of last 2 dims",
                 ));
             }
 
             if input.shape()[batch_dims..].contains(&0) {
-                return Err(OpError::InvalidValue(
+                return Err(OpError::invalid_value(
                     "Padded dimension for non-constant padding is empty",
                 ));
             }
@@ -306,7 +306,7 @@ impl Operator for Pad {
         let axes: Option<NdTensorView<i32, 1>> = inputs.get_as(3)?;
 
         if axes.is_some() {
-            return Err(OpError::UnsupportedValue(
+            return Err(OpError::unsupported_value(
                 "Pad operator does not yet support `axes` input",
             ));
         }
@@ -466,7 +466,7 @@ mod tests {
                 input: [[1., 2.], [3., 4.]].into(),
                 pads: [-3, 0, 0, 0].into(),
                 mode: PadMode::Constant,
-                expected: Err(OpError::InvalidValue(
+                expected: Err(OpError::invalid_value(
                     "Negative pads remove more elements than axis contains",
                 )),
             },
@@ -558,7 +558,7 @@ mod tests {
                 input: [[[1., 2., 3.]]].into(),
                 pads: [0, 0, 0, 2, 0, 0].into(),
                 mode: PadMode::Reflect,
-                expected: Err(OpError::UnsupportedValue(
+                expected: Err(OpError::unsupported_value(
                     "Pad only supports non-constant padding of last 2 dims",
                 )),
             },
@@ -567,7 +567,7 @@ mod tests {
                 input: Tensor::zeros(&[3, 0]),
                 pads: NdTensor::from([0, 2, 0, 0]),
                 mode: PadMode::Reflect,
-                expected: Err(OpError::InvalidValue(
+                expected: Err(OpError::invalid_value(
                     "Padded dimension for non-constant padding is empty",
                 )),
             },
@@ -700,14 +700,14 @@ mod tests {
                 input: input.clone(),
                 pads: from_slice(&[1]),
                 const_val: None,
-                expected_error: OpError::InvalidValue("padding length should be 2 * input dims"),
+                expected_error: OpError::invalid_value("padding length should be 2 * input dims"),
             },
             // Negative pads which remove more elements than an axis contains.
             Case {
                 input: input.clone(),
                 pads: from_slice(&[-3, 0, 0, 0]),
                 const_val: None,
-                expected_error: OpError::InvalidValue(
+                expected_error: OpError::invalid_value(
                     "Negative pads remove more elements than axis contains",
                 ),
             },

--- a/src/ops/pooling.rs
+++ b/src/ops/pooling.rs
@@ -44,7 +44,7 @@ impl AxisPadding {
                 let [pad_top, pad_left, pad_bottom, pad_right]: [usize; 4] = pads
                     .as_slice()
                     .try_into()
-                    .map_err(|_| OpError::InvalidValue("Expected 4 padding values"))?;
+                    .map_err(|_| OpError::invalid_value("Expected 4 padding values"))?;
                 let h_pad = AxisPadding::Fixed {
                     start: pad_top,
                     end: pad_bottom,
@@ -98,7 +98,7 @@ fn output_size_and_padding_for_axis(
             let dilated_kernel_size = kernel_size + (kernel_size - 1) * (dilation - 1);
 
             if padded_in_size < dilated_kernel_size {
-                return Err(OpError::InvalidValue("Input too small for kernel size"));
+                return Err(OpError::invalid_value("Input too small for kernel size"));
             }
 
             // Compute output size. The PyTorch docs provide the clearest
@@ -189,12 +189,12 @@ where
 {
     let spatial_dims = input.ndim().saturating_sub(2);
     if kernel_size.len() != spatial_dims {
-        return Err(OpError::InvalidValue(
+        return Err(OpError::invalid_value(
             "kernel_size len does not match spatial dims",
         ));
     }
     if strides.len() != spatial_dims {
-        return Err(OpError::InvalidValue(
+        return Err(OpError::invalid_value(
             "strides len does not match spatial dims",
         ));
     }
@@ -221,7 +221,7 @@ where
         }
         2 => { /* handled below */ }
         _ => {
-            return Err(OpError::UnsupportedValue(
+            return Err(OpError::unsupported_value(
                 "Only inputs with 1 or 2 spatial dims are supported",
             ));
         }
@@ -480,7 +480,7 @@ fn global_pool<T: Clone + Send + Sync>(
     kernel: &(dyn Fn(&[T]) -> T + Send + Sync),
 ) -> Result<Tensor<T>, OpError> {
     if input.ndim() < 2 {
-        return Err(OpError::InvalidValue("Input must have at least 2 dims"));
+        return Err(OpError::invalid_value("Input must have at least 2 dims"));
     }
 
     let batch = input.size(0);
@@ -869,7 +869,7 @@ mod tests {
         let err = global_max_pool(&pool, input.view()).err().unwrap();
         assert_eq!(
             err,
-            OpError::InvalidValue("Input must have at least 2 dims")
+            OpError::invalid_value("Input must have at least 2 dims")
         );
     }
 
@@ -1042,7 +1042,7 @@ mod tests {
                     strides: (1, 1),
                     padding: [0, 0, 0, 0].into(),
                     round_mode: RoundMode::Floor,
-                    expected: Err(OpError::InvalidValue("default")),
+                    expected: Err(OpError::invalid_value("default")),
                 }
             }
         }
@@ -1151,32 +1151,32 @@ mod tests {
             // Zero stride
             Case {
                 strides: (0, 0),
-                expected: Err(OpError::InvalidValue("Strides must be > 0")),
+                expected: Err(OpError::invalid_value("Strides must be > 0")),
                 ..Default::default()
             },
             // Zero dilation
             Case {
                 dilations: (0, 0),
-                expected: Err(OpError::InvalidValue("Dilations must be > 0")),
+                expected: Err(OpError::invalid_value("Dilations must be > 0")),
                 ..Default::default()
             },
             // Zero kernel size
             Case {
                 kernel_size: (0, 0),
-                expected: Err(OpError::InvalidValue("Kernel size must be > 0")),
+                expected: Err(OpError::invalid_value("Kernel size must be > 0")),
                 ..Default::default()
             },
             // Incorrect padding length
             Case {
                 padding: [0, 0].into(),
-                expected: Err(OpError::InvalidValue("Expected 4 padding values")),
+                expected: Err(OpError::invalid_value("Expected 4 padding values")),
                 ..Default::default()
             },
             // Dilated kernel size > input size
             Case {
                 in_size: (4, 4),
                 dilations: (2, 2),
-                expected: Err(OpError::InvalidValue("Input too small for kernel size")),
+                expected: Err(OpError::invalid_value("Input too small for kernel size")),
                 ..Default::default()
             },
         ];

--- a/src/ops/quantize.rs
+++ b/src/ops/quantize.rs
@@ -50,7 +50,7 @@ pub fn dequantize_linear<T: Copy + Default + Dequantize<f32> + Scalar + 'static>
     // compatibility with ONNX Runtime and its quantization tools.
     if let Some(scale) = scale.item() {
         let zero_point = if let Some(zp) = zero_point {
-            zp.item().copied().ok_or(OpError::InvalidValue(
+            zp.item().copied().ok_or(OpError::invalid_value(
                 "scale and zero_point must have same shape",
             ))?
         } else {
@@ -66,7 +66,7 @@ pub fn dequantize_linear<T: Copy + Default + Dequantize<f32> + Scalar + 'static>
         )?;
         let zero_point = if let Some(zp) = zero_point {
             zp.into_rank::<1>()
-                .map_err(|_| OpError::InvalidValue("scale and zero point must have same rank"))?
+                .map_err(|_| OpError::invalid_value("scale and zero point must have same rank"))?
                 .as_cow()
         } else {
             NdTensor::zeros(scale.shape()).into_cow()
@@ -92,7 +92,7 @@ pub fn dequantize_linear<T: Copy + Default + Dequantize<f32> + Scalar + 'static>
         // Safety: All elements are initialized
         Ok(unsafe { output.assume_init() })
     } else {
-        Err(OpError::UnsupportedValue(
+        Err(OpError::unsupported_value(
             "Blocked dequantization is not supported",
         ))
     }
@@ -209,7 +209,7 @@ where
     if let Some(scale) = scale.item() {
         let inv_scale = 1. / *scale;
         let zero_point = if let Some(zp) = zero_point {
-            zp.item().copied().ok_or(OpError::InvalidValue(
+            zp.item().copied().ok_or(OpError::invalid_value(
                 "scale and zero_point must have same shape",
             ))?
         } else {
@@ -245,7 +245,7 @@ where
         )?;
         let zero_point = if let Some(zp) = zero_point {
             zp.into_rank::<1>()
-                .map_err(|_| OpError::InvalidValue("scale and zero point must have same shape"))?
+                .map_err(|_| OpError::invalid_value("scale and zero point must have same shape"))?
                 .as_cow()
         } else {
             NdTensor::zeros(scale.shape()).into_cow()
@@ -268,7 +268,7 @@ where
         // Safety: All elements are initialized
         Ok(unsafe { output.assume_init() })
     } else {
-        Err(OpError::UnsupportedValue(
+        Err(OpError::unsupported_value(
             "Blocked quantization is not supported",
         ))
     }
@@ -578,7 +578,7 @@ mod tests {
                 input: Tensor::from([10u8, 5u8]).into(),
                 scale: Tensor::from([0.5, 2.]),
                 zero_point: Some(Tensor::from([1u8, 2, 3]).into()),
-                expected: Err(OpError::IncompatibleInputShapes(
+                expected: Err(OpError::incompatible_input_shapes(
                     "zero_point length does not match size of quantization axis",
                 )),
             },
@@ -588,7 +588,7 @@ mod tests {
                 input: Tensor::from([[10u8, 20], [30, 40]]).into(),
                 scale: Tensor::from(0.5),
                 zero_point: Some(Tensor::from([1u8, 2]).into()),
-                expected: Err(OpError::InvalidValue(
+                expected: Err(OpError::invalid_value(
                     "scale and zero_point must have same shape",
                 )),
             },
@@ -598,7 +598,7 @@ mod tests {
                 input: Tensor::from([[10u8, 20], [30, 40], [50, 60]]).into(),
                 scale: Tensor::from([0.5, 0.6]),
                 zero_point: None,
-                expected: Err(OpError::IncompatibleInputShapes(
+                expected: Err(OpError::incompatible_input_shapes(
                     "scale length does not match size of quantization axis",
                 )),
             },
@@ -608,7 +608,7 @@ mod tests {
                 input: Tensor::from([[10u8, 20], [30, 40]]).into(),
                 scale: Tensor::from([0.5, 2., 4.]),
                 zero_point: None,
-                expected: Err(OpError::IncompatibleInputShapes(
+                expected: Err(OpError::incompatible_input_shapes(
                     "scale length does not match size of quantization axis",
                 )),
             },
@@ -618,7 +618,7 @@ mod tests {
                 input: Tensor::from([[10u8, 20], [30, 40]]).into(),
                 scale: Tensor::from([[1., 2.], [3., 4.]]),
                 zero_point: Some(Tensor::from([[1u8, 2], [3, 4]]).into()),
-                expected: Err(OpError::UnsupportedValue(
+                expected: Err(OpError::unsupported_value(
                     "Blocked dequantization is not supported",
                 )),
             },

--- a/src/ops/random.rs
+++ b/src/ops/random.rs
@@ -239,7 +239,7 @@ impl Operator for Multinomial {
         let [batch_size, class_size] = input.shape();
 
         if class_size == 0 {
-            return Err(OpError::InvalidValue("input must have at least one class"));
+            return Err(OpError::invalid_value("input must have at least one class"));
         }
 
         let mut rng = rng_from_seed(self.seed);
@@ -331,7 +331,7 @@ impl Operator for Dropout {
         let ratio = inputs.get_as(1)?.unwrap_or(0.5);
         #[allow(clippy::manual_range_contains)]
         if ratio < 0. || ratio >= 1.0 {
-            return Err(OpError::InvalidValue("ratio must be in the range [0, 1)"));
+            return Err(OpError::invalid_value("ratio must be in the range [0, 1)"));
         }
 
         let training_mode = inputs.get_as::<i32>(2)?.unwrap_or(0) != 0;
@@ -726,7 +726,7 @@ mod tests {
         let result: Result<Tensor<i32>, _> = op.run_simple(input.view());
         assert_eq!(
             result.err(),
-            Some(OpError::InvalidValue("input must have at least one class"))
+            Some(OpError::invalid_value("input must have at least one class"))
         );
     }
 

--- a/src/ops/reduce.rs
+++ b/src/ops/reduce.rs
@@ -70,7 +70,7 @@ fn select_max_index<T, Cmp: Fn(&T, &T) -> std::cmp::Ordering>(
 ) -> Result<Tensor<i32>, OpError> {
     let resolved_axis = resolve_axis(input.ndim(), axis)?;
     if input.size(resolved_axis) == 0 {
-        return Err(OpError::InvalidValue(
+        return Err(OpError::invalid_value(
             "Cannot select index from empty sequence",
         ));
     }
@@ -1258,7 +1258,7 @@ pub fn topk<T: Copy + Default + PartialOrd + IsNaN>(
 
     let axis_size = values.size(axis);
     if k > axis_size {
-        return Err(OpError::InvalidValue("k > dimension size"));
+        return Err(OpError::invalid_value("k > dimension size"));
     }
 
     let topk_cmp = |(a_val, a_idx): &(T, usize), (b_val, b_idx): &(T, usize)| -> Ordering {
@@ -1330,7 +1330,7 @@ impl Operator for TopK {
         let values = inputs.require(0)?;
         let k = inputs.require_as::<i32>(1).and_then(|k| {
             if k < 0 {
-                Err(OpError::InvalidValue("k must be positive"))
+                Err(OpError::invalid_value("k must be positive"))
             } else {
                 Ok(k as usize)
             }
@@ -1443,7 +1443,7 @@ mod tests {
                 input: Tensor::<f32>::from_data(&[10, 0, 5], vec![]),
                 axis: 1,
                 keep_dims: false,
-                expected: Err(OpError::InvalidValue(
+                expected: Err(OpError::invalid_value(
                     "Cannot select index from empty sequence",
                 )),
             },
@@ -1919,10 +1919,16 @@ mod tests {
         let input = Tensor::from_data(&[3, 3], vec![1., 2., 3., 4., 5., 6., 7., 8., 9.]);
 
         let result = reduce_mean(&pool, input.view(), Some(&[3]), false /* keep_dims */);
-        assert_eq!(result.err(), Some(OpError::InvalidValue("Axis is invalid")));
+        assert_eq!(
+            result.err(),
+            Some(OpError::invalid_value("Axis is invalid"))
+        );
 
         let result = reduce_mean(&pool, input.view(), Some(&[-3]), false /* keep_dims */);
-        assert_eq!(result.err(), Some(OpError::InvalidValue("Axis is invalid")));
+        assert_eq!(
+            result.err(),
+            Some(OpError::invalid_value("Axis is invalid"))
+        );
     }
 
     // ONNX leaves `ReduceMean` over an empty set undefined. We follow numpy
@@ -2321,14 +2327,14 @@ mod tests {
             Case {
                 input: [0., 1., 2.].into(),
                 k: 4,
-                expected: Err(OpError::InvalidValue("k > dimension size")),
+                expected: Err(OpError::invalid_value("k > dimension size")),
                 ..Default::default()
             },
             // Scalar input
             Case {
                 input: Tensor::from(0.),
                 k: 2,
-                expected: Err(OpError::InvalidValue("Axis is invalid")),
+                expected: Err(OpError::invalid_value("Axis is invalid")),
                 ..Default::default()
             },
             // 2D input, take top-K over axis 1

--- a/src/ops/resize.rs
+++ b/src/ops/resize.rs
@@ -279,7 +279,7 @@ fn calc_output_size(
         ResizeTarget::Sizes(sizes) => sizes.size(0),
     };
     if target_len != input_shape.len() {
-        return Err(OpError::IncompatibleInputShapes(
+        return Err(OpError::incompatible_input_shapes(
             "scales/sizes length should equal input rank",
         ));
     }
@@ -298,7 +298,7 @@ fn calc_output_size(
     };
 
     if sizes.iter().any(|size| *size < 0) {
-        return Err(OpError::InvalidValue("scales/sizes must be positive"));
+        return Err(OpError::invalid_value("scales/sizes must be positive"));
     }
 
     Ok(ResizeGeometry {
@@ -401,7 +401,7 @@ fn resize_impl(
             opts,
         )
         .map(|y| y.into_shape(output_size.as_slice())),
-        _ => Err(OpError::UnsupportedValue(
+        _ => Err(OpError::unsupported_value(
             "Only 1D to 4D inputs are supported with up to two resized dimensions",
         )),
     }
@@ -1076,7 +1076,7 @@ mod tests {
                 image: Tensor::from_data(&[1, 1, 1, 1], vec![1.]),
                 scales: Some(Tensor::from([1., 1., 1.])),
                 sizes: None,
-                expected: CaseOutput::Error(OpError::IncompatibleInputShapes(
+                expected: CaseOutput::Error(OpError::incompatible_input_shapes(
                     "scales/sizes length should equal input rank",
                 )),
             },
@@ -1084,13 +1084,15 @@ mod tests {
                 image: Tensor::from_data(&[1, 1, 1, 1], vec![1.]),
                 scales: Some(Tensor::from([1., 1., -1., 1.])),
                 sizes: None,
-                expected: CaseOutput::Error(OpError::InvalidValue("scales/sizes must be positive")),
+                expected: CaseOutput::Error(OpError::invalid_value(
+                    "scales/sizes must be positive",
+                )),
             },
             Case {
                 image: Tensor::from_data(&[1, 1, 2, 2], vec![0.2, 0.7, 0.3, 0.8]),
                 scales: Some(Tensor::from_data(&[1, 1, 2, 2], vec![1., 1., 3., 3.])),
                 sizes: None,
-                expected: CaseOutput::Error(OpError::InvalidValue("scales must have 1 dims")),
+                expected: CaseOutput::Error(OpError::invalid_value("scales must have 1 dims")),
             },
             // Values for scales/sizes and input shapes which are legal according to the spec,
             // but not currently supported in our implementation.
@@ -1098,7 +1100,7 @@ mod tests {
                 image: Tensor::from_data(&[1, 1, 2, 2], vec![0.2, 0.7, 0.3, 0.8]),
                 scales: Some(Tensor::from([2., 1., 3., 3.])),
                 sizes: None,
-                expected: CaseOutput::Error(OpError::UnsupportedValue(
+                expected: CaseOutput::Error(OpError::unsupported_value(
                     "Only 1D to 4D inputs are supported with up to two resized dimensions",
                 )),
             },

--- a/src/ops/rnn.rs
+++ b/src/ops/rnn.rs
@@ -152,7 +152,7 @@ pub fn gru(
     // See note in https://pytorch.org/docs/stable/generated/torch.nn.GRU.html.
     if !linear_before_reset {
         // PyTorch and cuDNN
-        return Err(OpError::UnsupportedValue(
+        return Err(OpError::unsupported_value(
             "`linear_before_reset=0` is not supported",
         ));
     }
@@ -433,7 +433,7 @@ pub fn lstm(
     let hidden_size = hidden_x4 / 4;
 
     if weights.size(1) % 4 != 0 {
-        return Err(OpError::InvalidValue(
+        return Err(OpError::invalid_value(
             "weights dim 1 must be 4 * hidden_size",
         ));
     }
@@ -442,7 +442,7 @@ pub fn lstm(
     if let Some(bias) = bias.as_ref()
         && bias.size(1) % 8 != 0
     {
-        return Err(OpError::InvalidValue("bias dim 1 must be 8 * hidden_size"));
+        return Err(OpError::invalid_value("bias dim 1 must be 8 * hidden_size"));
     }
 
     let initial_hidden = initial_hidden

--- a/src/ops/scatter.rs
+++ b/src/ops/scatter.rs
@@ -67,12 +67,12 @@ pub fn scatter_elements<
     reduction: Option<ScatterReduction>,
 ) -> Result<Tensor<T>, OpError> {
     if indices.ndim() != data.ndim() {
-        return Err(OpError::InvalidValue(
+        return Err(OpError::invalid_value(
             "`data` and `indices` must have same rank",
         ));
     }
     if indices.shape() != updates.shape() {
-        return Err(OpError::InvalidValue(
+        return Err(OpError::invalid_value(
             "`indices` and `updates` must have same shape",
         ));
     }
@@ -89,7 +89,7 @@ pub fn scatter_elements<
 
         for (idx, update) in index_lane.zip(update_lane) {
             let Some(idx) = resolve_index(axis_size, *idx as isize) else {
-                return Err(OpError::InvalidValue("Index is invalid"));
+                return Err(OpError::invalid_value("Index is invalid"));
             };
             let out_el = &mut output_lane[[idx]];
             *out_el = scatter_reduce(*out_el, *update, reduction);
@@ -183,7 +183,7 @@ pub fn scatter_nd<
     reduction: Option<ScatterReduction>,
 ) -> Result<Tensor<T>, OpError> {
     if data.ndim() == 0 || indices.ndim() == 0 {
-        return Err(OpError::InvalidValue(
+        return Err(OpError::invalid_value(
             "`data` and `indices` must have rank >= 1",
         ));
     }
@@ -194,7 +194,7 @@ pub fn scatter_nd<
 
     let expected_update_dim = data.ndim() + indices.ndim() - k - 1;
     if updates.ndim() != expected_update_dim {
-        return Err(OpError::InvalidValue(
+        return Err(OpError::invalid_value(
             "`updates` does not have expected rank",
         ));
     }
@@ -203,7 +203,7 @@ pub fn scatter_nd<
     expected_update_shape.extend_from_slice(&indices.shape()[..indices.ndim() - 1]);
     expected_update_shape.extend_from_slice(&data.shape()[k..data.ndim()]);
     if updates.shape() != expected_update_shape.as_slice() {
-        return Err(OpError::InvalidValue(
+        return Err(OpError::invalid_value(
             "`updates` does not have expected shape",
         ));
     }
@@ -226,7 +226,7 @@ pub fn scatter_nd<
             .zip(output.shape().iter().zip(output.strides().iter()))
         {
             let idx = resolve_index(*size, *i as isize)
-                .ok_or(OpError::InvalidValue("invalid scatter index"))?;
+                .ok_or(OpError::invalid_value("invalid scatter index"))?;
             output_slice_offset += idx * stride;
         }
         let out_data = output.data_mut().unwrap();
@@ -317,7 +317,7 @@ mod tests {
                 indices: Tensor::from([4]),
                 updates: Tensor::from([1.]),
                 axis: 0,
-                expected: Err(OpError::InvalidValue("Index is invalid")),
+                expected: Err(OpError::invalid_value("Index is invalid")),
             },
             // Rank mismatch
             Case {
@@ -325,7 +325,7 @@ mod tests {
                 indices: Tensor::from([[4]]),
                 updates: Tensor::from([[1.]]),
                 axis: 0,
-                expected: Err(OpError::InvalidValue(
+                expected: Err(OpError::invalid_value(
                     "`data` and `indices` must have same rank",
                 )),
             },
@@ -335,7 +335,7 @@ mod tests {
                 indices: Tensor::from([4]),
                 updates: Tensor::from([1., 2.]),
                 axis: 0,
-                expected: Err(OpError::InvalidValue(
+                expected: Err(OpError::invalid_value(
                     "`indices` and `updates` must have same shape",
                 )),
             },
@@ -523,31 +523,31 @@ mod tests {
                 data: (5.).into(),
                 indices: [0].into(),
                 updates: [0.].into(),
-                expected: OpError::InvalidValue("`data` and `indices` must have rank >= 1"),
+                expected: OpError::invalid_value("`data` and `indices` must have rank >= 1"),
             },
             Case {
                 data: Tensor::from([0.]),
                 indices: Tensor::from(0),
                 updates: [0.].into(),
-                expected: OpError::InvalidValue("`data` and `indices` must have rank >= 1"),
+                expected: OpError::invalid_value("`data` and `indices` must have rank >= 1"),
             },
             Case {
                 data: Tensor::arange(1., 5., None),
                 indices: [[0], [1], [2], [3]].into(),
                 updates: [[1., 2., 3., 4.]].into(),
-                expected: OpError::InvalidValue("`updates` does not have expected rank"),
+                expected: OpError::invalid_value("`updates` does not have expected rank"),
             },
             Case {
                 data: Tensor::arange(1., 5., None),
                 indices: [[0], [1], [2], [3]].into(),
                 updates: [1., 2., 3., 4., 5.].into(),
-                expected: OpError::InvalidValue("`updates` does not have expected shape"),
+                expected: OpError::invalid_value("`updates` does not have expected shape"),
             },
             Case {
                 data: Tensor::arange(1., 5., None),
                 indices: [[0], [1], [2], [4]].into(),
                 updates: [1., 2., 3., 4.].into(),
-                expected: OpError::InvalidValue("invalid scatter index"),
+                expected: OpError::invalid_value("invalid scatter index"),
             },
         ];
 

--- a/src/ops/sequence.rs
+++ b/src/ops/sequence.rs
@@ -59,7 +59,7 @@ impl Operator for SequenceAt {
         let seq: &Sequence = ctx.inputs().require_as(0)?;
         let pos: i32 = ctx.inputs().require_as(1)?;
         let pos = resolve_index(seq.len(), pos as isize)
-            .ok_or(OpError::InvalidValue("Sequence position is invalid"))?;
+            .ok_or(OpError::invalid_value("Sequence position is invalid"))?;
         seq.at(pos)
             .unwrap()
             .to_owned_in(ctx.pool())
@@ -119,7 +119,7 @@ impl Operator for SequenceConstruct {
 
 fn sequence_erase(mut seq: Sequence, pos: Option<i32>) -> Result<Sequence, OpError> {
     let Some(max_index) = seq.len().checked_sub(1) else {
-        return Err(OpError::InvalidValue(
+        return Err(OpError::invalid_value(
             "Cannot remove element from empty sequence",
         ));
     };
@@ -127,7 +127,7 @@ fn sequence_erase(mut seq: Sequence, pos: Option<i32>) -> Result<Sequence, OpErr
     let pos = pos
         .map(|pos| {
             resolve_index(seq.len(), pos as isize)
-                .ok_or(OpError::InvalidValue("Sequence position is invalid"))
+                .ok_or(OpError::invalid_value("Sequence position is invalid"))
         })
         .transpose()?
         .unwrap_or(max_index);
@@ -188,18 +188,18 @@ fn sequence_insert(
     val: ValueView,
 ) -> Result<Sequence, OpError> {
     let ValueType::Tensor(val_dtype) = val.dtype() else {
-        return Err(OpError::InvalidValue("expected input to be a tensor"));
+        return Err(OpError::invalid_value("expected input to be a tensor"));
     };
 
     if seq.dtype() != val_dtype {
-        return Err(OpError::InvalidValue(
+        return Err(OpError::invalid_value(
             "Tensor type does not match sequence type",
         ));
     }
     let pos = pos
         .map(|pos| {
             resolve_index(seq.len() + 1, pos as isize)
-                .ok_or(OpError::InvalidValue("Sequence position is invalid"))
+                .ok_or(OpError::invalid_value("Sequence position is invalid"))
         })
         .transpose()?
         .unwrap_or(seq.len());
@@ -374,12 +374,14 @@ impl Operator for SplitToSequence {
                     if size >= 1 {
                         SplitSizes::Size(size)
                     } else {
-                        return Err(OpError::InvalidValue("Split size must be >= 1"));
+                        return Err(OpError::invalid_value("Split size must be >= 1"));
                     }
                 }
                 (1, _) => SplitSizes::Sizes(splits.nd_view()),
                 _ => {
-                    return Err(OpError::InvalidValue("Split size must be scalar or vector"));
+                    return Err(OpError::invalid_value(
+                        "Split size must be scalar or vector",
+                    ));
                 }
             }
         } else {
@@ -484,7 +486,7 @@ mod tests {
             Case {
                 seq: [1., 2.].map(Tensor::from).into(),
                 pos: 2,
-                expected: Err(OpError::InvalidValue("Sequence position is invalid")),
+                expected: Err(OpError::invalid_value("Sequence position is invalid")),
             },
         ];
 
@@ -568,13 +570,13 @@ mod tests {
             Case {
                 seq: test_seq.clone(),
                 pos: Some(5),
-                expected: Err(OpError::InvalidValue("Sequence position is invalid")),
+                expected: Err(OpError::invalid_value("Sequence position is invalid")),
             },
             // Removal from empty sequence
             Case {
                 seq: Sequence::new(DataType::Int32),
                 pos: None,
-                expected: Err(OpError::InvalidValue(
+                expected: Err(OpError::invalid_value(
                     "Cannot remove element from empty sequence",
                 )),
             },
@@ -637,14 +639,14 @@ mod tests {
                 seq: [1., 2.].map(Tensor::from).into(),
                 pos: Some(5),
                 value: Tensor::from(3.).into(),
-                expected: Err(OpError::InvalidValue("Sequence position is invalid")),
+                expected: Err(OpError::invalid_value("Sequence position is invalid")),
             },
             // Data type mismatch
             Case {
                 seq: [1., 2.].map(Tensor::from).into(),
                 pos: Some(2),
                 value: Tensor::from(3i32).into(),
-                expected: Err(OpError::InvalidValue(
+                expected: Err(OpError::invalid_value(
                     "Tensor type does not match sequence type",
                 )),
             },
@@ -702,7 +704,7 @@ mod tests {
                 seq: [[0], [1], [2]].map(Tensor::from).into(),
                 axis: 3,
                 new_axis: true,
-                expected: Err(OpError::InvalidValue("Axis is invalid")),
+                expected: Err(OpError::invalid_value("Axis is invalid")),
             },
         ];
 
@@ -771,7 +773,7 @@ mod tests {
                 splits: Some(Tensor::from(0)),
                 axis: 0,
                 keep_dims: true,
-                expected: Err(OpError::InvalidValue("Split size must be >= 1")),
+                expected: Err(OpError::invalid_value("Split size must be >= 1")),
             },
             // Invalid split rank
             Case {
@@ -779,7 +781,9 @@ mod tests {
                 splits: Some(Tensor::from([[1]])),
                 axis: 0,
                 keep_dims: true,
-                expected: Err(OpError::InvalidValue("Split size must be scalar or vector")),
+                expected: Err(OpError::invalid_value(
+                    "Split size must be scalar or vector",
+                )),
             },
         ];
 

--- a/src/ops/slice.rs
+++ b/src/ops/slice.rs
@@ -17,7 +17,7 @@ use crate::value::{Value, ValueView};
 macro_rules! check_input {
     ($cond:expr, $msg:literal) => {
         if !$cond {
-            return Err(OpError::InvalidValue($msg));
+            return Err(OpError::invalid_value($msg));
         }
     };
 }
@@ -607,7 +607,7 @@ mod tests {
                 Some(&case.steps.into()),
             )
             .err();
-            assert_eq!(err, Some(OpError::InvalidValue(case.expected)));
+            assert_eq!(err, Some(OpError::invalid_value(case.expected)));
         });
     }
 }

--- a/src/ops/split.rs
+++ b/src/ops/split.rs
@@ -49,17 +49,17 @@ pub fn split<T: Copy>(
     let outputs = match split {
         SplitSizes::Size(size) => {
             if size < 1 {
-                return Err(OpError::InvalidValue("Split size must be >= 1"));
+                return Err(OpError::invalid_value("Split size must be >= 1"));
             }
             split_with_chunk_size(size as usize)
         }
         SplitSizes::Sizes(split) => {
             if split.iter().any(|size| *size < 0) {
-                return Err(OpError::InvalidValue("Split sizes must be >= 0"));
+                return Err(OpError::invalid_value("Split sizes must be >= 0"));
             }
             let split_sum = split.iter().sum::<i32>() as usize;
             if split_sum != input.size(axis) {
-                return Err(OpError::InvalidValue(
+                return Err(OpError::invalid_value(
                     "Split sizes do not sum to dimension size",
                 ));
             }
@@ -78,10 +78,10 @@ pub fn split<T: Copy>(
         SplitSizes::NumSplits(n_splits) => {
             let n_splits = n_splits.as_usize();
             if n_splits == 0 {
-                return Err(OpError::InvalidValue("num_outputs must be > 0"));
+                return Err(OpError::invalid_value("num_outputs must be > 0"));
             }
             if n_splits > axis_size {
-                return Err(OpError::InvalidValue("num_outputs exceeds dim size"));
+                return Err(OpError::invalid_value("num_outputs exceeds dim size"));
             }
             split_with_chunk_size(axis_size.div_ceil(n_splits))
         }
@@ -280,27 +280,27 @@ mod tests {
             Case {
                 axis: 2,
                 splits: [1, 1].as_slice().into(),
-                expected: OpError::InvalidValue("Axis is invalid"),
+                expected: OpError::invalid_value("Axis is invalid"),
             },
             Case {
                 axis: 1,
                 splits: [1, 2].as_slice().into(),
-                expected: OpError::InvalidValue("Split sizes do not sum to dimension size"),
+                expected: OpError::invalid_value("Split sizes do not sum to dimension size"),
             },
             Case {
                 axis: 1,
                 splits: [1, -2].as_slice().into(),
-                expected: OpError::InvalidValue("Split sizes must be >= 0"),
+                expected: OpError::invalid_value("Split sizes must be >= 0"),
             },
             Case {
                 axis: 1,
                 splits: SplitSizes::NumSplits(0),
-                expected: OpError::InvalidValue("num_outputs must be > 0"),
+                expected: OpError::invalid_value("num_outputs must be > 0"),
             },
             Case {
                 axis: 1,
                 splits: SplitSizes::NumSplits(3),
-                expected: OpError::InvalidValue("num_outputs exceeds dim size"),
+                expected: OpError::invalid_value("num_outputs exceeds dim size"),
             },
         ];
 

--- a/src/ops/trilu.rs
+++ b/src/ops/trilu.rs
@@ -44,7 +44,7 @@ pub fn trilu<T: Copy + Default>(
     upper: bool,
 ) -> Result<Tensor<T>, OpError> {
     if input.ndim() < 2 {
-        return Err(OpError::InvalidValue("Input must have >= 2 dims"));
+        return Err(OpError::invalid_value("Input must have >= 2 dims"));
     }
 
     let mut output = Tensor::uninit_in(pool, input.shape());
@@ -205,7 +205,7 @@ mod tests {
         let result = trilu(&pool, input.view(), 0, true /* upper */);
         assert_eq!(
             result,
-            Err(OpError::InvalidValue("Input must have >= 2 dims"))
+            Err(OpError::invalid_value("Input must have >= 2 dims"))
         );
     }
 }

--- a/src/ops/unary_elementwise.rs
+++ b/src/ops/unary_elementwise.rs
@@ -627,7 +627,7 @@ fn prelu<T: Copy + Default + PartialOrd + std::ops::Mul<Output = T>>(
     slope: TensorView<T>,
 ) -> Result<Tensor<T>, OpError> {
     if !slope.can_broadcast_to(x.shape()) {
-        return Err(OpError::IncompatibleInputShapes(
+        return Err(OpError::incompatible_input_shapes(
             "Slope is not broadcastable to input shape",
         ));
     }
@@ -1180,7 +1180,7 @@ mod tests {
         let result: Result<Tensor, _> = op.run_simple((x.view(), slope_2d.view()));
         assert_eq!(
             result.err(),
-            Some(OpError::IncompatibleInputShapes(
+            Some(OpError::incompatible_input_shapes(
                 "Slope is not broadcastable to input shape"
             ))
         );

--- a/src/ops/unary_elementwise/contrib.rs
+++ b/src/ops/unary_elementwise/contrib.rs
@@ -20,7 +20,7 @@ fn bias_gelu(ctx: &OpRunContext, approximate: bool) -> Result<OutputList, OpErro
     let b: NdTensorView<_, 1> = inputs.require_as(1)?;
 
     if a.ndim() == 0 || a.size(a.ndim() - 1) != b.size(0) {
-        return Err(OpError::IncompatibleInputShapes(
+        return Err(OpError::incompatible_input_shapes(
             "bias length does not match last dimension of input",
         ));
     }
@@ -325,7 +325,7 @@ mod tests {
                 let result = op.run_simple::<_, Tensor>((input.view(), bias.view()));
                 assert_eq!(
                     result,
-                    Err(OpError::IncompatibleInputShapes(
+                    Err(OpError::incompatible_input_shapes(
                         "bias length does not match last dimension of input"
                     ))
                 );

--- a/src/ops/variadic_elementwise.rs
+++ b/src/ops/variadic_elementwise.rs
@@ -24,7 +24,7 @@ fn reduce_elementwise<T: Copy, R: Fn(T, T) -> T + Copy>(
     reduce: R,
 ) -> Result<Tensor<T>, OpError> {
     match inputs {
-        [] => Err(OpError::InvalidValue("Expected at least one input")),
+        [] => Err(OpError::invalid_value("Expected at least one input")),
         [a] => Ok(a.to_tensor_in(pool)),
         [a, b] => binary_op(pool, a.view(), b.view(), &reduce),
         [a, b, c @ ..] => {
@@ -241,7 +241,7 @@ mod tests {
             // Zero inputs
             Case {
                 inputs: vec![],
-                expected: Err(OpError::InvalidValue("Expected at least one input")),
+                expected: Err(OpError::invalid_value("Expected at least one input")),
             },
             // One input
             Case {
@@ -280,7 +280,9 @@ mod tests {
             // Two inputs, incompatible broadcast
             Case {
                 inputs: vec![[4., 5., 6.].into(), [[1., 2.], [3., 4.]].into()],
-                expected: Err(OpError::IncompatibleInputShapes("Cannot broadcast inputs")),
+                expected: Err(OpError::incompatible_input_shapes(
+                    "Cannot broadcast inputs",
+                )),
             },
             // Three inputs, incompatible broadcast
             Case {
@@ -289,7 +291,9 @@ mod tests {
                     Tensor::from(3.),
                     [[1., 2.], [3., 4.]].into(),
                 ],
-                expected: Err(OpError::IncompatibleInputShapes("Cannot broadcast inputs")),
+                expected: Err(OpError::incompatible_input_shapes(
+                    "Cannot broadcast inputs",
+                )),
             },
         ];
 


### PR DESCRIPTION
Change the static `str` payloads of `OpError` variants to `Cow<'static, str>` so they can contain dynamic details, while avoid allocation for static messages.

Add constructor functions to `OpError` to simplify creating errors with either static `str`s or `String`s.