### PR TITLE
Add `cli` and `cli-no-lto` make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,17 @@
 all:
 	cargo build --workspace
 
+.PHONY: cli
+cli:
+	cargo build -p rten-cli --release
+
+# Build with ThinLTO disabled. This makes the build faster but the binary will
+# be larger and slower. Performance is still usable though, unlike a debug
+# build.
+.PHONY: cli-no-lto
+cli-no-lto:
+	CARGO_PROFILE_RELEASE_LTO=off cargo build -p rten-cli --release
+
 .PHONY: schema
 schema: rten-model-file/src/schema_generated.rs rten-convert/rten_convert/schema_generated.py
 


### PR DESCRIPTION
Add Makefile targets to build the CLI with and without LTO. Disabling LTO speeds up the build by 20-30% while producing a binary that is slower but still has quite usable performance.

This came out of asking Claude to experiment with splitting up the main `rten` crate to reduce build times. The impact of splitting the crate was modest (~10%), but along the way it also reported the effect of disabling LTO and noticed the cost of [RustFFT](https://github.com/robertknight/rten/issues/1448).