### PR TITLE
Fuse per-channel Mul + Add into BatchNormalization

### DIFF
--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -26,12 +26,13 @@ mod pattern_matcher;
 use diagnostics::{DiagnosticLevel, Diagnostics};
 
 use fusions::{
-    AddSoftmaxFusion, ApproxGeluFusion, CastElimination, ComputeShapeFusion, ConvAddFusion,
-    ConvIntegerToFloatFusion, Fusion, FusionError, FusionVisitor, GeluFusion,
-    GroupedQueryAttentionMatMulFusion, IdentityFusion, LayerNormalizationFusion, MatMulAddFusion,
-    MatMulIntegerToFloatFusion, MatMulScaleFusion, PatternFusion, RMSNormalizationFusion,
-    ReciprocalFusion, ReduceMeanAxesFusion, RepeatInterleaveFusion, SafeSoftmaxFusion,
-    ShapeSliceToConstant, SiluFusion, SwishFusion, TransposeFusion,
+    AddSoftmaxFusion, ApproxGeluFusion, BatchNormalizationFusion, CastElimination,
+    ComputeShapeFusion, ConvAddFusion, ConvIntegerToFloatFusion, Fusion, FusionError,
+    FusionVisitor, GeluFusion, GroupedQueryAttentionMatMulFusion, IdentityFusion,
+    LayerNormalizationFusion, MatMulAddFusion, MatMulIntegerToFloatFusion, MatMulScaleFusion,
+    PatternFusion, RMSNormalizationFusion, ReciprocalFusion, ReduceMeanAxesFusion,
+    RepeatInterleaveFusion, SafeSoftmaxFusion, ShapeSliceToConstant, SiluFusion, SwishFusion,
+    TransposeFusion,
 };
 
 /// Errors that occur while applying graph optimizations.
