### PR TITLE
Support serializing ONNX models in rten-onnx

### DIFF
--- a/rten-onnx/src/onnx.rs
+++ b/rten-onnx/src/onnx.rs
@@ -11,7 +11,10 @@ use std::cell::RefCell;
 use std::fmt;
 use std::fs::File;
 
-use crate::protobuf::{DecodeMessage, Fields, OwnedValues, ProtobufError, ReadValue, ValueReader};
+use crate::protobuf::{
+    DecodeMessage, EncodeMessage, Fields, MessageWriter, OwnedValues, ProtobufError, ReadValue,
+    ValueReader, ValueWriter, WriteValue,
+};
 
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub struct AttributeType(pub i32);
@@ -101,6 +104,39 @@ impl DecodeMessage for AttributeProto {
     }
 }
 
+impl EncodeMessage for AttributeProto {
+    fn encode_fields<W: WriteValue>(
+        &self,
+        fields: &mut MessageWriter<W>,
+    ) -> Result<(), ProtobufError> {
+        if let Some(name) = &self.name {
+            fields.write_string(Self::NAME, name)?;
+        }
+        if let Some(f) = self.f {
+            fields.write_float(Self::F, f)?;
+        }
+        if let Some(i) = self.i {
+            fields.write_int64(Self::I, i)?;
+        }
+        if let Some(s) = &self.s {
+            fields.write_string(Self::S, s)?;
+        }
+        if let Some(t) = &self.t {
+            fields.write_message(Self::T, t)?;
+        }
+        if let Some(g) = &self.g {
+            fields.write_message(Self::G, g)?;
+        }
+        fields.write_repeated_float(Self::FLOATS, &self.floats)?;
+        fields.write_repeated_int64(Self::INTS, &self.ints)?;
+        fields.write_repeated_string(Self::STRINGS, &self.strings)?;
+        if let Some(ty) = self.r#type {
+            fields.write_enum(Self::TYPE, ty.0)?;
+        }
+        Ok(())
+    }
+}
+
 #[derive(Clone, Debug, Default)]
 pub struct NodeProto {
     pub domain: Option<String>,
@@ -154,6 +190,27 @@ impl DecodeMessage for NodeProto {
             }
         }
         Ok(msg)
+    }
+}
+
+impl EncodeMessage for NodeProto {
+    fn encode_fields<W: WriteValue>(
+        &self,
+        fields: &mut MessageWriter<W>,
+    ) -> Result<(), ProtobufError> {
+        fields.write_repeated_string(Self::INPUT, &self.input)?;
+        fields.write_repeated_string(Self::OUTPUT, &self.output)?;
+        if let Some(name) = &self.name {
+            fields.write_string(Self::NAME, name)?;
+        }
+        if let Some(op_type) = &self.op_type {
+            fields.write_string(Self::OP_TYPE, op_type)?;
+        }
+        fields.write_repeated_message(Self::ATTRIBUTE, &self.attribute)?;
+        if let Some(domain) = &self.domain {
+            fields.write_string(Self::DOMAIN, domain)?;
+        }
+        Ok(())
     }
 }
 
@@ -256,6 +313,33 @@ impl DecodeMessage for TensorProto {
             }
         }
         Ok(msg)
+    }
+}
+
+impl EncodeMessage for TensorProto {
+    fn encode_fields<W: WriteValue>(
+        &self,
+        fields: &mut MessageWriter<W>,
+    ) -> Result<(), ProtobufError> {
+        fields.write_repeated_int64(Self::DIMS, &self.dims)?;
+        if let Some(data_type) = self.data_type {
+            fields.write_enum(Self::DATA_TYPE, data_type.0)?;
+        }
+        fields.write_packed_float(Self::FLOAT_DATA, &self.float_data)?;
+        fields.write_packed_int32(Self::INT32_DATA, &self.int32_data)?;
+        fields.write_packed_int64(Self::INT64_DATA, &self.int64_data)?;
+        if let Some(name) = &self.name {
+            fields.write_string(Self::NAME, name)?;
+        }
+        if let Some(raw_data) = &self.raw_data {
+            fields.write_bytes(Self::RAW_DATA, raw_data.borrow().as_slice())?;
+        }
+        fields.write_packed_double(Self::DOUBLE_DATA, &self.double_data)?;
+        fields.write_repeated_message(Self::EXTERNAL_DATA, &self.external_data)?;
+        if let Some(data_location) = self.data_location {
+            fields.write_enum(Self::DATA_LOCATION, data_location.0)?;
+        }
+        Ok(())
     }
 }
 
@@ -371,6 +455,21 @@ impl DecodeMessage for Dimension {
     }
 }
 
+impl EncodeMessage for Dimension {
+    fn encode_fields<W: WriteValue>(
+        &self,
+        fields: &mut MessageWriter<W>,
+    ) -> Result<(), ProtobufError> {
+        if let Some(dim_value) = self.dim_value {
+            fields.write_int64(Self::DIM_VALUE, dim_value)?;
+        }
+        if let Some(dim_param) = &self.dim_param {
+            fields.write_string(Self::DIM_PARAM, dim_param)?;
+        }
+        Ok(())
+    }
+}
+
 #[derive(Clone, Debug, Default)]
 pub struct StringStringEntryProto {
     pub key: Option<String>,
@@ -403,6 +502,21 @@ impl DecodeMessage for StringStringEntryProto {
             }
         }
         Ok(msg)
+    }
+}
+
+impl EncodeMessage for StringStringEntryProto {
+    fn encode_fields<W: WriteValue>(
+        &self,
+        fields: &mut MessageWriter<W>,
+    ) -> Result<(), ProtobufError> {
+        if let Some(key) = &self.key {
+            fields.write_string(Self::KEY, key)?;
+        }
+        if let Some(value) = &self.value {
+            fields.write_string(Self::VALUE, value)?;
+        }
+        Ok(())
     }
 }
 
@@ -441,6 +555,21 @@ impl DecodeMessage for OperatorSetIdProto {
     }
 }
 
+impl EncodeMessage for OperatorSetIdProto {
+    fn encode_fields<W: WriteValue>(
+        &self,
+        fields: &mut MessageWriter<W>,
+    ) -> Result<(), ProtobufError> {
+        if let Some(domain) = &self.domain {
+            fields.write_string(Self::DOMAIN, domain)?;
+        }
+        if let Some(version) = self.version {
+            fields.write_int64(Self::VERSION, version)?;
+        }
+        Ok(())
+    }
+}
+
 #[derive(Clone, Debug, Default)]
 pub struct TensorShapeProto {
     pub dim: Vec<Dimension>,
@@ -468,6 +597,16 @@ impl DecodeMessage for TensorShapeProto {
             }
         }
         Ok(msg)
+    }
+}
+
+impl EncodeMessage for TensorShapeProto {
+    fn encode_fields<W: WriteValue>(
+        &self,
+        fields: &mut MessageWriter<W>,
+    ) -> Result<(), ProtobufError> {
+        fields.write_repeated_message(Self::DIM, &self.dim)?;
+        Ok(())
     }
 }
 
@@ -506,6 +645,21 @@ impl DecodeMessage for TypeProtoTensor {
     }
 }
 
+impl EncodeMessage for TypeProtoTensor {
+    fn encode_fields<W: WriteValue>(
+        &self,
+        fields: &mut MessageWriter<W>,
+    ) -> Result<(), ProtobufError> {
+        if let Some(elem_type) = self.elem_type {
+            fields.write_enum(Self::ELEM_TYPE, elem_type.0)?;
+        }
+        if let Some(shape) = &self.shape {
+            fields.write_message(Self::SHAPE, shape)?;
+        }
+        Ok(())
+    }
+}
+
 #[derive(Clone, Debug, Default)]
 pub struct TypeProtoSequence {
     pub elem_type: Option<TypeProto>,
@@ -533,6 +687,18 @@ impl DecodeMessage for TypeProtoSequence {
             }
         }
         Ok(msg)
