### PR TITLE
Make `--range` upper bound exclusive in CLI

### DIFF
--- a/rten-cli/src/input_generator.rs
+++ b/rten-cli/src/input_generator.rs
@@ -1,6 +1,7 @@
 //! Generation of random values for model inputs.
 
 use std::error::Error;
+use std::ops::Range;
 
 use rten::{DataType, Dimension, Value, ValueType};
 use rten_tensor::Tensor;
@@ -8,9 +9,38 @@ use rten_tensor::Tensor;
 use crate::dim_size::DimSize;
 use crate::input_range::InputRange;
 
-#[derive(Debug)]
+/// Generate random numbers of type `T`.
+trait Rng<T> {
+    /// Generate a random number in the range `r`.
+    fn generate(&mut self, r: Range<T>) -> T;
+}
+
+macro_rules! impl_rng {
+    ($type:ident) => {
+        impl Rng<$type> for fastrand::Rng {
+            fn generate(&mut self, r: Range<$type>) -> $type {
+                self.$type(r)
+            }
+        }
+    };
+}
+
+impl_rng!(i32);
+impl_rng!(i8);
+impl_rng!(u8);
+
+#[derive(Debug, PartialEq)]
 pub enum GenerateError {
     UnsupportedDataType(ValueType),
+    EmptyRange { input: String },
+}
+
+impl GenerateError {
+    fn empty_range(input: &str) -> Self {
+        Self::EmptyRange {
+            input: input.to_string(),
+        }
+    }
 }
 
 impl std::fmt::Display for GenerateError {
@@ -18,6 +48,9 @@ impl std::fmt::Display for GenerateError {
         match self {
             Self::UnsupportedDataType(dtype) => {
                 write!(f, "generation of {dtype} inputs is not supported")
+            }
+            Self::EmptyRange { input } => {
+                write!(f, "input range is empty for \"{input}\"")
             }
         }
     }
@@ -83,11 +116,22 @@ impl RandomInputGenerator {
             })
             .collect();
 
-        fn random_ints<T, F: FnMut() -> T>(shape: &[usize], generate: F) -> Value
+        // Generate an integer tensor with values in the range `[min, max)`.
+        fn random_ints<T: Copy + PartialOrd, R: Rng<T>>(
+            shape: &[usize],
+            min: T,
+            max: T,
+            rng: &mut R,
+            input: &str,
+        ) -> Result<Value, GenerateError>
         where
             Value: From<Tensor<T>>,
         {
-            Tensor::from_simple_fn(shape, generate).into()
+            if min >= max {
+                return Err(GenerateError::empty_range(input));
+            }
+            let tensor = Tensor::from_simple_fn(shape, || rng.generate(min..max));
+            Ok(tensor.into())
         }
 
         let range = range.map(|r| (r.min, r.max));
