### PR TITLE
Unify in-place and non-in-place layout and normalization operators

### DIFF
--- a/src/ops/layout.rs
+++ b/src/ops/layout.rs
@@ -6,7 +6,7 @@ use rten_base::num::AsUsize;
 use rten_shape_inference::ops as shape_ops;
 use rten_tensor::layout::is_valid_permutation;
 use rten_tensor::prelude::*;
-use rten_tensor::{NdTensorView, Tensor, TensorView};
+use rten_tensor::{CowTensor, NdTensorView, Tensor, TensorView};
 use smallvec::SmallVec;
 
 use crate::buffer_pool::{AutoReturn, BufferPool};
@@ -241,23 +241,13 @@ fn flattened_shape(shape: &[usize], axis: isize) -> Result<[usize; 2], OpError> 
 
 pub fn flatten<T: Copy>(
     pool: &BufferPool,
-    input: TensorView<T>,
+    input: CowTensor<T>,
     axis: isize,
 ) -> Result<Tensor<T>, OpError> {
     let shape = flattened_shape(input.shape(), axis)?;
-    let mut output = input.to_tensor_in(pool);
-    output.reshape(&shape);
+    let mut output = input.into_owned_in(pool);
+    output.reshape_in(pool, &shape);
     Ok(output)
-}
-
-pub fn flatten_in_place<T: Copy>(
-    pool: &BufferPool,
-    input: &mut Tensor<T>,
-    axis: isize,
-) -> Result<(), OpError> {
-    let shape = flattened_shape(input.shape(), axis)?;
-    input.reshape_in(pool, &shape);
-    Ok(())
 }
 
 #[derive(Debug)]
@@ -277,7 +267,7 @@ impl Operator for Flatten {
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let input = ctx.inputs().require(0)?;
         map_value_view!(input, x, {
-            flatten(ctx.pool(), x, self.axis).into_op_result()
+            flatten(ctx.pool(), x.as_cow(), self.axis).into_op_result()
         })
     }
 
@@ -292,8 +282,7 @@ impl Operator for Flatten {
     ) -> Result<OutputList, OpError> {
         let input = in_place.into_single();
         map_value!(input, x, {
-            flatten_in_place(ctx.pool(), &mut x, self.axis)?;
-            x.into_op_result()
+            flatten(ctx.pool(), x.into_cow(), self.axis).into_op_result()
         })
     }
 
