### PR TITLE
Validate input shapes in LSTM and GRU operators

### DIFF
--- a/src/ops/rnn.rs
+++ b/src/ops/rnn.rs
@@ -10,7 +10,7 @@ use crate::buffer_pool::{AutoReturn, BufferPool};
 use crate::infer_shapes::{InferShapes, impl_infer_shapes};
 use crate::operator::{
     IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType, OutputTypeList,
-    OutputTypesContext, static_dims,
+    OutputTypesContext, check_eq, static_dims,
 };
 use crate::ops::binary_elementwise::{add_in_place, mul_in_place};
 use crate::ops::unary_elementwise::{sigmoid, tanh};
@@ -158,21 +158,43 @@ pub fn gru(
     }
 
     let input = static_dims!(input, 3, "seq, batch, input")?;
+    let [seq_len, batch, input_size] = input.shape();
+
     let weights = static_dims!(weights, 3, "dir, hidden x 3, input")?;
-    let recurrent_weights = static_dims!(recurrent_weights, 3)?;
+    let hidden_x3 = weights.size(1);
+
+    if hidden_x3 % 3 != 0 {
+        return Err(OpError::invalid_value(
+            "weights dim 1 must be 3 * hidden_size",
+        ));
+    }
+    let hidden_size = hidden_x3 / 3;
+    let num_directions = direction.num_directions();
+
+    check_eq!(weights.size(0), num_directions)?;
+    check_eq!(weights.size(2), input_size)?;
+
+    let recurrent_weights = static_dims!(recurrent_weights, 3, "dir, hidden x 3, hidden")?;
+    check_eq!(recurrent_weights.size(0), num_directions)?;
+    check_eq!(recurrent_weights.size(1), hidden_size * 3)?;
+    check_eq!(recurrent_weights.size(2), hidden_size)?;
+
     let bias = bias
         .map(|bias| static_dims!(bias, 2, "dir, hidden x 6"))
         .transpose()?;
-
-    let [seq_len, batch, _input_size] = input.shape();
-    let [_directions, hidden_x3, _input_size] = weights.shape();
+    if let Some(bias) = bias.as_ref() {
+        check_eq!(bias.size(0), num_directions)?;
+        check_eq!(bias.size(1), hidden_size * 6)?;
+    }
 
     let initial_hidden = initial_hidden
-        .map(|initial_hidden| static_dims!(initial_hidden, 3))
+        .map(|initial_hidden| static_dims!(initial_hidden, 3, "dir, batch, hidden"))
         .transpose()?;
-
-    let num_directions = direction.num_directions();
-    let hidden_size = hidden_x3 / 3;
+    if let Some(initial_hidden) = initial_hidden.as_ref() {
+        check_eq!(initial_hidden.size(0), num_directions)?;
+        check_eq!(initial_hidden.size(1), batch)?;
+        check_eq!(initial_hidden.size(2), hidden_size)?;
+    }
 
     let mut hidden = initial_hidden
         .map(|t| t.to_tensor_in(pool))
