### PR TITLE
Fuse Conv + BatchNormalization into a single Conv

### DIFF
--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -27,8 +27,8 @@ use diagnostics::{DiagnosticLevel, Diagnostics};
 
 use fusions::{
     AddSoftmaxFusion, ApproxGeluFusion, BatchNormalizationFusion, CastElimination,
-    ComputeShapeFusion, ConvAddFusion, ConvIntegerToFloatFusion, Fusion, FusionError,
-    FusionVisitor, GeluFusion, GroupedQueryAttentionMatMulFusion, IdentityFusion,
+    ComputeShapeFusion, ConvAddFusion, ConvBatchNormFusion, ConvIntegerToFloatFusion, Fusion,
+    FusionError, FusionVisitor, GeluFusion, GroupedQueryAttentionMatMulFusion, IdentityFusion,
     LayerNormalizationFusion, MatMulAddFusion, MatMulIntegerToFloatFusion, MatMulScaleFusion,
     PatternFusion, RMSNormalizationFusion, ReciprocalFusion, ReduceMeanAxesFusion,
     RepeatInterleaveFusion, SafeSoftmaxFusion, ShapeSliceToConstant, SiluFusion, SwishFusion,
@@ -655,6 +655,7 @@ impl GraphOptimizer {
 
         // Convolution fusions
         fusions.push(ConvAddFusion {});
+        fusions.push(ConvBatchNormFusion {});
         fusions.push(ConvIntegerToFloatFusion {}.into_visitor());
 
         // Attention fusions.

--- a/src/optimize/fusions.rs
+++ b/src/optimize/fusions.rs
@@ -1703,13 +1703,18 @@ fn channel_count(shape: &[usize]) -> Option<usize> {
         .then(|| shape[1])
 }
 
-/// Create a constant containing a vector.
-fn vector_constant(data: Vec<f32>) -> Constant {
+/// Create a constant containing a tensor.
+fn tensor_constant(shape: &[usize], data: Vec<f32>) -> Constant {
     ConstantNode::new(
         None,
-        ConstantNodeData::Arc(ArcTensor::from_data(&[data.len()], Arc::new(data))),
+        ConstantNodeData::Arc(ArcTensor::from_data(shape, Arc::new(data))),
     )
     .into()
+}
+
+/// Create a constant containing a vector.
+fn vector_constant(data: Vec<f32>) -> Constant {
+    tensor_constant(&[data.len()], data)
 }
 
 /// Convert a constant with shape `[1, C, 1, ...]` into a `[C]` vector.
@@ -1885,6 +1890,125 @@ impl FusionVisitor for ConvAddFusion {
             fused_op: conv_op.clone_operator(),
             input_ids: vec![Some(conv_input), Some(conv_weight), None],
             new_constant_inputs: vec![(2, bias_const)],
+            output_ids: op_node.output_ids().to_vec(),
+            unused_input_ids: Vec::new(),
+        }))
+    }
+}
+
+/// Fuse `BatchNormalization(Conv(X, W, b))` into `Conv(X, W', b')`.
+///
+/// Fuse `BatchNormalization(Conv(X, W, b), scale, bias, mean, var)` into a
+/// `Conv` operator with adjusted weights and bias. For each channel the new
+/// weights `W'` and bias `b'` are computed as:
+///
+///    a = scale / (var + epsilon).sqrt()
+///    W' = W * a
+///    b' = (b - mean) * a + bias
+///
+/// This requires the weights, bias, scale and variance to all be constants.
+pub struct ConvBatchNormFusion {}
+
+impl FusionVisitor for ConvBatchNormFusion {
+    type State = ();
+
+    fn name(&self) -> &str {
+        "ConvBatchNormFusion"
+    }
+
+    fn prepare(&self, _: &Graph) {}
+
+    fn maybe_fuse(
+        &self,
+        _state: &(),
+        graph: &Graph,
+        _op_node_id: NodeId,
+        op_node: &OperatorNode,
+    ) -> Result<Fusion, FusionError> {
+        let Some(batch_norm) = op_node.operator().downcast_ref::<BatchNormalization>() else {
+            return Err(FusionError::NoMatch);
+        };
+        let [
+            Some(bn_input),
+            Some(scale),
+            Some(bn_bias),
+            Some(mean),
+            Some(var),
+        ] = op_node.input_ids()
+        else {
+            return Err(FusionError::NoMatch);
+        };
+
+        // The normalized input must be the output of a `Conv`.
+        let Some((_, conv_op)) = graph
+            .get_source_node(*bn_input)
+            .filter(|(_, op)| op.operator().downcast_ref::<Conv>().is_some())
+        else {
+            return Err(FusionError::NoMatch);
+        };
+        let (conv_input, conv_weight, conv_bias) = match conv_op.input_ids() {
+            [Some(input), Some(weight)] | [Some(input), Some(weight), None] => {
+                (*input, *weight, None)
+            }
+            [Some(input), Some(weight), Some(bias)] => (*input, *weight, Some(*bias)),
+            _ => return Err(FusionError::NoMatch),
+        };
+
+        // Weights have shape `[out_channels, in_channels / groups, ...kernel]`.
+        let Some(Node::Constant(weight_const)) = graph.get_node(conv_weight) else {
+            return Err(FusionError::CheckFailed("conv weights are not constant"));
+        };
+        let Some(weight_view) = TypedConstant::<f32>::as_typed_view(weight_const) else {
+            return Err(FusionError::CheckFailed("conv weights are not f32"));
+        };
+        let weight_shape = weight_const.shape().to_vec();
+        let Some((&out_channels, kernel_shape)) = weight_shape.split_first() else {
+            return Err(FusionError::CheckFailed("conv weights are a scalar"));
+        };
+        let elements_per_channel: usize = kernel_shape.iter().product();
+
+        let stats = [scale, bn_bias, mean, var].map(|id| graph.get_vector::<f32>(*id));
+        let [Some(scale), Some(bn_bias), Some(mean), Some(var)] = stats else {
+            return Err(FusionError::CheckFailed(
+                "batch norm inputs are not f32 vectors",
+            ));
+        };
+        if [scale, bn_bias, mean, var]
+            .iter()
+            .any(|stat| stat.len() != out_channels)
+        {
+            return Err(FusionError::CheckFailed(
+                "batch norm input size does not match conv output channels",
+            ));
+        }
+
+        let conv_bias = match conv_bias {
+            Some(bias_id) => match graph.get_vector::<f32>(bias_id) {
+                Some(bias) if bias.len() == out_channels => Some(bias),
+                _ => return Err(FusionError::CheckFailed("conv bias is not an f32 vector")),
+            },
+            None => None,
+        };
+
+        let mut weight_data = weight_view.to_vec();
+        let mut bias_data = Vec::with_capacity(out_channels);
+        for (chan, chan_weights) in weight_data.chunks_mut(elements_per_channel).enumerate() {
+            let alpha = scale[chan] / (var[chan] + batch_norm.epsilon).sqrt();
+            for weight in chan_weights {
+                *weight *= alpha;
+            }
+            let bias = conv_bias.map(|bias| bias[chan]).unwrap_or(0.);
+            bias_data.push((bias - mean[chan]) * alpha + bn_bias[chan]);
+        }
+
+        Ok(Fusion::Op(FusedOp {
+            name: op_node.name().map(|s| s.to_string()),
+            fused_op: conv_op.clone_operator(),
+            input_ids: vec![Some(conv_input), None, None],
+            new_constant_inputs: vec![
+                (1, tensor_constant(&weight_shape, weight_data)),
+                (2, vector_constant(bias_data)),
+            ],
             output_ids: op_node.output_ids().to_vec(),
             unused_input_ids: Vec::new(),
         }))

--- a/src/optimize/tests.rs
+++ b/src/optimize/tests.rs
@@ -15,10 +15,11 @@ use crate::graph::{
 };
 use crate::infer_shapes::InferShapeOptions;
 use crate::ops::{
-    Add, Cast, ComputeShape, Conv, ConvInteger, DynamicQuantizeLinear, Erf, Expand, FusedMatMul,
-    Gather, Gelu, GroupedQueryAttentionMatMul, Identity, If, IsNaN, LayerNormalization, MatMul,
-    MatMulInteger, Neg, Padding, Pow, RMSNormalization, ReduceMean, RepeatInterleave, Reshape,
-    Shape, Sigmoid, Slice, Softmax, Split, Sqrt, Swish, Tanh, Transpose, Unsqueeze, Where,
+    Add, BatchNormalization, Cast, ComputeShape, Conv, ConvInteger, DynamicQuantizeLinear, Erf,
+    Expand, FusedMatMul, Gather, Gelu, GroupedQueryAttentionMatMul, Identity, If, IsNaN,
+    LayerNormalization, MatMul, MatMulInteger, Neg, Padding, Pow, RMSNormalization, ReduceMean,
+    RepeatInterleave, Reshape, Shape, Sigmoid, Slice, Softmax, Split, Sqrt, Swish, Tanh, Transpose,
+    Unsqueeze, Where,
 };
 use crate::value::{DataType, Value, ValueType};
 
@@ -491,6 +492,93 @@ fn test_fuse_batch_normalization() {
         assert_eq!(input_value(3), [0.; 4]);
         assert_eq!(input_value(4), [1.; 4]);
     });
+}
+
+#[test]
+fn test_fuse_conv_batch_norm() {
+    #[derive(Debug)]
+    struct Case {
+        /// Bias of the `Conv`, or `None` if it has no bias input.
+        conv_bias: Option<[f32; 2]>,
+        expected_bias: [f32; 2],
+    }
+
+    // Weights are `[1., 2.]`, and the batch norm constants below give a scale
+    // of `[3. / 2., 4. / 2.]` per output channel.
+    let cases = [
+        Case {
+            conv_bias: Some([10., 20.]),
+            // `(10. - 1.) * 1.5 + 5.`, `(20. - 2.) * 2. + 6.`
+            expected_bias: [18.5, 42.],
+        },
+        Case {
+            conv_bias: None,
+            // `(0. - 1.) * 1.5 + 5.`, `(0. - 2.) * 2. + 6.`
+            expected_bias: [3.5, 2.],
+        },
+    ];
+
+    cases.test_each(
+        |&Case {
+             conv_bias,
+             expected_bias,
+         }| {
+            let graph = {
+                let x = Expr::value("x");
+
+                // Weight shape is `[out_channels, in_channels, kernel]`.
+                let weight = Expr::constant(Tensor::from([[[1.]], [[2.]]]));
+                let mut conv_inputs = vec![weight];
+                if let Some(bias) = conv_bias {
+                    conv_inputs.push(Expr::constant(Tensor::from(bias)));
+                }
+                let conv = x.apply(
+                    Conv {
+                        groups: 1,
+                        dilations: vec![1],
+                        padding: Padding::Same,
+                        strides: vec![1],
+                    },
+                    &conv_inputs,
+                    &[OutputMeta::NoMeta],
+                );
+
+                // `(var + epsilon).sqrt()` is 2, so the per-channel scale
+                // applied to the weights is `scale / 2`.
+                conv.apply(
+                    BatchNormalization { epsilon: 1. },
+                    &[
+                        Expr::constant(Tensor::from([3., 4.])),
+                        Expr::constant(Tensor::from([5., 6.])),
+                        Expr::constant(Tensor::from([1., 2.])),
+                        Expr::constant(Tensor::from([3., 3.])),
+                    ],
+                    &[OutputMeta::NoMeta],
+                )
+                .build_graph(["x"])
+            };
+
+            let graph = optimize_graph(graph).unwrap();
+
+            let (_, op) = graph.get_source_node(graph.output_ids()[0]).unwrap();
+            assert_eq!(op.operator().name(), "Conv");
+
+            let constant_value = |index: usize| -> Vec<f32> {
+                let input_id = op.input_ids()[index].expect("input should be present");
+                let constant = graph
+                    .get_node(input_id)
+                    .and_then(|n| n.as_constant())
+                    .expect("input should be a constant");
+                TypedConstant::<f32>::as_typed_view(constant)
+                    .expect("input should be an f32 constant")
+                    .iter()
+                    .copied()
+                    .collect()
+            };
+            assert_eq!(constant_value(1), [1.5, 4.]);
+            assert_eq!(constant_value(2), expected_bias);
+        },
+    );
 }
 
 #[test]


### PR DESCRIPTION
Fuse `BatchNormalization(Conv(X, W, b), scale, bias, mean, var)` into a single `Conv` operator with adjusted weights and bias. For each channel the new weights `W'` and bias `b'` are computed as:

```
a = scale / (var + epsilon).sqrt()
W' = W * a
b' = (b - mean) * a + bias
```

This requires the weights, bias, scale and variance to all be constants.

This fusion is expensive compared to most because it requires recomputing weights, rather than just altering the graph structure. In future it might be useful to add an option to limit optimizations to those which are "cheap" graph alterations. Users who want to optimize model load times should perform the optimization offline using existing ONNX optimization tools.