### PR TITLE
fix(protobuf): avoid unbounded allocation in ValueReader::read_bytes (CWE-770)

### DIFF
--- a/rten-onnx/src/protobuf/value.rs
+++ b/rten-onnx/src/protobuf/value.rs
@@ -136,8 +136,26 @@ impl<R: BufRead + Seek + Position> ReadValue for ValueReader<R> {
         &mut self,
         len: usize,
     ) -> Result<<Self::Types as FieldTypes>::Bytes, ProtobufError> {
-        let mut buf = vec![0; len];
-        self.inner.read_exact(&mut buf)?;
+        // Read exactly `len` bytes, growing the buffer incrementally instead of
+        // pre-allocating `vec![0; len]`. `len` is attacker-controlled (it comes
+        // from the protobuf wire), so a pre-allocation would let a malicious
+        // model request an arbitrarily large allocation before any of the
+        // declared bytes are actually read. This is an unbounded allocation
+        // (CWE-770) that can exhaust memory when parsing an untrusted model.
+        // Reading in chunks bounds the peak allocation to the number of bytes
+        // that are actually present, turning the DoS into a graceful error.
+        let mut buf = Vec::new();
+        let mut remaining = len;
+        let mut chunk = [0u8; 8192];
+        while remaining > 0 {
+            let to_read = remaining.min(chunk.len());
+            let n = self.inner.read(&mut chunk[..to_read])?;
+            if n == 0 {
+                return Err(ProtobufError::new(ErrorKind::Eof));
+            }
+            buf.extend_from_slice(&chunk[..n]);
+            remaining -= n;
+        }
         Ok(buf)
     }
 

--- a/rten-onnx/tests/untrusted_protobuf_alloc.rs
+++ b/rten-onnx/tests/untrusted_protobuf_alloc.rs
@@ -1,0 +1,77 @@
+//! 回归测试：手写 protobuf 解析器的 length-delimited 字段不得按线缆声明长度预分配。
+//!
+//! `ValueReader::read_bytes(len)` 的 `len` 来自不可信的 ONNX 模型文件（protobuf 线缆）。
+//! 旧实现 `vec![0; len]` 会在读取真实字节前先申请 `len` 字节，恶意模型把某字段
+//! `len` 声明成数 GiB 即可触发内存耗尽型 DoS（CWE-770）。修复后改为按实际可读
+//! 字节增量读取，峰值分配量被真实数据量限制。
+//!
+//! 本测试用进程级计数分配器记录「单次最大分配请求」：
+//!   - 修复版：峰值远小于阈值（仅分配真实存在的少量字节）
+//!   - 漏洞版（`git stash` 回退 src 后）：`vec![0; 256 MiB]` 单次请求远超阈值 → 断言失败
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use rten_onnx::protobuf::{Fields, ValueReader};
+
+/// 进程级分配器：转发给系统分配器，并记录见过的最大单次请求尺寸。
+struct CountingAllocator {
+    max_request: AtomicUsize,
+}
+
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        self.record(layout.size());
+        unsafe { System.alloc(layout) }
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) }
+    }
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        self.record(new_size);
+        unsafe { System.realloc(ptr, layout, new_size) }
+    }
+}
+
+impl CountingAllocator {
+    fn record(&self, size: usize) {
+        let mut cur = self.max_request.load(Ordering::Relaxed);
+        while size > cur {
+            match self.max_request.compare_exchange_weak(cur, size, Ordering::Relaxed, Ordering::Relaxed) {
+                Ok(_) => break,
+                Err(c) => cur = c,
+            }
+        }
+    }
+}
+
+#[global_allocator]
+static ALLOC: CountingAllocator = CountingAllocator {
+    max_request: AtomicUsize::new(0),
+};
+
+#[test]
+fn untrusted_length_delimited_does_not_preallocate() {
+    // 构造一个 protobuf 消息：字段 1、wire type 2（length-delimited），
+    // 声明长度 = 256 MiB（varint 0x80 0x80 0x80 0x80 0x10），但仅 4 字节真实载荷。
+    // 模拟恶意 ONNX 模型把 TensorProto.raw_data / String / 内嵌消息的声明长度夸大。
+    let mut bytes: Vec<u8> = vec![0x0A]; // tag: field 1, wire type 2
+    bytes.extend_from_slice(&[0x80, 0x80, 0x80, 0x80, 0x10]); // len = 4 GiB (4294967296)
+    bytes.extend_from_slice(&[1, 2, 3, 4]); // 4 字节真实载荷
+
+    let mut reader = ValueReader::from_buf(bytes);
+    let mut fields = Fields::new(&mut reader, None);
+    let mut field = fields.next().unwrap().unwrap();
+    let result = field.read_bytes();
+
+    // 截断的字段必须优雅报错，而不是静默成功或崩溃。
+    assert!(result.is_err(), "截断的 length-delimited 字段应返回错误");
+
+    // 峰值单次分配必须远小于声明长度（4 GiB）。修复版只分配真实存在的 4 字节，
+    // 漏洞版会 `vec![0; 4 GiB]` 一次性请求 4294967296 字节。
+    let max_request = ALLOC.max_request.load(Ordering::Relaxed);
+    assert!(
+        max_request < 64 * 1024 * 1024,
+        "峰值单次分配 {max_request} 字节 >= 64 MiB 阈值，说明仍按不可信声明长度预分配（CWE-770）"
+    );
+}


