### PR TITLE
Remove `unsafe_op_in_unsafe_fn` lint suppression in GEMM kernels

### DIFF
--- a/rten-gemm/src/kernels.rs
+++ b/rten-gemm/src/kernels.rs
@@ -1,7 +1,3 @@
-// The GEMM kernels contain many unsafe calls for performance reasons. This
-// lint was suppressed to simplify migration to the 2024 Rust edition.
-#![allow(unsafe_op_in_unsafe_fn)]
-
 use std::mem::MaybeUninit;
 use std::ops::Range;
 

--- a/rten-gemm/src/kernels/aarch64.rs
+++ b/rten-gemm/src/kernels/aarch64.rs
@@ -150,34 +150,40 @@ unsafe impl Kernel<f32, f32, f32> for ArmNeonKernel {
             (tmp_tile.as_mut_ptr() as *mut f32, NR, 0.)
         };
 
-        let gemm = GemmDispatch::<_, MR, NR_REGS>::new(
-            self.isa,
-            dest_ptr,
-            dest_row_stride,
-            a,
-            b,
-            depth,
-            alpha,
-            dest_beta,
-        );
+        let gemm = unsafe {
+            GemmDispatch::<_, MR, NR_REGS>::new(
+                self.isa,
+                dest_ptr,
+                dest_row_stride,
+                a,
+                b,
+                depth,
+                alpha,
+                dest_beta,
+            )
+        };
 
         debug_assert_eq!(MR, 4);
-        match used_rows {
-            4 => gemm.dispatch_broadcast_lane::<4>(),
-            3 => gemm.dispatch_broadcast_lane::<3>(),
-            2 => gemm.dispatch_broadcast_lane::<2>(),
-            1 => gemm.dispatch_broadcast_lane::<1>(),
-            _ => panic!("unsupported `used_rows` {}", used_rows),
+        unsafe {
+            match used_rows {
+                4 => gemm.dispatch_broadcast_lane::<4>(),
+                3 => gemm.dispatch_broadcast_lane::<3>(),
+                2 => gemm.dispatch_broadcast_lane::<2>(),
+                1 => gemm.dispatch_broadcast_lane::<1>(),
+                _ => panic!("unsupported `used_rows` {}", used_rows),
+            }
         }
 
         if used_cols != NR {
-            tmp_tile.accumulate_into(
-                tile_ptr as *mut MaybeUninit<f32>,
-                used_rows,
-                used_cols,
-                tile_row_stride,
-                beta,
-            );
+            unsafe {
+                tmp_tile.accumulate_into(
+                    tile_ptr as *mut MaybeUninit<f32>,
+                    used_rows,
+                    used_cols,
+                    tile_row_stride,
+                    beta,
+                );
+            }
         }
     }
 