+    }
+}
+
+impl EncodeMessage for TypeProtoSequence {
+    fn encode_fields<W: WriteValue>(
+        &self,
+        fields: &mut MessageWriter<W>,
+    ) -> Result<(), ProtobufError> {
+        if let Some(elem_type) = &self.elem_type {
+            fields.write_message(Self::ELEM_TYPE, elem_type)?;
+        }
+        Ok(())
     }
 }
 
@@ -571,6 +737,21 @@ impl DecodeMessage for TypeProto {
     }
 }
 
+impl EncodeMessage for TypeProto {
+    fn encode_fields<W: WriteValue>(
+        &self,
+        fields: &mut MessageWriter<W>,
+    ) -> Result<(), ProtobufError> {
+        if let Some(tensor_type) = &self.tensor_type {
+            fields.write_message(Self::TENSOR_TYPE, tensor_type)?;
+        }
+        if let Some(sequence) = &self.sequence {
+            fields.write_message(Self::SEQUENCE, sequence.as_ref())?;
+        }
+        Ok(())
+    }
+}
+
 #[derive(Clone, Debug, Default)]
 pub struct ValueInfoProto {
     pub name: Option<String>,
@@ -603,6 +784,21 @@ impl DecodeMessage for ValueInfoProto {
             }
         }
         Ok(msg)
+    }
+}
+
+impl EncodeMessage for ValueInfoProto {
+    fn encode_fields<W: WriteValue>(
+        &self,
+        fields: &mut MessageWriter<W>,
+    ) -> Result<(), ProtobufError> {
+        if let Some(name) = &self.name {
+            fields.write_string(Self::NAME, name)?;
+        }
+        if let Some(ty) = &self.r#type {
+            fields.write_message(Self::TYPE, ty)?;
+        }
+        Ok(())
     }
 }
 
@@ -657,6 +853,20 @@ impl DecodeMessage for GraphProto {
     }
 }
 
+impl EncodeMessage for GraphProto {
+    fn encode_fields<W: WriteValue>(
+        &self,
+        fields: &mut MessageWriter<W>,
+    ) -> Result<(), ProtobufError> {
+        fields.write_repeated_message(Self::NODE, &self.node)?;
+        fields.write_repeated_message(Self::INITIALIZER, &self.initializer)?;
+        fields.write_repeated_message(Self::INPUT, &self.input)?;
+        fields.write_repeated_message(Self::OUTPUT, &self.output)?;
+        fields.write_repeated_message(Self::VALUE_INFO, &self.value_info)?;
+        Ok(())
+    }
+}
+
 #[derive(Default)]
 pub struct ModelProto {
     pub ir_version: Option<i64>,
@@ -675,8 +885,8 @@ impl ModelProto {
     const OPSET_IMPORT: u64 = 8;
     const METADATA_PROPS: u64 = 14;
 
-    // The non-generic `parse_file` and `parse_buf` methods allow the parsing
-    // code to be compiled as part of the rten-onnx crate.
+    // The non-generic `parse_*` and `write_*` methods allow the parsing and
+    // serialization code to be compiled as part of the rten-onnx crate.
 
     /// Deserialize a `ModelProto` from a file.
     pub fn parse_file(file: File) -> Result<Self, ProtobufError> {
@@ -688,6 +898,21 @@ impl ModelProto {
     pub fn parse_buf(buf: &[u8]) -> Result<Self, ProtobufError> {
         let reader = ValueReader::from_buf(buf);
         ModelProto::decode(reader)
+    }
+
+    /// Serialize this model to a file.
+    pub fn write_file(&self, file: File) -> Result<(), ProtobufError> {
+        self.encode(ValueWriter::from_file(file))
+    }
+
+    /// Serialize this model to a buffer.
+    pub fn write_buf(&self) -> Result<Vec<u8>, ProtobufError> {
+        // Size the buffer up front to avoid repeatedly re-allocating and
+        // copying the tensor data as it grows.
+        let len = self.encoded_len()?;
+        let mut buf = Vec::with_capacity(len as usize);
+        self.encode(ValueWriter::new(&mut buf))?;
+        Ok(buf)
     }
 }
 
@@ -726,6 +951,29 @@ impl DecodeMessage for ModelProto {
             }
         }
         Ok(msg)
+    }
+}
+
+impl EncodeMessage for ModelProto {
+    fn encode_fields<W: WriteValue>(
+        &self,
+        fields: &mut MessageWriter<W>,
+    ) -> Result<(), ProtobufError> {
+        if let Some(ir_version) = self.ir_version {
+            fields.write_int64(Self::IR_VERSION, ir_version)?;
+        }
+        if let Some(producer_name) = &self.producer_name {
+            fields.write_string(Self::PRODUCER_NAME, producer_name)?;
+        }
+        if let Some(producer_version) = &self.producer_version {
+            fields.write_string(Self::PRODUCER_VERSION, producer_version)?;
+        }
+        if let Some(graph) = &self.graph {
+            fields.write_message(Self::GRAPH, graph)?;
+        }
+        fields.write_repeated_message(Self::OPSET_IMPORT, &self.opset_import)?;
+        fields.write_repeated_message(Self::METADATA_PROPS, &self.metadata_props)?;
+        Ok(())
     }
 }
 
@@ -786,10 +1034,15 @@ pub fn is_onnx_model(reader: impl ReadValue<Types = OwnedValues>) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use std::cell::RefCell;
     use std::fs::File;
     use std::path::PathBuf;
 