@@ -139,15 +183,15 @@ impl RandomInputGenerator {
                 }
                 Some(DataType::Int32) => {
                     let (min, max) = range.map_or((0, 255), |(min, max)| (min as i32, max as i32));
-                    random_ints(&resolved_shape, || self.rng.i32(min..=max))
+                    random_ints(&resolved_shape, min, max, &mut self.rng, name)?
                 }
                 Some(DataType::Int8) => {
                     let (min, max) = range.map_or((0, 127), |(min, max)| (min as i8, max as i8));
-                    random_ints(&resolved_shape, || self.rng.i8(min..=max))
+                    random_ints(&resolved_shape, min, max, &mut self.rng, name)?
                 }
                 Some(DataType::UInt8) => {
                     let (min, max) = range.map_or((0, 255), |(min, max)| (min as u8, max as u8));
-                    random_ints(&resolved_shape, || self.rng.u8(min..=max))
+                    random_ints(&resolved_shape, min, max, &mut self.rng, name)?
                 }
                 Some(dtype) => {
                     return Err(GenerateError::UnsupportedDataType(ValueType::Tensor(dtype)));
@@ -161,30 +205,33 @@ impl RandomInputGenerator {
 
 #[cfg(test)]
 mod tests {
+    use rten::{DataType, Dimension, Value, ValueType};
     use rten_tensor::prelude::*;
     use rten_testing::TestCases;
 
-    use super::*;
+    use super::{GenerateError, InputRange, RandomInputGenerator};
 
     /// Generate a random input with a given name and dtype, using the value
     /// range specified by `range`, if any.
-    fn generate(name: &str, dtype: DataType, range: Option<(f32, f32)>) -> Value {
+    fn generate(
+        name: &str,
+        dtype: DataType,
+        range: Option<(f32, f32)>,
+    ) -> Result<Value, GenerateError> {
         let range = range.map(|(min, max)| InputRange {
             input_name: name.to_string(),
             min,
             max,
         });
         let mut generator = RandomInputGenerator::new();
-        generator
-            .generate(
-                name,
-                Some(ValueType::Tensor(dtype)),
-                &[Dimension::Fixed(64)],
-                &[],
-                range.as_ref(),
-                |_dim_name, _dim_size_idx| {},
-            )
-            .unwrap()
+        generator.generate(
+            name,
+            Some(ValueType::Tensor(dtype)),
+            &[Dimension::Fixed(64)],
+            &[],
+            range.as_ref(),
+            |_dim_name, _dim_size_idx| {},
+        )
     }
 
     /// Extract the elements of a tensor value as floats, so that values of
@@ -245,8 +292,8 @@ mod tests {
             },
             Case {
                 dtype: DataType::Int8,
-                range: Some((-5., 5.)),
-                expected: (-5., 5.),
+                range: Some((-5., 6.)),
+                expected: (-5., 6.),
             },
             Case {
                 dtype: DataType::UInt8,
@@ -273,7 +320,7 @@ mod tests {
                  expected,
              }| {
                 let (min, max) = *expected;
-                let value = generate("x", *dtype, *range);
+                let value = generate("x", *dtype, *range).unwrap();
                 let outside: Vec<f32> = elements(&value)
                     .into_iter()
                     .filter(|x| *x < min || *x > max)
@@ -287,25 +334,77 @@ mod tests {
     }
 
     #[test]
+    fn test_generate_empty_range() {
+        #[derive(Debug)]
+        struct Case {
+            dtype: DataType,
+            range: (f32, f32),
+            expected: Option<GenerateError>,
+        }
+
+        let cases = [
+            // Empty ranges are OK for floats. All values will be `min`.
+            Case {
+                dtype: DataType::Float,
+                range: (0., 0.),
+                expected: None,
+            },
+            // Empty ranges of various integer types.
+            Case {
+                dtype: DataType::Int32,
+                range: (0., 0.),
+                expected: Some(GenerateError::empty_range("x")),
+            },
+            Case {
+                dtype: DataType::Int8,
+                range: (1., 1.),
+                expected: Some(GenerateError::empty_range("x")),
+            },
+            Case {
+                dtype: DataType::UInt8,
+                range: (2., 2.),
+                expected: Some(GenerateError::empty_range("x")),
+            },
+            // Range with start > end.
+            Case {
+                dtype: DataType::Int32,
+                range: (1., 0.),
+                expected: Some(GenerateError::empty_range("x")),
+            },
+        ];
+
+        cases.test_each(
+            |Case {
+                 dtype,
+                 range,
+                 expected,
+             }| {
+                let value = generate("x", *dtype, Some(*range)).err();
+                assert_eq!(value, *expected);
+            },
+        )
+    }
+
+    #[test]
     fn test_generate_name_heuristics() {
         // Inputs whose names match certain patterns get fixed values which are
         // more likely to be valid than random ones.
         assert_eq!(
-            elements(&generate("attention_mask", DataType::Int32, None)),
+            elements(&generate("attention_mask", DataType::Int32, None).unwrap()),
             [1.; 64]
         );
         assert_eq!(
-            elements(&generate("input_ids", DataType::Int32, None)),
+            elements(&generate("input_ids", DataType::Int32, None).unwrap()),
             [0.; 64]
         );
         assert_eq!(
-            elements(&generate("use_cache_branch", DataType::Int32, None)),
+            elements(&generate("use_cache_branch", DataType::Int32, None).unwrap()),
             [0.; 64]
         );
 
         // An explicitly specified range overrides these heuristics.
         assert_eq!(
-            elements(&generate("input_ids", DataType::Int32, Some((5., 5.)))),
+            elements(&generate("input_ids", DataType::Int32, Some((5., 6.))).unwrap()),
             [5.; 64]
         );
     }

--- a/rten-cli/src/main.rs
+++ b/rten-cli/src/main.rs
@@ -84,8 +84,9 @@ struct Args {
     #[argh(switch, short = 'q')]
     quiet: bool,
 
-    /// specify the range of randomly generated values for an input in the form `input_name=min:max`. Can be specified multiple times.
-    /// Input names may be quoted (eg. `"input.one"=0:10`).
+    /// specify `[min, max)` range of randomly generated values for an input in
+    /// the form `input_name=min:max`. Input names may be quoted (eg.
+    /// `"input.one"=0:10`).
     #[argh(option, short = 'r')]
     range: Vec<String>,
 


### PR DESCRIPTION
Change `--range input=min:max` in the CLI to generate values in the range `[min, max)` instead of `[min, max]` for integer tensors. Using an exclusive upper bound feels more intuitive as this is how ranges are usually specified in Rust (`min..max`) and Python (`min:max`). Also a common use case is to specify that index inputs must be less than some value (eg.  `0:sequence_len`). If inputs are out of range this often results in an error from a `Gather` operator which reports the valid range as `[min, max)`. Making `--range` use an exclusive upper bound aligns with that.

If the user specifies a range with `min <= max` for an integer tensor, this results in an error.