### PR TITLE
rten-convert: do not reopen an open NamedTemporaryFile by name

### DIFF
--- a/rten-convert/rten_convert/converter.py
+++ b/rten-convert/rten_convert/converter.py
@@ -6,6 +6,7 @@ from functools import reduce
 import hashlib
 import json
 from operator import mul
+from os import unlink
 from os.path import dirname, splitext
 import sys
 import struct
@@ -1497,11 +1498,17 @@ def main():
         # file that shares the same external data (if any) as the input file.
         #
         # See also https://github.com/robertknight/rten/issues/851.
-        with tempfile.NamedTemporaryFile(
-            dir=dirname(model_path), suffix=".infer_shapes.onnx"
-        ) as tmp:
+        tmp = tempfile.NamedTemporaryFile(
+            dir=dirname(model_path), suffix=".infer_shapes.onnx", delete=False
+        )
+        # Close the file to avoid an error on Windows if onnx functions attempt
+        # to re-open an already open file with a different share mode.
+        tmp.close()
+        try:
             onnx.shape_inference.infer_shapes_path(model_path, tmp.name, data_prop=True)
             model = onnx.load(tmp.name)
+        finally:
+            unlink(tmp.name)
     else:
         model = onnx.load(model_path)
 


### PR DESCRIPTION
Fix an issue where converting models on Windows failed when `--infer-shapes` was enabled (as it is by default), because the converter tried to re-open an already open `NamedTemporaryFile`.

Per https://docs.python.org/3.10/library/tempfile.html:

> Whether the name can be used to open the file a second time, while the
> named temporary file is still open, varies across platforms (it can be
> so used on Unix; it cannot on Windows)