### PR TITLE
Remove `.rten` format from default features for `rten` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,7 @@ serde_json = { workspace = true }
 crate-type = ["lib", "cdylib"]
 
 [features]
-default = ["contrib", "onnx_format", "rten_format"]
+default = ["contrib", "onnx_format"]
 
 # Enable all features that affect supported operators
 all-ops = ["fft", "random"]

--- a/rten-cli/Cargo.toml
+++ b/rten-cli/Cargo.toml
@@ -27,6 +27,9 @@ features = ["serde"]
 [dev-dependencies]
 rten-testing = { path = "../rten-testing" }
 
+[features]
+rten_format = ["rten/rten_format"]
+
 [lints.clippy]
 uninlined_format_args = "allow"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,7 +144,7 @@
 //!  - **mmap** - Enable loading models with memory mapping via [`Model::load_mmap`]
 //!  - **onnx_format** (enabled by default) - Enables support for loading `.onnx` models.
 //!  - **random** - Enables operators that generate random numbers
-//!  - **rten_format** (enabled by default) - Enables support for loading `.rten` models. This is
+//!  - **rten_format** - Enables support for loading `.rten` models. This is
 //!    a deprecated alternative model format.
 //!  - **wasm_api** - Generate WebAssembly API using wasm-bindgen
 //!

--- a/src/model.rs
+++ b/src/model.rs
@@ -38,7 +38,7 @@ pub use metadata::ModelMetadata;
 use file_type::FileType;
 use load_error::LoadErrorImpl;
 
-#[cfg(test)]
+#[cfg(all(test, feature = "rten_format"))]
 pub mod rten_builder;
 
 #[cfg(all(test, feature = "onnx_format"))]
@@ -975,9 +975,11 @@ mod tests {
         GraphProtoExt, ModelProtoExt, NodeProtoExt, ToTensorProto, ValueInfoProtoExt, create_node,
         create_tensor_from_view, create_value_info,
     };
+    #[cfg(feature = "rten_format")]
     use crate::model::rten_builder::{MetadataArgs, ModelBuilder, ModelFormat, OpType};
     use crate::model::{LoadErrorKind, Model, ModelOptions};
     use crate::op_registry;
+    #[cfg(feature = "rten_format")]
     use crate::ops;
     use crate::value::{DataType, Value, ValueType};
 
@@ -1031,6 +1033,7 @@ mod tests {
 
     /// Version of [`generate_model_buffer`] which creates a model in the
     /// `.rten` format.
+    #[cfg(feature = "rten_format")]
     fn generate_rten_model_buffer(format: ModelFormat) -> Vec<u8> {
         let mut builder = ModelBuilder::new(format);
         let mut graph_builder = builder.graph_builder();
@@ -1196,10 +1199,12 @@ mod tests {
                 buffer: generate_model_buffer(),
                 opts: None,
             },
+            #[cfg(feature = "rten_format")]
             Case {
                 buffer: generate_rten_model_buffer(ModelFormat::V1),
                 opts: None,
             },
+            #[cfg(feature = "rten_format")]
             Case {
                 buffer: generate_rten_model_buffer(ModelFormat::V2),
                 opts: None,
@@ -1264,6 +1269,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "rten_format")]
     #[test]
     fn test_load_invalid_model() {
         struct Case {


### PR DESCRIPTION
As part of https://github.com/robertknight/rten/issues/1470, make support for the `.rten` format opt-in rather than opt-out.

Various crate tests which rely on the `.rten` format are currently failing. I need to port these to use the ONNX format first and then rebase.