@@ -420,37 +442,53 @@ pub fn lstm(
     initial_hidden: Option<TensorView>,
     initial_cell: Option<TensorView>,
 ) -> Result<Vec<Tensor>, OpError> {
-    // TODO - Add validation of the sizes of individual dimensions in the inputs.
     let input = static_dims!(input, 3, "seq, batch, input")?;
-    let [seq_len, batch, _input_size] = input.shape();
+    let [seq_len, batch, input_size] = input.shape();
 
     let weights = static_dims!(weights, 3, "dir, hidden x 4, input")?;
-    let [_directions, hidden_x4, _input_size] = weights.shape();
+    let hidden_x4 = weights.size(1);
 
-    let recurrent_weights = static_dims!(recurrent_weights, 3, "dir, hidden x 4, hidden")?;
-
-    let num_directions = direction.num_directions();
-    let hidden_size = hidden_x4 / 4;
-
-    if weights.size(1) % 4 != 0 {
+    if hidden_x4 % 4 != 0 {
         return Err(OpError::invalid_value(
             "weights dim 1 must be 4 * hidden_size",
         ));
     }
+    let hidden_size = hidden_x4 / 4;
+    let num_directions = direction.num_directions();
 
-    let bias = bias.map(|bias| static_dims!(bias, 2)).transpose()?;
-    if let Some(bias) = bias.as_ref()
-        && bias.size(1) % 8 != 0
-    {
-        return Err(OpError::invalid_value("bias dim 1 must be 8 * hidden_size"));
+    check_eq!(weights.size(0), num_directions)?;
+    check_eq!(weights.size(2), input_size)?;
+
+    let recurrent_weights = static_dims!(recurrent_weights, 3, "dir, hidden x 4, hidden")?;
+    check_eq!(recurrent_weights.size(0), num_directions)?;
+    check_eq!(recurrent_weights.size(1), hidden_size * 4)?;
+    check_eq!(recurrent_weights.size(2), hidden_size)?;
+
+    let bias = bias
+        .map(|bias| static_dims!(bias, 2, "dir, hidden x 8"))
+        .transpose()?;
+    if let Some(bias) = bias.as_ref() {
+        check_eq!(bias.size(0), num_directions)?;
+        check_eq!(bias.size(1), hidden_size * 8)?;
     }
 
     let initial_hidden = initial_hidden
-        .map(|initial_hidden| static_dims!(initial_hidden, 3))
+        .map(|initial_hidden| static_dims!(initial_hidden, 3, "dir, batch, hidden"))
         .transpose()?;
+    if let Some(initial_hidden) = initial_hidden.as_ref() {
+        check_eq!(initial_hidden.size(0), num_directions)?;
+        check_eq!(initial_hidden.size(1), batch)?;
+        check_eq!(initial_hidden.size(2), hidden_size)?;
+    }
+
     let initial_cell = initial_cell
-        .map(|initial_cell| static_dims!(initial_cell, 3))
+        .map(|initial_cell| static_dims!(initial_cell, 3, "dir, batch, hidden"))
         .transpose()?;
+    if let Some(initial_cell) = initial_cell.as_ref() {
+        check_eq!(initial_cell.size(0), num_directions)?;
+        check_eq!(initial_cell.size(1), batch)?;
+        check_eq!(initial_cell.size(2), hidden_size)?;
+    }
 
     // Contiguous input and bias needed to allow reshaping below.
     let input = input.to_contiguous_in(pool).auto_return(pool);
@@ -666,6 +704,7 @@ mod tests {
     use serde_json::Value;
 
     use crate::buffer_pool::BufferPool;
+    use crate::operator::OpError;
     use crate::ops::{Direction, concat, gru, lstm, split};
 
     /// Read a float tensor from a JSON value.
@@ -1085,5 +1124,217 @@ mod tests {
         })
     }
 
-    // TODO - Add tests for incorrect input shapes
+    #[test]
+    fn test_rnn_ops_invalid_input_shapes() {
+        const SEQ_LEN: usize = 5;
+        const BATCH: usize = 2;
+        const HIDDEN: usize = 3;
+        const FEATURES: usize = 4;
+
+        /// Shapes of the inputs to an RNN operator.
+        #[derive(Debug)]
+        struct Shapes {
+            input: Vec<usize>,
+            weights: Vec<usize>,
+            recurrent_weights: Vec<usize>,
+            bias: Vec<usize>,
+            initial_hidden: Vec<usize>,
+            initial_cell: Vec<usize>,
+        }
+
+        /// Return valid input shapes for an RNN operator.
+        fn valid_shapes(op: Op, dir: Direction) -> Shapes {
+            let n_gates = match op {
+                Op::Gru => 3,
+                Op::Lstm => 4,
+            };
+            let dirs = dir.num_directions();
+            Shapes {
+                input: vec![SEQ_LEN, BATCH, FEATURES],
+                weights: vec![dirs, n_gates * HIDDEN, FEATURES],
+                recurrent_weights: vec![dirs, n_gates * HIDDEN, HIDDEN],
+                bias: vec![dirs, 2 * n_gates * HIDDEN],
+                initial_hidden: vec![dirs, BATCH, HIDDEN],
+                initial_cell: vec![dirs, BATCH, HIDDEN],
+            }
+        }
+
+        #[derive(Debug)]
+        struct Case {
+            /// Operators the case applies to.
+            ops: &'static [Op],
+
+            dir: Direction,
+
+            /// Change applied to a set of otherwise-valid input shapes.
+            invalidate: fn(&mut Shapes),
+
+            expected: OpError,
+        }
+
+        let cases = &[
+            // Weight dim 1 is not a multiple of the number of gates.
+            Case {
+                ops: &[Op::Lstm],
+                dir: Direction::Forward,
+                invalidate: |s| s.weights[1] += 1,
+                expected: OpError::invalid_value("weights dim 1 must be 4 * hidden_size"),
+            },
+            Case {
+                ops: &[Op::Gru],
+                dir: Direction::Forward,
+                invalidate: |s| s.weights[1] += 1,
+                expected: OpError::invalid_value("weights dim 1 must be 3 * hidden_size"),
+            },
+            // Inputs disagree with the `direction` attribute.
+            Case {
+                ops: &[Op::Lstm, Op::Gru],
+                dir: Direction::Bidirectional,
+                invalidate: |s| s.weights[0] = 1,
+                expected: OpError::incompatible_input_shapes("weights.size(0) != num_directions"),
+            },
+            Case {
+                ops: &[Op::Lstm, Op::Gru],
+                dir: Direction::Forward,
+                invalidate: |s| s.recurrent_weights[0] = 2,
+                expected: OpError::incompatible_input_shapes(
+                    "recurrent_weights.size(0) != num_directions",
+                ),
+            },
+            Case {
+                ops: &[Op::Lstm, Op::Gru],
+                dir: Direction::Forward,
+                invalidate: |s| s.bias[0] = 2,
+                expected: OpError::incompatible_input_shapes("bias.size(0) != num_directions"),
+            },
+            Case {
+                ops: &[Op::Lstm, Op::Gru],
+                dir: Direction::Forward,
+                invalidate: |s| s.initial_hidden[0] = 2,
+                expected: OpError::incompatible_input_shapes(
+                    "initial_hidden.size(0) != num_directions",
+                ),
+            },
+            Case {
+                ops: &[Op::Lstm],
+                dir: Direction::Forward,
+                invalidate: |s| s.initial_cell[0] = 2,
+                expected: OpError::incompatible_input_shapes(
+                    "initial_cell.size(0) != num_directions",
+                ),
+            },
+            // Inputs disagree about the input size.
+            Case {
+                ops: &[Op::Lstm, Op::Gru],
+                dir: Direction::Forward,
+                invalidate: |s| s.weights[2] += 1,
+                expected: OpError::incompatible_input_shapes("weights.size(2) != input_size"),
+            },
+            // Inputs disagree about the hidden size.
+            Case {
+                ops: &[Op::Lstm],
+                dir: Direction::Forward,
+                invalidate: |s| s.recurrent_weights[1] += 4,
+                expected: OpError::incompatible_input_shapes(
+                    "recurrent_weights.size(1) != hidden_size * 4",
+                ),
+            },
+            Case {
+                ops: &[Op::Gru],
+                dir: Direction::Forward,
+                invalidate: |s| s.recurrent_weights[1] += 3,
+                expected: OpError::incompatible_input_shapes(
+                    "recurrent_weights.size(1) != hidden_size * 3",
+                ),
+            },
+            Case {
+                ops: &[Op::Lstm, Op::Gru],
+                dir: Direction::Forward,
+                invalidate: |s| s.recurrent_weights[2] += 1,
+                expected: OpError::incompatible_input_shapes(
+                    "recurrent_weights.size(2) != hidden_size",
+                ),
+            },
+            Case {
+                ops: &[Op::Lstm],
+                dir: Direction::Forward,
+                invalidate: |s| s.bias[1] += 8,
+                expected: OpError::incompatible_input_shapes("bias.size(1) != hidden_size * 8"),
+            },
+            Case {
+                ops: &[Op::Gru],
+                dir: Direction::Forward,
+                invalidate: |s| s.bias[1] += 6,
+                expected: OpError::incompatible_input_shapes("bias.size(1) != hidden_size * 6"),
+            },
+            Case {
+                ops: &[Op::Lstm, Op::Gru],
+                dir: Direction::Forward,
+                invalidate: |s| s.initial_hidden[2] += 1,
+                expected: OpError::incompatible_input_shapes(
+                    "initial_hidden.size(2) != hidden_size",
+                ),
+            },
+            Case {
+                ops: &[Op::Lstm],
+                dir: Direction::Forward,
+                invalidate: |s| s.initial_cell[2] += 1,
+                expected: OpError::incompatible_input_shapes("initial_cell.size(2) != hidden_size"),
+            },
+            // Inputs disagree about the batch size.
+            Case {
+                ops: &[Op::Lstm, Op::Gru],
+                dir: Direction::Forward,
+                invalidate: |s| s.initial_hidden[1] += 1,
+                expected: OpError::incompatible_input_shapes("initial_hidden.size(1) != batch"),
+            },
+            Case {
+                ops: &[Op::Lstm],
+                dir: Direction::Forward,
+                invalidate: |s| s.initial_cell[1] += 1,
+                expected: OpError::incompatible_input_shapes("initial_cell.size(1) != batch"),
+            },
+        ];
+
+        cases.test_each(|case| {
+            for &op in case.ops {
+                let pool = BufferPool::new();
+
+                let mut shapes = valid_shapes(op, case.dir);
+                (case.invalidate)(&mut shapes);
+
+                let input = Tensor::zeros(&shapes.input);
+                let weights = Tensor::zeros(&shapes.weights);
+                let recurrent_weights = Tensor::zeros(&shapes.recurrent_weights);
+                let bias = Tensor::zeros(&shapes.bias);
+                let initial_hidden = Tensor::zeros(&shapes.initial_hidden);
+                let initial_cell = Tensor::zeros(&shapes.initial_cell);
+
+                let result = match op {
+                    Op::Lstm => lstm(
+                        &pool,
+                        case.dir,
+                        input.view(),
+                        weights.view(),
+                        recurrent_weights.view(),
+                        Some(bias.view()),
+                        Some(initial_hidden.view()),
+                        Some(initial_cell.view()),
+                    ),
+                    Op::Gru => gru(
+                        &pool,
+                        case.dir,
+                        input.view(),
+                        weights.view(),
+                        recurrent_weights.view(),
+                        Some(bias.view()),
+                        Some(initial_hidden.view()),
+                        true, /* linear_before_reset */
+                    ),
+                };
+
+                assert_eq!(result.err().as_ref(), Some(&case.expected), "op {:?}", op);
+            }
+        })
+    }
 }


### PR DESCRIPTION
Add missing checks for compatibility between input shapes and attributes in the LSTM and GRU ops. This fixes panics that could be triggered by mismatched inputs.

Fixes #1274