@@ -645,6 +646,7 @@ impl GraphOptimizer {
         // Normalization fusions
         fusions.push(LayerNormalizationFusion {}.into_visitor());
         fusions.push(RMSNormalizationFusion {}.into_visitor());
+        fusions.push(BatchNormalizationFusion {});
 
         // Matmul fusions
         fusions.push(MatMulAddFusion {}.into_visitor());

--- a/src/optimize/fusions.rs
+++ b/src/optimize/fusions.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use rten_shape_inference::{SymExpr, Symbol};
-use rten_tensor::{ArcTensor, NdTensorView, SliceRange};
+use rten_tensor::{ArcTensor, AsView, NdTensorView, SliceRange};
 
 use crate::graph::{
     Constant, ConstantNode, ConstantNodeData, Dimension, Graph, Node, NodeId, OperatorNode,
@@ -14,9 +14,10 @@ use crate::graph::{
 use crate::operator::Operator;
 use crate::ops::transform_inputs::TransformInputsBuilder;
 use crate::ops::{
-    AddSoftmax, Cast, ComputeShape, Conv, ConvInteger, ConvIntegerToFloat, FusedMatMul, Gelu,
-    GroupedQueryAttentionMatMul, LayerNormalization, MatMulIntegerToFloat, RMSNormalization,
-    Reciprocal, ReduceMean, RepeatInterleave, Shape, Silu, Softmax, Swish, SymbolInfo, Transpose,
+    AddSoftmax, BatchNormalization, Cast, ComputeShape, Conv, ConvInteger, ConvIntegerToFloat,
+    FusedMatMul, Gelu, GroupedQueryAttentionMatMul, LayerNormalization, MatMulIntegerToFloat,
+    RMSNormalization, Reciprocal, ReduceMean, RepeatInterleave, Shape, Silu, Softmax, Swish,
+    SymbolInfo, Transpose,
 };
 use crate::optimize::pattern_matcher::{Match, Pattern};
 use crate::value::ValueType;
@@ -1690,6 +1691,118 @@ impl PatternFusion for GroupedQueryAttentionMatMulFusion {
     }
 }
 
+/// If `shape` has the form `[1, C, 1, ...]`, return `C`.
+fn channel_count(shape: &[usize]) -> Option<usize> {
+    if shape.len() < 2 {
+        return None;
+    }
+    shape
+        .iter()
+        .enumerate()
+        .all(|(axis, &size)| axis == 1 || size == 1)
+        .then(|| shape[1])
+}
+
+/// Create a constant containing a vector.
+fn vector_constant(data: Vec<f32>) -> Constant {
+    ConstantNode::new(
+        None,
+        ConstantNodeData::Arc(ArcTensor::from_data(&[data.len()], Arc::new(data))),
+    )
+    .into()
+}
+
+/// Convert a constant with shape `[1, C, 1, ...]` into a `[C]` vector.
+fn channel_vector(graph: &Graph, const_id: NodeId, rank: usize) -> Result<Vec<f32>, FusionError> {
+    let Some(Node::Constant(const_node)) = graph.get_node(const_id) else {
+        return Err(FusionError::NoMatch);
+    };
+    if const_node.shape().len() != rank || channel_count(const_node.shape()).is_none() {
+        return Err(FusionError::CheckFailed("constant is not per-channel"));
+    }
+    let Some(view) = TypedConstant::<f32>::as_typed_view(const_node) else {
+        return Err(FusionError::CheckFailed("constant is not an f32 constant"));
+    };
+    Ok(view.to_vec())
+}
+
+/// Fuse `Add(Mul(X, scale), bias)` into `BatchNormalization(X, scale, bias, mean, var)`.
+pub struct BatchNormalizationFusion {}
+
+impl FusionVisitor for BatchNormalizationFusion {
+    type State = Pattern;
+
+    fn name(&self) -> &str {
+        "BatchNormalizationFusion"
+    }
+
+    fn prepare(&self, _: &Graph) -> Pattern {
+        Pattern::binary_op(
+            "Add",
+            Pattern::binary_op("Mul", Pattern::symbol("x"), Pattern::const_symbol("scale")),
+            Pattern::const_symbol("bias"),
+        )
+    }
+
+    fn maybe_fuse(
+        &self,
+        pattern: &Pattern,
+        graph: &Graph,
+        op_node_id: NodeId,
+        op_node: &OperatorNode,
+    ) -> Result<Fusion, FusionError> {
+        let pat_match = pattern
+            .test(op_node_id, graph)
+            .ok_or(FusionError::NoMatch)?;
+        let (Some(x), Some(scale_id), Some(bias_id)) = (
+            pat_match.node_id("x"),
+            pat_match.node_id("scale"),
+            pat_match.node_id("bias"),
+        ) else {
+            return Err(FusionError::NoMatch);
+        };
+
+        // Extract `[C]` vectors from `[1, C, 1, 1]` scale and bias tensors.
+        let x_shape = graph
+            .get_node(x)
+            .and_then(|node| node.shape())
+            .ok_or(FusionError::CheckFailed("unknown input shape"))?;
+        let scale = channel_vector(graph, scale_id, x_shape.len())?;
+        let bias = channel_vector(graph, bias_id, x_shape.len())?;
+        if scale.len() != bias.len() {
+            return Err(FusionError::CheckFailed("scale and bias sizes differ"));
+        }
+        let channels = scale.len();
+
+        // Check `C` matches channel count of input. Otherwise the `Mul` op
+        // will either fail or broadcast the input.
+        match x_shape.get(1) {
+            Some(Dimension::Fixed(size)) if *size == channels => {}
+            _ => {
+                return Err(FusionError::CheckFailed(
+                    "input channel count does not match scale",
+                ));
+            }
+        }
+
+        Ok(Fusion::Op(FusedOp {
+            name: op_node.name().map(|s| s.to_string()),
+            fused_op: Arc::new(BatchNormalization { epsilon: 0. }),
+            input_ids: vec![Some(x), None, None, None, None],
+            new_constant_inputs: vec![
+                (1, vector_constant(scale)),
+                (2, vector_constant(bias)),
+                // input mean and variance. Set to 0 and 1 respectively so
+                // they have no effect.
+                (3, vector_constant(vec![0.; channels])),
+                (4, vector_constant(vec![1.; channels])),
+            ],
+            output_ids: op_node.output_ids().to_vec(),
+            unused_input_ids: Vec::new(),
+        }))
+    }
+}
+
 /// Fuse `Add(Conv(X, W), bias)` into `Conv(X, W, bias)`.
 pub struct ConvAddFusion {}
 
@@ -1757,12 +1870,7 @@ impl FusionVisitor for ConvAddFusion {
             return Err(FusionError::NoMatch);
         };
         let bias_shape = bias_const.shape();
-        let is_per_channel_bias = bias_shape.len() == conv_rank
-            && bias_shape
-                .iter()
-                .enumerate()
-                .all(|(axis, &size)| size == if axis == 1 { out_channels } else { 1 });
-        if !is_per_channel_bias {
+        if bias_shape.len() != conv_rank || channel_count(bias_shape) != Some(out_channels) {
             return Err(FusionError::CheckFailed("bias is not a per-channel bias"));
         }
         let Some(bias_view) = TypedConstant::<f32>::as_typed_view(bias_const) else {
@@ -1770,12 +1878,7 @@ impl FusionVisitor for ConvAddFusion {
         };
 
         // Create the `[out_channels]` bias constant.
-        let bias_data: Vec<f32> = bias_view.iter().copied().collect();
-        let bias_const: Constant = ConstantNode::new(
-            None,
-            ConstantNodeData::Arc(ArcTensor::from_data(&[out_channels], Arc::new(bias_data))),
-        )
-        .into();
+        let bias_const = vector_constant(bias_view.iter().copied().collect());
 
         Ok(Fusion::Op(FusedOp {
             name: op_node.name().map(|s| s.to_string()),

--- a/src/optimize/tests.rs
+++ b/src/optimize/tests.rs
@@ -440,6 +440,60 @@ fn test_fuse_conv_add() {
 }
 
 #[test]
+fn test_fuse_batch_normalization() {
+    #[derive(Debug)]
+    struct Case {
+        /// Rank of the input and of the scale and bias constants.
+        rank: usize,
+    }
+
+    let cases = [Case { rank: 2 }, Case { rank: 3 }, Case { rank: 4 }];
+
+    cases.test_each(|&Case { rank }| {
+        let channels = 4;
+        let graph = {
+            let mut x_shape = vec![Dimension::from("batch"), Dimension::from(channels)];
+            x_shape.extend(std::iter::repeat_n(Dimension::from(8), rank - 2));
+            let x = Expr::value_with_info("x", ValueType::Tensor(DataType::Float), &x_shape);
+
+            // Per-channel scale and bias broadcast over `x`: `[1, C, 1, ...]`.
+            let mut const_shape = vec![1, channels];
+            const_shape.extend(std::iter::repeat_n(1, rank - 2));
+            let scale = Tensor::<f32>::full(const_shape.as_slice(), 2.);
+            let bias = Tensor::<f32>::full(const_shape.as_slice(), 3.);
+
+            (x * scale + bias).build_graph(["x"])
+        };
+
+        let graph = optimize_graph(graph).unwrap();
+
+        let (_, op) = graph.get_source_node(graph.output_ids()[0]).unwrap();
+        assert_eq!(op.operator().name(), "BatchNormalization");
+
+        // The scale, bias, mean and variance inputs should all be `[C]`
+        // vectors. Mean and variance are chosen so that the normalization
+        // reduces to `x * scale + bias`.
+        let input_value = |index: usize| -> Vec<f32> {
+            let input_id = op.input_ids()[index].expect("input should be present");
+            let constant = graph
+                .get_node(input_id)
+                .and_then(|n| n.as_constant())
+                .expect("input should be a constant");
+            assert_eq!(constant.shape(), [channels]);
+            TypedConstant::<f32>::as_typed_view(constant)
+                .expect("input should be an f32 constant")
+                .iter()
+                .copied()
+                .collect()
+        };
+        assert_eq!(input_value(1), [2.; 4]);
+        assert_eq!(input_value(2), [3.; 4]);
+        assert_eq!(input_value(3), [0.; 4]);
+        assert_eq!(input_value(4), [1.; 4]);
+    });
+}
+
+#[test]
 fn test_no_fuse_conv_add_non_channel_bias() {
     // A value added to the Conv output which broadcasts over a non-channel
     // axis (here the last/width axis, shape `[1, 1, 1, 4]`) is a valid add but


### PR DESCRIPTION
Fuse `Add(Mul(X, scale), bias)` into `BatchNormalization` where `scale` and `bias` have shape `(1, C, 1, 1)` and `X` has shape `(B, C, H)` or `(B, C, H, W)`.

Tested with the model from https://huggingface.co/docling-project/docling-layout-heron-onnx.