@@ -331,22 +337,24 @@ unsafe impl Kernel<u8, i8, i32> for ArmInt8DotKernel {
         let (b_data, b_meta) = packing::int8::extract_packed_b::<{ Self::NR }>(b);
 
         const NR_REGS: usize = ArmInt8DotKernel::NR / X32_LANES;
-        simd_int8_gemm::<_, _, { Self::MR }, { Self::NR }, NR_REGS>(
-            self.isa,
-            tile_ptr,
-            tile_row_stride,
-            a_data,
-            b_data,
-            used_rows,
-            used_cols,
-            depth,
-            beta != 0, // accumulate
-            a_meta.zero_points,
-            b_meta.zero_points,
-            &a_meta.row_sums,
-            &b_meta.col_sums,
-            self.dot_isa,
-        )
+        unsafe {
+            simd_int8_gemm::<_, _, { Self::MR }, { Self::NR }, NR_REGS>(
+                self.isa,
+                tile_ptr,
+                tile_row_stride,
+                a_data,
+                b_data,
+                used_rows,
+                used_cols,
+                depth,
+                beta != 0, // accumulate
+                a_meta.zero_points,
+                b_meta.zero_points,
+                &a_meta.row_sums,
+                &b_meta.col_sums,
+                self.dot_isa,
+            )
+        }
     }
 
     fn gemv_kernel(
@@ -521,8 +529,9 @@ unsafe impl Kernel<u8, i8, i32> for ArmInt8MlalKernel {
         // Compute `tmp[row][0..2] += a[row] * b` where `a` and `b` are `uint16x8_t`s.
         macro_rules! compute_row {
             ($row:literal, $a:ident, $b:ident) => {
-                tmp[$row][0] = vmlal_laneq_u16::<$row>(tmp[$row][0], vget_low_u16($b), $a);
-                tmp[$row][1] = vmlal_high_laneq_u16::<$row>(tmp[$row][1], $b, $a);
+                tmp[$row][0] =
+                    unsafe { vmlal_laneq_u16::<$row>(tmp[$row][0], vget_low_u16($b), $a) };
+                tmp[$row][1] = unsafe { vmlal_high_laneq_u16::<$row>(tmp[$row][1], $b, $a) };
             };
         }
 
@@ -534,11 +543,11 @@ unsafe impl Kernel<u8, i8, i32> for ArmInt8MlalKernel {
         let depth_remainder = depth % 2;
 
         for k_block in 0..depth_blocks {
-            let a_vec = u8_ops.load_ptr(a_data.as_ptr().add(k_block * u8_ops.len()));
+            let a_vec = unsafe { u8_ops.load_ptr(a_data.as_ptr().add(k_block * u8_ops.len())) };
             let a_lo = u8_ops.extend_low(a_vec);
             let a_hi = u8_ops.extend_high(a_vec);
 
-            let b_vec = u8_ops.load_ptr(b.as_ptr().add(k_block * u8_ops.len()));
+            let b_vec = unsafe { u8_ops.load_ptr(b.as_ptr().add(k_block * u8_ops.len())) };
             let b_lo = u8_ops.extend_low(b_vec);
             let b_hi = u8_ops.extend_high(b_vec);
 
@@ -569,24 +578,24 @@ unsafe impl Kernel<u8, i8, i32> for ArmInt8MlalKernel {
         if depth_remainder != 0 {
             let a_buf: [u8; 16] = std::array::from_fn(|i| {
                 if i < MR {
-                    *a_data.as_ptr().add(depth_blocks * u8_ops.len() + i)
+                    unsafe { *a_data.as_ptr().add(depth_blocks * u8_ops.len() + i) }
                 } else {
                     0
                 }
             });
             let b_buf: [u8; 16] = std::array::from_fn(|i| {
                 if i < NR {
-                    *b.as_ptr().add(depth_blocks * u8_ops.len() + i)
+                    unsafe { *b.as_ptr().add(depth_blocks * u8_ops.len() + i) }
                 } else {
                     0
                 }
             });
 
-            let a_vec = u8_ops.load_ptr(a_buf.as_ptr());
+            let a_vec = unsafe { u8_ops.load_ptr(a_buf.as_ptr()) };
             let a_lo = u8_ops.extend_low(a_vec);
             let _a_hi = u8_ops.extend_high(a_vec);
 
-            let b_vec = u8_ops.load_ptr(b_buf.as_ptr());
+            let b_vec = unsafe { u8_ops.load_ptr(b_buf.as_ptr()) };
             let b_lo = u8_ops.extend_low(b_vec);
             let _b_hi = u8_ops.extend_high(b_vec);
 
@@ -602,24 +611,26 @@ unsafe impl Kernel<u8, i8, i32> for ArmInt8MlalKernel {
 
         // Cast accumulator from U32 to I32
         let tmp: [[I32; NR_REGS]; MR] =
-            std::mem::transmute::<[[U32; NR_REGS]; MR], [[I32; NR_REGS]; MR]>(tmp);
+            unsafe { std::mem::transmute::<[[U32; NR_REGS]; MR], [[I32; NR_REGS]; MR]>(tmp) };
 
         // Adjust accumulators to account for zero points and write to output
         // tile.
-        simd_int8_gemm_epilogue(
-            self.isa,
-            tile_ptr,
-            tile_row_stride,
-            used_rows,
-            used_cols,
-            depth,
-            accumulate,
-            a_meta.zero_points,
-            a_meta.row_sums,
-            b_meta.zero_points,
-            b_meta.col_sums,
-            tmp,
-        );
+        unsafe {
+            simd_int8_gemm_epilogue(
+                self.isa,
+                tile_ptr,
+                tile_row_stride,
+                used_rows,
+                used_cols,
+                depth,
+                accumulate,
+                a_meta.zero_points,
+                a_meta.row_sums,
+                b_meta.zero_points,
+                b_meta.col_sums,
+                tmp,
+            );
+        }
     }
 
     fn gemv_kernel(
@@ -687,12 +698,14 @@ unsafe impl Int8DotProduct for NeonNativeDotProd {
 
             // Use inline asm here because the `vdotq_u32` intrinsic is not
             // stabilized yet.
-            asm! {
-                "udot {result:v}.4s, {a:v}.16b, {b:v}.16b",
-                result = inout(vreg) c,
-                a = in(vreg) a,
-                b = in(vreg) b,
-                options(nostack)
+            unsafe {
+                asm! {
+                    "udot {result:v}.4s, {a:v}.16b, {b:v}.16b",
+                    result = inout(vreg) c,
+                    a = in(vreg) a,
+                    b = in(vreg) b,
+                    options(nostack)
+                }
             }
 
             vreinterpretq_s32_u32(c)
@@ -725,13 +738,15 @@ unsafe impl Int8DotProduct for NeonNativeDotProd {
 
             // Use inline asm here because the `vdotq_laneq_u32` intrinsic is not
             // stabilized yet.
-            asm! {
-                "udot {result:v}.4s, {a:v}.16b, {b:v}.4B[{idx}]",
-                result = inout(vreg) c,
-                a = in(vreg) a,
-                b = in(vreg) b,
-                idx = const IDX,
-                options(nostack)
+            unsafe {
+                asm! {
+                    "udot {result:v}.4s, {a:v}.16b, {b:v}.4B[{idx}]",
+                    result = inout(vreg) c,
+                    a = in(vreg) a,
+                    b = in(vreg) b,
+                    idx = const IDX,
+                    options(nostack)
+                }
             }
 
             vreinterpretq_s32_u32(c)
@@ -965,10 +980,10 @@ unsafe impl Kernel<u8, i8, i32> for ArmInt8MMKernel {
         // B and performs ROW_TILES * COL_TILES mini matmuls (2x8 @ 8x2 => 2x2),
         // collectively updating an MR x NR x i32 output tile in registers.
         for k_block in 0..n_depth_tiles {
-            let col_tiles: [U8; COL_TILES] = std::array::from_fn(|c| {
+            let col_tiles: [U8; COL_TILES] = std::array::from_fn(|c| unsafe {
                 u8_ops.load_ptr(b_ptr.add(k_block * b_tile_size + c * u8_ops.len()))
             });
-            let row_tiles: [U8; ROW_TILES] = std::array::from_fn(|r| {
+            let row_tiles: [U8; ROW_TILES] = std::array::from_fn(|r| unsafe {
                 u8_ops.load_ptr(a_ptr.add(k_block * a_tile_size + r * u8_ops.len()))
             });
 
@@ -976,12 +991,14 @@ unsafe impl Kernel<u8, i8, i32> for ArmInt8MMKernel {
                 for c in 0..COL_TILES {
                     // Use inline asm here because the `vmmlaq_u32` intrinsic is
                     // not stabilized yet.
-                    core::arch::asm! {
-                        "ummla {result:v}.4s, {a:v}.16b, {b:v}.16b",
-                        result = inout(vreg) tmp[r][c],
-                        a = in(vreg) row_tiles[r],
-                        b = in(vreg) col_tiles[c],
-                        options(nostack)
+                    unsafe {
+                        core::arch::asm! {
+                            "ummla {result:v}.4s, {a:v}.16b, {b:v}.16b",
+                            result = inout(vreg) tmp[r][c],
+                            a = in(vreg) row_tiles[r],
+                            b = in(vreg) col_tiles[c],
+                            options(nostack)
+                        }
                     }
                 }
             }
@@ -1015,20 +1032,22 @@ unsafe impl Kernel<u8, i8, i32> for ArmInt8MMKernel {
             })
         });
 
-        simd_int8_gemm_epilogue(
-            self.dot_kernel.isa,
-            tile_ptr,
-            tile_row_stride,
-            used_rows,
-            used_cols,
-            depth,
-            accumulate,
-            a_meta.zero_points,
-            a_meta.row_sums,
-            b_meta.zero_points,
-            b_meta.col_sums,
-            tmp,
-        );
+        unsafe {
+            simd_int8_gemm_epilogue(
+                self.dot_kernel.isa,
+                tile_ptr,
+                tile_row_stride,
+                used_rows,
+                used_cols,
+                depth,
+                accumulate,
+                a_meta.zero_points,
+                a_meta.row_sums,
+                b_meta.zero_points,
+                b_meta.col_sums,
+                tmp,
+            );
+        }
     }
 
     fn gemv_kernel(

--- a/rten-gemm/src/kernels/generic.rs
+++ b/rten-gemm/src/kernels/generic.rs
@@ -145,37 +145,43 @@ unsafe impl Kernel<f32, f32, f32> for GenericKernel {
             (tmp_tile.as_mut_ptr() as *mut f32, NR, 0.)
         };
 
-        let gemm = GemmDispatch::<_, MR, NR_REGS>::new(
-            self.isa,
-            dest_ptr,
-            dest_row_stride,
-            a,
-            b,
-            depth,
-            alpha,
-            dest_beta,
-        );
+        let gemm = unsafe {
+            GemmDispatch::<_, MR, NR_REGS>::new(
+                self.isa,
+                dest_ptr,
+                dest_row_stride,
+                a,
+                b,
+                depth,
+                alpha,
+                dest_beta,
+            )
+        };
 
-        match used_rows {
-            8 => gemm.dispatch::<8>(),
-            7 => gemm.dispatch::<7>(),
-            6 => gemm.dispatch::<6>(),
-            5 => gemm.dispatch::<5>(),
-            4 => gemm.dispatch::<4>(),
-            3 => gemm.dispatch::<3>(),
-            2 => gemm.dispatch::<2>(),
-            1 => gemm.dispatch::<1>(),
-            _ => panic!("unsupported `used_rows` {}", used_rows),
+        unsafe {
+            match used_rows {
+                8 => gemm.dispatch::<8>(),
+                7 => gemm.dispatch::<7>(),
+                6 => gemm.dispatch::<6>(),
+                5 => gemm.dispatch::<5>(),
+                4 => gemm.dispatch::<4>(),
+                3 => gemm.dispatch::<3>(),
+                2 => gemm.dispatch::<2>(),
+                1 => gemm.dispatch::<1>(),
+                _ => panic!("unsupported `used_rows` {}", used_rows),
+            }
         }
 
         if used_cols != NR {
-            tmp_tile.accumulate_into(
-                tile_ptr as *mut MaybeUninit<f32>,
-                used_rows,
-                used_cols,
-                tile_row_stride,
-                beta,
-            );
+            unsafe {
+                tmp_tile.accumulate_into(
+                    tile_ptr as *mut MaybeUninit<f32>,
+                    used_rows,
+                    used_cols,
+                    tile_row_stride,
+                    beta,
+                );
+            }
         }
     }
 
@@ -340,28 +346,32 @@ unsafe impl Kernel<u8, i8, i32> for GenericKernel {
         if dest_beta == 0 {
             for row in 0..used_rows {
                 for col in 0..used_cols {
-                    dest_ptr
-                        .add(row * dest_row_stride + col)
-                        .write(tmp[row][col]);
+                    unsafe {
+                        dest_ptr
+                            .add(row * dest_row_stride + col)
+                            .write(tmp[row][col])
+                    };
                 }
             }
         } else {
             // nb. We require that beta is 0 or 1, so here it is 1.
             for row in 0..used_rows {
                 for col in 0..used_cols {
-                    *dest_ptr.add(row * dest_row_stride + col) += tmp[row][col];
+                    unsafe { *dest_ptr.add(row * dest_row_stride + col) += tmp[row][col] };
                 }
             }
         }
 
         if use_tmp_tile {
-            tmp_tile.accumulate_into(
-                tile_ptr as *mut MaybeUninit<i32>,
-                used_rows,
-                used_cols,
-                tile_row_stride,
-                beta,
-            );
+            unsafe {
+                tmp_tile.accumulate_into(
+                    tile_ptr as *mut MaybeUninit<i32>,
+                    used_rows,
+                    used_cols,
+                    tile_row_stride,
+                    beta,
+                );
+            }
         }
     }
 

--- a/rten-gemm/src/kernels/simd_generic.rs
+++ b/rten-gemm/src/kernels/simd_generic.rs
@@ -235,16 +235,18 @@ impl<'a, I: Isa, const MR: usize, const NR_REGS: usize> GemmDispatch<'a, I, MR, 
     /// Run the kernel to update an output tile with `ROWS` rows.
     #[inline(always)]
     pub unsafe fn dispatch<const ROWS: usize>(&self) {
-        simd_gemm::<I, MR, NR_REGS, ROWS>(
-            self.isa,
-            self.tile_ptr,
-            self.tile_row_stride,
-            self.a,
-            self.b,
-            self.depth,
-            self.alpha,
-            self.beta,
-        )
+        unsafe {
+            simd_gemm::<I, MR, NR_REGS, ROWS>(
+                self.isa,
+                self.tile_ptr,
+                self.tile_row_stride,
+                self.a,
+                self.b,
+                self.depth,
+                self.alpha,
+                self.beta,
+            )
+        }
     }
 
     /// Run the kernel to update an output tile with `ROWS` rows.
@@ -255,16 +257,18 @@ impl<'a, I: Isa, const MR: usize, const NR_REGS: usize> GemmDispatch<'a, I, MR, 
     #[cfg(target_arch = "aarch64")]
     #[inline(always)]
     pub unsafe fn dispatch_broadcast_lane<const ROWS: usize>(&self) {
-        simd_gemm_broadcast_lane::<I, MR, NR_REGS, ROWS>(
-            self.isa,
-            self.tile_ptr,
-            self.tile_row_stride,
-            self.a,
-            self.b,
-            self.depth,
-            self.alpha,
-            self.beta,
-        )
+        unsafe {
+            simd_gemm_broadcast_lane::<I, MR, NR_REGS, ROWS>(
+                self.isa,
+                self.tile_ptr,
+                self.tile_row_stride,
+                self.a,
+                self.b,
+                self.depth,
+                self.alpha,
+                self.beta,
+            )
+        }
     }
 }
 
@@ -327,14 +331,14 @@ pub unsafe fn simd_gemm<I: Isa, const MR: usize, const NR_REGS: usize, const ROW
         let b_off = k * NR_REGS * ops.len();
 
         // Prefetch B for the next iteration
-        ops.prefetch(b_ptr.add((k + 1) * NR_REGS * ops.len()));
+        ops.prefetch(unsafe { b_ptr.add((k + 1) * NR_REGS * ops.len()) });
 
         for i in 0..NR_REGS {
-            b_rows[i] = ops.load_ptr(b_ptr.add(b_off + i * ops.len()));
+            b_rows[i] = unsafe { ops.load_ptr(b_ptr.add(b_off + i * ops.len())) };
         }
 
         for i in 0..ROWS {
-            let a_val = *a_ptr.add(i * a_row_stride + k);
+            let a_val = unsafe { *a_ptr.add(i * a_row_stride + k) };
             let a_broadcast = ops.splat(a_val);
 
             for j in 0..NR_REGS {
@@ -345,7 +349,7 @@ pub unsafe fn simd_gemm<I: Isa, const MR: usize, const NR_REGS: usize, const ROW
 
     // Prefetch output before the final computation loop
     for i in 0..ROWS {
-        ops.prefetch_write(tile_ptr.add(tile_row_stride * i));
+        ops.prefetch_write(unsafe { tile_ptr.add(tile_row_stride * i) });
     }
 
     // Perform final outer product update.
@@ -353,11 +357,11 @@ pub unsafe fn simd_gemm<I: Isa, const MR: usize, const NR_REGS: usize, const ROW
     let b_off = k * NR_REGS * ops.len();
 
     for i in 0..NR_REGS {
-        b_rows[i] = ops.load_ptr(b_ptr.add(b_off + i * ops.len()));
+        b_rows[i] = unsafe { ops.load_ptr(b_ptr.add(b_off + i * ops.len())) };
     }
 
     for i in 0..ROWS {
-        let a_val = *a_ptr.add(i * a_row_stride + k);
+        let a_val = unsafe { *a_ptr.add(i * a_row_stride + k) };
         let a_broadcast = ops.splat(a_val);
 
         for j in 0..NR_REGS {
@@ -365,7 +369,7 @@ pub unsafe fn simd_gemm<I: Isa, const MR: usize, const NR_REGS: usize, const ROW
         }
     }
 
-    let get_out_ptr = |i, j| tile_ptr.add(tile_row_stride * i + j * ops.len());
+    let get_out_ptr = |i, j| unsafe { tile_ptr.add(tile_row_stride * i + j * ops.len()) };
 
     // Write to output tile.
     //
@@ -377,15 +381,15 @@ pub unsafe fn simd_gemm<I: Isa, const MR: usize, const NR_REGS: usize, const ROW
         for i in 0..ROWS {
             for j in 0..NR_REGS {
                 let out_ptr = get_out_ptr(i, j);
-                ops.store_ptr(tmp[i][j], out_ptr);
+                unsafe { ops.store_ptr(tmp[i][j], out_ptr) };
             }
         }
     } else if beta == 1. && alpha == 1. {
         for i in 0..ROWS {
             for j in 0..NR_REGS {
                 let out_ptr = get_out_ptr(i, j);
-                let out_val = ops.add(ops.load_ptr(out_ptr), tmp[i][j]);
-                ops.store_ptr(out_val, out_ptr);
+                let out_val = ops.add(unsafe { ops.load_ptr(out_ptr) }, tmp[i][j]);
+                unsafe { ops.store_ptr(out_val, out_ptr) };
             }
         }
     } else if beta == 0. {
@@ -395,7 +399,7 @@ pub unsafe fn simd_gemm<I: Isa, const MR: usize, const NR_REGS: usize, const ROW
             for j in 0..NR_REGS {
                 let out_ptr = get_out_ptr(i, j);
                 let out_val = ops.mul(tmp[i][j], alpha_broadcast);
-                ops.store_ptr(out_val, out_ptr);
+                unsafe { ops.store_ptr(out_val, out_ptr) };
             }
         }
     } else {
@@ -405,9 +409,9 @@ pub unsafe fn simd_gemm<I: Isa, const MR: usize, const NR_REGS: usize, const ROW
         for i in 0..ROWS {
             for j in 0..NR_REGS {
                 let out_ptr = get_out_ptr(i, j);
-                let out_val = ops.mul(ops.load_ptr(out_ptr), beta_broadcast);
+                let out_val = ops.mul(unsafe { ops.load_ptr(out_ptr) }, beta_broadcast);
                 let out_val = ops.mul_add(tmp[i][j], alpha_broadcast, out_val);
-                ops.store_ptr(out_val, out_ptr);
+                unsafe { ops.store_ptr(out_val, out_ptr) };
             }
         }
     }
@@ -476,7 +480,7 @@ pub unsafe fn simd_gemm_broadcast_lane<
         ($k_base:ident, $k_offset:literal) => {
             let b_off = ($k_base + $k_offset) * NR_REGS * v_len;
             for i in 0..NR_REGS {
-                b_rows[i] = ops.load_ptr(b_ptr.add(b_off + i * v_len));
+                b_rows[i] = unsafe { ops.load_ptr(b_ptr.add(b_off + i * v_len)) };
             }
             for i in 0..ROWS {
                 // On Arm, the `broadcast_lane` and `mul_add` operations can be
@@ -494,7 +498,7 @@ pub unsafe fn simd_gemm_broadcast_lane<
     let mut k_base = 0;
     while depth - k_base >= VEC_LEN {
         for i in 0..ROWS {
-            a_tiles[i] = ops.load_ptr(a_ptr.add(i * a_row_stride + k_base));
+            a_tiles[i] = unsafe { ops.load_ptr(a_ptr.add(i * a_row_stride + k_base)) };
         }
         k_step!(k_base, 0);
         k_step!(k_base, 1);
@@ -504,14 +508,14 @@ pub unsafe fn simd_gemm_broadcast_lane<
     }
     while k_base < depth {
         for i in 0..ROWS {
-            let a_val = *a_ptr.add(i * a_row_stride + k_base);
+            let a_val = unsafe { *a_ptr.add(i * a_row_stride + k_base) };
             a_tiles[i] = ops.splat(a_val);
         }
         k_step!(k_base, 0);
         k_base += 1;
     }
 
-    let get_out_ptr = |i, j| tile_ptr.add(tile_row_stride * i + j * ops.len());
+    let get_out_ptr = |i, j| unsafe { tile_ptr.add(tile_row_stride * i + j * ops.len()) };
 
     // Write to output tile.
     //
@@ -523,15 +527,15 @@ pub unsafe fn simd_gemm_broadcast_lane<
         for i in 0..ROWS {
             for j in 0..NR_REGS {
                 let out_ptr = get_out_ptr(i, j);
-                ops.store_ptr(tmp[i][j], out_ptr);
+                unsafe { ops.store_ptr(tmp[i][j], out_ptr) };
             }
         }
     } else if beta == 1. && alpha == 1. {
         for i in 0..ROWS {
             for j in 0..NR_REGS {
                 let out_ptr = get_out_ptr(i, j);
-                let out_val = ops.add(ops.load_ptr(out_ptr), tmp[i][j]);
-                ops.store_ptr(out_val, out_ptr);
+                let out_val = ops.add(unsafe { ops.load_ptr(out_ptr) }, tmp[i][j]);
+                unsafe { ops.store_ptr(out_val, out_ptr) };
             }
         }
     } else if beta == 0. {
@@ -541,7 +545,7 @@ pub unsafe fn simd_gemm_broadcast_lane<
             for j in 0..NR_REGS {
                 let out_ptr = get_out_ptr(i, j);
                 let out_val = ops.mul(tmp[i][j], alpha_broadcast);
-                ops.store_ptr(out_val, out_ptr);
+                unsafe { ops.store_ptr(out_val, out_ptr) };
             }
         }
     } else {
@@ -551,9 +555,9 @@ pub unsafe fn simd_gemm_broadcast_lane<
         for i in 0..ROWS {
             for j in 0..NR_REGS {
                 let out_ptr = get_out_ptr(i, j);
-                let out_val = ops.mul(ops.load_ptr(out_ptr), beta_broadcast);
+                let out_val = ops.mul(unsafe { ops.load_ptr(out_ptr) }, beta_broadcast);
                 let out_val = ops.mul_add(tmp[i][j], alpha_broadcast, out_val);
-                ops.store_ptr(out_val, out_ptr);
+                unsafe { ops.store_ptr(out_val, out_ptr) };
             }
         }
     }
@@ -612,7 +616,7 @@ pub unsafe fn simd_int8_gemm<I: Isa, D, const MR: usize, const NR: usize, const 
     let n_depth_tiles = depth.div_ceil(4);
     for k_block in 0..n_depth_tiles {
         // Load `[4, NR]` microtile from B
-        let b_vec: [I::I8; NR_REGS] = std::array::from_fn(|i| {
+        let b_vec: [I::I8; NR_REGS] = std::array::from_fn(|i| unsafe {
             i8_ops.load_ptr(b_ptr.add((k_block * NR + i * ops.len()) * 4) as *const i8)
         });
 
@@ -657,20 +661,22 @@ pub unsafe fn simd_int8_gemm<I: Isa, D, const MR: usize, const NR: usize, const 
 
     // Adjust accumulators to account for zero points and write results to
     // output tile.
-    simd_int8_gemm_epilogue(
-        isa,
-        tile_ptr,
-        tile_row_stride,
-        used_rows,
-        used_cols,
-        depth,
-        accumulate,
-        a_zero_points,
-        *a_row_sums,
-        b_zero_points,
-        *b_col_sums,
-        tmp,
-    );
+    unsafe {
+        simd_int8_gemm_epilogue(
+            isa,
+            tile_ptr,
+            tile_row_stride,
+            used_rows,
+            used_cols,
+            depth,
+            accumulate,
+            a_zero_points,
+            *a_row_sums,
+            b_zero_points,
+            *b_col_sums,
+            tmp,
+        );
+    }
 }
 
 /// Common epilogue for int8 GEMM kernels which adjusts the accumulators to
@@ -732,7 +738,7 @@ pub unsafe fn simd_int8_gemm_epilogue<
 
     // Scale zero points by row and column sums and subtract from output tile.
     let b_col_sums: [I::I32; NR_REGS] =
-        std::array::from_fn(|i| ops.load_ptr(b_col_sums.as_ptr().add(i * ops.len())));
+        std::array::from_fn(|i| unsafe { ops.load_ptr(b_col_sums.as_ptr().add(i * ops.len())) });
     for row in 0..MR {
         let a_zero = ops.splat(a_zero_points[row]);
         let a_sum = ops.splat(a_row_sums[row]);
@@ -747,7 +753,7 @@ pub unsafe fn simd_int8_gemm_epilogue<
 
     // Write from accumulator in registers back to output.
     let output_tile_ptr =
-        |row, col_block| tile_ptr.add(row * tile_row_stride + col_block * ops.len());
+        |row, col_block| unsafe { tile_ptr.add(row * tile_row_stride + col_block * ops.len()) };
 
     if used_rows == MR && used_cols == NR {
         // Full output tile
@@ -755,9 +761,10 @@ pub unsafe fn simd_int8_gemm_epilogue<
             for c_block in 0..NR_REGS {
                 let tile_ptr = output_tile_ptr(row, c_block);
                 if accumulate {
-                    tmp[row][c_block] = ops.add(ops.load_ptr(tile_ptr), tmp[row][c_block]);
+                    tmp[row][c_block] =
+                        ops.add(unsafe { ops.load_ptr(tile_ptr) }, tmp[row][c_block]);
                 }
-                ops.store_ptr(tmp[row][c_block], tile_ptr);
+                unsafe { ops.store_ptr(tmp[row][c_block], tile_ptr) };
             }
         }
     } else {
@@ -770,9 +777,9 @@ pub unsafe fn simd_int8_gemm_epilogue<
 
                 for c in 0..used_cols {
                     if accumulate {
-                        tmp[c] += *tile_ptr.add(c);
+                        tmp[c] += unsafe { *tile_ptr.add(c) };
                     }
-                    tile_ptr.add(c).write(tmp[c]);
+                    unsafe { tile_ptr.add(c).write(tmp[c]) };
                 }
             }
         }
@@ -1035,14 +1042,14 @@ unsafe fn simd_int8_gemv_transposed<I: Isa, const CAST_B_U8: bool>(
     let one_u8 = i8_ops.splat(1);
 
     for col in 0..b.cols() {
-        let b_ptr = b_ptr.add(col * b.col_stride());
+        let b_ptr = unsafe { b_ptr.add(col * b.col_stride()) };
         let mut acc = ops.zero();
         let mut col_sum = ops.zero();
         let mut k_tiles = range_chunks_exact(0..depth, i8_ops.len());
 
         for k_tile in k_tiles.by_ref() {
-            let a = i8_ops.load_ptr(a_ptr.add(k_tile.start) as *const i8);
-            let b = i8_ops.load_ptr(b_ptr.add(k_tile.start));
+            let a = unsafe { i8_ops.load_ptr(a_ptr.add(k_tile.start) as *const i8) };
+            let b = unsafe { i8_ops.load_ptr(b_ptr.add(k_tile.start)) };
             let b = if CAST_B_U8 {
                 i8_ops.xor(b, bit_flip_mask)
             } else {
@@ -1057,8 +1064,8 @@ unsafe fn simd_int8_gemv_transposed<I: Isa, const CAST_B_U8: bool>(
         let mut col_sum = ops.sum(col_sum);
 
         for k in k_tiles.remainder() {
-            let a = *a_ptr.add(k) as i32;
-            let b = *b_ptr.add(k) as i32;
+            let a = unsafe { *a_ptr.add(k) } as i32;
+            let b = unsafe { *b_ptr.add(k) } as i32;
             let b = if CAST_B_U8 { b + b_zero_shift } else { b };
             acc += a * b;
             col_sum += b;
@@ -1070,11 +1077,11 @@ unsafe fn simd_int8_gemv_transposed<I: Isa, const CAST_B_U8: bool>(
             .unwrap_or(b_zero_shift);
         let acc = (depth as i32 * a_zero * b_zero) + acc - row_sum * b_zero - col_sum * a_zero;
 
-        let out_ptr = out.data.get_unchecked_mut(col);
+        let out_ptr = unsafe { out.data.get_unchecked_mut(col) };
         if !out.beta {
             out_ptr.write(acc);
         } else {
-            out_ptr.write(out_ptr.assume_init() + acc);
+            out_ptr.write(unsafe { out_ptr.assume_init() } + acc);
         }
     }
 }

--- a/rten-gemm/src/kernels/wasm.rs
+++ b/rten-gemm/src/kernels/wasm.rs
@@ -143,37 +143,43 @@ unsafe impl Kernel<f32, f32, f32> for WasmKernel {
             (tmp_tile.as_mut_ptr() as *mut f32, NR, 0.)
         };
 
-        let gemm = GemmDispatch::<_, MR, NR_REGS>::new(
-            self.isa,
-            dest_ptr,
-            dest_row_stride,
-            a,
-            b,
-            depth,
-            alpha,
-            dest_beta,
-        );
+        let gemm = unsafe {
+            GemmDispatch::<_, MR, NR_REGS>::new(
+                self.isa,
+                dest_ptr,
+                dest_row_stride,
+                a,
+                b,
+                depth,
+                alpha,
+                dest_beta,
+            )
+        };
 
-        match used_rows {
-            8 => gemm.dispatch::<8>(),
-            7 => gemm.dispatch::<7>(),
-            6 => gemm.dispatch::<6>(),
-            5 => gemm.dispatch::<5>(),
-            4 => gemm.dispatch::<4>(),
-            3 => gemm.dispatch::<3>(),
-            2 => gemm.dispatch::<2>(),
-            1 => gemm.dispatch::<1>(),
-            _ => panic!("unsupported `used_rows` {}", used_rows),
+        unsafe {
+            match used_rows {
+                8 => gemm.dispatch::<8>(),
+                7 => gemm.dispatch::<7>(),
+                6 => gemm.dispatch::<6>(),
+                5 => gemm.dispatch::<5>(),
+                4 => gemm.dispatch::<4>(),
+                3 => gemm.dispatch::<3>(),
+                2 => gemm.dispatch::<2>(),
+                1 => gemm.dispatch::<1>(),
+                _ => panic!("unsupported `used_rows` {}", used_rows),
+            }
         }
 
         if used_cols != NR {
-            tmp_tile.accumulate_into(
-                tile_ptr as *mut MaybeUninit<f32>,
-                used_rows,
-                used_cols,
-                tile_row_stride,
-                beta,
-            );
+            unsafe {
+                tmp_tile.accumulate_into(
+                    tile_ptr as *mut MaybeUninit<f32>,
+                    used_rows,
+                    used_cols,
+                    tile_row_stride,
+                    beta,
+                );
+            }
         }
     }
 
@@ -317,22 +323,24 @@ unsafe impl Kernel<u8, i8, i32> for WasmInt8Kernel {
         let (b, b_meta) = packing::int8::extract_packed_b::<{ Self::NR }>(b);
 
         const NR_REGS: usize = WasmInt8Kernel::NR / X32_LANES;
-        simd_int8_gemm::<_, _, { Self::MR }, { Self::NR }, NR_REGS>(
-            self.isa,
-            tile_ptr,
-            tile_row_stride,
-            a_data,
-            b,
-            used_rows,
-            used_cols,
-            depth,
-            beta != 0, // accumulate
-            a_meta.zero_points,
-            b_meta.zero_points,
-            &a_meta.row_sums,
-            &b_meta.col_sums,
-            self.isa,
-        )
+        unsafe {
+            simd_int8_gemm::<_, _, { Self::MR }, { Self::NR }, NR_REGS>(
+                self.isa,
+                tile_ptr,
+                tile_row_stride,
+                a_data,
+                b,
+                used_rows,
+                used_cols,
+                depth,
+                beta != 0, // accumulate
+                a_meta.zero_points,
+                b_meta.zero_points,
+                &a_meta.row_sums,
+                &b_meta.col_sums,
+                self.isa,
+            )
+        }
     }
 
     fn gemv_kernel(

--- a/rten-gemm/src/kernels/x86_64.rs
+++ b/rten-gemm/src/kernels/x86_64.rs
@@ -198,35 +198,41 @@ unsafe impl Kernel<f32, f32, f32> for FmaKernel {
             (tmp_tile.as_mut_ptr() as *mut f32, NR, 0.)
         };
 
-        let gemm = GemmDispatch::<_, MR, NR_REGS>::new(
-            self.isa,
-            dest_ptr,
-            dest_row_stride,
-            a,
-            b,
-            depth,
-            alpha,
-            dest_beta,
-        );
+        let gemm = unsafe {
+            GemmDispatch::<_, MR, NR_REGS>::new(
+                self.isa,
+                dest_ptr,
+                dest_row_stride,
+                a,
+                b,
+                depth,
+                alpha,
+                dest_beta,
+            )
+        };
 
-        match used_rows {
-            6 => gemm.dispatch::<6>(),
-            5 => gemm.dispatch::<5>(),
-            4 => gemm.dispatch::<4>(),
-            3 => gemm.dispatch::<3>(),
-            2 => gemm.dispatch::<2>(),
-            1 => gemm.dispatch::<1>(),
-            _ => panic!("unsupported `used_rows` {}", used_rows),
+        unsafe {
+            match used_rows {
+                6 => gemm.dispatch::<6>(),
+                5 => gemm.dispatch::<5>(),
+                4 => gemm.dispatch::<4>(),
+                3 => gemm.dispatch::<3>(),
+                2 => gemm.dispatch::<2>(),
+                1 => gemm.dispatch::<1>(),
+                _ => panic!("unsupported `used_rows` {}", used_rows),
+            }
         }
 
         if used_cols != NR {
-            tmp_tile.accumulate_into(
-                tile_ptr as *mut MaybeUninit<f32>,
-                used_rows,
-                used_cols,
-                tile_row_stride,
-                beta,
-            );
+            unsafe {
+                tmp_tile.accumulate_into(
+                    tile_ptr as *mut MaybeUninit<f32>,
+                    used_rows,
+                    used_cols,
+                    tile_row_stride,
+                    beta,
+                );
+            }
         }
     }
 
@@ -413,35 +419,41 @@ unsafe impl Kernel<f32, f32, f32> for Avx512Kernel {
             (tmp_tile.as_mut_ptr() as *mut f32, NR, 0.)
         };
 
-        let gemm = GemmDispatch::<_, MR, NR_REGS>::new(
-            self.isa,
-            dest_ptr,
-            dest_row_stride,
-            a,
-            b,
-            depth,
-            alpha,
-            dest_beta,
-        );
+        let gemm = unsafe {
+            GemmDispatch::<_, MR, NR_REGS>::new(
+                self.isa,
+                dest_ptr,
+                dest_row_stride,
+                a,
+                b,
+                depth,
+                alpha,
+                dest_beta,
+            )
+        };
 
-        match used_rows {
-            6 => gemm.dispatch::<6>(),
-            5 => gemm.dispatch::<5>(),
-            4 => gemm.dispatch::<4>(),
-            3 => gemm.dispatch::<3>(),
-            2 => gemm.dispatch::<2>(),
-            1 => gemm.dispatch::<1>(),
-            _ => panic!("unsupported `used_rows` {}", used_rows),
+        unsafe {
+            match used_rows {
+                6 => gemm.dispatch::<6>(),
+                5 => gemm.dispatch::<5>(),
+                4 => gemm.dispatch::<4>(),
+                3 => gemm.dispatch::<3>(),
+                2 => gemm.dispatch::<2>(),
+                1 => gemm.dispatch::<1>(),
+                _ => panic!("unsupported `used_rows` {}", used_rows),
+            }
         }
 
         if used_cols != NR {
-            tmp_tile.accumulate_into(
-                tile_ptr as *mut MaybeUninit<f32>,
-                used_rows,
-                used_cols,
-                tile_row_stride,
-                beta,
-            );
+            unsafe {
+                tmp_tile.accumulate_into(
+                    tile_ptr as *mut MaybeUninit<f32>,
+                    used_rows,
+                    used_cols,
+                    tile_row_stride,
+                    beta,
+                );
+            }
         }
     }
 
@@ -621,22 +633,24 @@ unsafe impl Kernel<u8, i8, i32> for Avx2Int8Kernel {
         let (b, b_meta) = packing::int8::extract_packed_b::<{ Self::NR }>(b);
 
         const NR_REGS: usize = Avx2Int8Kernel::NR / AVX2_X32_LANES;
-        simd_int8_gemm::<_, _, { Self::MR }, { Self::NR }, NR_REGS>(
-            self.isa,
-            tile_ptr,
-            tile_row_stride,
-            a_data,
-            b,
-            used_rows,
-            used_cols,
-            depth,
-            beta != 0, // accumulate
-            a_meta.zero_points,
-            b_meta.zero_points,
-            &a_meta.row_sums,
-            &b_meta.col_sums,
-            self.isa,
-        )
+        unsafe {
+            simd_int8_gemm::<_, _, { Self::MR }, { Self::NR }, NR_REGS>(
+                self.isa,
+                tile_ptr,
+                tile_row_stride,
+                a_data,
+                b,
+                used_rows,
+                used_cols,
+                depth,
+                beta != 0, // accumulate
+                a_meta.zero_points,
+                b_meta.zero_points,
+                &a_meta.row_sums,
+                &b_meta.col_sums,
+                self.isa,
+            )
+        }
     }
 
     fn gemv_kernel(
@@ -848,39 +862,43 @@ unsafe impl Kernel<u8, i8, i32> for Avx512Int8Kernel {
 
         const NR_REGS: usize = Avx512Int8Kernel::NR / AVX512_X32_LANES;
         if let Some(vnni_dot) = self.vnni_dot {
-            simd_int8_gemm::<_, _, { Self::MR }, { Self::NR }, NR_REGS>(
-                self.isa,
-                tile_ptr,
-                tile_row_stride,
-                a_data,
-                b,
-                used_rows,
-                used_cols,
-                depth,
-                beta != 0, // accumulate
-                a_meta.zero_points,
-                b_meta.zero_points,
-                &a_meta.row_sums,
-                &b_meta.col_sums,
-                vnni_dot,
-            )
+            unsafe {
+                simd_int8_gemm::<_, _, { Self::MR }, { Self::NR }, NR_REGS>(
+                    self.isa,
+                    tile_ptr,
+                    tile_row_stride,
+                    a_data,
+                    b,
+                    used_rows,
+                    used_cols,
+                    depth,
+                    beta != 0, // accumulate
+                    a_meta.zero_points,
+                    b_meta.zero_points,
+                    &a_meta.row_sums,
+                    &b_meta.col_sums,
+                    vnni_dot,
+                )
+            }
         } else {
-            simd_int8_gemm::<_, _, { Self::MR }, { Self::NR }, NR_REGS>(
-                self.isa,
-                tile_ptr,
-                tile_row_stride,
-                a_data,
-                b,
-                used_rows,
-                used_cols,
-                depth,
-                beta != 0, // accumulate
-                a_meta.zero_points,
-                b_meta.zero_points,
-                &a_meta.row_sums,
-                &b_meta.col_sums,
-                self.isa, // Use non-VNNI dot product
-            )
+            unsafe {
+                simd_int8_gemm::<_, _, { Self::MR }, { Self::NR }, NR_REGS>(
+                    self.isa,
+                    tile_ptr,
+                    tile_row_stride,
+                    a_data,
+                    b,
+                    used_rows,
+                    used_cols,
+                    depth,
+                    beta != 0, // accumulate
+                    a_meta.zero_points,
+                    b_meta.zero_points,
+                    &a_meta.row_sums,
+                    &b_meta.col_sums,
+                    self.isa, // Use non-VNNI dot product
+                )
+            }
         }
     }
 
@@ -1007,12 +1025,14 @@ unsafe fn avx512_vnni_u8i8i32_dot_product(a: I8x64, b: I8x64, mut c: I32x16) -> 
     // By using asm we can use this instruction after a dynamic flag check
     // within the kernel.
     use std::arch::asm;
-    asm! {
-        "vpdpbusd {result}, {a}, {b}",
-        result = inout(zmm_reg) c.0,
-        a = in(zmm_reg) a.0,
-        b = in(zmm_reg) b.0,
-        options(nostack)
+    unsafe {
+        asm! {
+            "vpdpbusd {result}, {a}, {b}",
+            result = inout(zmm_reg) c.0,
+            a = in(zmm_reg) a.0,
+            b = in(zmm_reg) b.0,
+            options(nostack)
+        }
     }
     c
 }


### PR DESCRIPTION
Remove the module-level `allow(unsafe_op_in_unsafe_fn)` from `rten-gemm/src/kernels.rs` and add `unsafe` blocks around the individual unsafe operations. The module-level suppression was originally used to make migration to Rust 2024 easier.