-    use super::{ModelProto, is_onnx_model};
+    use super::{
+        AttributeProto, AttributeType, DataLocation, DataType, Dimension, GraphProto, ModelProto,
+        NodeProto, OperatorSetIdProto, StringStringEntryProto, TensorProto, TensorShapeProto,
+        TypeProto, TypeProtoSequence, TypeProtoTensor, ValueInfoProto, is_onnx_model,
+    };
     use crate::protobuf::{DecodeMessage, ValueReader};
 
     fn test_file_path(path: &str) -> PathBuf {
@@ -852,6 +1105,350 @@ mod tests {
         assert_eq!(graph.input[0].name.as_deref(), Some("input"));
         assert_eq!(graph.output.len(), 1);
         assert_eq!(graph.output[0].name.as_deref(), Some("logits"));
+    }
+
+    /// Create a model which uses every message type and field that this module
+    /// supports.
+    fn create_test_model() -> ModelProto {
+        let raw_data: Vec<u8> = (0..6).flat_map(|i| (i as f32).to_le_bytes()).collect();
+        let raw_init = TensorProto {
+            name: Some("weights".to_string()),
+            dims: vec![2, 3],
+            data_type: Some(DataType::FLOAT),
+            raw_data: Some(RefCell::new(raw_data)),
+            ..Default::default()
+        };
+
+        // Tensor which uses the typed data fields instead of `raw_data`, and
+        // references external data.
+        let typed_init = TensorProto {
+            name: Some("typed".to_string()),
+            dims: vec![2],
+            data_type: Some(DataType::FLOAT),
+            float_data: vec![1.0, 2.0],
+            int32_data: vec![3, -4],
+            int64_data: vec![5, -6],
+            double_data: vec![7.0, 8.0],
+            external_data: vec![StringStringEntryProto {
+                key: Some("location".to_string()),
+                value: Some("weights.bin".to_string()),
+            }],
+            data_location: Some(DataLocation::EXTERNAL),
+            ..Default::default()
+        };
+
+        let subgraph = GraphProto {
+            node: vec![NodeProto {
+                op_type: Some("Identity".to_string()),
+                input: vec!["x".to_string()],
+                output: vec!["y".to_string()],
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        let attrs = vec![
+            AttributeProto {
+                name: Some("float_attr".to_string()),
+                f: Some(0.5),
+                r#type: Some(AttributeType::FLOAT),
+                ..Default::default()
+            },
+            AttributeProto {
+                name: Some("int_attr".to_string()),
+                i: Some(-3),
+                r#type: Some(AttributeType::INT),
+                ..Default::default()
+            },
+            AttributeProto {
+                name: Some("string_attr".to_string()),
+                s: Some("str_value".to_string()),
+                r#type: Some(AttributeType::STRING),
+                ..Default::default()
+            },
+            AttributeProto {
+                name: Some("floats_attr".to_string()),
+                floats: vec![1.0, 2.0],
+                r#type: Some(AttributeType::FLOATS),
+                ..Default::default()
+            },
+            AttributeProto {
+                name: Some("ints_attr".to_string()),
+                ints: vec![3, -4],
+                r#type: Some(AttributeType::INTS),
+                ..Default::default()
+            },
+            AttributeProto {
+                name: Some("strings_attr".to_string()),
+                strings: vec!["a".to_string(), "b".to_string()],
+                ..Default::default()
+            },
+            AttributeProto {
+                name: Some("tensor_attr".to_string()),
+                t: Some(raw_init.clone()),
+                ..Default::default()
+            },
+            AttributeProto {
+                name: Some("graph_attr".to_string()),
+                g: Some(subgraph),
+                r#type: Some(AttributeType::GRAPH),
+                ..Default::default()
+            },
+        ];
+
+        let node = NodeProto {
+            name: Some("test_node".to_string()),
+            op_type: Some("TestOp".to_string()),
+            domain: Some("test.domain".to_string()),
+            input: vec!["input".to_string(), "weights".to_string()],
+            output: vec!["output".to_string()],
+            attribute: attrs,
+        };
+
+        let input = ValueInfoProto {
+            name: Some("input".to_string()),
+            r#type: Some(TypeProto {
+                tensor_type: Some(TypeProtoTensor {
+                    elem_type: Some(DataType::FLOAT),
+                    shape: Some(TensorShapeProto {
+                        dim: vec![
+                            Dimension {
+                                dim_param: Some("batch".to_string()),
+                                ..Default::default()
+                            },
+                            Dimension {
+                                dim_value: Some(3),
+                                ..Default::default()
+                            },
+                        ],
+                    }),
+                }),
+                ..Default::default()
+            }),
+        };
+
+        // Output with a sequence type, to cover `TypeProto.sequence`.
+        let output = ValueInfoProto {
+            name: Some("output".to_string()),
+            r#type: Some(TypeProto {
+                sequence: Some(Box::new(TypeProtoSequence {
+                    elem_type: Some(TypeProto {
+                        tensor_type: Some(TypeProtoTensor {
+                            elem_type: Some(DataType::INT64),
+                            shape: None,
+                        }),
+                        ..Default::default()
+                    }),
+                })),
+                ..Default::default()
+            }),
+        };
+
+        let graph = GraphProto {
+            node: vec![node],
+            initializer: vec![raw_init, typed_init],
+            input: vec![input],
+            output: vec![output],
+            value_info: vec![ValueInfoProto {
+                name: Some("intermediate".to_string()),
+                r#type: None,
+            }],
+        };
+
+        ModelProto {
+            ir_version: Some(9),
+            producer_name: Some("rten-onnx".to_string()),
+            producer_version: Some("0.1.0".to_string()),
+            graph: Some(graph),
+            opset_import: vec![
+                OperatorSetIdProto {
+                    domain: Some(String::new()),
+                    version: Some(18),
+                },
+                OperatorSetIdProto {
+                    domain: Some("test.domain".to_string()),
+                    version: Some(1),
+                },
+            ],
+            metadata_props: vec![StringStringEntryProto {
+                key: Some("key".to_string()),
+                value: Some("value".to_string()),
+            }],
+        }
+    }
+
+    #[test]
+    fn test_write_model() {
+        let model = create_test_model();
+        let buf = model.write_buf().unwrap();
+        let decoded = ModelProto::parse_buf(&buf).unwrap();
+
+        assert_eq!(decoded.ir_version, Some(9));
+        assert_eq!(decoded.producer_name.as_deref(), Some("rten-onnx"));
+        assert_eq!(decoded.producer_version.as_deref(), Some("0.1.0"));
+
+        let opsets: Vec<_> = decoded
+            .opset_import
+            .iter()
+            .map(|os| (os.domain.as_deref().unwrap(), os.version.unwrap()))
+            .collect();
+        assert_eq!(opsets, [("", 18), ("test.domain", 1)]);
+
+        let metadata: Vec<_> = decoded
+            .metadata_props
+            .iter()
+            .map(|prop| (prop.key.as_deref().unwrap(), prop.value.as_deref().unwrap()))
+            .collect();
+        assert_eq!(metadata, [("key", "value")]);
+
+        let graph = decoded.graph.unwrap();
+
+        // Check the node and its attributes.
+        assert_eq!(graph.node.len(), 1);
+        let node = &graph.node[0];
+        assert_eq!(node.name.as_deref(), Some("test_node"));
+        assert_eq!(node.op_type.as_deref(), Some("TestOp"));
+        assert_eq!(node.domain.as_deref(), Some("test.domain"));
+        assert_eq!(node.input, ["input", "weights"]);
+        assert_eq!(node.output, ["output"]);
+
+        let attrs = &node.attribute;
+        let attr_names: Vec<_> = attrs
+            .iter()
+            .map(|attr| attr.name.as_deref().unwrap())
+            .collect();
+        assert_eq!(
+            attr_names,
+            [
+                "float_attr",
+                "int_attr",
+                "string_attr",
+                "floats_attr",
+                "ints_attr",
+                "strings_attr",
+                "tensor_attr",
+                "graph_attr"
+            ]
+        );
+        assert_eq!(attrs[0].f, Some(0.5));
+        assert_eq!(attrs[0].r#type, Some(AttributeType::FLOAT));
+        assert_eq!(attrs[1].i, Some(-3));
+        assert_eq!(attrs[2].s.as_deref(), Some("str_value"));
+        assert_eq!(attrs[3].floats, [1.0, 2.0]);
+        assert_eq!(attrs[4].ints, [3, -4]);
+        assert_eq!(attrs[5].strings, ["a", "b"]);
+        assert_eq!(attrs[6].t.as_ref().unwrap().dims, [2, 3]);
+
+        let subgraph = attrs[7].g.as_ref().unwrap();
+        assert_eq!(subgraph.node.len(), 1);
+        assert_eq!(subgraph.node[0].op_type.as_deref(), Some("Identity"));
+        assert_eq!(subgraph.node[0].input, ["x"]);
+        assert_eq!(subgraph.node[0].output, ["y"]);
+
+        // Check the initializer which uses `raw_data`.
+        assert_eq!(graph.initializer.len(), 2);
+        let raw_init = &graph.initializer[0];
+        assert_eq!(raw_init.name.as_deref(), Some("weights"));
+        assert_eq!(raw_init.dims, [2, 3]);
+        assert_eq!(raw_init.data_type, Some(DataType::FLOAT));
+        let expected_raw: Vec<u8> = (0..6).flat_map(|i| (i as f32).to_le_bytes()).collect();
+        assert_eq!(*raw_init.raw_data.as_ref().unwrap().borrow(), expected_raw);
+
+        // Check the initializer which uses the typed data fields.
+        let typed_init = &graph.initializer[1];
+        assert_eq!(typed_init.float_data, [1.0, 2.0]);
+        assert_eq!(typed_init.int32_data, [3, -4]);
+        assert_eq!(typed_init.int64_data, [5, -6]);
+        assert_eq!(typed_init.double_data, [7.0, 8.0]);
+        assert_eq!(typed_init.data_location, Some(DataLocation::EXTERNAL));
+        assert_eq!(typed_init.external_data.len(), 1);
+        assert_eq!(typed_init.external_data[0].key.as_deref(), Some("location"));
+        assert_eq!(
+            typed_init.external_data[0].value.as_deref(),
+            Some("weights.bin")
+        );
+
+        // Check value types and shapes.
+        let input_type = graph.input[0].r#type.as_ref().unwrap();
+        let tensor_type = input_type.tensor_type.as_ref().unwrap();
+        assert_eq!(graph.input[0].name.as_deref(), Some("input"));
+        assert_eq!(tensor_type.elem_type, Some(DataType::FLOAT));
+        let dims = &tensor_type.shape.as_ref().unwrap().dim;
+        assert_eq!(dims[0].dim_param.as_deref(), Some("batch"));
+        assert_eq!(dims[1].dim_value, Some(3));
+
+        let output_type = graph.output[0].r#type.as_ref().unwrap();
+        let seq_elem_type = output_type
+            .sequence
+            .as_ref()
+            .unwrap()
+            .elem_type
+            .as_ref()
+            .unwrap();
+        assert_eq!(graph.output[0].name.as_deref(), Some("output"));
+        assert_eq!(
+            seq_elem_type.tensor_type.as_ref().unwrap().elem_type,
+            Some(DataType::INT64)
+        );
+
+        assert_eq!(graph.value_info.len(), 1);
+        assert_eq!(graph.value_info[0].name.as_deref(), Some("intermediate"));
+    }
+
+    // Test that writing a model and reading it back preserves the fields
+    // that this module supports.
+    #[test]
+    fn test_write_mnist() {
+        let model_path = test_file_path("mnist.onnx");
+        let file = File::open(model_path).unwrap();
+        let model = ModelProto::parse_file(file).unwrap();
+
+        let buf = model.write_buf().unwrap();
+        let decoded = ModelProto::parse_buf(&buf).unwrap();
+
+        assert_eq!(decoded.ir_version, model.ir_version);
+        assert_eq!(decoded.producer_name, model.producer_name);
+        assert_eq!(decoded.producer_version, model.producer_version);
+        assert_eq!(decoded.opset_import.len(), model.opset_import.len());
+
+        let graph = model.graph.as_ref().unwrap();
+        let decoded_graph = decoded.graph.as_ref().unwrap();
+
+        let ops = |graph: &GraphProto| -> Vec<String> {
+            graph
+                .node
+                .iter()
+                .map(|node| {
+                    format!(
+                        "{}({}) -> ({})",
+                        node.op_type.as_deref().unwrap_or_default(),
+                        node.input.join(", "),
+                        node.output.join(", ")
+                    )
+                })
+                .collect()
+        };
+        assert_eq!(ops(decoded_graph), ops(graph));
+
+        let weights = |graph: &GraphProto| -> Vec<(String, Vec<i64>, Vec<u8>)> {
+            graph
+                .initializer
+                .iter()
+                .map(|init| {
+                    (
+                        init.name.clone().unwrap_or_default(),
+                        init.dims.clone(),
+                        init.raw_data
+                            .as_ref()
+                            .map(|data| data.borrow().clone())
+                            .unwrap_or_default(),
+                    )
+                })
+                .collect()
+        };
+        assert_eq!(weights(decoded_graph), weights(graph));
+
+        assert_eq!(decoded.write_buf().unwrap(), buf);
     }
 
     #[test]

--- a/rten-onnx/src/protobuf.rs
+++ b/rten-onnx/src/protobuf.rs
@@ -40,10 +40,14 @@
 mod errors;
 mod field;
 mod message;
+mod message_writer;
 mod value;
+mod value_writer;
 pub mod varint;
 
 pub use errors::{ErrorKind, ProtobufError};
 pub use field::{Field, FieldValue, Fields};
 pub use message::DecodeMessage;
+pub use message_writer::{EncodeMessage, MessageWriter};
 pub use value::{FieldTypes, OwnedValues, ReadPos, ReadValue, ValueReader};
+pub use value_writer::{CountingWriter, ValueWriter, WriteValue};

--- a/rten-onnx/src/protobuf/errors.rs
+++ b/rten-onnx/src/protobuf/errors.rs
@@ -109,6 +109,9 @@ pub enum ErrorKind {
 
     /// A variable length field was not read or skipped over.
     FieldNotConsumed,
+
+    /// The actual and expected lengths of an encoded message did not match.
+    LengthMismatch,
 }
 
 impl Display for ErrorKind {
@@ -125,6 +128,7 @@ impl Display for ErrorKind {
             ErrorKind::FieldNotConsumed => {
                 write!(f, "variable-length field not consumed or skipped")
             }
+            ErrorKind::LengthMismatch => write!(f, "encoded message length mismatch"),
         }
     }
 }

