### PR TITLE
Add `TensorBase::bit_cast` method

### DIFF
--- a/rten-base/src/byte_cast.rs
+++ b/rten-base/src/byte_cast.rs
@@ -10,6 +10,9 @@ use std::mem::{ManuallyDrop, MaybeUninit};
 /// This type must only be implemented for `Copy` types which contain no
 /// padding.
 pub unsafe trait ToByteArray: Copy {
+    /// Array of bytes whose length is equal to the alignment of the type.
+    type Align: AsRef<[u8]>;
+
     /// View of this type as an array of bytes.
     type Bytes: AsRef<[u8]>;
 
@@ -22,6 +25,7 @@ pub unsafe trait ToByteArray: Copy {
 macro_rules! impl_to_byte_array {
     ($type:ty) => {
         unsafe impl ToByteArray for $type {
+            type Align = [u8; align_of::<$type>()];
             type Bytes = [u8; size_of::<$type>()];
 
             fn to_bytes(self) -> Self::Bytes {
@@ -43,6 +47,7 @@ impl_to_byte_array!(f32);
 impl_to_byte_array!(f64);
 
 unsafe impl ToByteArray for bool {
+    type Align = [u8; 1];
     type Bytes = [u8; 1];
 
     fn to_bytes(self) -> [u8; 1] {

--- a/rten-tensor/src/storage.rs
+++ b/rten-tensor/src/storage.rs
@@ -6,6 +6,8 @@ use std::mem::MaybeUninit;
 use std::ops::Range;
 use std::sync::Arc;
 
+use rten_base::byte_cast::{FromByteArray, ToByteArray, cast_vec};
+
 use crate::assume_init::AssumeInit;
 
 /// Trait for backing storage used by tensors and views.
@@ -251,6 +253,19 @@ pub unsafe trait StorageMut: Storage {
     }
 }
 
+/// Reinterpret the bytes of this storage as type `U`.
+///
+/// The storage's element type [`Storage::Elem`] and `U` must both be `Copy`
+/// types with no padding and the same size and alignment, for which any bit
+/// pattern is valid.
+///
+/// This is a cheap operation which does not copy the data.
+pub trait CastStorage<U>: Storage {
+    type Output: Storage;
+
+    fn bit_cast(self) -> Self::Output;
+}
+
 unsafe impl<T> Storage for Vec<T> {
     type Elem = T;
 
@@ -262,6 +277,18 @@ unsafe impl<T> Storage for Vec<T> {
 
     fn as_ptr(&self) -> *const T {
         self.as_ptr()
+    }
+}
+
+impl<T: ToByteArray, U: FromByteArray> CastStorage<U> for Vec<T>
+where
+    U: FromByteArray<Bytes = T::Bytes, Align = T::Align>,
+{
+    type Output = Vec<U>;
+
+    fn bit_cast(self) -> Self::Output {
+        // T and U have same size and alignment, so cast always succeeds.
+        cast_vec::<T, U>(self).unwrap()
     }
 }
 
@@ -380,6 +407,23 @@ unsafe impl<T> Storage for ViewData<'_, T> {
     }
 }
 
+impl<'a, T: ToByteArray + 'static, U: FromByteArray + 'static> CastStorage<U> for ViewData<'a, T>
+where
+    U: FromByteArray<Bytes = T::Bytes, Align = T::Align>,
+{
+    type Output = ViewData<'a, U>;
+
+    fn bit_cast(self) -> Self::Output {
+        // Types T and U have the same size and alignment and any bit pattern
+        // is valid for both. Hence we can re-interpret `self.ptr as *const U`.
+        ViewData {
+            ptr: self.ptr as *const U,
+            len: self.len,
+            _marker: PhantomData,
+        }
+    }
+}
+
 impl<'a, T> AssumeInit for ViewData<'a, MaybeUninit<T>> {
     type Output = ViewData<'a, T>;
 
@@ -478,6 +522,23 @@ unsafe impl<T> StorageMut for ViewMutData<'_, T> {
     }
 }
 
+impl<'a, T: ToByteArray + 'static, U: FromByteArray + 'static> CastStorage<U> for ViewMutData<'a, T>
+where
+    U: FromByteArray<Bytes = T::Bytes, Align = T::Align>,
+{
+    type Output = ViewMutData<'a, U>;
+
+    fn bit_cast(self) -> Self::Output {
+        // Types T and U have the same size and alignment and any bit pattern
+        // is valid for both. Hence we can re-interpret `self.ptr as *mut U`.
+        ViewMutData {
+            ptr: self.ptr as *mut U,
+            len: self.len,
+            _marker: PhantomData,
+        }
+    }
+}
+
 impl<'a, T> AssumeInit for ViewMutData<'a, MaybeUninit<T>> {
     type Output = ViewMutData<'a, T>;
 
@@ -527,6 +588,20 @@ where
         match self {
             Cow::Owned(vec) => CowData::Owned(vec),
             Cow::Borrowed(slice) => CowData::Borrowed(slice.into_storage()),
+        }
+    }
+}
+
+impl<'a, T: ToByteArray + 'static, U: FromByteArray + 'static> CastStorage<U> for CowData<'a, T>
+where
+    U: FromByteArray<Bytes = T::Bytes, Align = T::Align>,
+{
+    type Output = CowData<'a, U>;
+
+    fn bit_cast(self) -> Self::Output {
+        match self {
+            CowData::Owned(vec) => CowData::Owned(vec.bit_cast()),
+            CowData::Borrowed(view) => CowData::Borrowed(view.bit_cast()),
         }
     }
 }

--- a/rten-tensor/src/tensor.rs
+++ b/rten-tensor/src/tensor.rs
@@ -22,7 +22,8 @@ use crate::layout::{
 use crate::overlap::may_have_internal_overlap;
 use crate::slice_range::{IntoSliceItems, SliceItem};
 use crate::storage::{
-    Alloc, CowData, GlobalAlloc, IntoStorage, Storage, StorageMut, ViewData, ViewMutData,
+    Alloc, CastStorage, CowData, GlobalAlloc, IntoStorage, Storage, StorageMut, ViewData,
+    ViewMutData,
 };
 use crate::type_num::IndexCount;
 use crate::{Contiguous, RandomSource};
@@ -745,6 +746,21 @@ impl<S: Storage, L: Layout> TensorBase<S, L> {
     /// Return a raw pointer to the tensor's underlying data.
     pub fn data_ptr(&self) -> *const S::Elem {
         self.data.as_ptr()
+    }
+
+    /// Reinterpret the bytes of this tensor as type `U`.
+    ///
+    /// Types `T` and `U` must be `Copy` types with the same size and alignment,
+    /// with no padding and for which any bit pattern is valid.
+    pub fn bit_cast<U>(self) -> TensorBase<<S as CastStorage<U>>::Output, L>
+    where
+        S: CastStorage<U>,
+    {
+        let TensorBase { data, layout } = self;
+        TensorBase {
+            data: data.bit_cast(),
+            layout,
+        }
     }
 }
 

--- a/rten-tensor/src/tensor/tests.rs
+++ b/rten-tensor/src/tensor/tests.rs
@@ -302,6 +302,35 @@ fn test_axis_iter_mut() {
 }
 
 #[test]
+fn test_bit_cast() {
+    // Owned
+    let tensor = NdTensor::from([[1i32, 2], [3, 4]]);
+    let unsigned_tensor = tensor.bit_cast::<u32>();
+    assert_eq!(unsigned_tensor, NdTensor::from([[1u32, 2], [3, 4]]));
+
+    // View
+    let tensor = NdTensor::from([[1i32, 2], [3, 4]]);
+    let unsigned_tensor = tensor.view().bit_cast::<u32>();
+    assert_eq!(unsigned_tensor, NdTensor::from([[1u32, 2], [3, 4]]).view());
+
+    // Cow (borrowed)
+    let tensor = NdTensor::from([[1i32, 2], [3, 4]]);
+    let unsigned_tensor = tensor.as_cow().bit_cast::<u32>();
+    assert_eq!(
+        unsigned_tensor,
+        NdTensor::from([[1u32, 2], [3, 4]]).as_cow()
+    );
+
+    // Cow (owned)
+    let tensor = NdTensor::from([[1i32, 2], [3, 4]]);
+    let unsigned_tensor = tensor.into_cow().bit_cast::<u32>();
+    assert_eq!(
+        unsigned_tensor,
+        NdTensor::from([[1u32, 2], [3, 4]]).into_cow()
+    );
+}
+
+#[test]
 fn test_broadcast() {
     let data = vec![1., 2., 3., 4.];
     let dest_shape = [3, 1, 2, 2];


### PR DESCRIPTION
This reinterprets the bytes of a tensor's storage as a different type without copying. The source and target types must be `Copy` types with the same size and alignment, no padding and for which any bit pattern is valid. For example: `i32`, `u32` and `f32` are all bit-castable to each other.