@@ -392,24 +381,14 @@ fn resolve_shape(
 
 pub fn reshape<T: Copy>(
     pool: &BufferPool,
-    input: TensorView<T>,
+    input: CowTensor<T>,
     shape: &NdTensorView<i32, 1>,
     allow_zero: bool,
 ) -> Result<Tensor<T>, OpError> {
     let out_shape = resolve_shape(input.shape(), shape, allow_zero)?;
-    let output = input.to_tensor_in(pool).into_shape(out_shape.as_slice());
+    let mut output = input.into_owned_in(pool);
+    output.reshape_in(pool, &out_shape);
     Ok(output)
-}
-
-pub fn reshape_in_place<T: Copy>(
-    pool: &BufferPool,
-    input: &mut Tensor<T>,
-    shape: &NdTensorView<i32, 1>,
-    allow_zero: bool,
-) -> Result<(), OpError> {
-    let out_shape = resolve_shape(input.shape(), shape, allow_zero)?;
-    input.reshape_in(pool, &out_shape);
-    Ok(())
 }
 
 #[derive(Debug)]
@@ -432,7 +411,7 @@ impl Operator for Reshape {
         let shape = inputs.require_as(1)?;
 
         map_value_view!(input, x, {
-            reshape(ctx.pool(), x, &shape, self.allow_zero).into_op_result()
+            reshape(ctx.pool(), x.as_cow(), &shape, self.allow_zero).into_op_result()
         })
     }
 
@@ -449,8 +428,7 @@ impl Operator for Reshape {
         let shape = ctx.inputs().require_as(1)?;
 
         map_value!(input, output, {
-            reshape_in_place(ctx.pool(), &mut output, &shape, self.allow_zero)?;
-            output.into_op_result()
+            reshape(ctx.pool(), output.into_cow(), &shape, self.allow_zero).into_op_result()
         })
     }
 
@@ -557,10 +535,11 @@ impl Operator for Size {
 
 impl_infer_shapes!(Size, _op, shape_ops::Size);
 
-pub fn squeeze_in_place<T: Clone>(
-    input: &mut Tensor<T>,
+pub fn squeeze<T: Clone>(
+    pool: &BufferPool,
+    input: CowTensor<T>,
     axes: Option<NdTensorView<i32, 1>>,
-) -> Result<(), OpError> {
+) -> Result<Tensor<T>, OpError> {
     let sorted_axes = if let Some(axes) = axes {
         let axes = resolve_axes(input.ndim(), axes.iter())?;
         for axis in axes.iter() {
@@ -580,20 +559,11 @@ pub fn squeeze_in_place<T: Clone>(
             .collect()
     };
 
+    let mut output = input.into_owned_in(pool);
     for (n_removed, axis) in sorted_axes.into_iter().enumerate() {
-        input.remove_axis(axis - n_removed);
+        output.remove_axis(axis - n_removed);
     }
 
-    Ok(())
-}
-
-pub fn squeeze<T: Copy>(
-    pool: &BufferPool,
-    input: TensorView<T>,
-    axes: Option<NdTensorView<i32, 1>>,
-) -> Result<Tensor<T>, OpError> {
-    let mut output = input.to_tensor_in(pool);
-    squeeze_in_place(&mut output, axes)?;
     Ok(output)
 }
 
@@ -614,7 +584,9 @@ impl Operator for Squeeze {
         let input = inputs.require(0)?;
         let axes = inputs.get_as(1)?;
 
-        map_value_view!(input, x, { squeeze(ctx.pool(), x, axes).into_op_result() })
+        map_value_view!(input, x, {
+            squeeze(ctx.pool(), x.as_cow(), axes).into_op_result()
+        })
     }
 
     fn in_place_inputs(&self) -> BitSet<u16> {
@@ -630,8 +602,7 @@ impl Operator for Squeeze {
         let axes = ctx.inputs().get_as(1)?;
 
         map_value!(input, output, {
-            squeeze_in_place(&mut output, axes)?;
-            output.into_op_result()
+            squeeze(ctx.pool(), output.into_cow(), axes).into_op_result()
         })
     }
 
@@ -707,8 +678,9 @@ impl_infer_shapes!(
     }
 );
 
-pub fn unsqueeze_in_place<T: Clone>(
-    mut input: Tensor<T>,
+pub fn unsqueeze<T: Clone>(
+    pool: &BufferPool,
+    input: CowTensor<T>,
     axes: &NdTensorView<i32, 1>,
 ) -> Result<Tensor<T>, OpError> {
     let mut resolved_axes: SmallVec<[usize; 4]> = SmallVec::with_capacity(axes.len());
@@ -726,19 +698,12 @@ pub fn unsqueeze_in_place<T: Clone>(
         return Err(OpError::invalid_value("Axes must be unique"));
     }
 
+    let mut output = input.into_owned_in(pool);
     for axis in resolved_axes {
-        input.insert_axis(axis);
+        output.insert_axis(axis);
     }
 
-    Ok(input)
-}
-
-pub fn unsqueeze<T: Copy>(
-    pool: &BufferPool,
-    input: TensorView<T>,
-    axes: &NdTensorView<i32, 1>,
-) -> Result<Tensor<T>, OpError> {
-    unsqueeze_in_place(input.to_tensor_in(pool), axes)
+    Ok(output)
 }
 
 #[derive(Debug)]
@@ -759,7 +724,7 @@ impl Operator for Unsqueeze {
         let axes = inputs.require_as(1)?;
 
         map_value_view!(input, x, {
-            unsqueeze(ctx.pool(), x, &axes).into_op_result()
+            unsqueeze(ctx.pool(), x.as_cow(), &axes).into_op_result()
         })
     }
 
@@ -776,7 +741,7 @@ impl Operator for Unsqueeze {
         let axes = ctx.inputs().require_as(1)?;
 
         map_value!(input, output, {
-            unsqueeze_in_place(output, &axes)?.into_op_result()
+            unsqueeze(ctx.pool(), output.into_cow(), &axes).into_op_result()
         })
     }
 
@@ -804,8 +769,7 @@ mod tests {
     use crate::buffer_pool::BufferPool;
     use crate::operator::{OpError, OperatorExt};
     use crate::ops::layout::{
-        Reshape, Shape, Size, expand, flatten, reshape, reshape_in_place, squeeze,
-        squeeze_in_place, transpose, unsqueeze,
+        Reshape, Shape, Size, expand, flatten, reshape, squeeze, transpose, unsqueeze,
     };
     use crate::value::Value;
 
@@ -1033,7 +997,7 @@ mod tests {
             let pool = BufferPool::new();
             let input = Tensor::<f32>::zeros(case.shape.as_slice());
             let result =
-                flatten(&pool, input.view(), case.axis).map(|tensor| tensor.shape().to_vec());
+                flatten(&pool, input.as_cow(), case.axis).map(|tensor| tensor.shape().to_vec());
             assert_eq!(result, case.expected);
         })
     }
@@ -1170,7 +1134,7 @@ mod tests {
             let pool = BufferPool::new();
             let input = Tensor::<f32>::zeros(case.input);
             let shape = NdTensorView::from(case.shape);
-            let result = reshape(&pool, input.view(), &shape.view(), case.allow_zero);
+            let result = reshape(&pool, input.as_cow(), &shape.view(), case.allow_zero);
             let shape = result.as_ref().map(|t| t.shape());
             assert_eq!(shape, case.expected.as_deref());
         }
@@ -1179,12 +1143,12 @@ mod tests {
     #[test]
     fn test_reshape_in_place() {
         let pool = BufferPool::new();
-        let mut input = Tensor::from_data(&[2, 2], vec![-0.5, 0.5, 3.0, -5.5]);
+        let input = Tensor::from_data(&[2, 2], vec![-0.5, 0.5, 3.0, -5.5]);
         let shape = NdTensor::from([4]);
         let expected = input.to_shape([4].as_slice());
-        reshape_in_place(
+        let input = reshape(
             &pool,
-            &mut input,
+            input.into_cow(),
             &shape.view(),
             false, /* allow_zero */
         )
@@ -1297,17 +1261,17 @@ mod tests {
 
         // Remove all 1-size axes.
         expected.reshape(&[5, 5]);
-        let result = squeeze(&pool, input.view(), None).unwrap();
+        let result = squeeze(&pool, input.as_cow(), None).unwrap();
         expect_equal(&result, &expected)?;
 
         // Remove final 1-size axis.
         expected.reshape(&[1, 5, 5]);
-        let result = squeeze(&pool, input.view(), Some(NdTensor::from([3]).view())).unwrap();
+        let result = squeeze(&pool, input.as_cow(), Some(NdTensor::from([3]).view())).unwrap();
         expect_equal(&result, &expected)?;
 
         // Remove first 1-size axis.
         expected.reshape(&[5, 5, 1]);
-        let result = squeeze(&pool, input.view(), Some(NdTensor::from([0]).view())).unwrap();
+        let result = squeeze(&pool, input.as_cow(), Some(NdTensor::from([0]).view())).unwrap();
         expect_equal(&result, &expected)?;
 
         Ok(())
@@ -1315,13 +1279,14 @@ mod tests {
 
     #[test]
     fn test_squeeze_in_place() -> Result<(), Box<dyn Error>> {
+        let pool = BufferPool::new();
         let mut rng = XorShiftRng::new(5678);
 
         // Contiguous tensor
-        let mut input = Tensor::<f32>::rand(&[1, 1, 5, 5], &mut rng);
+        let input = Tensor::<f32>::rand(&[1, 1, 5, 5], &mut rng);
         let expected = input.clone().into_shape([5, 5].as_slice());
 
-        squeeze_in_place(&mut input, None).unwrap();
+        let input = squeeze(&pool, input.into_cow(), None).unwrap();
         expect_equal(&input, &expected)?;
 
         // Non-contiguous tensor
@@ -1329,7 +1294,7 @@ mod tests {
         input.permute(&[3, 2, 1, 0]);
         let expected = input.clone().into_shape([5, 2, 5].as_slice());
 
-        squeeze_in_place(&mut input, None).unwrap();
+        let input = squeeze(&pool, input.into_cow(), None).unwrap();
         expect_equal(&input, &expected)?;
 
         Ok(())
@@ -1341,7 +1306,7 @@ mod tests {
         let input = Tensor::<f32>::rand(&[1, 5, 5, 1], &mut rng);
 
         let pool = BufferPool::new();
-        let result = squeeze(&pool, input.view(), Some(NdTensor::from([1]).view()));
+        let result = squeeze(&pool, input.as_cow(), Some(NdTensor::from([1]).view()));
 
         assert_eq!(
             result.err(),
@@ -1417,16 +1382,16 @@ mod tests {
         let input = Tensor::<f32>::rand(&[3, 4, 5], &mut rng);
 
         // Unsqueeze with axes in increasing order
-        let output = unsqueeze(&pool, input.view(), &NdTensor::from([0, 4]).view()).unwrap();
+        let output = unsqueeze(&pool, input.as_cow(), &NdTensor::from([0, 4]).view()).unwrap();
         assert_eq!(output.shape(), &[1, 3, 4, 5, 1]);
 
         // Unsqueeze with axes in decreasing order
-        let output = unsqueeze(&pool, input.view(), &NdTensor::from([4, 0]).view()).unwrap();
+        let output = unsqueeze(&pool, input.as_cow(), &NdTensor::from([4, 0]).view()).unwrap();
         assert_eq!(output.shape(), &[1, 3, 4, 5, 1]);
 
         // Unsqueeze a scalar into a 1-item vec
         let scalar = Tensor::from(2.0);
-        let output = unsqueeze(&pool, scalar.view(), &NdTensor::from([0]).view()).unwrap();
+        let output = unsqueeze(&pool, scalar.as_cow(), &NdTensor::from([0]).view()).unwrap();
         assert_eq!(output.shape(), &[1]);
         assert_eq!(output.to_vec(), &[2.0]);
     }
@@ -1438,7 +1403,7 @@ mod tests {
         let input = Tensor::<f32>::rand(&[10, 20], &mut rng);
 
         // Invalid dimension index
-        let result = unsqueeze(&pool, input.view(), &NdTensor::from([3]).view());
+        let result = unsqueeze(&pool, input.as_cow(), &NdTensor::from([3]).view());
         assert_eq!(
             result.err(),
             Some(OpError::invalid_value(
@@ -1447,7 +1412,7 @@ mod tests {
         );
 
         // Repeated dimension index
-        let result = unsqueeze(&pool, input.view(), &NdTensor::from([1, 1]).view());
+        let result = unsqueeze(&pool, input.as_cow(), &NdTensor::from([1, 1]).view());
         assert_eq!(
             result.err(),
             Some(OpError::invalid_value("Axes must be unique"))

--- a/src/ops/norm.rs
+++ b/src/ops/norm.rs
@@ -5,7 +5,7 @@ use rayon::prelude::*;
 use rten_base::bit_set::BitSet;
 use rten_simd::SimdOp;
 use rten_tensor::prelude::*;
-use rten_tensor::{NdTensorView, Tensor, TensorView};
+use rten_tensor::{CowTensor, NdTensorView, Tensor, TensorView};
 use rten_vecmath as vecmath;
 
 use crate::buffer_pool::BufferPool;
@@ -616,16 +616,12 @@ impl Operator for RMSNormalization {
 /// Normalize lanes of `input` along `axis` by their L1 or L2 norm.
 pub fn lp_normalization(
     pool: &BufferPool,
-    input: TensorView,
+    output: CowTensor<f32>,
     axis: isize,
     p: u32,
 ) -> Result<Tensor, OpError> {
-    let mut output = input.to_tensor_in(pool);
-    lp_normalization_in_place(&mut output, axis, p)?;
-    Ok(output)
-}
+    let mut output = output.into_owned_in(pool);
 
-pub fn lp_normalization_in_place(output: &mut Tensor, axis: isize, p: u32) -> Result<(), OpError> {
     fn scale_by_norm(lane: &mut [f32], norm: f32) {
         // ONNX specifies a zero output, rather than NaN, for zero norms.
         if norm == 0. {
@@ -652,7 +648,9 @@ pub fn lp_normalization_in_place(output: &mut Tensor, axis: isize, p: u32) -> Re
         }
     };
 
-    normalize_lanes(output, axis, normalize)
+    normalize_lanes(&mut output, axis, normalize)?;
+
+    Ok(output)
 }
 
 #[derive(Debug)]
@@ -671,8 +669,8 @@ impl Operator for LpNormalization {
     }
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
-        let input = ctx.inputs().require_as(0)?;
-        lp_normalization(ctx.pool(), input, self.axis, self.p).into_op_result()
+        let input: TensorView<f32> = ctx.inputs().require_as(0)?;
+        lp_normalization(ctx.pool(), input.as_cow(), self.axis, self.p).into_op_result()
     }
 
     fn in_place_inputs(&self) -> BitSet<u16> {
@@ -682,11 +680,10 @@ impl Operator for LpNormalization {
     fn run_in_place(
         &self,
         in_place: InPlaceInputs,
-        _ctx: &OpRunContext,
+        ctx: &OpRunContext,
     ) -> Result<OutputList, OpError> {
-        let mut output: Tensor = in_place.into_single().try_into()?;
-        lp_normalization_in_place(&mut output, self.axis, self.p)?;
-        output.into_op_result()
+        let output: Tensor = in_place.into_single().try_into()?;
+        lp_normalization(ctx.pool(), output.into_cow(), self.axis, self.p).into_op_result()
     }
 
     fn output_types(&self, _ctx: &OutputTypesContext) -> Option<OutputTypeList> {
@@ -1235,19 +1232,19 @@ mod tests {
         let input = Tensor::from([[3., 4.], [1., -1.]]);
 
         // L2 normalization along the last axis.
-        let result = lp_normalization(&pool, input.view(), -1, 2).unwrap();
+        let result = lp_normalization(&pool, input.as_cow(), -1, 2).unwrap();
         let norm_1 = 2f32.sqrt();
         let expected = Tensor::from([[3. / 5., 4. / 5.], [1. / norm_1, -1. / norm_1]]);
         expect_equal(&result, &expected)?;
 
         // L1 normalization along axis 0.
-        let result = lp_normalization(&pool, input.view(), 0, 1).unwrap();
+        let result = lp_normalization(&pool, input.as_cow(), 0, 1).unwrap();
         let expected = Tensor::from([[3. / 4., 4. / 5.], [1. / 4., -1. / 5.]]);
         expect_equal(&result, &expected)?;
 
         // Lanes with a zero norm are set to zero rather than NaN.
         let zero_input = Tensor::from([[0., 0.], [3., 4.]]);
-        let result = lp_normalization(&pool, zero_input.view(), -1, 2).unwrap();
+        let result = lp_normalization(&pool, zero_input.as_cow(), -1, 2).unwrap();
         let expected = Tensor::from([[0., 0.], [3. / 5., 4. / 5.]]);
         expect_equal(&result, &expected)?;
 
@@ -1260,7 +1257,7 @@ mod tests {
         expect_equal(&result, &expected)?;
 
         // Unsupported p value.
-        let result = lp_normalization(&pool, input.view(), 0, 3);
+        let result = lp_normalization(&pool, input.as_cow(), 0, 3);
         assert_eq!(
             result.err(),
             Some(OpError::unsupported_value("`p` must be 1 or 2"))

--- a/src/ops/norm.rs
+++ b/src/ops/norm.rs
@@ -188,17 +188,18 @@ fn normalize_each_channel<'a>(
         });
 }
 
-/// Perform in-place batch normalization on an `NC*` tensor.
+/// Perform batch normalization on an `NC*` tensor.
 ///
 /// See <https://github.com/onnx/onnx/blob/main/docs/Operators.md#batchnormalization>.
-pub fn batch_norm_in_place(
-    input: &mut Tensor,
+pub fn batch_norm(
+    pool: &BufferPool,
+    input: CowTensor<f32>,
     scale: &NdTensorView<f32, 1>,
     bias: &NdTensorView<f32, 1>,
     mean: &NdTensorView<f32, 1>,
     var: &NdTensorView<f32, 1>,
     epsilon: f32,
-) -> Result<(), OpError> {
+) -> Result<Tensor, OpError> {
     if input.ndim() < 1 {
         return Err(OpError::invalid_value("Input must have at least 1 dim"));
     }
@@ -209,7 +210,8 @@ pub fn batch_norm_in_place(
     check_eq!(mean.size(0), channels)?;
     check_eq!(var.size(0), channels)?;
 
-    normalize_each_channel(input, |chan| NormalizeOptions {
+    let mut output = input.into_owned_in(pool);
+    normalize_each_channel(&mut output, |chan| NormalizeOptions {
         mean_normalize: MeanNormalize::Static {
             mean: mean[chan],
             variance: var[chan],
@@ -220,23 +222,6 @@ pub fn batch_norm_in_place(
         ..Default::default()
     });
 
-    Ok(())
-}
-
-/// Perform batch normalization on an `NC*` tensor.
-///
-/// See <https://github.com/onnx/onnx/blob/main/docs/Operators.md#batchnormalization>.
-pub fn batch_norm(
-    pool: &BufferPool,
-    input: TensorView,
-    scale: &NdTensorView<f32, 1>,
-    bias: &NdTensorView<f32, 1>,
-    mean: &NdTensorView<f32, 1>,
-    var: &NdTensorView<f32, 1>,
-    epsilon: f32,
-) -> Result<Tensor, OpError> {
-    let mut output = input.to_tensor_in(pool);
-    batch_norm_in_place(&mut output, scale, bias, mean, var, epsilon)?;
     Ok(output)
 }
 
@@ -274,7 +259,7 @@ impl Operator for BatchNormalization {
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let inputs = ctx.inputs();
-        let input = inputs.require_as(0)?;
+        let input: TensorView<f32> = inputs.require_as(0)?;
         let scale = inputs.require_as(1)?;
         let bias = inputs.require_as(2)?;
         let mean = inputs.require_as(3)?;
@@ -282,7 +267,16 @@ impl Operator for BatchNormalization {
 
         self.check_outputs(ctx)?;
 
-        batch_norm(ctx.pool(), input, &scale, &bias, &mean, &var, self.epsilon).into_op_result()
+        batch_norm(
+            ctx.pool(),
+            input.as_cow(),
+            &scale,
+            &bias,
+            &mean,
+            &var,
+            self.epsilon,
+        )
+        .into_op_result()
     }
 
     fn in_place_inputs(&self) -> BitSet<u16> {
@@ -295,7 +289,7 @@ impl Operator for BatchNormalization {
         ctx: &OpRunContext,
     ) -> Result<OutputList, OpError> {
         let inputs = ctx.inputs();
-        let mut output: Tensor = in_place.into_single().try_into()?;
+        let output: Tensor = in_place.into_single().try_into()?;
         let scale = inputs.require_as(1)?;
         let bias = inputs.require_as(2)?;
         let mean = inputs.require_as(3)?;
@@ -303,9 +297,16 @@ impl Operator for BatchNormalization {
 
         self.check_outputs(ctx)?;
 
-        batch_norm_in_place(&mut output, &scale, &bias, &mean, &var, self.epsilon)?;
-
-        output.into_op_result()
+        batch_norm(
+            ctx.pool(),
+            output.into_cow(),
+            &scale,
+            &bias,
+            &mean,
+            &var,
+            self.epsilon,
+        )
+        .into_op_result()
     }
 
     fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
@@ -319,22 +320,11 @@ impl Operator for BatchNormalization {
 
 pub fn instance_normalization(
     pool: &BufferPool,
-    input: TensorView,
+    input: CowTensor<f32>,
     scale: NdTensorView<f32, 1>,
     bias: NdTensorView<f32, 1>,
     epsilon: Option<f32>,
 ) -> Result<Tensor, OpError> {
-    let mut output = input.to_tensor_in(pool);
-    instance_normalization_in_place(&mut output, scale, bias, epsilon)?;
-    Ok(output)
-}
-
-pub fn instance_normalization_in_place(
-    input: &mut Tensor,
-    scale: NdTensorView<f32, 1>,
-    bias: NdTensorView<f32, 1>,
-    epsilon: Option<f32>,
-) -> Result<(), OpError> {
     let &[_batch, chans, ..] = input.shape() else {
         return Err(OpError::invalid_value("expected input with >= 2 dims"));
     };
@@ -354,14 +344,15 @@ pub fn instance_normalization_in_place(
         ));
     }
 
-    normalize_each_channel(input, |chan| NormalizeOptions {
+    let mut output = input.into_owned_in(pool);
+    normalize_each_channel(&mut output, |chan| NormalizeOptions {
         epsilon,
         scale: scale[chan],
         bias: bias[chan],
         ..Default::default()
     });
 
-    Ok(())
+    Ok(output)
 }
 
 #[derive(Debug)]
@@ -380,12 +371,13 @@ impl Operator for InstanceNormalization {
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
         let inputs = ctx.inputs();
-        let input = inputs.require_as(0)?;
+        let input: TensorView<f32> = inputs.require_as(0)?;
 
         let scale = inputs.require_as(1)?;
         let bias = inputs.require_as(2)?;
 
-        instance_normalization(ctx.pool(), input, scale, bias, self.epsilon).into_op_result()
+        instance_normalization(ctx.pool(), input.as_cow(), scale, bias, self.epsilon)
+            .into_op_result()
     }
 
     fn in_place_inputs(&self) -> BitSet<u16> {
@@ -397,14 +389,13 @@ impl Operator for InstanceNormalization {
         in_place: InPlaceInputs,
         ctx: &OpRunContext,
     ) -> Result<OutputList, OpError> {
-        let mut output: Tensor = in_place.into_single().try_into()?;
+        let output: Tensor = in_place.into_single().try_into()?;
         let inputs = ctx.inputs();
         let scale = inputs.require_as(1)?;
         let bias = inputs.require_as(2)?;
 
-        instance_normalization_in_place(&mut output, scale, bias, self.epsilon)?;
-
-        output.into_op_result()
+        instance_normalization(ctx.pool(), output.into_cow(), scale, bias, self.epsilon)
+            .into_op_result()
     }
 
     fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
@@ -695,12 +686,6 @@ impl Operator for LpNormalization {
     }
 }
 
-pub fn log_softmax(pool: &BufferPool, input: TensorView, axis: isize) -> Result<Tensor, OpError> {
-    let mut output = input.to_tensor_in(pool);
-    log_softmax_in_place(&mut output, axis)?;
-    Ok(output)
-}
-
 /// Grain size for parallelizing [`normalize_lanes`].
 const NORMALIZE_GRAIN_SIZE: usize = 1024;
 
@@ -757,10 +742,16 @@ fn normalize_lanes<T: Clone + Send, F: Fn(&mut [T]) + Send + Sync>(
     Ok(())
 }
 
-pub fn log_softmax_in_place(output: &mut Tensor, axis: isize) -> Result<(), OpError> {
-    normalize_lanes(output, axis, |lane| {
+pub fn log_softmax(
+    pool: &BufferPool,
+    input: CowTensor<f32>,
+    axis: isize,
+) -> Result<Tensor, OpError> {
+    let mut output = input.into_owned_in(pool);
+    normalize_lanes(&mut output, axis, |lane| {
         vecmath::LogSoftmax::new_mut(lane).dispatch();
-    })
+    })?;
+    Ok(output)
 }
 
 #[derive(Debug)]
@@ -778,8 +769,8 @@ impl Operator for LogSoftmax {
     }
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
-        let input = ctx.inputs().require_as(0)?;
-        log_softmax(ctx.pool(), input, self.axis).into_op_result()
+        let input: TensorView<f32> = ctx.inputs().require_as(0)?;
+        log_softmax(ctx.pool(), input.as_cow(), self.axis).into_op_result()
     }
 
     fn in_place_inputs(&self) -> BitSet<u16> {
@@ -789,11 +780,10 @@ impl Operator for LogSoftmax {
     fn run_in_place(
         &self,
         in_place: InPlaceInputs,
-        _ctx: &OpRunContext,
+        ctx: &OpRunContext,
     ) -> Result<OutputList, OpError> {
-        let mut output: Tensor = in_place.into_single().try_into()?;
-        log_softmax_in_place(&mut output, self.axis)?;
-        output.into_op_result()
+        let output: Tensor = in_place.into_single().try_into()?;
+        log_softmax(ctx.pool(), output.into_cow(), self.axis).into_op_result()
     }
 
     fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
@@ -816,30 +806,21 @@ pub enum NanHandling {
 
 pub fn softmax(
     pool: &BufferPool,
-    input: TensorView,
+    input: CowTensor<f32>,
     axis: isize,
     nan_handling: NanHandling,
 ) -> Result<Tensor, OpError> {
-    let mut output = input.to_tensor_in(pool);
-    softmax_in_place(&mut output, axis, nan_handling)?;
-    Ok(output)
-}
-
-pub fn softmax_in_place(
-    output: &mut Tensor,
-    axis: isize,
-    nan_handling: NanHandling,
-) -> Result<(), OpError> {
     let flush_nans = match nan_handling {
         NanHandling::KeepNans => false,
         NanHandling::FlushToZero => true,
     };
-    normalize_lanes(output, axis, |lane| {
+    let mut output = input.into_owned_in(pool);
+    normalize_lanes(&mut output, axis, |lane| {
         vecmath::Softmax::new_mut(lane)
             .flush_nans_to_zero(flush_nans)
             .dispatch();
     })?;
-    Ok(())
+    Ok(output)
 }
 
 #[derive(Debug)]
@@ -874,8 +855,8 @@ impl Operator for Softmax {
     }
 
     fn run(&self, ctx: &OpRunContext) -> Result<OutputList, OpError> {
-        let input = ctx.inputs().require_as(0)?;
-        softmax(ctx.pool(), input, self.axis, self.nan_handling()).into_op_result()
+        let input: TensorView<f32> = ctx.inputs().require_as(0)?;
+        softmax(ctx.pool(), input.as_cow(), self.axis, self.nan_handling()).into_op_result()
     }
 
     fn in_place_inputs(&self) -> BitSet<u16> {
@@ -885,11 +866,16 @@ impl Operator for Softmax {
     fn run_in_place(
         &self,
         in_place: InPlaceInputs,
-        _ctx: &OpRunContext,
+        ctx: &OpRunContext,
     ) -> Result<OutputList, OpError> {
-        let mut output = in_place.into_single().try_into()?;
-        softmax_in_place(&mut output, self.axis, self.nan_handling())?;
-        output.into_op_result()
+        let output: Tensor = in_place.into_single().try_into()?;
+        softmax(
+            ctx.pool(),
+            output.into_cow(),
+            self.axis,
+            self.nan_handling(),
+        )
+        .into_op_result()
     }
 
     fn as_infer_shapes(&self) -> Option<&dyn InferShapes> {
@@ -921,8 +907,8 @@ mod tests {
 
     use super::NORMALIZE_GRAIN_SIZE;
     use super::{
-        LpNormalization, NanHandling, batch_norm, batch_norm_in_place, instance_normalization,
-        layer_normalization, log_softmax, lp_normalization, rms_normalization, softmax,
+        LpNormalization, NanHandling, batch_norm, instance_normalization, layer_normalization,
+        log_softmax, lp_normalization, rms_normalization, softmax,
     };
     use crate::buffer_pool::BufferPool;
     use crate::operator::{InputList, OperatorExt};
@@ -976,7 +962,7 @@ mod tests {
 
             let result = batch_norm(
                 &pool,
-                input.view(),
+                input.as_cow(),
                 &scale[..n_chans].into(),
                 &bias[..n_chans].into(),
                 &mean[..n_chans].into(),
@@ -1001,7 +987,7 @@ mod tests {
         let pool = BufferPool::new();
         let result = batch_norm(
             &pool,
-            input.view(),
+            input.as_cow(),
             &scale.into(),
             &bias.into(),
             &mean.into(),
@@ -1017,7 +1003,7 @@ mod tests {
 
     #[test]
     fn test_batch_norm_in_place() -> Result<(), Box<dyn Error>> {
-        let mut input = Tensor::from_data(&[1, 2, 1, 1], vec![1.0, 2.0]);
+        let input = Tensor::from_data(&[1, 2, 1, 1], vec![1.0, 2.0]);
         let scale = &[3.0, 3.0];
         let bias = &[0.1, 0.2];
         let mean = &[0.5, -0.5];
@@ -1029,8 +1015,10 @@ mod tests {
         let y2 = (input[[0, 1, 0, 0]] - mean[1]) / (var[1] + epsilon).sqrt() * scale[1] + bias[1];
         let expected = Tensor::from_data(&[1, 2, 1, 1], vec![y1, y2]);
 
-        batch_norm_in_place(
-            &mut input,
+        let pool = BufferPool::new();
+        let input = batch_norm(
+            &pool,
+            input.into_cow(),
             &scale.into(),
             &bias.into(),
             &mean.into(),
@@ -1069,7 +1057,7 @@ mod tests {
 
         let pool = BufferPool::new();
         let result =
-            instance_normalization(&pool, input.view(), scale.nd_view(), bias.nd_view(), None)
+            instance_normalization(&pool, input.as_cow(), scale.nd_view(), bias.nd_view(), None)
                 .unwrap();
 
         expect_eq_1e4(&result, &expected)?;
@@ -1273,18 +1261,18 @@ mod tests {
         // 1D input
         let mut input = Tensor::from([0.1634, 0.8647, 0.6401, 0.8265, 0.0560, 0.2345]);
         let expected = Tensor::from([-2.1447, -1.4434, -1.6680, -1.4816, -2.2521, -2.0736]);
-        let result = log_softmax(&pool, input.view(), 0).unwrap();
+        let result = log_softmax(&pool, input.as_cow(), 0).unwrap();
         expect_eq_1e4(&result, &expected)?;
 
         // Second dimension of 2D input
         input.reshape(&[2, 3]);
         let expected = Tensor::from([[-1.5319, -0.8306, -1.0552], [-0.7011, -1.4716, -1.2931]]);
-        let result = log_softmax(&pool, input.view(), 1).unwrap();
+        let result = log_softmax(&pool, input.as_cow(), 1).unwrap();
         expect_eq_1e4(&result, &expected)?;
 
         // First dimension of 2D input
         let expected = Tensor::from([[-1.0787, -0.3684, -0.5108], [-0.4156, -1.1771, -0.9164]]);
-        let result = log_softmax(&pool, input.view(), 0).unwrap();
+        let result = log_softmax(&pool, input.as_cow(), 0).unwrap();
         expect_eq_1e4(&result, &expected)?;
 
         // Second dimension of 2D input with multiple entries in first dim
@@ -1296,7 +1284,7 @@ mod tests {
             [-2.0104, -1.3091, -1.5337, -1.3473, -2.1178],
             [-2.0104, -1.3091, -1.5337, -1.3473, -2.1178],
         ]);
-        let result = log_softmax(&pool, matrix_input.view(), 1).unwrap();
+        let result = log_softmax(&pool, matrix_input.as_cow(), 1).unwrap();
         expect_eq_1e4(&result, &matrix_expected)?;
 
         Ok(())
@@ -1309,23 +1297,23 @@ mod tests {
         // Softmax on a 1D input
         let mut input = Tensor::from([0.1634, 0.8647, 0.6401, 0.8265, 0.0560, 0.2304]);
         let expected = Tensor::from([0.1172, 0.2362, 0.1887, 0.2274, 0.1052, 0.1253]);
-        let result = softmax(&pool, input.view(), 0, NanHandling::KeepNans).unwrap();
+        let result = softmax(&pool, input.as_cow(), 0, NanHandling::KeepNans).unwrap();
         expect_eq_1e4(&result, &expected)?;
 
         // Softmax over empty axis
         let empty_vec = Tensor::zeros(&[0]);
-        let result = softmax(&pool, empty_vec.view(), 0, NanHandling::KeepNans).unwrap();
+        let result = softmax(&pool, empty_vec.as_cow(), 0, NanHandling::KeepNans).unwrap();
         expect_eq_1e4(&result, &empty_vec)?;
 
         // Softmax on final dimension of 2D input
         input.reshape(&[2, 3]);
         let expected = Tensor::from([[0.2161, 0.4358, 0.3481], [0.4966, 0.2298, 0.2736]]);
-        let result = softmax(&pool, input.view(), 1, NanHandling::KeepNans).unwrap();
+        let result = softmax(&pool, input.as_cow(), 1, NanHandling::KeepNans).unwrap();
         expect_eq_1e4(&result, &expected)?;
 
         // Softmax on first dimension of 2D input
         let expected = Tensor::from([[0.3400, 0.6918, 0.6010], [0.6600, 0.3082, 0.3990]]);
-        let result = softmax(&pool, input.view(), 0, NanHandling::KeepNans).unwrap();
+        let result = softmax(&pool, input.as_cow(), 0, NanHandling::KeepNans).unwrap();
         expect_eq_1e4(&result, &expected)?;
 
         // Softmax on second dimension of 2D input with multiple entries in
@@ -1338,7 +1326,7 @@ mod tests {
             [0.1339, 0.2701, 0.2157, 0.2599, 0.1203],
             [0.1339, 0.2701, 0.2157, 0.2599, 0.1203],
         ]);
-        let result = softmax(&pool, matrix_input.view(), 1, NanHandling::KeepNans).unwrap();
+        let result = softmax(&pool, matrix_input.as_cow(), 1, NanHandling::KeepNans).unwrap();
         expect_eq_1e4(&result, &matrix_expected)?;
 
         Ok(())
@@ -1364,7 +1352,7 @@ mod tests {
 
         input.permute(&[1, 0]);
         let pool = BufferPool::new();
-        let result = softmax(&pool, input.view(), 1, NanHandling::KeepNans).unwrap();
+        let result = softmax(&pool, input.as_cow(), 1, NanHandling::KeepNans).unwrap();
 
         expect_eq_1e4(&result, &expected)?;
 
@@ -1386,13 +1374,13 @@ mod tests {
 
         let mut rng = XorShiftRng::new(1234);
         let input = Tensor::rand(&[1, 1, 3, 3], &mut rng);
-        let result = softmax(&pool, input.view(), 1, NanHandling::KeepNans).unwrap();
+        let result = softmax(&pool, input.as_cow(), 1, NanHandling::KeepNans).unwrap();
         check_result(result);
 
         // "Large" output, where output size exceeds the parallelism grain size.
         let mut rng = XorShiftRng::new(1234);
         let input = Tensor::rand(&[4, NORMALIZE_GRAIN_SIZE / 2], &mut rng);
-        let result = softmax(&pool, input.view(), 1, NanHandling::KeepNans).unwrap();
+        let result = softmax(&pool, input.as_cow(), 1, NanHandling::KeepNans).unwrap();
         check_result(result);
     }
 
@@ -1404,12 +1392,12 @@ mod tests {
 
         // When all inputs are -inf, normal softmax produces NaN.
         let input = Tensor::from([f32::NEG_INFINITY, f32::NEG_INFINITY, f32::NEG_INFINITY]);
-        let result = softmax(&pool, input.view(), 0, NanHandling::KeepNans).unwrap();
+        let result = softmax(&pool, input.as_cow(), 0, NanHandling::KeepNans).unwrap();
         assert!(result.iter().all(|x| x.is_nan()));
 
         // With flush_nans_to_zero, output should be all zeros.
         let input = Tensor::from([f32::NEG_INFINITY, f32::NEG_INFINITY, f32::NEG_INFINITY]);
-        let result = softmax(&pool, input.view(), 0, NanHandling::FlushToZero).unwrap();
+        let result = softmax(&pool, input.as_cow(), 0, NanHandling::FlushToZero).unwrap();
         assert_eq!(result.to_vec(), vec![0., 0., 0.]);
     }
 }

--- a/src/ops/operators.rs
+++ b/src/ops/operators.rs
@@ -227,7 +227,7 @@ impl<S: Storage<Elem = f32> + Sync, L: Layout + Clone + Sync> FloatOperators for
     }
 
     fn softmax(&self, axis: isize) -> Result<Tensor, OpError> {
-        run_operator(|pool| softmax(pool, self.as_dyn(), axis, NanHandling::KeepNans))
+        run_operator(|pool| softmax(pool, self.as_dyn().as_cow(), axis, NanHandling::KeepNans))
     }
 
     #[cfg(feature = "fft")]

--- a/src/ops/reduce.rs
+++ b/src/ops/reduce.rs
@@ -6,7 +6,7 @@ use rten_shape_inference::ops as shape_ops;
 use rten_simd::SimdOp;
 use rten_tensor;
 use rten_tensor::prelude::*;
-use rten_tensor::{NdTensor, NdTensorView, Tensor, TensorView};
+use rten_tensor::{Tensor, TensorView};
 use rten_vecmath as vecmath;
 
 use crate::buffer_pool::BufferPool;
@@ -18,7 +18,6 @@ use crate::operator::{
     InputList, IntoOpResult, OpError, OpRunContext, Operator, OutputList, OutputType,
     OutputTypeList, OutputTypesContext,
 };
-use crate::ops::layout::squeeze_in_place;
 use crate::ops::{map_value_view, resolve_axes, resolve_axis};
 use crate::slice_reductions::{slice_fold_assoc, slice_sum};
 use crate::value::{DataType, ValueType, ValueView};
@@ -106,9 +105,7 @@ fn select_max_index<T, Cmp: Fn(&T, &T) -> std::cmp::Ordering>(
     let mut reduced = Tensor::<i32>::from_data(&reduced_shape, reduced_data);
 
     if !keep_dims {
-        let axes = &[resolved_axis as i32];
-        let axes = NdTensorView::from(axes);
-        squeeze_in_place(&mut reduced, Some(axes)).expect("Invalid axis");
+        reduced.remove_axis(resolved_axis);
     }
 
     Ok(reduced)
@@ -513,9 +510,11 @@ fn reduce<T: Copy>(
     let mut reduced = Tensor::<T>::from_data(&reduced_shape, reduced_data);
 
     if !keep_dims {
-        let resolved_axes_i32: NdTensor<i32, 1> =
-            resolved_axes.iter().map(|axis| *axis as i32).collect();
-        squeeze_in_place(&mut reduced, Some(resolved_axes_i32.view())).expect("Invalid axis");
+        // `resolved_axes` is sorted, so each removal shifts the remaining
+        // axes down by one.
+        for (n_removed, axis) in resolved_axes.iter().enumerate() {
+            reduced.remove_axis(axis - n_removed);
+        }
     }
 
     Ok(reduced)


### PR DESCRIPTION
https://github.com/robertknight/rten/pull/1461 introduced a pattern of using `CowTensor` to unify in-place and non-in-place implementations of operators for cases where the non-in-place variant just copies the input and then runs the in-place version. This PR applies the same idea to other layout and normalization operators.