### PR TITLE
Build rten-simd docs for Arm and WASM on docs.rs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,9 @@ jobs:
     - name: Docs
       run: |
         make docs
+    - name: Docs (WASM)
+      run: make wasm-docs
+      if: ${{ matrix.os == 'ubuntu-latest' }}
     - name: Setup Python
       run: |
         python -m venv .venv

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,10 @@ wasm-nosimd:
 .PHONY: wasm-all
 wasm-all: wasm wasm-nosimd
 
+.PHONY: wasm-docs
+wasm-docs:
+	RUSTDOCFLAGS="-D warnings $(WASM_TARGET_FEATURES)" cargo doc -p rten-simd --target wasm32-unknown-unknown
+
 # Run wasm tests using `make wasm-test PACKAGE={package_name}`
 #
 # WASM tests run with `--nocapture` as otherwise assertion failure panic messages

--- a/rten-simd/Cargo.toml
+++ b/rten-simd/Cargo.toml
@@ -17,3 +17,11 @@ crate-type = ["lib"]
 # See comments about `needless_range_loop` in root Cargo.toml.
 needless_range_loop = "allow"
 manual_memcpy = "allow"
+
+[package.metadata.docs.rs]
+# As of August 2026, docs.rs only builds x86_64 Linux by default. Add other
+# supported architectures so their types appear.
+additional-targets = ["aarch64-unknown-linux-gnu", "wasm32-unknown-unknown"]
+# WASM SIMD support requires the `simd128` target feature to be enabled.
+# Other targets ignore this flag with a warning.
+rustdoc-args = ["-C", "target-feature=+simd128"]


### PR DESCRIPTION
Change the docs.rs configuration in rten-simd so that docs are built for aarch64 and wasm32 architectures. Also verify the WASM docs build in CI.

Fixes #953