### PR TITLE
Optimize GRU and LSTM operators

### DIFF
--- a/src/ops/rnn.rs
+++ b/src/ops/rnn.rs
@@ -1,10 +1,14 @@
 use std::iter::Rev;
+use std::mem::MaybeUninit;
 use std::ops::Range;
 
-use rten_gemm::{GemmExecutor, GemmInputA, GemmInputB, GemmOptions};
+use rayon::prelude::*;
+use rten_gemm::{BiasVector, GemmExecutor, GemmInputA, GemmInputB, GemmOptions, GemmUninitOptions};
 use rten_shape_inference::ops as shape_ops;
+use rten_simd::SimdUnaryOp;
 use rten_tensor::prelude::*;
-use rten_tensor::{NdTensor, NdTensorView, Tensor, TensorView};
+use rten_tensor::{NdTensor, NdTensorView, NdTensorViewMut, Tensor, TensorView};
+use rten_vecmath as vecmath;
 
 use crate::buffer_pool::{AutoReturn, BufferPool};
 use crate::infer_shapes::{InferShapes, impl_infer_shapes};
@@ -12,8 +16,6 @@ use crate::operator::{
     IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType, OutputTypeList,
     OutputTypesContext, check_eq,
 };
-use crate::ops::binary_elementwise::{add_in_place, mul_in_place};
-use crate::ops::unary_elementwise::{sigmoid, tanh};
 use crate::value::{DataType, ValueType};
 
 /// Direction that an RNN operator will traverse the input sequence in.