--- a/rten-onnx/src/protobuf/field.rs
+++ b/rten-onnx/src/protobuf/field.rs
@@ -30,14 +30,14 @@ impl FieldValue {
     /// Encode a field with the value and wire type of `self` and the given
     /// field number.
     fn encode(self, number: u64) -> Vec<u8> {
-        use crate::protobuf::varint::encode_varint;
-        let encode_type_number = |wire_type| encode_varint(wire_type | (number << 3));
+        use crate::protobuf::varint::encode_varint_vec;
+        let encode_type_number = |wire_type| encode_varint_vec(wire_type | (number << 3));
 
         let mut buf = Vec::new();
         match self {
             Self::Varint(val) => {
                 buf.extend(encode_type_number(0));
-                buf.extend(encode_varint(val));
+                buf.extend(encode_varint_vec(val));
             }
             Self::I64(val) => {
                 buf.extend(encode_type_number(1));
@@ -45,7 +45,7 @@ impl FieldValue {
             }
             Self::Len(len) => {
                 buf.extend(encode_type_number(2));
-                buf.extend(encode_varint(len));
+                buf.extend(encode_varint_vec(len));
             }
             Self::Sgroup => {
                 buf.extend(encode_type_number(3));
@@ -467,7 +467,7 @@ impl<'r, R: ReadValue> Fields<'r, R> {
 #[cfg(test)]
 mod tests {
     use super::{FieldValue, Fields};
-    use crate::protobuf::varint::encode_varint;
+    use crate::protobuf::varint::encode_varint_vec;
     use crate::protobuf::{ErrorKind, ProtobufError, ValueReader};
 
     fn read_fields(buf: &[u8]) -> Result<Vec<(u64, FieldValue)>, ProtobufError> {
@@ -598,8 +598,8 @@ mod tests {
         let mut buf = Vec::new();
         buf.extend(FieldValue::Varint(1).encode(1)); // Non-packed repeated
         buf.extend(FieldValue::Len(2).encode(1)); // Packed repeated
-        buf.extend(encode_varint(2));
-        buf.extend(encode_varint(3));
+        buf.extend(encode_varint_vec(2));
+        buf.extend(encode_varint_vec(3));
 
         let mut reader = ValueReader::from_buf(buf);
         let mut fields = Fields::new(&mut reader, Some("TestMessage"));

--- a/rten-onnx/src/protobuf/message_writer.rs
+++ b/rten-onnx/src/protobuf/message_writer.rs
@@ -1,0 +1,520 @@
+use std::any::type_name;
+
+use crate::protobuf::errors::{ErrorKind, ProtobufError};
+use crate::protobuf::value_writer::{CountingWriter, WriteValue};
+use crate::protobuf::varint::varint_len;
+
+// Wire types. See <https://protobuf.dev/programming-guides/encoding/#structure>.
+const WIRE_VARINT: u64 = 0;
+const WIRE_LEN: u64 = 2;
+const WIRE_I32: u64 = 5;
+
+/// Writes the fields of a single message.
+pub struct MessageWriter<'w, W: WriteValue> {
+    writer: &'w mut W,
+
+    /// Total length of embedded message content which was not written because
+    /// the writer only measures lengths.
+    ///
+    /// When [`WriteValue::COUNT_ONLY`] is set, the length of each embedded
+    /// message is measured by [`EncodeMessage::encoded_len`] and recorded here
+    /// rather than visiting the message's fields a second time.
+    skipped_len: u64,
+
+    /// Debug name of the message type.
+    context: Option<&'static str>,
+}
+
+impl<'w, W: WriteValue> MessageWriter<'w, W> {
+    /// Create a writer which writes the fields of a message to `writer`.
+    ///
+    /// `context` is the name of the message type being written, for debugging
+    /// purposes.
+    pub fn new(writer: &'w mut W, context: Option<&'static str>) -> Self {
+        Self {
+            writer,
+            skipped_len: 0,
+            context,
+        }
+    }
+
+    /// Write the value of a field with schema type `int32`.
+    pub fn write_int32(&mut self, number: u64, val: i32) -> Result<(), ProtobufError> {
+        // `int32` values are sign-extended to 64 bits before being encoded.
+        self.write_varint_field(number, val as i64 as u64)
+    }
+
+    /// Write the value of a field with schema type `int64`.
+    pub fn write_int64(&mut self, number: u64, val: i64) -> Result<(), ProtobufError> {
+        self.write_varint_field(number, val as u64)
+    }
+
+    /// Write the value of a field where the schema type is an enum.
+    pub fn write_enum(&mut self, number: u64, val: i32) -> Result<(), ProtobufError> {
+        self.write_int32(number, val)
+    }
+
+    /// Write the value of a field with schema type `float`.
+    pub fn write_float(&mut self, number: u64, val: f32) -> Result<(), ProtobufError> {
+        self.write_tag(number, WIRE_I32)?;
+        self.writer.write_i32(i32::from_le_bytes(val.to_le_bytes()))
+    }
+
+    /// Write the value of a field with schema type `string`.
+    pub fn write_string(&mut self, number: u64, val: &str) -> Result<(), ProtobufError> {
+        self.write_bytes(number, val.as_bytes())
+    }
+
+    /// Write the value of a field with schema type `bytes`.
+    pub fn write_bytes(&mut self, number: u64, val: &[u8]) -> Result<(), ProtobufError> {
+        self.write_tag(number, WIRE_LEN)?;
+        self.writer.write_varint(val.len() as u64)?;
+        self.writer.write_bytes(val)
+    }
+
+    /// Write an embedded message as the value of a field.
+    pub fn write_message<M: EncodeMessage>(
+        &mut self,
+        number: u64,
+        msg: &M,
+    ) -> Result<(), ProtobufError> {
+        let len = msg.encoded_len()?;
+
+        self.write_tag(number, WIRE_LEN)?;
+        self.writer.write_varint(len)?;
+
+        if W::COUNT_ONLY {
+            self.skipped_len += len;
+            return Ok(());
+        }
+
+        let start = self.writer.position();
+        let context = Some(type_name::<M>());
+        msg.encode_fields(&mut MessageWriter::new(&mut *self.writer, context))?;
+
+        // Verify that `encode_fields` wrote the number of bytes computed by
+        // `encoded_len`.
+        let written = self.writer.position() - start;
+        if written != len {
+            return Err(ProtobufError::new(ErrorKind::LengthMismatch).with_context(context, None));
+        }
+
+        Ok(())
+    }
+
+    /// Write the elements of an un-packed `repeated int64` field.
+    pub fn write_repeated_int64(&mut self, number: u64, vals: &[i64]) -> Result<(), ProtobufError> {
+        for val in vals {
+            self.write_int64(number, *val)?;
+        }
+        Ok(())
+    }
+
+    /// Write the elements of an un-packed `repeated float` field.
+    pub fn write_repeated_float(&mut self, number: u64, vals: &[f32]) -> Result<(), ProtobufError> {
+        for val in vals {
+            self.write_float(number, *val)?;
+        }
+        Ok(())
+    }
+
+    /// Write the elements of a `repeated string` field.
+    pub fn write_repeated_string<S: AsRef<str>>(
+        &mut self,
+        number: u64,
+        vals: &[S],
+    ) -> Result<(), ProtobufError> {
+        for val in vals {
+            self.write_string(number, val.as_ref())?;
+        }
+        Ok(())
+    }
+
+    /// Write the elements of a repeated field with an embedded message type.
+    pub fn write_repeated_message<M: EncodeMessage>(
+        &mut self,
+        number: u64,
+        msgs: &[M],
+    ) -> Result<(), ProtobufError> {
+        for msg in msgs {
+            self.write_message(number, msg)?;
+        }
+        Ok(())
+    }
+
+    /// Write the elements of a packed `repeated int32` field.
+    pub fn write_packed_int32(&mut self, number: u64, vals: &[i32]) -> Result<(), ProtobufError> {
+        self.write_packed_varints(number, vals.iter().map(|val| *val as i64 as u64))
+    }
+
+    /// Write the elements of a packed `repeated int64` field.
+    pub fn write_packed_int64(&mut self, number: u64, vals: &[i64]) -> Result<(), ProtobufError> {
+        self.write_packed_varints(number, vals.iter().map(|val| *val as u64))
+    }
+
+    /// Write the elements of a packed `repeated float` field.
+    pub fn write_packed_float(&mut self, number: u64, vals: &[f32]) -> Result<(), ProtobufError> {
+        if vals.is_empty() {
+            return Ok(());
+        }
+        self.write_tag(number, WIRE_LEN)?;
+        self.writer.write_varint(vals.len() as u64 * 4)?;
+        for val in vals {
+            self.writer
+                .write_i32(i32::from_le_bytes(val.to_le_bytes()))?;
+        }
+        Ok(())
+    }
+
+    /// Write the elements of a packed `repeated double` field.
+    pub fn write_packed_double(&mut self, number: u64, vals: &[f64]) -> Result<(), ProtobufError> {
+        if vals.is_empty() {
+            return Ok(());
+        }
+        self.write_tag(number, WIRE_LEN)?;
+        self.writer.write_varint(vals.len() as u64 * 8)?;
+        for val in vals {
+            self.writer
+                .write_i64(i64::from_le_bytes(val.to_le_bytes()))?;
+        }
+        Ok(())
+    }
+
+    fn write_packed_varints(
+        &mut self,
+        number: u64,
+        vals: impl Iterator<Item = u64> + Clone,
+    ) -> Result<(), ProtobufError> {
+        let len: u64 = vals.clone().map(|val| varint_len(val) as u64).sum();
+        if len == 0 {
+            return Ok(());
+        }
+        self.write_tag(number, WIRE_LEN)?;
+        self.writer.write_varint(len)?;
+        for val in vals {
+            self.writer.write_varint(val)?;
+        }
+        Ok(())
+    }
+
+    fn write_varint_field(&mut self, number: u64, val: u64) -> Result<(), ProtobufError> {
+        self.write_tag(number, WIRE_VARINT)?;
+        self.writer.write_varint(val)
+    }
+
+    fn write_tag(&mut self, number: u64, wire_type: u64) -> Result<(), ProtobufError> {
+        self.writer
+            .write_varint((number << 3) | wire_type)
+            .map_err(|err| err.with_context(self.context, Some(number)))
+    }
+}
+
+/// Defines how to serialize a type as an encoded message.
+pub trait EncodeMessage {
+    /// Write the fields of this message.
+    ///
+    /// Implementations must write the same fields with the same values each
+    /// time they are called for a given message, as the message is visited once
+    /// to determine its encoded length and once to write it.
+    fn encode_fields<W: WriteValue>(
+        &self,
+        fields: &mut MessageWriter<W>,
+    ) -> Result<(), ProtobufError>;
+
+    /// Return the length of this message in bytes when encoded.
+    ///
+    /// This visits the fields of the message using [`CountingWriter`].
+    fn encoded_len(&self) -> Result<u64, ProtobufError> {
+        let mut counter = CountingWriter::new();
+        let context = Some(type_name::<Self>());
+        let mut fields = MessageWriter::new(&mut counter, context);
+        self.encode_fields(&mut fields)?;
+        let skipped_len = fields.skipped_len;
+        Ok(counter.position() + skipped_len)
+    }
+
+    /// Encode this message to a writer.
+    fn encode<W: WriteValue>(&self, mut writer: W) -> Result<(), ProtobufError> {
+        let context = Some(type_name::<Self>());
+        {
+            let mut fields = MessageWriter::new(&mut writer, context);
+            self.encode_fields(&mut fields)?;
+        }
+        writer.flush()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::Cell;
+
+    use super::{EncodeMessage, MessageWriter};
+    use crate::protobuf::{
+        ErrorKind, FieldValue, Fields, ProtobufError, ValueReader, ValueWriter, WriteValue,
+    };
+
+    /// Encode a message and return the encoded bytes.
+    fn encode<M: EncodeMessage>(msg: &M) -> Vec<u8> {
+        let mut buf = Vec::new();
+        msg.encode(ValueWriter::new(&mut buf)).unwrap();
+
+        assert_eq!(msg.encoded_len().unwrap(), buf.len() as u64);
+
+        buf
+    }
+
+    /// Read the number and value of each field in an encoded message.
+    fn read_fields(buf: &[u8]) -> Vec<(u64, FieldValue)> {
+        let mut reader = ValueReader::from_buf(buf);
+        let mut fields = Fields::new(&mut reader, None);
+
+        let mut field_vals = Vec::new();
+        while let Some(mut field) = fields.next().unwrap() {
+            field_vals.push((field.number(), field.value()));
+            field.skip().unwrap();
+        }
+        field_vals
+    }
+
+    // Message which writes each kind of scalar field.
+    struct Scalars;
+
+    impl EncodeMessage for Scalars {
+        fn encode_fields<W: WriteValue>(
+            &self,
+            fields: &mut MessageWriter<W>,
+        ) -> Result<(), ProtobufError> {
+            fields.write_int32(1, -5)?;
+            fields.write_int64(2, 1234)?;
+            fields.write_enum(3, 7)?;
+            fields.write_float(4, 0.5)?;
+            fields.write_string(5, "hello")?;
+            fields.write_bytes(6, &[1, 2, 3])
+        }
+    }
+
+    #[test]
+    fn test_write_scalar_fields() {
+        let buf = encode(&Scalars);
+
+        let mut reader = ValueReader::from_buf(&buf);
+        let mut fields = Fields::new(&mut reader, None);
+
+        let field = fields.next().unwrap().unwrap();
+        assert_eq!(field.number(), 1);
+        assert_eq!(field.get_int32().unwrap(), -5);
+        drop(field);
+
+        let field = fields.next().unwrap().unwrap();
+        assert_eq!(field.number(), 2);
+        assert_eq!(field.get_int64().unwrap(), 1234);
+        drop(field);
+
+        let field = fields.next().unwrap().unwrap();
+        assert_eq!(field.number(), 3);
+        assert_eq!(field.get_enum().unwrap(), 7);
+        drop(field);
+
+        let field = fields.next().unwrap().unwrap();
+        assert_eq!(field.number(), 4);
+        assert_eq!(field.get_float().unwrap(), 0.5);
+        drop(field);
+
+        let mut field = fields.next().unwrap().unwrap();
+        assert_eq!(field.number(), 5);
+        assert_eq!(field.read_string().unwrap(), "hello");
+        drop(field);
+
+        let mut field = fields.next().unwrap().unwrap();
+        assert_eq!(field.number(), 6);
+        assert_eq!(field.read_bytes().unwrap(), [1, 2, 3]);
+        drop(field);
+
+        assert!(fields.next().unwrap().is_none());
+    }
+
+    // Message which writes repeated fields using packed and un-packed
+    // representations.
+    struct Repeated;
+
+    impl EncodeMessage for Repeated {
+        fn encode_fields<W: WriteValue>(
+            &self,
+            fields: &mut MessageWriter<W>,
+        ) -> Result<(), ProtobufError> {
+            fields.write_repeated_int64(1, &[1, 2])?;
+            fields.write_repeated_float(2, &[1.0, 2.0])?;
+            fields.write_repeated_string(3, &["a".to_string(), "b".to_string()])?;
+            fields.write_packed_int32(4, &[3, 4])?;
+            fields.write_packed_int64(5, &[5, 6])?;
+            fields.write_packed_float(6, &[3.0, 4.0])?;
+            fields.write_packed_double(7, &[5.0, 6.0])?;
+
+            // Empty repeated fields should be omitted entirely.
+            fields.write_repeated_int64(8, &[])?;
+            fields.write_repeated_float(9, &[])?;
+            fields.write_packed_int32(10, &[])?;
+            fields.write_packed_int64(11, &[])?;
+            fields.write_packed_float(12, &[])?;
+            fields.write_packed_double(13, &[])
+        }
+    }
+
+    #[test]
+    fn test_write_repeated_fields() {
+        let buf = encode(&Repeated);
+
+        assert_eq!(
+            read_fields(&buf),
+            [
+                // repeated int64
+                (1, FieldValue::Varint(1)),
+                (1, FieldValue::Varint(2)),
+                // repeated float
+                (2, FieldValue::I32(1.0f32.to_bits() as i32)),
+                (2, FieldValue::I32(2.0f32.to_bits() as i32)),
+                // repeated string
+                (3, FieldValue::Len(1)),
+                (3, FieldValue::Len(1)),
+                // packed i32
+                (4, FieldValue::Len(2)),
+                // packed i64
+                (5, FieldValue::Len(2)),
+                // packed float
+                (6, FieldValue::Len(8)),
+                // packed double
+                (7, FieldValue::Len(16)),
+            ]
+        );
+
+        // Verify the result can be read using `ValueReader`.
+        let mut reader = ValueReader::from_buf(&buf);
+        let mut fields = Fields::new(&mut reader, None);
+        let mut int64s = Vec::new();
+        let mut floats = Vec::new();
+        let mut strings = Vec::new();
+        let mut int32s = Vec::new();
+        let mut packed_int64s = Vec::new();
+        let mut packed_floats = Vec::new();
+        let mut doubles = Vec::new();
+
+        while let Some(mut field) = fields.next().unwrap() {
+            match field.number() {
+                1 => int64s.extend(field.read_repeated_int64().unwrap().map(|x| x.unwrap())),
+                2 => floats.extend(field.read_repeated_float().unwrap().map(|x| x.unwrap())),
+                3 => strings.push(field.read_string().unwrap()),
+                4 => int32s.extend(field.read_repeated_int32().unwrap().map(|x| x.unwrap())),
+                5 => packed_int64s.extend(field.read_repeated_int64().unwrap().map(|x| x.unwrap())),
+                6 => packed_floats.extend(field.read_repeated_float().unwrap().map(|x| x.unwrap())),
+                7 => doubles.extend(field.read_repeated_double().unwrap().map(|x| x.unwrap())),
+                _ => panic!("unexpected field {}", field.number()),
+            }
+        }
+
+        assert_eq!(int64s, [1, 2]);
+        assert_eq!(floats, [1.0, 2.0]);
+        assert_eq!(strings, ["a", "b"]);
+        assert_eq!(int32s, [3, 4]);
+        assert_eq!(packed_int64s, [5, 6]);
+        assert_eq!(packed_floats, [3.0, 4.0]);
+        assert_eq!(doubles, [5.0, 6.0]);
+    }
+
+    // Message with several levels of nesting. Each level writes one scalar
+    // field followed by `depth` nested messages.
+    struct Nested {
+        depth: u32,
+    }
+
+    impl EncodeMessage for Nested {
+        fn encode_fields<W: WriteValue>(
+            &self,
+            fields: &mut MessageWriter<W>,
+        ) -> Result<(), ProtobufError> {
+            fields.write_int32(1, self.depth as i32)?;
+            if self.depth > 0 {
+                let child = Nested {
+                    depth: self.depth - 1,
+                };
+                fields.write_repeated_message(2, &[child])?;
+            }
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn test_write_nested_messages() {
+        let msg = Nested { depth: 3 };
+        let buf = encode(&msg);
+
+        // Read the nested messages back. This will fail if the length prefix
+        // written for any level is incorrect.
+        fn read_nested(buf: &[u8], depths: &mut Vec<i32>) {
+            let mut reader = ValueReader::from_buf(buf);
+            let mut fields = Fields::new(&mut reader, None);
+            while let Some(mut field) = fields.next().unwrap() {
+                match field.number() {
+                    1 => depths.push(field.get_int32().unwrap()),
+                    2 => {
+                        let nested = field.read_bytes().unwrap();
+                        read_nested(&nested, depths);
+                    }
+                    _ => panic!("unexpected field {}", field.number()),
+                }
+            }
+        }
+
+        let mut depths = Vec::new();
+        read_nested(&buf, &mut depths);
+
+        assert_eq!(depths, [3, 2, 1, 0]);
+    }
+
+    // Message which writes a different number of fields each time it is
+    // encoded.
+    struct Inconsistent {
+        encode_count: Cell<u32>,
+    }
+
+    impl EncodeMessage for Inconsistent {
+        fn encode_fields<W: WriteValue>(
+            &self,
+            fields: &mut MessageWriter<W>,
+        ) -> Result<(), ProtobufError> {
+            self.encode_count.set(self.encode_count.get() + 1);
+            for i in 0..self.encode_count.get() {
+                fields.write_int32(1, i as i32)?;
+            }
+            Ok(())
+        }
+    }
+
+    struct InconsistentParent {
+        child: Inconsistent,
+    }
+
+    impl EncodeMessage for InconsistentParent {
+        fn encode_fields<W: WriteValue>(
+            &self,
+            fields: &mut MessageWriter<W>,
+        ) -> Result<(), ProtobufError> {
+            fields.write_message(1, &self.child)
+        }
+    }
+
+    #[test]
+    fn test_inconsistent_message_length() {
+        let msg = InconsistentParent {
+            child: Inconsistent {
+                encode_count: Cell::new(0),
+            },
+        };
+
+        let mut buf = Vec::new();
+        let err = msg
+            .encode(ValueWriter::new(&mut buf))
+            .expect_err("expected error");
+
+        assert!(matches!(err.kind(), ErrorKind::LengthMismatch));
+    }
+}

--- a/rten-onnx/src/protobuf/value.rs
+++ b/rten-onnx/src/protobuf/value.rs
@@ -330,13 +330,13 @@ impl<'a, R: ReadValue> ReadValue for LimitReader<'a, R> {
 mod tests {
     use super::{LimitReader, ReadValue, ValueReader};
     use crate::protobuf::ErrorKind;
-    use crate::protobuf::varint::encode_varint;
+    use crate::protobuf::varint::encode_varint_vec;
 
     fn test_read_value<R: ReadValue>(make_reader: impl Fn(Vec<u8>) -> R) {
         let mut buf = Vec::new();
         buf.extend((42i32).to_le_bytes());
         buf.extend((84i64).to_le_bytes());
-        buf.extend(encode_varint(1234));
+        buf.extend(encode_varint_vec(1234));
         buf.extend([1, 2, 3, 4]);
         buf.extend("hello world".as_bytes());
 
@@ -378,12 +378,12 @@ mod tests {
         let mut buf = Vec::new();
         buf.extend((42i32).to_le_bytes());
         buf.extend((84i64).to_le_bytes());
-        buf.extend(encode_varint(1234));
+        buf.extend(encode_varint_vec(1234));
         buf.extend([1, 2, 3, 4]);
         buf.extend("hello world".as_bytes());
 
         let limit = buf.len();
-        buf.extend(encode_varint(5678));
+        buf.extend(encode_varint_vec(5678));
 
         let mut reader = ValueReader::from_buf(buf);
 

--- a/rten-onnx/src/protobuf/value_writer.rs
+++ b/rten-onnx/src/protobuf/value_writer.rs
@@ -1,0 +1,233 @@
+//! Traits and types for writing primitive values in Protocol Buffers messages.
+
+use std::fs::File;
+use std::io::{BufWriter, Write};
+
+use crate::protobuf::errors::ProtobufError;
+use crate::protobuf::varint::{MAX_VARINT_LEN, encode_varint, varint_len};
+
+/// Trait for writing primitive values to a Protocol Buffers message.
+pub trait WriteValue {
+    /// True if this writer only counts the bytes that would be written, rather
+    /// than writing them.
+    ///
+    /// Writers of embedded messages use this to avoid recursing into a message
+    /// whose length has already been measured.
+    const COUNT_ONLY: bool = false;
+
+    /// Write a 4-byte little-endian value.
+    fn write_i32(&mut self, val: i32) -> Result<(), ProtobufError>;
+
+    /// Write an 8-byte little-endian value.
+    fn write_i64(&mut self, val: i64) -> Result<(), ProtobufError>;
+
+    /// Write an LEB128-encoded varint.
+    ///
+    /// See <https://protobuf.dev/programming-guides/encoding/#varints>.
+    fn write_varint(&mut self, val: u64) -> Result<(), ProtobufError>;
+
+    /// Write the content of a `bytes` or `string` field.
+    fn write_bytes(&mut self, bytes: &[u8]) -> Result<(), ProtobufError>;
+
+    /// Flush any buffered data to the underlying output.
+    fn flush(&mut self) -> Result<(), ProtobufError>;
+
+    /// Return the number of bytes written so far.
+    fn position(&self) -> u64;
+}
+
+impl<W: WriteValue + ?Sized> WriteValue for &mut W {
+    const COUNT_ONLY: bool = W::COUNT_ONLY;
+
+    fn write_i32(&mut self, val: i32) -> Result<(), ProtobufError> {
+        (**self).write_i32(val)
+    }
+
+    fn write_i64(&mut self, val: i64) -> Result<(), ProtobufError> {
+        (**self).write_i64(val)
+    }
+
+    fn write_varint(&mut self, val: u64) -> Result<(), ProtobufError> {
+        (**self).write_varint(val)
+    }
+
+    fn write_bytes(&mut self, bytes: &[u8]) -> Result<(), ProtobufError> {
+        (**self).write_bytes(bytes)
+    }
+
+    fn flush(&mut self) -> Result<(), ProtobufError> {
+        (**self).flush()
+    }
+
+    fn position(&self) -> u64 {
+        (**self).position()
+    }
+}
+
+/// A Protocol Buffers primitive writer that writes to an output stream.
+pub struct ValueWriter<W> {
+    inner: W,
+    pos: u64,
+}
+
+impl<W: Write> ValueWriter<W> {
+    /// Create a value writer which writes to `inner`.
+    pub fn new(inner: W) -> Self {
+        Self { inner, pos: 0 }
+    }
+
+    /// Return the wrapped writer.
+    pub fn into_inner(self) -> W {
+        self.inner
+    }
+}
+
+impl ValueWriter<BufWriter<File>> {
+    /// Convenience method that creates a writer which writes to a file.
+    pub fn from_file(file: File) -> Self {
+        Self::new(BufWriter::new(file))
+    }
+}
+
+impl<W: Write> WriteValue for ValueWriter<W> {
+    fn write_i32(&mut self, val: i32) -> Result<(), ProtobufError> {
+        self.inner.write_all(&val.to_le_bytes())?;
+        self.pos += 4;
+        Ok(())
+    }
+
+    fn write_i64(&mut self, val: i64) -> Result<(), ProtobufError> {
+        self.inner.write_all(&val.to_le_bytes())?;
+        self.pos += 8;
+        Ok(())
+    }
+
+    fn write_varint(&mut self, val: u64) -> Result<(), ProtobufError> {
+        let mut buf = [0; MAX_VARINT_LEN];
+        let encoded = encode_varint(val, &mut buf);
+        self.inner.write_all(encoded)?;
+        self.pos += encoded.len() as u64;
+        Ok(())
+    }
+
+    fn write_bytes(&mut self, bytes: &[u8]) -> Result<(), ProtobufError> {
+        self.inner.write_all(bytes)?;
+        self.pos += bytes.len() as u64;
+        Ok(())
+    }
+
+    fn flush(&mut self) -> Result<(), ProtobufError> {
+        self.inner.flush()?;
+        Ok(())
+    }
+
+    fn position(&self) -> u64 {
+        self.pos
+    }
+}
+
+/// A Protocol Buffers primitive writer that counts bytes instead of writing
+/// them.
+///
+/// This is used to determine the length of a message before writing it.
+#[derive(Default)]
+pub struct CountingWriter {
+    pos: u64,
+}
+
+impl CountingWriter {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl WriteValue for CountingWriter {
+    const COUNT_ONLY: bool = true;
+
+    fn write_i32(&mut self, _val: i32) -> Result<(), ProtobufError> {
+        self.pos += 4;
+        Ok(())
+    }
+
+    fn write_i64(&mut self, _val: i64) -> Result<(), ProtobufError> {
+        self.pos += 8;
+        Ok(())
+    }
+
+    fn write_varint(&mut self, val: u64) -> Result<(), ProtobufError> {
+        self.pos += varint_len(val) as u64;
+        Ok(())
+    }
+
+    fn write_bytes(&mut self, bytes: &[u8]) -> Result<(), ProtobufError> {
+        self.pos += bytes.len() as u64;
+        Ok(())
+    }
+
+    fn flush(&mut self) -> Result<(), ProtobufError> {
+        Ok(())
+    }
+
+    fn position(&self) -> u64 {
+        self.pos
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CountingWriter, ValueWriter, WriteValue};
+    use crate::protobuf::varint::encode_varint_vec;
+    use crate::protobuf::{ReadValue, ValueReader};
+
+    fn write_values<W: WriteValue>(writer: &mut W) {
+        assert_eq!(writer.position(), 0);
+
+        writer.write_i32(42).unwrap();
+        assert_eq!(writer.position(), 4);
+
+        writer.write_i64(84).unwrap();
+        assert_eq!(writer.position(), 12);
+
+        writer.write_varint(1234).unwrap();
+        assert_eq!(writer.position(), 14);
+
+        writer.write_bytes(&[1, 2, 3, 4]).unwrap();
+        assert_eq!(writer.position(), 18);
+
+        writer.write_bytes("hello world".as_bytes()).unwrap();
+        assert_eq!(writer.position(), 29);
+
+        writer.flush().unwrap();
+    }
+
+    #[test]
+    fn test_value_writer() {
+        let mut buf = Vec::new();
+        let mut writer = ValueWriter::new(&mut buf);
+        write_values(&mut writer);
+
+        // Verify expected bytes were written.
+        let mut expected = Vec::new();
+        expected.extend((42i32).to_le_bytes());
+        expected.extend((84i64).to_le_bytes());
+        expected.extend(encode_varint_vec(1234));
+        expected.extend([1, 2, 3, 4]);
+        expected.extend("hello world".as_bytes());
+        assert_eq!(buf, expected);
+
+        // Verify that message can be read with `ValueReader`.
+        let mut reader = ValueReader::from_buf(buf);
+        assert_eq!(reader.read_i32().unwrap(), 42);
+        assert_eq!(reader.read_i64().unwrap(), 84);
+        assert_eq!(reader.read_varint().unwrap(), 1234);
+        assert_eq!(reader.read_bytes(4).unwrap(), [1, 2, 3, 4]);
+        assert_eq!(reader.read_string(11).unwrap(), "hello world");
+    }
+
+    #[test]
+    fn test_counting_writer() {
+        let mut writer = CountingWriter::new();
+        write_values(&mut writer);
+        assert_eq!(writer.position(), 29);
+    }
+}

--- a/rten-onnx/src/protobuf/varint.rs
+++ b/rten-onnx/src/protobuf/varint.rs
@@ -11,7 +11,7 @@ use std::io::BufRead;
 ///
 /// A decoded varint is a u64 value. Each byte contains 7 value bits and one
 /// continuation bit. Hence we need 9 "full" bytes plus one bit from the 10th byte.
-const MAX_VARINT_LEN: usize = 10;
+pub const MAX_VARINT_LEN: usize = 10;
 
 #[derive(Debug)]
 pub enum VarintError {
@@ -69,30 +69,46 @@ pub fn read_varint<R: BufRead>(mut src: R) -> Result<u64, VarintError> {
     Err(VarintError::InvalidVarint)
 }
 
-#[cfg(test)]
-pub fn encode_varint(mut val: u64) -> Vec<u8> {
-    let mut bytes = Vec::with_capacity(10);
+/// Encode `val` as a varint into `buf` and return the encoded bytes.
+///
+/// This will write between one and [`MAX_VARINT_LEN`] bytes.
+pub fn encode_varint(mut val: u64, buf: &mut [u8; MAX_VARINT_LEN]) -> &[u8] {
+    let mut len = 0;
 
     loop {
-        let mut byte = (val & 0x7f) as u8;
+        let byte = (val & 0x7f) as u8;
         if val <= 0x7f {
-            bytes.push(byte);
+            buf[len] = byte;
+            len += 1;
             break;
         } else {
-            byte |= 0x80;
-            bytes.push(byte);
-            val = val >> 7;
+            buf[len] = byte | 0x80;
+            len += 1;
+            val >>= 7;
         }
     }
 
-    bytes
+    &buf[..len]
+}
+
+/// Return the number of bytes that `val` occupies when encoded as a varint.
+pub fn varint_len(val: u64) -> usize {
+    // Each byte holds 7 value bits. `val | 1` makes the zero case return 1.
+    let value_bits = u64::BITS - (val | 1).leading_zeros();
+    value_bits.div_ceil(7) as usize
+}
+
+#[cfg(test)]
+pub fn encode_varint_vec(val: u64) -> Vec<u8> {
+    let mut buf = [0; MAX_VARINT_LEN];
+    encode_varint(val, &mut buf).to_vec()
 }
 
 #[cfg(test)]
 mod tests {
     use std::io::{BufRead, Cursor, Read};
 
-    use super::{VarintError, encode_varint, read_varint};
+    use super::{VarintError, encode_varint_vec, read_varint, varint_len};
 
     /// Like `Cursor`, but behaves as if the internal buffer only has a capacity
     /// of one.
@@ -131,7 +147,7 @@ mod tests {
         let mut values: Vec<u64> = (0..1024).collect();
         values.push(u64::MAX);
         for val in values {
-            let buf = encode_varint(val);
+            let buf = encode_varint_vec(val);
             let mut cur = Cursor::new(buf);
             let decoded_val = read_varint(&mut cur).unwrap();
             assert_eq!(decoded_val, val);
@@ -154,7 +170,7 @@ mod tests {
 
         // Longer sequence of varints.
         let values = [0, 1, 150, u64::MAX, 2];
-        let buf: Vec<u8> = values.iter().copied().flat_map(encode_varint).collect();
+        let buf: Vec<u8> = values.iter().copied().flat_map(encode_varint_vec).collect();
 
         let mut decoded_values = Vec::new();
         let mut cur = Cursor::new(buf);
@@ -176,15 +192,24 @@ mod tests {
     #[test]
     fn test_read_varint_refill() {
         let val = 65535;
-        let buf = encode_varint(val);
+        let buf = encode_varint_vec(val);
         let mut cur = OneByteCursor::new(&buf);
         let decoded = read_varint(&mut cur).unwrap();
         assert_eq!(decoded, val);
     }
 
     #[test]
+    fn test_varint_len() {
+        let mut values: Vec<u64> = (0..1024).collect();
+        values.extend([u64::MAX, i32::MAX as u64, u32::MAX as u64]);
+        for val in values {
+            assert_eq!(varint_len(val), encode_varint_vec(val).len(), "value {val}");
+        }
+    }
+
+    #[test]
     fn test_invalid_varint() {
-        let mut buf = encode_varint(u64::MAX);
+        let mut buf = encode_varint_vec(u64::MAX);
         assert_eq!(buf.len(), 10);
         buf[9] += 1;
         let decoded = read_varint(&mut Cursor::new(buf));


### PR DESCRIPTION
Extend rten-onnx with APIs to support writing ONNX files. The initial use case is for porting some tests in the main crate which currently use the `.rten` format to use the `.onnx` format instead.

The changes consist of:

- `MessageWriter` and `ValueWriter` types for writing protobuf messages
- An `EncodeMessage` trait which message types can implement to enable serialization
- Implementations of `EncodeMessage` for the ONNX types

Part of https://github.com/robertknight/rten/issues/1470.