### PR DESCRIPTION
## Summary

`ValueReader::read_bytes` (in `rten-onnx/src/protobuf/value.rs`) allocated
`vec![0; len]` where `len` comes directly from the protobuf wire — the length
prefix of a length-delimited field. ONNX models are untrusted input (downloaded
from the internet or supplied by users), so a crafted model can declare an
arbitrarily large length for any `bytes` field (e.g. `TensorProto.raw_data`, a
string field, or an embedded message) and force the parser to allocate that
many bytes **before** reading any of the declared data. This is an unbounded
allocation (CWE-770) that causes a denial of service.

## Details

The vulnerable code:

```rust
fn read_bytes(&mut self, len: usize) -> Result<Vec<u8>, ProtobufError> {
    let mut buf = vec![0; len];          // <-- len from the untrusted wire
    self.inner.read_exact(&mut buf)?;
    Ok(buf)
}
```

`len` is attacker-controlled. The surrounding `LimitReader` only bounds how
*many* bytes may be *read*, not how many may be *allocated* — its
`check_has_bytes` guard compares against `end = position + len`, which is
exactly the declared length, so it never rejects an oversized request. As a
result a 10-byte field declaring a 4 GiB length makes the parser request a
~4.29 billion× amplification allocation up front. On memory-constrained hosts
this aborts the process via `handle_alloc_error`; on larger hosts it silently
commits gigabytes for data that is not present.

## Impact

| | Vulnerable | Fixed |
|---|---|---|
| Peak allocation for a field declaring `len = 4 GiB` with 4 bytes of real payload | ~4 GiB (4294967296 B) requested immediately | bounded by the 4 real bytes present |
| Outcome on truncated/malicious input | memory-exhaustion DoS (abort or huge commit) | graceful `Eof` error |
| Legitimate inputs (incl. large real weight tensors) | unchanged | unchanged |

## Fix

Read exactly `len` bytes by growing the buffer from the bytes that are actually
present, instead of pre-allocating `len`:

```rust
fn read_bytes(&mut self, len: usize) -> Result<Vec<u8>, ProtobufError> {
    let mut buf = Vec::new();
    let mut remaining = len;
    let mut chunk = [0u8; 8192];
    while remaining > 0 {
        let to_read = remaining.min(chunk.len());
        let n = self.inner.read(&mut chunk[..to_read])?;
        if n == 0 {
            return Err(ProtobufError::new(ErrorKind::Eof));
        }
        buf.extend_from_slice(&chunk[..n]);
        remaining -= n;
    }
    Ok(buf)
}
```

No API change and no behaviour change for valid inputs: a field still yields
exactly `len` bytes when they are present, and a truncated field still errors —
just without the unbounded upfront allocation.

## Testing

- Added `rten-onnx/tests/untrusted_protobuf_alloc.rs`. It installs a
  process-global counting allocator and parses a length-delimited field that
  declares a 4 GiB length but carries only 4 bytes of payload. It asserts the
  parse returns an error **and** that the peak single allocation stays well
  below the declared length.
- Verified bidirectionally: with the old `vec![0; len]` the test fails (peak
  allocation = 4294967296 B); with the fix it passes.
- All existing `rten-onnx` unit tests still pass (`test_read_bytes`,
  `test_read_string`, `test_read_message`, `test_decode_mnist`, …), confirming
  normal protobuf parsing is unaffected.

## Notes

- No CVE requested; happy to help open a RustSec / GHSA advisory if you'd like
  one, since ONNX models are a clear untrusted-input boundary.
- I have not modified `Cargo.toml`; the new test file is auto-discovered via
  `autotests`.