@@ -78,21 +80,54 @@ fn sequence_for_dir(op_dirs: Direction, dir: usize, seq_len: usize) -> Sequence 
 
 /// Like [`std::iter::zip`], but combines 3 iterators.
 fn zip3<T1, T2, T3>(
-    a: impl Iterator<Item = T1>,
-    b: impl Iterator<Item = T2>,
-    c: impl Iterator<Item = T3>,
+    a: impl IntoIterator<Item = T1>,
+    b: impl IntoIterator<Item = T2>,
+    c: impl IntoIterator<Item = T3>,
 ) -> impl Iterator<Item = (T1, T2, T3)> {
-    a.zip(b.zip(c)).map(|(a, (b, c))| (a, b, c))
+    a.into_iter()
+        .zip(b.into_iter().zip(c))
+        .map(|(a, (b, c))| (a, b, c))
 }
 
 /// Like [`std::iter::zip`], but combines 4 iterators.
 fn zip4<T1, T2, T3, T4>(
-    a: impl Iterator<Item = T1>,
-    b: impl Iterator<Item = T2>,
-    c: impl Iterator<Item = T3>,
-    d: impl Iterator<Item = T4>,
+    a: impl IntoIterator<Item = T1>,
+    b: impl IntoIterator<Item = T2>,
+    c: impl IntoIterator<Item = T3>,
+    d: impl IntoIterator<Item = T4>,
 ) -> impl Iterator<Item = (T1, T2, T3, T4)> {
-    zip3(a, b, c.zip(d)).map(|(a, b, (c, d))| (a, b, c, d))
+    zip3(a, b, c.into_iter().zip(d)).map(|(a, b, (c, d))| (a, b, c, d))
+}
+
+/// Compute the input projection `input @ input_weights + input_bias` for every
+/// gate and timestep in a single GEMM.
+///
+/// `input_mat` has shape `[seq_len * batch, input_size]` and `input_weights`
+/// has shape `[input_size, n_gates * hidden_size]`. The result has shape
+/// `[seq_len, batch, n_gates * hidden_size]`.
+fn input_projection(
+    pool: &BufferPool,
+    gemm: &GemmExecutor,
+    input_mat: NdTensorView<f32, 2>,
+    input_weights: NdTensorView<f32, 2>,
+    input_bias: Option<&[f32]>,
+    seq_len: usize,
+    batch: usize,
+) -> NdTensor<f32, 3> {
+    let mut output = NdTensor::uninit_in(pool, [seq_len, batch, input_weights.size(1)]);
+    gemm.gemm_uninit(
+        output.data_mut().unwrap(),
+        GemmInputA::Unpacked(input_mat),
+        GemmInputB::Unpacked(input_weights),
+        GemmUninitOptions {
+            bias: input_bias.map(BiasVector::Row),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    // Safety: `gemm_uninit` initialized every element of `output`.
+    unsafe { output.assume_init() }
 }
 
 /// Sequence length threshold for prepacking weights.
@@ -171,157 +206,164 @@ pub fn gru(
         check_eq!(initial_hidden.shape(), [num_directions, batch, hidden_size])?;
     }
 
+    let input_mat = input
+        .reshaped_in(pool, [seq_len * batch, input_size])
+        .auto_return(pool);
+    // Contiguous bias needed so per-gate slices can be passed to GEMM.
+    let bias = bias.map(|b| b.to_contiguous());
+
     let mut hidden = initial_hidden
         .map(|t| t.to_tensor_in(pool))
         .unwrap_or_else(|| NdTensor::zeros_in(pool, [num_directions, batch, hidden_size]));
-    let mut hidden_seq = NdTensor::zeros_in(pool, [seq_len, num_directions, batch, hidden_size]);
-
-    // Indices of gates in the concatenated weight and bias tensors.
-    const UPDATE_GATE: usize = 0;
-    const RESET_GATE: usize = 1;
-    const HIDDEN_GATE: usize = 2;
-
-    let n_gates = 3;
-    let mut gates = NdTensor::zeros_in(pool, [batch, n_gates * hidden_size]).auto_return(pool);
-    let gate_range = |gate| (gate * hidden_size)..((gate + 1) * hidden_size);
-
-    // Scratch space for output of `hidden_state @ hidden_weights` matmul.
-    let mut hidden_scratch =
-        NdTensor::zeros_in(pool, [batch, n_gates * hidden_size]).auto_return(pool);
+    let mut hidden_seq = NdTensor::uninit_in(pool, [seq_len, num_directions, batch, hidden_size]);
 
     let gemm = GemmExecutor::new();
-    for dir in 0..num_directions {
-        let prepack = seq_len >= PREPACK_MIN_SEQ_LEN;
 
-        let input_weights = weights.slice(dir).transposed();
-        let packed_input_weights =
-            prepack.then(|| gemm.prepack_b_in(pool, input_weights).auto_return(pool));
-        let input_weights = packed_input_weights
-            .as_ref()
-            .map(|packed| GemmInputB::Packed(packed))
-            .unwrap_or(GemmInputB::Unpacked(input_weights));
+    // From the ONNX spec, the intermediate values are computed as:
+    //
+    //   zt = f(Xt*(Wz^T) + Ht-1*(Rz^T) + Wbz + Rbz)
+    //   rt = f(Xt*(Wr^T) + Ht-1*(Rr^T) + Wbr + Rbr)
+    //
+    //   If `linear_before_reset` is true:
+    //     ht = tanh(dot(input, hidden_w) + rt * (dot(hidden, rec_hidden_w) + rec_hidden_bias) + hidden_bias)
+    //   Else:
+    //     ht = tanh(dot(input, hidden_w) + dot((rt * hidden), rec_hidden_w) + rec_hidden_bias + hidden_bias)
+    //
+    //   Ht = (1 - zt) (.) ht + zt (.) (Ht-1)
+    //
+    // Where:
+    //
+    //  - `zt`, `rt` and `ht` are the update, reset and hidden gates
+    //  - `Xt`, `Ht` are the input and hidden states at time `t`
+    //  - `W{z,r,h}` and `R{z,r,h}` are the input and recurrent weights
+    //  - `Wb{z,r,h}` and `Rb{z,r,h}` are the input and recurrent biases
+    //  - `f` and `g` are activations. f=sigmoid, g=tanh
+    //
+    // In the `linear_before_reset=true` case, which is all we currently
+    // support, the matrix multiplications for all gates can be combined into
+    // two: one for `input @ input_weights`, one for `hidden @ hidden_weights`.
 
-        let hidden_weights = recurrent_weights.slice(dir).transposed();
-        let packed_hidden_weights =
-            prepack.then(|| gemm.prepack_b_in(pool, hidden_weights).auto_return(pool));
-        let hidden_weights = packed_hidden_weights
-            .as_ref()
-            .map(|packed| GemmInputB::Packed(packed))
-            .unwrap_or(GemmInputB::Unpacked(hidden_weights));
+    hidden
+        .axis_iter_mut(0)
+        .into_par_iter()
+        .zip(hidden_seq.axis_iter_mut(1))
+        .enumerate()
+        .for_each(|(dir, (mut hidden, mut hidden_seq))| {
+            let n_gates = 3;
+            let input_bias = bias
+                .as_ref()
+                .map(|b| b.slice((dir, ..(n_gates * hidden_size))).data().unwrap());
 
-        let input_bias = bias
-            .as_ref()
-            .map(|b| b.slice((dir, ..(n_gates * hidden_size))));
-        let hidden_bias = bias
-            .as_ref()
-            .map(|b| b.slice((dir, (n_gates * hidden_size)..)));
-
-        for seq in sequence_for_dir(direction, dir, seq_len) {
-            let in_item = input.slice([seq]);
-            let hidden_item = hidden.slice([dir]);
-
-            // From the ONNX spec, the intermediate values are computed as:
-            //
-            //   zt = f(Xt*(Wz^T) + Ht-1*(Rz^T) + Wbz + Rbz)
-            //   rt = f(Xt*(Wr^T) + Ht-1*(Rr^T) + Wbr + Rbr)
-            //
-            //   If `linear_before_reset` is true:
-            //     ht = tanh(dot(input, hidden_w) + rt * (dot(hidden, rec_hidden_w) + rec_hidden_bias) + hidden_bias)
-            //   Else:
-            //     ht = tanh(dot(input, hidden_w) + dot((rt * hidden), rec_hidden_w) + rec_hidden_bias + hidden_bias)
-            //
-            //   Ht = (1 - zt) (.) ht + zt (.) (Ht-1)
-            //
-            // Where:
-            //
-            //  - `zt`, `rt` and `ht` are the update, reset and hidden gates
-            //  - `Xt`, `Ht` are the input and hidden states at time `t`
-            //  - `W{z,r,h}` and `R{z,r,h}` are the input and recurrent weights
-            //  - `Wb{z,r,h}` and `Rb{z,r,h}` are the input and recurrent biases
-            //  - `f` and `g` are activations. f=sigmoid, g=tanh
-            //
-            // In the `linear_before_reset=true` case, which is all we currently
-            // support, the matrix multiplications for all gates can be
-            // combined into two: one for `input @ input_weights`, one for
-            // `hidden @ hidden_weights`.
-
-            // Compute `input @ weights + bias` for all gates.
-            gemm.gemm(
-                gates.data_mut().expect("expected contiguous input"),
-                GemmInputA::Unpacked(in_item),
-                input_weights,
-                GemmOptions::default(),
+            // Compute input projection for all timesteps at once.
+            let mut input_proj = input_projection(
+                pool,
+                &gemm,
+                input_mat.view(),
+                weights.slice(dir).transposed(),
+                input_bias,
+                seq_len,
+                batch,
             )
-            .unwrap();
-            if let Some(input_bias) = input_bias {
-                add_in_place(gates.as_dyn_mut(), input_bias.as_dyn());
+            .auto_return(pool);
+
+            let prepack = seq_len >= PREPACK_MIN_SEQ_LEN;
+            let hidden_weights = recurrent_weights.slice(dir).transposed();
+            let packed_hidden_weights =
+                prepack.then(|| gemm.prepack_b_in(pool, hidden_weights).auto_return(pool));
+            let hidden_weights = packed_hidden_weights
+                .as_ref()
+                .map(|packed| GemmInputB::Packed(packed))
+                .unwrap_or(GemmInputB::Unpacked(hidden_weights));
+
+            // Scratch space for output of `hidden_state @ hidden_weights` matmul.
+            let mut hidden_scratch =
+                NdTensor::zeros_in(pool, [batch, n_gates * hidden_size]).auto_return(pool);
+            let hidden_bias = bias
+                .as_ref()
+                .map(|b| b.slice((dir, (n_gates * hidden_size)..)).data().unwrap());
+
+            for seq in sequence_for_dir(direction, dir, seq_len) {
+                // Compute `hidden @ hidden_weights + hidden_bias` for all gates.
+                gemm.gemm(
+                    hidden_scratch.data_mut().unwrap(),
+                    GemmInputA::Unpacked(hidden.view()),
+                    hidden_weights,
+                    GemmOptions {
+                        bias: hidden_bias.map(BiasVector::Row),
+                        ..Default::default()
+                    },
+                )
+                .unwrap();
+
+                let gates = input_proj.slice_mut([seq]);
+                let hidden_seq = hidden_seq.slice_mut([seq]);
+                gru_step(
+                    hidden_size,
+                    gates,
+                    hidden_scratch.view(),
+                    hidden.view_mut(),
+                    hidden_seq,
+                );
             }
+        });
 
-            // Compute `hidden @ hidden_weights + hidden_bias` for all gates.
-            gemm.gemm(
-                hidden_scratch.data_mut().unwrap(),
-                GemmInputA::Unpacked(hidden_item),
-                hidden_weights,
-                GemmOptions::default(),
-            )
-            .unwrap();
-            if let Some(hidden_bias) = hidden_bias {
-                add_in_place(hidden_scratch.as_dyn_mut(), hidden_bias.as_dyn());
-            }
-
-            // Combine inputs for reset and update gates and apply activation.
-            let mut update_reset_gates = gates.slice_mut((
-                ..,
-                gate_range(UPDATE_GATE).start..gate_range(RESET_GATE).end,
-            ));
-            let hidden_scratch_reset_update_gates = hidden_scratch.slice((
-                ..,
-                gate_range(UPDATE_GATE).start..gate_range(RESET_GATE).end,
-            ));
-            add_in_place(
-                update_reset_gates.as_dyn_mut(),
-                hidden_scratch_reset_update_gates.as_dyn(),
-            );
-
-            // Copy gates before applying activation because `sigmoid_in_place`
-            // and `tanh_in_place` are slow with non-contiguous tensors, and
-            // `update_reset_gates` will be non-contiguous if the batch size is
-            // > 1. See https://github.com/robertknight/rten/issues/192.
-            //
-            // Note `gate_range` can be still used because the update and reset
-            // gates are in the same positions in the `update_reset_gates` slice
-            // as `gates`.
-            let update_reset_gates = sigmoid(pool, update_reset_gates.as_dyn()).auto_return(pool);
-            let update_reset_gates = update_reset_gates.nd_view::<2>();
-            let update_gate = update_reset_gates.slice((.., gate_range(UPDATE_GATE)));
-            let reset_gate = update_reset_gates.slice((.., gate_range(RESET_GATE)));
-
-            // Combine inputs for hidden gate and apply activation.
-            let mut hidden_gate_recurrent = hidden_scratch.slice_mut((.., gate_range(HIDDEN_GATE)));
-            mul_in_place(hidden_gate_recurrent.as_dyn_mut(), reset_gate.as_dyn());
-
-            let mut hidden_gate = gates.slice_mut((.., gate_range(HIDDEN_GATE)));
-            add_in_place(hidden_gate.as_dyn_mut(), hidden_gate_recurrent.as_dyn());
-
-            // See note above about `sigmoid_in_place`.
-            let hidden_gate = tanh(pool, hidden_gate.as_dyn()).auto_return(pool);
-
-            // Compute next hidden state
-            let mut hidden_item = hidden.slice_mut([dir]);
-
-            for (hidden, update, hidden_gate) in zip3(
-                hidden_item.iter_mut(),
-                update_gate.iter(),
-                hidden_gate.iter(),
-            ) {
-                *hidden = (1. - update) * hidden_gate + update * (*hidden);
-            }
-
-            hidden_seq.slice_mut([seq, dir]).copy_from(&hidden_item);
-        }
-    }
+    // Safety: The loop above wrote to every element of `hidden_seq`.
+    let hidden_seq = unsafe { hidden_seq.assume_init() };
 
     Ok([hidden_seq.into_dyn(), hidden.into_dyn()].into())
+}
+
+/// Compute one GRU timestep for a batch of inputs, updating the hidden state
+/// in place and writing a copy of the new hidden state to `out`.
+///
+/// `gates` has shape `[batch, 3 * hidden_size]` and contains the input
+/// projection `Xt @ W^T + Wb` for this timestep, with the update, reset and
+/// hidden gates concatenated along the last dimension. It is also used as
+/// scratch space. `hidden_scratch` has the same shape and contains the
+/// recurrent projection `Ht-1 @ R^T + Rb`. `hidden` and `out` have shape
+/// `[batch, hidden_size]`.
+///
+/// All inputs must be contiguous in the last dimension.
+fn gru_step(
+    hidden_size: usize,
+    mut gates: NdTensorViewMut<f32, 2>,
+    hidden_scratch: NdTensorView<f32, 2>,
+    mut hidden: NdTensorViewMut<f32, 2>,
+    mut out: NdTensorViewMut<MaybeUninit<f32>, 2>,
+) {
+    for (mut gates, scratch, mut hidden, mut out) in zip4(
+        gates.lanes_mut(1),
+        hidden_scratch.lanes(1),
+        hidden.lanes_mut(1),
+        out.lanes_mut(1),
+    ) {
+        // Inputs are expected to be contiguous in the last dimension.
+        let gates = gates.as_slice_mut().unwrap();
+        let scratch = scratch.as_slice().unwrap();
+        let hidden = hidden.as_slice_mut().unwrap();
+        let out = out.as_slice_mut().unwrap();
+
+        // zt = sigmoid(Xt*(Wz^T) + Wbz + Ht-1*(Rz^T) + Rbz), rt likewise.
+        let (update_reset, hidden_gate) = gates.split_at_mut(2 * hidden_size);
+        let (scratch_update_reset, scratch_hidden) = scratch.split_at(2 * hidden_size);
+        for (x, s) in update_reset.iter_mut().zip(scratch_update_reset) {
+            *x += s;
+        }
+        vecmath::Sigmoid {}.map_mut(update_reset);
+        let (update, reset) = update_reset.split_at(hidden_size);
+
+        // ht = tanh(Xt*(Wh^T) + Wbh + rt (.) (Ht-1*(Rh^T) + Rbh))
+        for (x, s, r) in zip3(hidden_gate.iter_mut(), scratch_hidden, reset) {
+            *x += r * s;
+        }
+        vecmath::Tanh {}.map_mut(hidden_gate);
+
+        // Ht = (1 - zt) (.) ht + zt (.) Ht-1
+        for (hidden, update, hidden_gate, out) in zip4(hidden, update, hidden_gate, out) {
+            *hidden = (1. - *update) * *hidden_gate + update * (*hidden);
+            out.write(*hidden);
+        }
+    }
 }
 
 /// Gated Recurrent Unit operator.
@@ -452,18 +494,11 @@ pub fn lstm(
         check_eq!(initial_cell.shape(), [num_directions, batch, hidden_size])?;
     }
 
-    // Contiguous input and bias needed to allow reshaping below.
-    let input = input.to_contiguous_in(pool).auto_return(pool);
+    let input_mat = input
+        .reshaped_in(pool, [seq_len * batch, input_size])
+        .auto_return(pool);
+    // Contiguous bias needed so per-gate slices can be passed to GEMM.
     let bias = bias.map(|t| t.to_contiguous());
-
-    // Indices of gates in the concatenated weight and bias tensors.
-    const INPUT_GATE: usize = 0;
-    const OUTPUT_GATE: usize = 1;
-    const FORGET_GATE: usize = 2;
-    const CELL_GATE: usize = 3;
-
-    let n_gates = 4;
-    let mut gates = NdTensor::zeros_in(pool, [batch, n_gates * hidden_size]);
 
     let mut cell = initial_cell
         .map(|t| t.to_tensor_in(pool))
@@ -472,128 +507,163 @@ pub fn lstm(
         .map(|t| t.to_tensor_in(pool))
         .unwrap_or_else(|| NdTensor::zeros_in(pool, [num_directions, batch, hidden_size]));
 
-    let mut hidden_seq =
-        NdTensor::<f32, 4>::zeros_in(pool, [seq_len, num_directions, batch, hidden_size]);
+    let mut hidden_seq = NdTensor::uninit_in(pool, [seq_len, num_directions, batch, hidden_size]);
 
     let gemm = GemmExecutor::new();
 
-    let gate_range = |gate| (gate * hidden_size)..((gate + 1) * hidden_size);
+    // From the ONNX spec, the intermediate values are computed as:
+    //
+    // - it = f(Xt*(Wi^T) + Ht-1*(Ri^T) + Pi (.) Ct-1 + Wbi + Rbi)
+    // - ft = f(Xt*(Wf^T) + Ht-1*(Rf^T) + Pf (.) Ct-1 + Wbf + Rbf)
+    // - ct = g(Xt*(Wc^T) + Ht-1*(Rc^T) + Wbc + Rbc)
+    // - Ct = ft (.) Ct-1 + it (.) ct
+    // - ot = f(Xt*(Wo^T) + Ht-1*(Ro^T) + Po (.) Ct + Wbo + Rbo)
+    // - Ht = ot (.) h(Ct)
+    //
+    // Where:
+    //
+    //  - `it`, `ft`, `ct` and `ot` are the input, forget, cell and output gates
+    //  - `Xt`, `Ht` and `Ct` are the input, hidden state and cell state at time `t`
+    //  - `W{i,o,f,c}` and `R{i,o,f,c}` are the input and recurrent gate weights
+    //  - `Wb{i,o,f,c}` and `Rb{i,o,f,c}` are the input and recurrent gate biases
+    //  - `P{i,o,f,c}` are peephole weights. These are not currently
+    //    supported.
+    //  - `f`, `g` and `h` are activations. `f`=sigmoid, `g` and `h`
+    //    are tanh.
+    //
+    // The matrix multiplications for all gates are combined into two: one for
+    // `input @ input_weights`, one for `hidden @ hidden_weights`.
 
-    for dir in 0..num_directions {
-        let prepack = seq_len >= PREPACK_MIN_SEQ_LEN;
+    hidden
+        .axis_iter_mut(0)
+        .into_par_iter()
+        .zip(cell.axis_iter_mut(0))
+        .zip(hidden_seq.axis_iter_mut(1))
+        .enumerate()
+        .for_each(|(dir, ((mut hidden, mut cell), mut hidden_seq))| {
+            let n_gates = 4;
+            let input_bias = bias
+                .as_ref()
+                .map(|b| b.slice((dir, ..(n_gates * hidden_size))).data().unwrap());
+            let hidden_bias = bias
+                .as_ref()
+                .map(|b| b.slice((dir, (n_gates * hidden_size)..)).data().unwrap());
 
-        let input_weights = weights.slice(dir).transposed();
-        let packed_input_weights =
-            prepack.then(|| gemm.prepack_b_in(pool, input_weights).auto_return(pool));
-        let input_weights = packed_input_weights
-            .as_ref()
-            .map(|packed| GemmInputB::Packed(packed))
-            .unwrap_or(GemmInputB::Unpacked(input_weights));
-
-        let hidden_weights = recurrent_weights.slice(dir).transposed();
-        let packed_hidden_weights =
-            prepack.then(|| gemm.prepack_b_in(pool, hidden_weights).auto_return(pool));
-        let hidden_weights = packed_hidden_weights
-            .as_ref()
-            .map(|packed| GemmInputB::Packed(packed))
-            .unwrap_or(GemmInputB::Unpacked(hidden_weights));
-
-        let input_bias = bias
-            .as_ref()
-            .map(|b| b.slice((dir, ..(n_gates * hidden_size))));
-        let hidden_bias = bias
-            .as_ref()
-            .map(|b| b.slice((dir, (n_gates * hidden_size)..)));
-
-        for seq in sequence_for_dir(direction, dir, seq_len) {
-            // From the ONNX spec, the intermediate values are computed as:
-            //
-            // - it = f(Xt*(Wi^T) + Ht-1*(Ri^T) + Pi (.) Ct-1 + Wbi + Rbi)
-            // - ft = f(Xt*(Wf^T) + Ht-1*(Rf^T) + Pf (.) Ct-1 + Wbf + Rbf)
-            // - ct = g(Xt*(Wc^T) + Ht-1*(Rc^T) + Wbc + Rbc)
-            // - Ct = ft (.) Ct-1 + it (.) ct
-            // - ot = f(Xt*(Wo^T) + Ht-1*(Ro^T) + Po (.) Ct + Wbo + Rbo)
-            // - Ht = ot (.) h(Ct)
-            //
-            // Where:
-            //
-            //  - `it`, `ft`, `ct` and `ot` are the input, forget, cell and output gates
-            //  - `Xt`, `Ht` and `Ct` are the input, hidden state and cell state at time `t`
-            //  - `W{i,o,f,c}` and `R{i,o,f,c}` are the input and recurrent gate weights
-            //  - `Wb{i,o,f,c}` and `Rb{i,o,f,c}` are the input and recurrent gate biases
-            //  - `P{i,o,f,c}` are peephole weights. These are not currently
-            //    supported.
-            //  - `f`, `g` and `h` are activations. `f`=sigmoid, `g` and `h`
-            //    are tanh.
-            let in_item = input.slice([seq]);
-            let hidden_item = hidden.slice([dir]);
-
-            // Update input, output, forget and cell gates.
-            gemm.gemm(
-                gates.data_mut().expect("expected contiguous input"),
-                GemmInputA::Unpacked(in_item),
-                input_weights,
-                GemmOptions::default(),
+            // Compute input projection for all timesteps at once.
+            let mut input_proj = input_projection(
+                pool,
+                &gemm,
+                input_mat.view(),
+                weights.slice(dir).transposed(),
+                input_bias,
+                seq_len,
+                batch,
             )
-            .unwrap();
-            if let Some(input_bias) = input_bias {
-                add_in_place(gates.as_dyn_mut(), input_bias.as_dyn());
+            .auto_return(pool);
+
+            let prepack = seq_len >= PREPACK_MIN_SEQ_LEN;
+            let hidden_weights = recurrent_weights.slice(dir).transposed();
+            let packed_hidden_weights =
+                prepack.then(|| gemm.prepack_b_in(pool, hidden_weights).auto_return(pool));
+            let hidden_weights = packed_hidden_weights
+                .as_ref()
+                .map(|packed| GemmInputB::Packed(packed))
+                .unwrap_or(GemmInputB::Unpacked(hidden_weights));
+
+            for seq in sequence_for_dir(direction, dir, seq_len) {
+                // Add `hidden @ hidden_weights + hidden_bias` into the input
+                // projection to get the summed inputs for all gates.
+                let mut gates = input_proj.slice_mut([seq]);
+                gemm.gemm(
+                    gates.data_mut().unwrap(),
+                    GemmInputA::Unpacked(hidden.view()),
+                    hidden_weights,
+                    GemmOptions {
+                        beta: 1.,
+                        bias: hidden_bias.map(BiasVector::Row),
+                        ..Default::default()
+                    },
+                )
+                .unwrap();
+
+                lstm_step(
+                    hidden_size,
+                    gates,
+                    hidden.view_mut(),
+                    cell.view_mut(),
+                    hidden_seq.slice_mut([seq]),
+                );
             }
+        });
 
-            gemm.gemm(
-                gates.data_mut().expect("expected contiguous input"),
-                GemmInputA::Unpacked(hidden_item),
-                hidden_weights,
-                GemmOptions {
-                    beta: 1.,
-                    ..Default::default()
-                },
-            )
-            .unwrap();
-            if let Some(hidden_bias) = hidden_bias {
-                add_in_place(gates.as_dyn_mut(), hidden_bias.as_dyn());
-            }
-
-            // Copy gates to work around `tanh_in_place` and `sigmoid_in_place`
-            // being slow for non-contiguous inputs. See notes in GRU op.
-            let iof_gates = gates.slice((
-                ..,
-                gate_range(INPUT_GATE).start..gate_range(FORGET_GATE).end,
-            ));
-            let iof_gates = sigmoid(pool, iof_gates.as_dyn()).auto_return(pool);
-            let iof_gates = iof_gates.nd_view::<2>();
-
-            let input_gate = iof_gates.slice((.., gate_range(INPUT_GATE)));
-            let out_gate = iof_gates.slice((.., gate_range(OUTPUT_GATE)));
-            let forget_gate = iof_gates.slice((.., gate_range(FORGET_GATE)));
-
-            let cell_gate = gates.slice((.., gate_range(CELL_GATE)));
-            let cell_gate = tanh(pool, cell_gate.as_dyn()).auto_return(pool);
-
-            // Update cell and hidden state
-            let mut cell_item = cell.slice_mut([dir]);
-
-            for (cell, forget_gate, input_gate, cell_gate) in zip4(
-                cell_item.iter_mut(),
-                forget_gate.iter(),
-                input_gate.iter(),
-                cell_gate.iter(),
-            ) {
-                *cell = forget_gate * *cell + input_gate * cell_gate;
-            }
-
-            let mut hidden_item = hidden.slice_mut([dir]);
-            for (hidden, out_gate, cell) in
-                zip3(hidden_item.iter_mut(), out_gate.iter(), cell_item.iter())
-            {
-                *hidden = out_gate * cell.tanh()
-            }
-
-            hidden_seq.slice_mut([seq, dir]).copy_from(&hidden_item);
-        }
-    }
+    // Safety: The loop above wrote to every element of `hidden_seq`.
+    let hidden_seq = unsafe { hidden_seq.assume_init() };
 
     Ok([hidden_seq.into_dyn(), hidden.into_dyn(), cell.into_dyn()].into())
+}
+
+/// Compute one LSTM timestep for a batch of inputs, updating the hidden and
+/// cell states in place and writing a copy of the new hidden state to `out`.
+///
+/// `gates` has shape `[batch, 4 * hidden_size]` and contains the summed input
+/// and recurrent projections `Xt @ W^T + Wb + Ht-1 @ R^T + Rb` for this
+/// timestep, with the input, output, forget and cell gates concatenated along
+/// the last dimension. It is also used as scratch space. `hidden`, `cell` and
+/// `out` have shape `[batch, hidden_size]`.
+///
+/// All inputs must be contiguous in the last dimension.
+fn lstm_step(
+    hidden_size: usize,
+    mut gates: NdTensorViewMut<f32, 2>,
+    mut hidden: NdTensorViewMut<f32, 2>,
+    mut cell: NdTensorViewMut<f32, 2>,
+    mut out: NdTensorViewMut<MaybeUninit<f32>, 2>,
+) {
+    for (mut gates, mut hidden, mut cell, mut out) in zip4(
+        gates.lanes_mut(1),
+        hidden.lanes_mut(1),
+        cell.lanes_mut(1),
+        out.lanes_mut(1),
+    ) {
+        // Inputs are expected to be contiguous in the last dimension.
+        let gates = gates.as_slice_mut().unwrap();
+        let hidden = hidden.as_slice_mut().unwrap();
+        let cell = cell.as_slice_mut().unwrap();
+        let out = out.as_slice_mut().unwrap();
+
+        // it = sigmoid(Xt*(Wi^T) + Wbi + Ht-1*(Ri^T) + Rbi), ot and ft likewise.
+        let (iof_gates, cell_gate) = gates.split_at_mut(3 * hidden_size);
+        vecmath::Sigmoid {}.map_mut(iof_gates);
+        let (input_gate, of_gates) = iof_gates.split_at(hidden_size);
+        let (out_gate, forget_gate) = of_gates.split_at(hidden_size);
+
+        // ct = tanh(Xt*(Wc^T) + Wbc + Ht-1*(Rc^T) + Rbc)
+        vecmath::Tanh {}.map_mut(cell_gate);
+
+        // Ct = ft (.) Ct-1 + it (.) ct
+        for (cell, forget, input, cell_gate) in zip4(
+            cell.iter_mut(),
+            forget_gate.iter(),
+            input_gate.iter(),
+            cell_gate.iter(),
+        ) {
+            *cell = forget * *cell + input * cell_gate;
+        }
+
+        // Ht = ot (.) tanh(Ct). The cell gate is no longer needed, so reuse it
+        // as scratch space for computing `tanh(Ct)`.
+        cell_gate.copy_from_slice(cell);
+        vecmath::Tanh {}.map_mut(cell_gate);
+        for (hidden, out_gate, tanh_cell, out) in zip4(
+            hidden.iter_mut(),
+            out_gate.iter(),
+            cell_gate.iter(),
+            out.iter_mut(),
+        ) {
+            *hidden = out_gate * tanh_cell;
+            out.write(*hidden);
+        }
+    }
 }
 
 /// Long Short-Term Memory operator.

--- a/src/ops/unary_elementwise.rs
+++ b/src/ops/unary_elementwise.rs
@@ -672,7 +672,6 @@ impl Operator for PRelu {
 
 declare_operator!(Sigmoid);
 impl_operator!(Sigmoid, [FloatTensor]);
-impl_operator_fn!(Sigmoid, sigmoid);
 impl_get_kernel!(Sigmoid, f32, SimdKernel(vecmath::Sigmoid {}));
 
 // Sigmoid Linear Unit (SiLU) function.
@@ -754,7 +753,6 @@ impl_get_kernel!(Tan, f32, |val: f32| val.tan());
 
 declare_operator!(Tanh);
 impl_operator!(Tanh, [FloatTensor]);
-impl_operator_fn!(Tanh, tanh);
 impl_get_kernel!(Tanh, f32, SimdKernel(vecmath::Tanh {}));
 
 #[cfg(feature = "contrib")]


### PR DESCRIPTION
Optimize the GRU and LSTM operators as follows:

 1. Compute the input projection for the whole sequence in one large GEMM, rather than one smaller GEMM per time step. Larger GEMMs have better arithmetic intensity.
 2. Combine the gate and hidden state updates at each timestep into one fused in-place update for each batch item. This eliminates copying of data into a temporary buffer and improves cache use.
 3. When the operator is bidirectional, compute the outputs for both directions in parallel.
 4. Fuse bias addition into GEMMs. `rten-gemm` already has APIs for this.
 5. Avoid unnecessary zeroing of the output buffer before writing into it

On the Ocrs text recognition model, this reduces end-to-end time by around 10%
with seq=256, batch=100. Tested with:

```
rten ~/.cache/ocrs/text-recognition.rten -s seq=256 -s batch=100 -n 10
```

Fixes https://github.com/robertknight/rten/issues/1441, part of https://github.com/robertknight/rten/issues/1444.