### PR TITLE
Add `TensorBase::is_owned`

### DIFF
--- a/rten-tensor/src/tensor.rs
+++ b/rten-tensor/src/tensor.rs
@@ -1507,6 +1507,13 @@ impl<'a, T, L: Layout> TensorBase<CowData<'a, T>, L> {
         }
     }
 
+    /// Return true if this tensor owns its data.
+    ///
+    /// If true, [`into_owned`](Self::into_owned) will not copy.
+    pub fn is_owned(&self) -> bool {
+        matches!(self.data, CowData::Owned(_))
+    }
+
     /// Convert this copy-on-write tensor into an owned tensor.
     ///
     /// This is cheap if the data is already owned or requires a copy otherwise.

--- a/rten-tensor/src/tensor/tests.rs
+++ b/rten-tensor/src/tensor/tests.rs
@@ -931,6 +931,13 @@ fn test_into_dyn() {
 }
 
 #[test]
+fn test_is_owned() {
+    let tensor = NdTensor::from_data([2, 2], vec![1, 2, 3, 4]);
+    assert!(!tensor.as_cow().is_owned());
+    assert!(tensor.into_cow().is_owned());
+}
+
+#[test]
 fn test_into_owned() {
     // Borrowed data is copied into an owned tensor.
     let tensor = NdTensor::from_data([2, 2], vec![1, 2, 3, 4]);


### PR DESCRIPTION
This can be used to check before calling `into_owned` if it would require copying the data, like `Cow::is_owned`.

This is currently not used in the main crate, but may be useful in future to enable sharing code between in-place and non-in-place versions of operators.